### PR TITLE
Add PR review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,8 +1,17 @@
 name: PR Review by OpenHands
 
 on:
+  # Use pull_request_target to allow fork PRs to access secrets when triggered by maintainers
+  # Security: This workflow runs when:
+  #   1. A new PR is opened (non-draft), OR
+  #   2. A draft PR is marked as ready for review, OR
+  #   3. A maintainer adds the 'review-this' label, OR
+  #   4. A maintainer requests openhands-agent or all-hands-bot as a reviewer
+  # Adding labels and requesting reviewers requires write access.
+  # The PR code is explicitly checked out for review, but secrets are only accessible
+  # because the workflow runs in the base repository context.
   pull_request_target:
-    types: [labeled, review_requested]
+    types: [opened, ready_for_review, labeled, review_requested]
 
 permissions:
   contents: read
@@ -11,7 +20,15 @@ permissions:
 
 jobs:
   pr-review:
+    # Run when one of the following conditions is met:
+    #   1. A new non-draft PR is opened by a non-first-time contributor, OR
+    #   2. A draft PR is converted to ready for review by a non-first-time contributor, OR
+    #   3. 'review-this' label is added, OR
+    #   4. openhands-agent or all-hands-bot is requested as a reviewer
+    # Note: FIRST_TIME_CONTRIBUTOR and NONE PRs require manual trigger via label/reviewer request.
     if: |
+      (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
+      (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
       github.event.label.name == 'review-this' ||
       github.event.requested_reviewer.login == 'openhands-agent' ||
       github.event.requested_reviewer.login == 'all-hands-bot'
@@ -25,6 +42,9 @@ jobs:
         with:
           llm-model: litellm_proxy/claude-sonnet-4-5-20250929
           llm-base-url: https://llm-proxy.app.all-hands.dev
-          use-sub-agents: "false"
+          # [DEPRECATED] review-style is no longer used; standard and roasted are merged
+          # review-style: roasted
+          use-sub-agents: 'false' # Disabled by default (issue #208: high cost / timeouts)
           llm-api-key: ${{ secrets.LLM_API_KEY }}
-          github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || github.token }}
+          github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
+          lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@
 - OpenHands repo bootstrap files live under `.openhands/`:
   - `.openhands/setup.sh` installs frontend dependencies with `npm ci` when needed, creates `.env` from `.env.sample` if missing, appends `VITE_WORKING_DIR` for this repo when unset, and generates `src/i18n/declaration.ts` via `npm run make-i18n`.
   - `.openhands/pre-commit.sh` mirrors the repo's local quality gate with `npm run lint && npm run test`.
-- `.github/workflows/pr-review.yml` is configured for on-demand OpenHands reviews only (`review-this` label or requesting `openhands-agent` / `all-hands-bot`), uses the OpenHands app LLM proxy defaults, and expects a repository `LLM_API_KEY` secret.
+- `.github/workflows/pr-review.yml` mirrors the OpenHands/extensions PR review workflow: it auto-runs for newly opened non-draft PRs and `ready_for_review` events from established contributors, still supports the `review-this` label / `openhands-agent` / `all-hands-bot` reviewer triggers, uses the OpenHands app LLM proxy defaults, and expects `LLM_API_KEY`, `OPENHANDS_BOT_GITHUB_PAT_PUBLIC`, and optional `LMNR_SKILLS_API_KEY` repository secrets.
 - HeroUI rollback / migration notes:
   - The attempted HeroUI v3 upgrade changed global theme wiring and homepage design tokens enough that the repo currently prefers `@heroui/react@2.8.10` until a broader visual validation pass is done.
   - Keep the v2 Tailwind integration active via `@plugin '../hero.ts'` in `src/tailwind.css` and source HeroUI classes from `node_modules/@heroui/theme/dist/**/*`.


### PR DESCRIPTION
## Summary
- sync `.github/workflows/pr-review.yml` with the current OpenHands/extensions PR review workflow
- enable automatic PR review runs for eligible `opened` and `ready_for_review` events in addition to manual triggers
- document the updated workflow behavior and required secrets in `AGENTS.md`

## Testing
- `npm test`

Closes #47

_AI-generated by OpenHands on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/102b5d59-903e-48e5-b263-5f28ec8a46ac)