### PR TITLE
Fix Windows dev startup

### DIFF
--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   buildSafeDevConfig,
+  buildNpmScriptCommand,
   formatMissingAgentServerGuidance,
 } from "../../scripts/dev-safe.mjs";
 
@@ -27,7 +28,7 @@ describe("formatMissingAgentServerGuidance", () => {
     );
     expect(guidance).toContain('export PATH="$HOME/.local/bin:$PATH"');
     expect(guidance).toContain(
-      "/workspace/project/agent-server-gui/README.md",
+      path.join("/workspace/project/agent-server-gui", "README.md"),
     );
     expect(guidance).toContain(
       "https://docs.astral.sh/uv/getting-started/installation/",
@@ -49,7 +50,7 @@ describe("buildSafeDevConfig", () => {
     expect(config.backendHost).toBe("127.0.0.1:18000");
     expect(config.workingDir).toBe(cwd);
     expect(config.stateDir).toBe(
-      path.join(cwd, ".openhands-dev", "safe-dev-18000"),
+      path.resolve(cwd, ".openhands-dev", "safe-dev-18000"),
     );
     expect(config.tmuxTmpDir).toBe(path.join(config.stateDir, "tmux"));
     expect(config.conversationsPath).toBe(
@@ -74,8 +75,60 @@ describe("buildSafeDevConfig", () => {
     expect(config.vscodePort).toBe(19010);
     expect(config.backendBaseUrl).toBe("http://127.0.0.1:19000");
     expect(config.backendHost).toBe("127.0.0.1:19000");
-    expect(config.stateDir).toBe(path.join(cwd, ".tmp", "dev-safe"));
+    expect(config.stateDir).toBe(path.resolve(cwd, ".tmp", "dev-safe"));
     expect(config.workingDir).toBe("/workspace/custom-repo");
+  });
+});
+
+describe("buildNpmScriptCommand", () => {
+  it("reuses npm's own CLI path when available", () => {
+    const command = buildNpmScriptCommand(
+      "dev:frontend",
+      "win32",
+      {
+        npm_execpath: "C:\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+        npm_node_execpath: "C:\\nodejs\\node.exe",
+      },
+      "C:\\fallback\\node.exe",
+    );
+
+    expect(command).toEqual({
+      command: "C:\\nodejs\\node.exe",
+      args: [
+        "C:\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+        "run",
+        "dev:frontend",
+      ],
+    });
+  });
+
+  it("runs npm directly on POSIX platforms", () => {
+    const command = buildNpmScriptCommand("dev:frontend", "linux", {});
+
+    expect(command).toEqual({
+      command: "npm",
+      args: ["run", "dev:frontend"],
+    });
+  });
+
+  it("runs npm through cmd.exe on Windows", () => {
+    const command = buildNpmScriptCommand("dev:frontend", "win32", {
+      ComSpec: "C:\\Windows\\System32\\cmd.exe",
+    });
+
+    expect(command).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", "npm", "run", "dev:frontend"],
+    });
+  });
+
+  it("falls back to cmd.exe when ComSpec is unavailable on Windows", () => {
+    const command = buildNpmScriptCommand("dev:frontend", "win32", {});
+
+    expect(command).toEqual({
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", "npm", "run", "dev:frontend"],
+    });
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.18",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/typescript-client": "github:OpenHands/typescript-client#39228dd",
+        "@openhands/typescript-client": "github:OpenHands/typescript-client#7d20f119d68893903c3eab7070416e6317f72716",
         "@react-router/node": "7.14.1",
         "@react-router/serve": "7.14.1",
         "@tailwindcss/vite": "4.2.2",
@@ -3353,10 +3353,11 @@
     },
     "node_modules/@openhands/typescript-client": {
       "version": "0.1.1",
-      "resolved": "git+ssh://git@github.com/OpenHands/typescript-client.git#4716d2ed8f76d4bf00285acbafb8ec7d4a4fe233",
+      "resolved": "git+ssh://git@github.com/OpenHands/typescript-client.git#7d20f119d68893903c3eab7070416e6317f72716",
+      "integrity": "sha512-WPm20BYImlFilbjKBXkHSa1EBT486Rc3vbJFSAMY/LHm7/78rMuKF8GO0uq0FhscM+q+vocJ62bYA5vC8Y2Zpw==",
       "license": "MIT",
       "dependencies": {
-        "@openrouter/sdk": "^0.12.1",
+        "@openrouter/sdk": "^0.12.21",
         "ws": "^8.20.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.18",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/typescript-client": "github:OpenHands/typescript-client#39228dd",
+    "@openhands/typescript-client": "github:OpenHands/typescript-client#7d20f119d68893903c3eab7070416e6317f72716",
     "@react-router/node": "7.14.1",
     "@react-router/serve": "7.14.1",
     "@tailwindcss/vite": "4.2.2",

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -73,6 +73,32 @@ export function buildSafeDevConfig(cwd = process.cwd(), env = process.env) {
   };
 }
 
+export function buildNpmScriptCommand(
+  scriptName,
+  platform = process.platform,
+  env = process.env,
+  nodeExecPath = process.execPath,
+) {
+  if (env.npm_execpath) {
+    return {
+      command: env.npm_node_execpath || nodeExecPath,
+      args: [env.npm_execpath, "run", scriptName],
+    };
+  }
+
+  if (platform === "win32") {
+    return {
+      command: env.ComSpec || "cmd.exe",
+      args: ["/d", "/s", "/c", "npm", "run", scriptName],
+    };
+  }
+
+  return {
+    command: "npm",
+    args: ["run", scriptName],
+  };
+}
+
 async function waitForServer(url, timeoutMs = DEFAULT_WAIT_TIMEOUT_MS) {
   const startedAt = Date.now();
 
@@ -184,8 +210,8 @@ async function main() {
     throw error;
   }
 
-  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-  frontend = spawnProcess(npmCommand, ["run", "dev:frontend"], {
+  const frontendCommand = buildNpmScriptCommand("dev:frontend");
+  frontend = spawnProcess(frontendCommand.command, frontendCommand.args, {
     cwd: config.cwd,
     env: {
       ...process.env,

--- a/src/hooks/use-websocket.ts
+++ b/src/hooks/use-websocket.ts
@@ -156,7 +156,7 @@ export const useWebSocket = <T = string>(
   }, [url, connectWebSocket]);
 
   const sendMessage = React.useCallback(
-    (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
+    (data: string | Blob | BufferSource) => {
       if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
         wsRef.current.send(data);
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0",
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- launch the frontend npm script from `dev-safe` through npm's own CLI path when available, with OS-specific fallbacks for direct runs
- repin `@openhands/typescript-client` to a commit that includes the Windows `rimraf dist` install fix from OpenHands/typescript-client#137
- make the dev-safe tests path-portable and cover the npm command selection paths
- unblock local verification on the current toolchain with the TypeScript 6 deprecation setting and a narrower WebSocket send type

## Verification
- `npm ci`
- `npx vitest run __tests__/scripts/dev-safe.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run dev` smoke reached the frontend dev server at `http://localhost:3001/`