### PR TITLE
Align conversation startup with settings models

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -56,6 +56,16 @@ describe("buildStartConversationRequest", () => {
       api_key: "nested-key",
       base_url: "https://nested.example.com",
     });
+    expect(payload.agent.condenser).toEqual({
+      kind: "LLMSummarizingCondenser",
+      llm: {
+        model: "nested-model",
+        api_key: "nested-key",
+        base_url: "https://nested.example.com",
+        usage_id: "condenser",
+      },
+      max_size: 120,
+    });
     expect(payload.agent.tools).toEqual([
       { name: "terminal", params: {} },
       { name: "file_editor", params: {} },

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { buildStartConversationRequest } from "#/api/agent-server-adapter";
+import { DEFAULT_SETTINGS } from "#/services/settings";
+
 const { mockGetAgentServerWorkingDir } = vi.hoisted(() => ({
-  mockGetAgentServerWorkingDir: vi.fn(() => "/workspace/project/agent-server-gui"),
+  mockGetAgentServerWorkingDir: vi.fn(
+    () => "/workspace/project/agent-server-gui",
+  ),
 }));
 
 vi.mock("#/api/agent-server-config", () => ({
@@ -11,32 +16,125 @@ vi.mock("#/api/agent-server-config", () => ({
   getConfiguredWorkerUrls: vi.fn(() => []),
 }));
 
-import { buildStartConversationRequest } from "#/api/agent-server-adapter";
-import { DEFAULT_SETTINGS } from "#/services/settings";
-
 describe("buildStartConversationRequest", () => {
-  it("uses the SDK-registered tool names for live agent-server conversations", () => {
+  it("uses nested settings as the source of truth and keeps SDK tool names", () => {
     const payload = buildStartConversationRequest({
       settings: {
         ...DEFAULT_SETTINGS,
-        llm_model: "litellm_proxy/claude-opus-4-5-20251101",
+        llm_model: "stale-top-level-model",
+        agent_settings: {
+          ...DEFAULT_SETTINGS.agent_settings,
+          agent: "CodeActAgent",
+          llm: {
+            model: "nested-model",
+            api_key: "  nested-key  ",
+            base_url: " https://nested.example.com ",
+          },
+          condenser: {
+            enabled: true,
+            max_size: 120,
+          },
+        },
+        conversation_settings: {
+          ...DEFAULT_SETTINGS.conversation_settings,
+          max_iterations: 123,
+        },
       },
       query: "hello",
     }) as {
-      agent: { tools: Array<{ name: string; params: Record<string, unknown> }> };
+      agent: Record<string, unknown> & {
+        llm: Record<string, unknown>;
+        tools: Array<{ name: string; params: Record<string, unknown> }>;
+      };
       workspace: { working_dir: string };
       initial_message: { content: Array<{ text: string }> };
+      max_iterations: number;
     };
 
+    expect(payload.agent.llm).toMatchObject({
+      model: "nested-model",
+      api_key: "nested-key",
+      base_url: "https://nested.example.com",
+    });
     expect(payload.agent.tools).toEqual([
       { name: "terminal", params: {} },
       { name: "file_editor", params: {} },
       { name: "task_tracker", params: {} },
       { name: "browser_tool_set", params: {} },
     ]);
+    expect(payload.agent.agent).toBeUndefined();
     expect(payload.workspace.working_dir).toBe(
       "/workspace/project/agent-server-gui",
     );
+    expect(payload.max_iterations).toBe(123);
     expect(payload.initial_message.content[0]?.text).toBe("hello");
+  });
+
+  it("derives confirmation and security settings the same way as OpenHands", () => {
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          ...DEFAULT_SETTINGS.agent_settings,
+          llm: { model: "nested-model" },
+        },
+        conversation_settings: {
+          ...DEFAULT_SETTINGS.conversation_settings,
+          confirmation_mode: true,
+          security_analyzer: "llm",
+        },
+      },
+    }) as {
+      confirmation_policy: Record<string, unknown>;
+      security_analyzer: Record<string, unknown>;
+    };
+
+    expect(payload.confirmation_policy).toEqual({
+      kind: "ConfirmRisky",
+      threshold: "HIGH",
+      confirm_unknown: true,
+    });
+    expect(payload.security_analyzer).toEqual({
+      kind: "LLMSecurityAnalyzer",
+    });
+  });
+
+  it("forwards supported conversation runtime fields from nested settings", () => {
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          ...DEFAULT_SETTINGS.agent_settings,
+          llm: { model: "nested-model" },
+        },
+        conversation_settings: {
+          ...DEFAULT_SETTINGS.conversation_settings,
+          hook_config: { on_start: [] },
+          tool_module_qualnames: { demo_tool: "pkg.tools.demo" },
+          agent_definitions: [
+            { name: "reviewer", system_prompt: "be helpful" },
+          ],
+        },
+      },
+      conversationInstructions: "Follow the repo conventions.",
+      plugins: [
+        { source: "github.com/org/plugin", ref: "main", repo_path: "/" },
+      ],
+    }) as Record<string, unknown>;
+
+    expect(payload.hook_config).toEqual({ on_start: [] });
+    expect(payload.tool_module_qualnames).toEqual({
+      demo_tool: "pkg.tools.demo",
+    });
+    expect(payload.agent_definitions).toEqual([
+      { name: "reviewer", system_prompt: "be helpful" },
+    ]);
+    expect(payload.plugins).toEqual([
+      { source: "github.com/org/plugin", ref: "main", repo_path: "/" },
+    ]);
+    expect(payload.initial_message).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "Follow the repo conventions." }],
+    });
   });
 });

--- a/__tests__/api/settings-service.test.ts
+++ b/__tests__/api/settings-service.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import SettingsService from "#/api/settings-service/settings-service.api";
+
+const STORAGE_KEY = "openhands-agent-server-settings";
+
+describe("SettingsService", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("treats nested SDK settings as the source of truth when loading", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        agent: "Agent",
+        llm_model: "stale-top-level-model",
+        llm_base_url: "https://stale.example.com",
+        llm_api_key: "stale-key",
+        enable_default_condenser: false,
+        condenser_max_size: 12,
+        confirmation_mode: false,
+        security_analyzer: null,
+        max_iterations: 5,
+        agent_settings: {
+          agent: "CodeActAgent",
+          llm: {
+            model: "nested-model",
+            base_url: "https://nested.example.com",
+            api_key: "nested-key",
+          },
+          condenser: {
+            enabled: true,
+            max_size: 321,
+          },
+        },
+        conversation_settings: {
+          confirmation_mode: true,
+          security_analyzer: "llm",
+          max_iterations: 77,
+        },
+      }),
+    );
+
+    const settings = await SettingsService.getSettings();
+
+    expect(settings.agent).toBe("CodeActAgent");
+    expect(settings.llm_model).toBe("nested-model");
+    expect(settings.llm_base_url).toBe("https://nested.example.com");
+    expect(settings.llm_api_key).toBe("nested-key");
+    expect(settings.enable_default_condenser).toBe(true);
+    expect(settings.condenser_max_size).toBe(321);
+    expect(settings.confirmation_mode).toBe(true);
+    expect(settings.security_analyzer).toBe("llm");
+    expect(settings.max_iterations).toBe(77);
+    expect(settings.agent_settings?.agent).toBe("CodeActAgent");
+  });
+
+  it("keeps top-level mirrors in sync when saving nested settings diffs", async () => {
+    await SettingsService.saveSettings({
+      agent_settings_diff: {
+        agent: "CodeActAgent",
+        llm: {
+          model: "saved-model",
+          base_url: "https://saved.example.com",
+          api_key: "saved-key",
+        },
+      },
+      conversation_settings_diff: {
+        confirmation_mode: true,
+        security_analyzer: "llm",
+        max_iterations: 33,
+      },
+    });
+
+    const settings = await SettingsService.getSettings();
+
+    expect(settings.llm_model).toBe("saved-model");
+    expect(settings.llm_base_url).toBe("https://saved.example.com");
+    expect(settings.llm_api_key).toBe("saved-key");
+    expect(settings.confirmation_mode).toBe(true);
+    expect(settings.security_analyzer).toBe("llm");
+    expect(settings.max_iterations).toBe(33);
+    expect(settings.agent_settings?.llm).toMatchObject({
+      model: "saved-model",
+      base_url: "https://saved.example.com",
+      api_key: "saved-key",
+    });
+    expect(settings.conversation_settings).toMatchObject({
+      confirmation_mode: true,
+      security_analyzer: "llm",
+      max_iterations: 33,
+    });
+  });
+});

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -225,6 +225,33 @@ function buildInitialMessage(
   };
 }
 
+function buildCondenserConfig(
+  llm: SettingsRecord,
+  rawCondenser: unknown,
+): SettingsRecord | undefined {
+  const condenser = toRecord(rawCondenser);
+
+  if (condenser.enabled !== true) {
+    return undefined;
+  }
+
+  const condenserLlm = {
+    ...llm,
+    usage_id: "condenser",
+  };
+
+  const config: SettingsRecord = {
+    kind: "LLMSummarizingCondenser",
+    llm: condenserLlm,
+  };
+
+  if (typeof condenser.max_size === "number") {
+    config.max_size = condenser.max_size;
+  }
+
+  return config;
+}
+
 function buildConfiguredAgentSettings(settings: Settings): SettingsRecord {
   const agentSettings = toRecord(settings.agent_settings);
   const llm = toRecord(agentSettings.llm);
@@ -246,11 +273,19 @@ function buildConfiguredAgentSettings(settings: Settings): SettingsRecord {
     delete llm.base_url;
   }
 
+  const condenser = buildCondenserConfig(llm, agentSettings.condenser);
+
   AGENT_SETTINGS_METADATA_KEYS.forEach((key) => delete agentSettings[key]);
 
   const mcpConfig = toRecord(agentSettings.mcp_config);
   if (Object.keys(mcpConfig).length === 0 || !("mcpServers" in mcpConfig)) {
     delete agentSettings.mcp_config;
+  }
+
+  if (condenser) {
+    agentSettings.condenser = condenser;
+  } else {
+    delete agentSettings.condenser;
   }
 
   return {

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -139,14 +139,56 @@ export function toV1ConversationPage(data: {
   };
 }
 
-function getConfirmationPolicy(settings: Settings) {
-  return settings.confirmation_mode
-    ? { kind: "AlwaysConfirm" }
-    : { kind: "NeverConfirm" };
+type SettingsRecord = Record<string, unknown>;
+
+const AGENT_SETTINGS_METADATA_KEYS = new Set([
+  "schema_version",
+  "agent_kind",
+  "agent",
+]);
+
+const CONVERSATION_SETTINGS_METADATA_KEYS = new Set([
+  "schema_version",
+  "agent_settings",
+  "workspace",
+  "conversation_id",
+  "initial_message",
+  "plugins",
+]);
+
+function toRecord(value: unknown): SettingsRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return structuredClone(value as SettingsRecord);
 }
 
-function getSecurityAnalyzer(settings: Settings) {
-  switch (settings.security_analyzer) {
+function normalizeSecretString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function getConversationConfirmationPolicy(
+  conversationSettings: SettingsRecord,
+) {
+  if (conversationSettings.confirmation_mode !== true) {
+    return { kind: "NeverConfirm" };
+  }
+
+  if (conversationSettings.security_analyzer === "llm") {
+    return { kind: "ConfirmRisky", threshold: "HIGH", confirm_unknown: true };
+  }
+
+  return { kind: "AlwaysConfirm" };
+}
+
+function getConversationSecurityAnalyzer(conversationSettings: SettingsRecord) {
+  switch (conversationSettings.security_analyzer) {
     case "llm":
       return { kind: "LLMSecurityAnalyzer" };
     case "pattern":
@@ -170,7 +212,9 @@ function buildInitialMessage(
   query?: string,
   conversationInstructions?: string,
 ) {
-  const parts = [query?.trim(), conversationInstructions?.trim()].filter(Boolean);
+  const parts = [query?.trim(), conversationInstructions?.trim()].filter(
+    Boolean,
+  );
   if (parts.length === 0) {
     return null;
   }
@@ -181,75 +225,149 @@ function buildInitialMessage(
   };
 }
 
+function buildConfiguredAgentSettings(settings: Settings): SettingsRecord {
+  const agentSettings = toRecord(settings.agent_settings);
+  const llm = toRecord(agentSettings.llm);
+
+  llm.model =
+    typeof llm.model === "string" ? llm.model : DEFAULT_SETTINGS.llm_model;
+
+  const apiKey = normalizeSecretString(llm.api_key);
+  if (apiKey) {
+    llm.api_key = apiKey;
+  } else {
+    delete llm.api_key;
+  }
+
+  const baseUrl = normalizeSecretString(llm.base_url);
+  if (baseUrl) {
+    llm.base_url = baseUrl;
+  } else {
+    delete llm.base_url;
+  }
+
+  AGENT_SETTINGS_METADATA_KEYS.forEach((key) => delete agentSettings[key]);
+
+  const mcpConfig = toRecord(agentSettings.mcp_config);
+  if (Object.keys(mcpConfig).length === 0 || !("mcpServers" in mcpConfig)) {
+    delete agentSettings.mcp_config;
+  }
+
+  return {
+    ...agentSettings,
+    llm,
+    tools: getAgentTools(),
+  };
+}
+
+function createAgentFromSettings(agentSettings: SettingsRecord) {
+  return {
+    kind: "Agent",
+    ...agentSettings,
+  };
+}
+
+function buildConfiguredConversationSettings(options: {
+  settings: Settings;
+  query?: string;
+  conversationInstructions?: string;
+  plugins?: PluginSpec[];
+}): SettingsRecord {
+  const { settings, query, conversationInstructions, plugins } = options;
+  const conversationSettings = toRecord(settings.conversation_settings);
+  const initialMessage = buildInitialMessage(query, conversationInstructions);
+
+  CONVERSATION_SETTINGS_METADATA_KEYS.forEach(
+    (key) => delete conversationSettings[key],
+  );
+
+  return {
+    ...conversationSettings,
+    workspace: {
+      kind: "LocalWorkspace",
+      working_dir: getAgentServerWorkingDir(),
+    },
+    ...(initialMessage ? { initial_message: initialMessage } : {}),
+    ...(plugins?.length
+      ? {
+          plugins: plugins.map((plugin) => ({
+            source: plugin.source,
+            ...(plugin.ref ? { ref: plugin.ref } : {}),
+            ...(plugin.repo_path ? { repo_path: plugin.repo_path } : {}),
+          })),
+        }
+      : {}),
+  };
+}
+
 export function buildStartConversationRequest(options: {
   settings: Settings;
   query?: string;
   conversationInstructions?: string;
   plugins?: PluginSpec[];
 }) {
-  const { settings, query, conversationInstructions, plugins } = options;
-
-  const llm: Record<string, unknown> = {
-    model: settings.llm_model || DEFAULT_SETTINGS.llm_model,
-  };
-
-  if (settings.llm_api_key) {
-    llm.api_key = settings.llm_api_key;
-  }
-  if (settings.llm_base_url) {
-    llm.base_url = settings.llm_base_url;
-  }
-
-  const agent: Record<string, unknown> = {
-    kind: "Agent",
-    llm,
-    tools: getAgentTools(),
-  };
+  const agentSettings = buildConfiguredAgentSettings(options.settings);
+  const agent = createAgentFromSettings(agentSettings);
+  const conversationSettings = buildConfiguredConversationSettings(options);
 
   const payload: Record<string, unknown> = {
     agent,
-    workspace: {
-      kind: "LocalWorkspace",
-      working_dir: getAgentServerWorkingDir(),
-    },
-    confirmation_policy: getConfirmationPolicy(settings),
-    max_iterations: settings.max_iterations ?? 500,
+    workspace: conversationSettings.workspace,
+    confirmation_policy:
+      getConversationConfirmationPolicy(conversationSettings),
+    max_iterations:
+      typeof conversationSettings.max_iterations === "number"
+        ? conversationSettings.max_iterations
+        : 500,
     stuck_detection: true,
     autotitle: true,
   };
 
-  const securityAnalyzer = getSecurityAnalyzer(settings);
+  const securityAnalyzer =
+    getConversationSecurityAnalyzer(conversationSettings);
   if (securityAnalyzer) {
     payload.security_analyzer = securityAnalyzer;
   }
 
-  const initialMessage = buildInitialMessage(query, conversationInstructions);
-  if (initialMessage) {
-    payload.initial_message = initialMessage;
+  if (conversationSettings.initial_message) {
+    payload.initial_message = conversationSettings.initial_message;
   }
 
-  if (plugins?.length) {
-    payload.plugins = plugins.map((plugin) => ({
-      source: plugin.source,
-      ...(plugin.ref ? { ref: plugin.ref } : {}),
-      ...(plugin.repo_path ? { repo_path: plugin.repo_path } : {}),
-    }));
+  if (conversationSettings.plugins) {
+    payload.plugins = conversationSettings.plugins;
+  }
+
+  if (conversationSettings.hook_config) {
+    payload.hook_config = conversationSettings.hook_config;
+  }
+
+  if (conversationSettings.tool_module_qualnames) {
+    payload.tool_module_qualnames = conversationSettings.tool_module_qualnames;
+  }
+
+  if (conversationSettings.agent_definitions) {
+    payload.agent_definitions = conversationSettings.agent_definitions;
   }
 
   return payload;
 }
 
 export async function downloadTextFile(path: string): Promise<string> {
-  const response = await createHttpClient().get<ArrayBuffer>("/api/file/download", {
-    params: { path },
-    responseType: "arrayBuffer",
-  });
+  const response = await createHttpClient().get<ArrayBuffer>(
+    "/api/file/download",
+    {
+      params: { path },
+      responseType: "arrayBuffer",
+    },
+  );
 
   return new TextDecoder().decode(response.data);
 }
 
-export function createSandboxInfo(conversation: V1AppConversation): V1SandboxInfo {
-  const exposed_urls = getConfiguredWorkerUrls().map((url, index) => ({
+export function createSandboxInfo(
+  conversation: V1AppConversation,
+): V1SandboxInfo {
+  const exposedUrls = getConfiguredWorkerUrls().map((url, index) => ({
     name: `WORKER_${index + 1}`,
     url,
   }));
@@ -260,20 +378,23 @@ export function createSandboxInfo(conversation: V1AppConversation): V1SandboxInf
     sandbox_spec_id: conversation.sandbox_id,
     status: conversation.sandbox_status,
     session_api_key: conversation.session_api_key,
-    exposed_urls,
+    exposed_urls: exposedUrls,
     created_at: conversation.created_at,
   };
 }
 
 export async function loadSkillsForConversation(
-  _conversation: V1AppConversation | null | undefined,
+  conversation: V1AppConversation | null | undefined,
 ): Promise<GetSkillsResponse> {
+  const projectDir =
+    conversation?.workspace?.working_dir ?? getAgentServerWorkingDir();
+
   const response = await createSkillsClient().getSkills({
     load_public: true,
     load_user: true,
     load_project: true,
     load_org: false,
-    project_dir: getAgentServerWorkingDir(),
+    project_dir: projectDir,
   });
 
   return { skills: response.skills ?? [] };

--- a/src/api/settings-service/settings-service.api.ts
+++ b/src/api/settings-service/settings-service.api.ts
@@ -26,6 +26,15 @@ const readStoredSettings = (): Partial<Settings> => {
 };
 
 const syncDerivedSettings = (settings: Partial<Settings>): Settings => {
+  const agentSettings = mergeRecords(
+    DEFAULT_SETTINGS.agent_settings ?? {},
+    settings.agent_settings ?? {},
+  );
+  const conversationSettings = mergeRecords(
+    DEFAULT_SETTINGS.conversation_settings ?? {},
+    settings.conversation_settings ?? {},
+  );
+
   const merged = {
     ...deepClone(DEFAULT_SETTINGS),
     ...settings,
@@ -33,39 +42,54 @@ const syncDerivedSettings = (settings: Partial<Settings>): Settings => {
       ...(DEFAULT_SETTINGS.provider_tokens_set ?? {}),
       ...(settings.provider_tokens_set ?? {}),
     },
-    agent_settings: mergeRecords(
-      DEFAULT_SETTINGS.agent_settings ?? {},
-      settings.agent_settings ?? {},
-    ),
-    conversation_settings: mergeRecords(
-      DEFAULT_SETTINGS.conversation_settings ?? {},
-      settings.conversation_settings ?? {},
-    ),
+    agent_settings: agentSettings,
+    conversation_settings: conversationSettings,
   } as Settings;
+
+  const llm = agentSettings.llm as Record<string, SettingsValue> | undefined;
+  const condenser = agentSettings.condenser as
+    | Record<string, SettingsValue>
+    | undefined;
+
+  if (typeof agentSettings.agent === "string") {
+    merged.agent = agentSettings.agent;
+  }
+  if (typeof llm?.model === "string" && llm.model.length > 0) {
+    merged.llm_model = llm.model;
+  }
+  if (typeof llm?.base_url === "string") {
+    merged.llm_base_url = llm.base_url;
+  }
+  if (typeof llm?.api_key === "string") {
+    merged.llm_api_key = llm.api_key;
+  }
+  if (typeof condenser?.enabled === "boolean") {
+    merged.enable_default_condenser = condenser.enabled;
+  }
+  if (typeof condenser?.max_size === "number") {
+    merged.condenser_max_size = condenser.max_size;
+  }
+  if (agentSettings.mcp_config) {
+    merged.mcp_config = agentSettings.mcp_config as Settings["mcp_config"];
+  }
+
+  if (typeof conversationSettings.confirmation_mode === "boolean") {
+    merged.confirmation_mode = conversationSettings.confirmation_mode;
+  }
+  if (
+    typeof conversationSettings.security_analyzer === "string" ||
+    conversationSettings.security_analyzer === null
+  ) {
+    merged.security_analyzer = conversationSettings.security_analyzer as
+      | string
+      | null;
+  }
+  if (typeof conversationSettings.max_iterations === "number") {
+    merged.max_iterations = conversationSettings.max_iterations;
+  }
 
   merged.llm_api_key_set = !!merged.llm_api_key;
   merged.search_api_key_set = !!merged.search_api_key;
-
-  merged.agent_settings = {
-    ...(merged.agent_settings ?? {}),
-    agent: "Agent",
-    llm: {
-      model: merged.llm_model,
-      base_url: merged.llm_base_url,
-    },
-    condenser: {
-      enabled: merged.enable_default_condenser,
-      max_size: merged.condenser_max_size,
-    },
-    ...(merged.mcp_config ? { mcp_config: merged.mcp_config } : {}),
-  };
-
-  merged.conversation_settings = {
-    ...(merged.conversation_settings ?? {}),
-    confirmation_mode: merged.confirmation_mode,
-    security_analyzer: merged.security_analyzer,
-    max_iterations: merged.max_iterations,
-  };
 
   return merged;
 };
@@ -96,7 +120,9 @@ class SettingsService {
     const agentSettingsDiff = (settings.agent_settings_diff ??
       settings.agent_settings) as Record<string, SettingsValue> | undefined;
     const conversationSettingsDiff = (settings.conversation_settings_diff ??
-      settings.conversation_settings) as Record<string, SettingsValue> | undefined;
+      settings.conversation_settings) as
+      | Record<string, SettingsValue>
+      | undefined;
 
     const nextAgentSettings = mergeRecords(
       current.agent_settings ?? {},
@@ -114,7 +140,9 @@ class SettingsService {
       conversation_settings: nextConversationSettings,
     };
 
-    const llm = nextAgentSettings.llm as Record<string, SettingsValue> | undefined;
+    const llm = nextAgentSettings.llm as
+      | Record<string, SettingsValue>
+      | undefined;
     const condenser = nextAgentSettings.condenser as
       | Record<string, SettingsValue>
       | undefined;
@@ -139,7 +167,8 @@ class SettingsService {
     }
 
     if (typeof nextConversationSettings.confirmation_mode === "boolean") {
-      nextSettings.confirmation_mode = nextConversationSettings.confirmation_mode;
+      nextSettings.confirmation_mode =
+        nextConversationSettings.confirmation_mode;
     }
     if (typeof nextConversationSettings.security_analyzer === "string") {
       nextSettings.security_analyzer =
@@ -149,7 +178,8 @@ class SettingsService {
       nextSettings.max_iterations = nextConversationSettings.max_iterations;
     }
     if (nextAgentSettings.mcp_config) {
-      nextSettings.mcp_config = nextAgentSettings.mcp_config as Settings["mcp_config"];
+      nextSettings.mcp_config =
+        nextAgentSettings.mcp_config as Settings["mcp_config"];
     }
 
     delete nextSettings.agent_settings_diff;


### PR DESCRIPTION
## Summary
- make nested `agent_settings` / `conversation_settings` authoritative when loading browser-stored settings
- derive `/api/conversations` startup payloads from those nested settings instead of the legacy top-level mirrors
- align confirmation policy derivation with `OpenHands/OpenHands` by using `ConfirmRisky` when confirmation mode is enabled with the LLM security analyzer
- add regression coverage for settings sync and startup request construction

## Testing
- `npx prettier --check src/api/agent-server-adapter.ts src/api/settings-service/settings-service.api.ts __tests__/api/agent-server-adapter.test.ts __tests__/api/settings-service.test.ts`
- `npx eslint src/api/agent-server-adapter.ts src/api/settings-service/settings-service.api.ts __tests__/api/agent-server-adapter.test.ts __tests__/api/settings-service.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test -- __tests__/api/agent-server-adapter.test.ts __tests__/api/settings-service.test.ts`
- `npm test`

Closes #37.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._
