### PR TITLE
Add OpenHands repository setup automation

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,30 @@
+name: PR Review by OpenHands
+
+on:
+  pull_request_target:
+    types: [labeled, review_requested]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr-review:
+    if: |
+      github.event.label.name == 'review-this' ||
+      github.event.requested_reviewer.login == 'openhands-agent' ||
+      github.event.requested_reviewer.login == 'all-hands-bot'
+    concurrency:
+      group: pr-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Run PR Review
+        uses: OpenHands/extensions/plugins/pr-review@main
+        with:
+          llm-model: litellm_proxy/claude-sonnet-4-5-20250929
+          llm-base-url: https://llm-proxy.app.all-hands.dev
+          use-sub-agents: "false"
+          llm-api-key: ${{ secrets.LLM_API_KEY }}
+          github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || github.token }}

--- a/.openhands/pre-commit.sh
+++ b/.openhands/pre-commit.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT" || exit 1
+
+npm run lint
+npm run test

--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+
+cd "$REPO_ROOT" || exit 1
+
+if [ ! -d node_modules ]; then
+  npm ci
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  cp .env.sample "$ENV_FILE"
+fi
+
+if ! grep -Eq '^[[:space:]]*VITE_WORKING_DIR=' "$ENV_FILE"; then
+  printf '\nVITE_WORKING_DIR="%s"\n' "$REPO_ROOT" >> "$ENV_FILE"
+fi
+
+if [ ! -f src/i18n/declaration.ts ]; then
+  npm run make-i18n
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,7 @@
 
 - README expectation: the very first section should be a concrete from-scratch quickstart for running this frontend against a real `openhands-agent-server` (clone, install backend, optional `.env`, run `npm run dev`). Keep live-backend instructions ahead of general project overview.
 - As an OpenHands incubator **Sandbox** project, the repo should carry the standard sandbox warning badge in `README.md` and include a root `LICENSE` file to satisfy the incubator-program requirements.
+- OpenHands repo bootstrap files live under `.openhands/`:
+  - `.openhands/setup.sh` installs frontend dependencies with `npm ci` when needed, creates `.env` from `.env.sample` if missing, appends `VITE_WORKING_DIR` for this repo when unset, and generates `src/i18n/declaration.ts` via `npm run make-i18n`.
+  - `.openhands/pre-commit.sh` mirrors the repo's local quality gate with `npm run lint && npm run test`.
+- `.github/workflows/pr-review.yml` is configured for on-demand OpenHands reviews only (`review-this` label or requesting `openhands-agent` / `all-hands-bot`), uses the OpenHands app LLM proxy defaults, and expects a repository `LLM_API_KEY` secret.


### PR DESCRIPTION
## Summary
- add `.openhands/setup.sh` to install dependencies, create `.env` from `.env.sample`, and pin `VITE_WORKING_DIR` to this repo when unset
- add `.openhands/pre-commit.sh` so OpenHands can run the repo's lint and test commands before committing
- add an on-demand `.github/workflows/pr-review.yml` workflow wired to the OpenHands PR review action and app LLM proxy defaults
- document the new OpenHands repo setup files in `AGENTS.md`

## Testing
- `bash -n .openhands/setup.sh .openhands/pre-commit.sh`
- `npx prettier --check .github/workflows/pr-review.yml`
- `./.openhands/pre-commit.sh` *(fails due to pre-existing repo-wide lint/test issues unrelated to this change; see Notes)*

## Notes
- The PR review workflow expects a repository secret named `LLM_API_KEY`.
- Existing repo-wide validation failures seen locally:
  - `npm run lint` reports pre-existing lint/prettier issues in existing `src/api/*` files
  - `npm run test` reports pre-existing failures that expect a reachable/mock agent server, plus an existing `settings-form` assertion failure

Closes #22

_AI-generated by OpenHands on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/74b69aa9-b522-4cd7-ade6-48031343b7a6)