### PR TITLE
Scope conversation Zustand stores per provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@
 - GitHub PR-review automation should stay aligned with the current OpenHands repo conventions: keep the review workflow at `.github/workflows/pr-review-by-openhands.yml`, keep the companion `.github/workflows/pr-review-evaluation.yml`, auto-run on newly opened non-draft PRs and `ready_for_review` events from established contributors, still support the `review-this` label / `openhands-agent` / `all-hands-bot` reviewer triggers, use the OpenHands app LLM proxy defaults, and use the dual-trigger pattern (`pull_request` for same-repo PRs, `pull_request_target` for forks) so workflow changes can self-verify without widening fork secret exposure.
 - The repo now includes `.agents/skills/custom-codereview-guide.md`, adapted from `OpenHands/software-agent-sdk`, to force PR reviews to always leave either an APPROVE or COMMENT review instead of silently finishing with no review object.
 
+- Conversation UI state is now scoped through `src/context/conversation-context.tsx`. Conversation components/hooks should import zustand hooks from that context (or `global-store-hooks` for genuinely app-global stores) instead of importing directly from `src/stores`; wrap embeddable conversation surfaces in `ConversationProvider` when they are used outside the route-level `ConversationView`.
+
 - HeroUI v3 migration notes:
   - The repo now uses `@heroui/react@3.0.3` plus `@heroui/styles@3.0.3`.
   - `src/tailwind.css` should import `@heroui/styles`; the old `hero.ts` Tailwind plugin file was removed and should not be reintroduced.
@@ -99,7 +101,6 @@
 - `AgentServerUIRoot`'s themed inner wrapper must set a default `color: var(--foreground)` in addition to the `dark` / `data-theme` markers; otherwise inherited text and `currentColor` SVG icons fall back to dark browser defaults after CSS scoping, causing dark-on-dark regressions on pages like the home screen.
 - Theme/customization tokens for the embedded shell are exposed as `--oh-*` CSS variables. Override them through `styleOverrides`, `style`, or host CSS targeting `[data-agent-server-ui]`; Tailwind theme tokens in `src/tailwind.css` should continue to reference those variables with `@theme inline` so host apps can restyle the UI without reworking component class names.
 - Regression coverage for the CSS isolation work lives in `__tests__/agent-server-ui-providers.test.tsx`, `__tests__/agent-server-ui-style-scope.test.ts`, and the browser-level `tests/css-isolation.spec.ts` Playwright test.
-
 
 - Library packaging notes:
   - Public npm entrypoints now come from `src/index.ts` → `src/lib/index.ts`, with domain barrels under `src/components/{conversation,terminal,browser,files,settings,sidebar}/index.ts`.

--- a/__tests__/components/browser.test.tsx
+++ b/__tests__/components/browser.test.tsx
@@ -7,11 +7,18 @@ vi.mock("#/hooks/use-conversation-id", () => ({
   useConversationId: () => ({ conversationId: "test-conversation-id" }),
 }));
 
-vi.mock("#/context/conversation-context", () => ({
-  useConversation: () => ({ conversationId: "test-conversation-id" }),
-  ConversationProvider: ({ children }: { children: React.ReactNode }) =>
-    children,
-}));
+vi.mock("#/context/conversation-context", async () => {
+  const { useBrowserStore } = await vi.importActual<
+    typeof import("#/stores/browser-store")
+  >("#/stores/browser-store");
+
+  return {
+    useConversation: () => ({ conversationId: "test-conversation-id" }),
+    useBrowserStore,
+    ConversationProvider: ({ children }: { children: React.ReactNode }) =>
+      children,
+  };
+});
 
 vi.mock("react-i18next", async () => {
   const actual = await vi.importActual("react-i18next");

--- a/__tests__/conversation-provider.test.tsx
+++ b/__tests__/conversation-provider.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { AgentState } from "#/types/agent-state";
+import {
+  ActionSecurityRisk,
+  ConversationProvider,
+  useAgentStore,
+  useBrowserStore,
+  useCommandStore,
+  useConversationStore,
+  useEventMessageStore,
+  useMetricsStore,
+  useSecurityAnalyzerStore,
+  useStatusStore,
+} from "#/context/conversation-context";
+
+function readState(name: string) {
+  return JSON.parse(screen.getByTestId(`${name}-state`).textContent ?? "{}");
+}
+
+function ScopedProbe({ name }: { name: string }) {
+  const conversation = useConversationStore();
+  const status = useStatusStore();
+  const eventMessage = useEventMessageStore();
+  const agent = useAgentStore();
+  const browser = useBrowserStore();
+  const command = useCommandStore();
+  const metrics = useMetricsStore();
+  const securityAnalyzer = useSecurityAnalyzerStore();
+
+  return (
+    <section>
+      <pre data-testid={`${name}-state`}>
+        {JSON.stringify({
+          selectedTab: conversation.selectedTab,
+          statusMessage: status.curStatusMessage.message,
+          submittedEventIds: eventMessage.submittedEventIds,
+          agentState: agent.curAgentState,
+          browserUrl: browser.url,
+          commands: command.commands,
+          metricsCost: metrics.cost,
+          securityLogs: securityAnalyzer.logs.map((log) => log.content),
+        })}
+      </pre>
+      <button
+        type="button"
+        onClick={() => {
+          conversation.setSelectedTab("terminal");
+          status.setCurStatusMessage({
+            status_update: true,
+            type: "info",
+            id: `${name}-status`,
+            message: `${name} status`,
+          });
+          eventMessage.addSubmittedEventId(42);
+          agent.setCurrentAgentState(AgentState.RUNNING);
+          browser.setUrl(`https://${name}.example.com`);
+          command.appendInput(`${name} command`);
+          metrics.setMetrics({
+            cost: 1,
+            max_budget_per_task: null,
+            usage: null,
+          });
+          securityAnalyzer.appendSecurityAnalyzerInput({
+            id: 1,
+            args: {
+              command: `${name} risky command`,
+              security_risk: ActionSecurityRisk.HIGH,
+            },
+          });
+        }}
+      >
+        Mutate {name}
+      </button>
+    </section>
+  );
+}
+
+describe("ConversationProvider", () => {
+  it("scopes conversation stores per provider instance", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <>
+        <ConversationProvider conversationId="alpha">
+          <ScopedProbe name="alpha" />
+        </ConversationProvider>
+        <ConversationProvider conversationId="beta">
+          <ScopedProbe name="beta" />
+        </ConversationProvider>
+      </>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Mutate alpha" }));
+
+    expect(readState("alpha")).toMatchObject({
+      selectedTab: "terminal",
+      statusMessage: "alpha status",
+      submittedEventIds: [42],
+      agentState: AgentState.RUNNING,
+      browserUrl: "https://alpha.example.com",
+      commands: [{ content: "alpha command", type: "input" }],
+      metricsCost: 1,
+      securityLogs: ["alpha risky command"],
+    });
+
+    expect(readState("beta")).toMatchObject({
+      selectedTab: "editor",
+      statusMessage: "",
+      submittedEventIds: [],
+      agentState: AgentState.LOADING,
+      browserUrl: "https://github.com/OpenHands/OpenHands",
+      commands: [],
+      metricsCost: null,
+      securityLogs: [],
+    });
+  });
+});

--- a/__tests__/hooks/mutation/use-unified-resume-conversation-sandbox.test.tsx
+++ b/__tests__/hooks/mutation/use-unified-resume-conversation-sandbox.test.tsx
@@ -5,12 +5,7 @@ import React from "react";
 import { SandboxService } from "#/api/sandbox-service/sandbox-service.api";
 import V1ConversationService from "#/api/conversation-service/v1-conversation-service.api";
 import { useUnifiedResumeConversationSandbox } from "#/hooks/mutation/use-unified-start-conversation";
-
-// Mock the error message store
-vi.mock("#/stores/error-message-store", () => ({
-  useErrorMessageStore: (selector: (state: { removeErrorMessage: () => void }) => unknown) =>
-    selector({ removeErrorMessage: vi.fn() }),
-}));
+import { ConversationProvider } from "#/context/conversation-context";
 
 describe("useUnifiedResumeConversationSandbox", () => {
   let queryClient: QueryClient;
@@ -27,13 +22,18 @@ describe("useUnifiedResumeConversationSandbox", () => {
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>
-      {children}
+      <ConversationProvider conversationId="test-conv-id">
+        {children}
+      </ConversationProvider>
     </QueryClientProvider>
   );
 
   it("invalidates sandbox and vscode_url queries on settled", async () => {
     // Mock the API calls in the mutation chain
-    vi.spyOn(V1ConversationService, "batchGetAppConversations").mockResolvedValue([
+    vi.spyOn(
+      V1ConversationService,
+      "batchGetAppConversations",
+    ).mockResolvedValue([
       {
         id: "test-conv-id",
         created_by_user_id: null,
@@ -56,15 +56,22 @@ describe("useUnifiedResumeConversationSandbox", () => {
         updated_at: new Date().toISOString(),
       },
     ]);
-    vi.spyOn(SandboxService, "resumeSandbox").mockResolvedValue({ success: true });
+    vi.spyOn(SandboxService, "resumeSandbox").mockResolvedValue({
+      success: true,
+    });
 
     // Pre-populate query cache with stale sandbox data
-    queryClient.setQueryData(["sandboxes", "batch", ["test-sandbox-id"]], [
-      {
-        sandbox_id: "test-sandbox-id",
-        exposed_urls: [{ name: "VSCODE", url: "https://old-runtime.example.com" }],
-      },
-    ]);
+    queryClient.setQueryData(
+      ["sandboxes", "batch", ["test-sandbox-id"]],
+      [
+        {
+          sandbox_id: "test-sandbox-id",
+          exposed_urls: [
+            { name: "VSCODE", url: "https://old-runtime.example.com" },
+          ],
+        },
+      ],
+    );
     queryClient.setQueryData(["unified", "vscode_url", "test-conv-id"], {
       url: "https://old-runtime.example.com",
       error: null,
@@ -73,7 +80,9 @@ describe("useUnifiedResumeConversationSandbox", () => {
     // Spy on invalidateQueries
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const { result } = renderHook(() => useUnifiedResumeConversationSandbox(), { wrapper });
+    const { result } = renderHook(() => useUnifiedResumeConversationSandbox(), {
+      wrapper,
+    });
 
     // Trigger the mutation
     result.current.mutate({ conversationId: "test-conv-id" });

--- a/__tests__/hooks/use-handle-plan-click.test.tsx
+++ b/__tests__/hooks/use-handle-plan-click.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { useHandlePlanClick } from "#/hooks/use-handle-plan-click";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
 import {
@@ -13,7 +13,9 @@ import type { Conversation } from "#/api/open-hands.types";
 import { V1AppConversation } from "#/api/conversation-service/v1-conversation-service.types";
 
 // Mock dependencies
-vi.mock("#/stores/conversation-store");
+vi.mock("#/context/conversation-context", () => ({
+  useConversationStore: vi.fn(),
+}));
 vi.mock("#/hooks/query/use-active-conversation");
 vi.mock("#/hooks/mutation/use-create-conversation");
 vi.mock("#/utils/conversation-local-storage");
@@ -37,7 +39,9 @@ function asMockReturnValue<T>(value: Partial<T>): T {
   return value as T;
 }
 
-function makeConversation(overrides?: Partial<V1AppConversation>): V1AppConversation {
+function makeConversation(
+  overrides?: Partial<V1AppConversation>,
+): V1AppConversation {
   return {
     id: "conv-123",
     title: "Test Conversation",

--- a/__tests__/i18n/library-namespace.test.ts
+++ b/__tests__/i18n/library-namespace.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 
 describe("library i18n namespace scoping", () => {
   it("exports raw translation resources for host-app registration", async () => {
-    const { OPENHANDS_I18N_NAMESPACE, translationResources } = await import(
-      "../../src/i18n"
-    );
+    const { OPENHANDS_I18N_NAMESPACE, translationResources } =
+      await import("../../src/i18n");
 
     expect(OPENHANDS_I18N_NAMESPACE).toBe("openhands");
     expect(translationResources.en).toHaveProperty("ERROR$GENERIC");
@@ -14,9 +13,8 @@ describe("library i18n namespace scoping", () => {
   });
 
   it("configures standalone i18n to load the openhands namespace by default", async () => {
-    const { OPENHANDS_I18N_NAMESPACE, createAgentServerI18n } = await import(
-      "../../src/i18n"
-    );
+    const { OPENHANDS_I18N_NAMESPACE, createAgentServerI18n } =
+      await import("../../src/i18n");
 
     const instance = createAgentServerI18n();
 
@@ -51,5 +49,5 @@ describe("library i18n namespace scoping", () => {
 
     expect(globalI18n.hasResourceBundle("en", "openhands")).toBe(false);
     expect(globalI18n.t("HOST_ONLY")).toBe("Host only");
-  });
+  }, 10_000);
 });

--- a/src/components/features/browser/browser.tsx
+++ b/src/components/features/browser/browser.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { BrowserSnapshot } from "./browser-snapshot";
 import { EmptyBrowserMessage } from "./empty-browser-message";
 import { useConversationId } from "#/hooks/use-conversation-id";
-import { useBrowserStore } from "#/stores/browser-store";
+import { useBrowserStore } from "#/context/conversation-context";
 
 export function BrowserPanel() {
   const { url, screenshotSrc, reset } = useBrowserStore();

--- a/src/components/features/chat/btw-messages.tsx
+++ b/src/components/features/chat/btw-messages.tsx
@@ -1,5 +1,5 @@
 import CheckCircle from "#/icons/check-circle-solid.svg?react";
-import { useBtwStore } from "#/stores/btw-store";
+import { useBtwStore } from "#/context/global-store-hooks";
 import { GenericEventMessage } from "./generic-event-message";
 
 function GotItButton({ onClick }: { onClick: () => void }) {

--- a/src/components/features/chat/change-agent-button.tsx
+++ b/src/components/features/chat/change-agent-button.tsx
@@ -6,7 +6,7 @@ import { I18nKey } from "#/i18n/declaration";
 import CodeTagIcon from "#/icons/code-tag.svg?react";
 import ChevronDownSmallIcon from "#/icons/chevron-down-small.svg?react";
 import LessonPlanIcon from "#/icons/lesson-plan.svg?react";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { ChangeAgentContextMenu } from "./change-agent-context-menu";
 import { cn } from "#/utils/utils";
 import { useAgentState } from "#/hooks/use-agent-state";

--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -11,7 +11,7 @@ import { useScrollToBottom } from "#/hooks/use-scroll-to-bottom";
 import { TypingIndicator } from "./typing-indicator";
 import { ChatSuggestions } from "./chat-suggestions";
 import { ScrollProvider } from "#/context/scroll-context";
-import { useInitialQueryStore } from "#/stores/initial-query-store";
+import { useInitialQueryStore } from "#/context/global-store-hooks";
 import { useSendMessage } from "#/hooks/use-send-message";
 import { useAgentState } from "#/hooks/use-agent-state";
 import { useHandleBuildPlanClick } from "#/hooks/use-handle-build-plan-click";
@@ -20,13 +20,15 @@ import { ScrollToBottomButton } from "#/components/shared/buttons/scroll-to-bott
 import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { ChatMessagesSkeleton } from "./chat-messages-skeleton";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
-import { useErrorMessageStore } from "#/stores/error-message-store";
-import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
+import {
+  useConversationStore,
+  useErrorMessageStore,
+  useOptimisticUserMessageStore,
+} from "#/context/conversation-context";
 import { ErrorMessageBanner } from "./error-message-banner";
 import { Messages as V1Messages } from "#/components/v1/chat";
 import { useUnifiedUploadFiles } from "#/hooks/mutation/use-unified-upload-files";
 import { validateFiles } from "#/utils/file-validation";
-import { useConversationStore } from "#/stores/conversation-store";
 import ConfirmationModeEnabled from "./confirmation-mode-enabled";
 import { useTaskPolling } from "#/hooks/query/use-task-polling";
 import { useConversationWebSocket } from "#/contexts/conversation-websocket-context";

--- a/src/components/features/chat/chat-suggestions.tsx
+++ b/src/components/features/chat/chat-suggestions.tsx
@@ -4,7 +4,7 @@ import { Suggestions } from "#/components/features/suggestions/suggestions";
 import { I18nKey } from "#/i18n/declaration";
 import BuildIt from "#/icons/build-it.svg?react";
 import { SUGGESTIONS } from "#/utils/suggestions";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 
 interface ChatSuggestionsProps {
   onSuggestionsClick: (value: string) => void;

--- a/src/components/features/chat/components/chat-input-container.tsx
+++ b/src/components/features/chat/components/chat-input-container.tsx
@@ -4,7 +4,7 @@ import { UploadedFiles } from "../uploaded-files";
 import { ChatInputRow } from "./chat-input-row";
 import { ChatInputActions } from "./chat-input-actions";
 import { SlashCommandMenu } from "./slash-command-menu";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { cn } from "#/utils/utils";
 import { SlashCommandItem } from "#/hooks/chat/use-slash-command";
 

--- a/src/components/features/chat/components/chat-input-field.tsx
+++ b/src/components/features/chat/components/chat-input-field.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { cn } from "#/utils/utils";
 
 interface ChatInputFieldProps {

--- a/src/components/features/chat/custom-chat-input.tsx
+++ b/src/components/features/chat/custom-chat-input.tsx
@@ -8,7 +8,7 @@ import { useSlashCommand } from "#/hooks/chat/use-slash-command";
 import { ChatInputGrip } from "./components/chat-input-grip";
 import { ChatInputContainer } from "./components/chat-input-container";
 import { HiddenFileInput } from "./components/hidden-file-input";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { V1SandboxStatus } from "#/api/sandbox-service/sandbox-service.types";
 
 export interface CustomChatInputProps {

--- a/src/components/features/chat/event-content-helpers/get-action-content.ts
+++ b/src/components/features/chat/event-content-helpers/get-action-content.ts
@@ -1,4 +1,4 @@
-import { ActionSecurityRisk } from "#/stores/security-analyzer-store";
+import { ActionSecurityRisk } from "#/context/conversation-context";
 import {
   FileWriteAction,
   CommandAction,

--- a/src/components/features/chat/git-control-bar.tsx
+++ b/src/components/features/chat/git-control-bar.tsx
@@ -17,8 +17,8 @@ import { GitControlBarTooltipWrapper } from "./git-control-bar-tooltip-wrapper";
 import { OpenRepositoryModal } from "./open-repository-modal";
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
-import { useHomeStore } from "#/stores/home-store";
-import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
+import { useHomeStore } from "#/context/global-store-hooks";
+import { useOptimisticUserMessageStore } from "#/context/conversation-context";
 
 interface GitControlBarProps {
   onSuggestionsClick: (value: string) => void;

--- a/src/components/features/chat/interactive-chat-box.tsx
+++ b/src/components/features/chat/interactive-chat-box.tsx
@@ -6,7 +6,7 @@ import { useBtwInterceptor } from "#/hooks/chat/use-btw-interceptor";
 import { AgentState } from "#/types/agent-state";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { GitControlBar } from "./git-control-bar";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { useAgentState } from "#/hooks/use-agent-state";
 import { processFiles, processImages } from "#/utils/file-processing";
 import { useSubConversationTaskPolling } from "#/hooks/query/use-sub-conversation-task-polling";

--- a/src/components/features/chat/messages.tsx
+++ b/src/components/features/chat/messages.tsx
@@ -4,7 +4,7 @@ import { OpenHandsObservation } from "#/types/core/observations";
 import { isOpenHandsAction, isOpenHandsObservation } from "#/types/core/guards";
 import { EventMessage } from "./event-message";
 import { ChatMessage } from "./chat-message";
-import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
+import { useOptimisticUserMessageStore } from "#/context/conversation-context";
 
 interface MessagesProps {
   messages: (OpenHandsAction | OpenHandsObservation)[];

--- a/src/components/features/chat/uploaded-files.tsx
+++ b/src/components/features/chat/uploaded-files.tsx
@@ -1,6 +1,6 @@
 import { UploadedFile } from "./uploaded-file";
 import { UploadedImage } from "./uploaded-image";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 
 export function UploadedFiles() {
   const {

--- a/src/components/features/controls/agent-status.tsx
+++ b/src/components/features/controls/agent-status.tsx
@@ -8,7 +8,7 @@ import ClockIcon from "#/icons/u-clock-three.svg?react";
 import { ChatResumeAgentButton } from "../chat/chat-play-button";
 import { cn, isTaskPolling } from "#/utils/utils";
 import { AgentLoading } from "./agent-loading";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import CircleErrorIcon from "#/icons/circle-error.svg?react";
 import { useAgentState } from "#/hooks/use-agent-state";
 import { useUnifiedWebSocketStatus } from "#/hooks/use-unified-websocket-status";

--- a/src/components/features/controls/git-tools-submenu.tsx
+++ b/src/components/features/controls/git-tools-submenu.tsx
@@ -10,7 +10,7 @@ import {
   getCreatePRPrompt,
   getCreateNewBranchPrompt,
 } from "#/utils/utils";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 
 import ArrowUpIcon from "#/icons/u-arrow-up.svg?react";
 import ArrowDownIcon from "#/icons/u-arrow-down.svg?react";

--- a/src/components/features/controls/macros-submenu.tsx
+++ b/src/components/features/controls/macros-submenu.tsx
@@ -8,7 +8,7 @@ import PrStatusIcon from "#/icons/pr-status.svg?react";
 import DocumentIcon from "#/icons/document.svg?react";
 import WaterIcon from "#/icons/u-water.svg?react";
 import { I18nKey } from "#/i18n/declaration";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { REPO_SUGGESTIONS } from "#/utils/suggestions/repo-suggestions";
 import { CONTEXT_MENU_ICON_TEXT_CLASSNAME } from "#/utils/constants";
 

--- a/src/components/features/controls/server-status.tsx
+++ b/src/components/features/controls/server-status.tsx
@@ -4,7 +4,7 @@ import { AgentState } from "#/types/agent-state";
 import { useAgentState } from "#/hooks/use-agent-state";
 import { useTaskPolling } from "#/hooks/query/use-task-polling";
 import { getStatusColor, getStatusText } from "#/utils/utils";
-import { useErrorMessageStore } from "#/stores/error-message-store";
+import { useErrorMessageStore } from "#/context/conversation-context";
 import { V1SandboxStatus } from "#/api/sandbox-service/sandbox-service.types";
 
 export interface ServerStatusProps {

--- a/src/components/features/conversation/conversation-main/conversation-main.tsx
+++ b/src/components/features/conversation/conversation-main/conversation-main.tsx
@@ -3,7 +3,7 @@ import { ChatInterfaceWrapper } from "./chat-interface-wrapper";
 import { ConversationTabContent } from "../conversation-tabs/conversation-tab-content/conversation-tab-content";
 import { ResizeHandle } from "../../../ui/resize-handle";
 import { useResizablePanels } from "#/hooks/use-resizable-panels";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { useBreakpoint } from "#/hooks/use-breakpoint";
 
 function getMobileChatPanelClass(isRightPanelShown: boolean) {

--- a/src/components/features/conversation/conversation-tabs/conversation-tab-content/conversation-tab-content.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tab-content/conversation-tab-content.tsx
@@ -7,7 +7,7 @@ import { TabContainer } from "./tab-container";
 import { TabContentArea } from "./tab-content-area";
 import { ConversationTabTitle } from "../conversation-tab-title";
 import Terminal from "#/components/features/terminal/terminal";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { useConversationId } from "#/hooks/use-conversation-id";
 
 // Lazy load all tab components

--- a/src/components/features/conversation/conversation-tabs/conversation-tab-title.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tab-title.tsx
@@ -3,7 +3,7 @@ import RefreshIcon from "#/icons/u-refresh.svg?react";
 import { useUnifiedGetGitChanges } from "#/hooks/query/use-unified-get-git-changes";
 import { useHandleBuildPlanClick } from "#/hooks/use-handle-build-plan-click";
 import { useAgentState } from "#/hooks/use-agent-state";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { AgentState } from "#/types/agent-state";
 import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";

--- a/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
@@ -4,7 +4,7 @@ import { ContextMenuListItem } from "../../context-menu/context-menu-list-item";
 import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { useConversationLocalStorageState } from "#/utils/conversation-local-storage";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { I18nKey } from "#/i18n/declaration";
 import TerminalIcon from "#/icons/terminal.svg?react";
 import GlobeIcon from "#/icons/globe.svg?react";

--- a/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
@@ -14,7 +14,7 @@ import { ConversationTabNav } from "./conversation-tab-nav";
 import { ChatActionTooltip } from "../../chat/chat-action-tooltip";
 import { I18nKey } from "#/i18n/declaration";
 import { VSCodeTooltipContent } from "./vscode-tooltip-content";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { ConversationTabsContextMenu } from "./conversation-tabs-context-menu";
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { useSelectConversationTab } from "#/hooks/use-select-conversation-tab";

--- a/src/components/features/conversation/metrics-modal/metrics-modal.tsx
+++ b/src/components/features/conversation/metrics-modal/metrics-modal.tsx
@@ -8,7 +8,7 @@ import { CostSection } from "./cost-section";
 import { UsageSection } from "./usage-section";
 import { ContextWindowSection } from "./context-window-section";
 import { EmptyState } from "./empty-state";
-import useMetricsStore from "#/stores/metrics-store";
+import { useMetricsStore } from "#/context/conversation-context";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useSandboxMetrics } from "#/hooks/query/use-sandbox-metrics";
 

--- a/src/components/features/home/git-repo-dropdown/git-repo-dropdown.tsx
+++ b/src/components/features/home/git-repo-dropdown/git-repo-dropdown.tsx
@@ -23,7 +23,7 @@ import { GenericDropdownMenu } from "../shared/generic-dropdown-menu";
 import { useConfig } from "#/hooks/query/use-config";
 import { I18nKey } from "#/i18n/declaration";
 import RepoIcon from "#/icons/repo.svg?react";
-import { useHomeStore } from "#/stores/home-store";
+import { useHomeStore } from "#/context/global-store-hooks";
 import { Typography } from "#/ui/typography";
 
 export interface GitRepoDropdownProps {

--- a/src/components/features/home/repo-selection-form.tsx
+++ b/src/components/features/home/repo-selection-form.tsx
@@ -13,7 +13,7 @@ import RepoForkedIcon from "#/icons/repo-forked.svg?react";
 import { GitProviderDropdown } from "./git-provider-dropdown";
 import { GitBranchDropdown } from "./git-branch-dropdown";
 import { GitRepoDropdown } from "./git-repo-dropdown";
-import { useHomeStore } from "#/stores/home-store";
+import { useHomeStore } from "#/context/global-store-hooks";
 
 interface RepositorySelectionFormProps {
   onRepoSelection: (repo: GitRepository | null) => void;

--- a/src/components/features/home/tasks/task-card.tsx
+++ b/src/components/features/home/tasks/task-card.tsx
@@ -3,7 +3,7 @@ import { SuggestedTask } from "#/utils/types";
 import { useIsCreatingConversation } from "#/hooks/use-is-creating-conversation";
 import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
 import { TaskIssueNumber } from "./task-issue-number";
-import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
+import { useOptimisticUserMessageStore } from "#/context/global-store-hooks";
 import { useNavigation } from "#/context/navigation-context";
 import { cn } from "#/utils/utils";
 

--- a/src/components/shared/buttons/confirmation-buttons.tsx
+++ b/src/components/shared/buttons/confirmation-buttons.tsx
@@ -5,11 +5,13 @@ import { AgentState } from "#/types/agent-state";
 import { generateAgentStateChangeEvent } from "#/services/agent-state-service";
 import { ActionTooltip } from "../action-tooltip";
 import { isOpenHandsAction, isActionOrObservation } from "#/types/core/guards";
-import { ActionSecurityRisk } from "#/stores/security-analyzer-store";
+import {
+  ActionSecurityRisk,
+  useEventMessageStore,
+  useEventStore,
+} from "#/context/conversation-context";
 import { RiskAlert } from "#/components/shared/risk-alert";
 import WarningIcon from "#/icons/u-warning.svg?react";
-import { useEventMessageStore } from "#/stores/event-message-store";
-import { useEventStore } from "#/stores/use-event-store";
 import { isV0Event } from "#/types/v1/type-guards";
 import { useSendMessage } from "#/hooks/use-send-message";
 

--- a/src/components/shared/buttons/v1-confirmation-buttons.tsx
+++ b/src/components/shared/buttons/v1-confirmation-buttons.tsx
@@ -5,8 +5,10 @@ import { AgentState } from "#/types/agent-state";
 import { ActionTooltip } from "../action-tooltip";
 import { RiskAlert } from "#/components/shared/risk-alert";
 import WarningIcon from "#/icons/u-warning.svg?react";
-import { useEventMessageStore } from "#/stores/event-message-store";
-import { useEventStore } from "#/stores/use-event-store";
+import {
+  useEventMessageStore,
+  useEventStore,
+} from "#/context/conversation-context";
 import { isV1Event, isActionEvent } from "#/types/v1/type-guards";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useAgentState } from "#/hooks/use-agent-state";

--- a/src/components/v1/chat/event-message.tsx
+++ b/src/components/v1/chat/event-message.tsx
@@ -10,7 +10,7 @@ import {
   isHookExecutionEvent,
 } from "#/types/v1/type-guards";
 import { useConfig } from "#/hooks/query/use-config";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { useAgentState } from "#/hooks/use-agent-state";
 import { AgentState } from "#/types/agent-state";
 import { ChatMessage } from "../../features/chat/chat-message";

--- a/src/components/v1/chat/messages.tsx
+++ b/src/components/v1/chat/messages.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { OpenHandsEvent } from "#/types/v1/core";
 import { EventMessage } from "./event-message";
 import { ChatMessage } from "../../features/chat/chat-message";
-import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
+import { useOptimisticUserMessageStore } from "#/context/conversation-context";
 import { usePlanPreviewEvents } from "./hooks/use-plan-preview-events";
 // TODO: Implement microagent functionality for V1 when APIs support V1 event IDs
 // import { AgentState } from "#/types/agent-state";

--- a/src/context/conversation-context.tsx
+++ b/src/context/conversation-context.tsx
@@ -1,0 +1,370 @@
+import React from "react";
+import { useStore } from "zustand";
+import type { StoreApi } from "zustand";
+import {
+  createAgentStore,
+  useAgentStore as useGlobalAgentStore,
+  type AgentStore,
+  type AgentStoreApi,
+} from "#/stores/agent-store";
+import {
+  createBrowserStore,
+  useBrowserStore as useGlobalBrowserStore,
+  type BrowserStore,
+  type BrowserStoreApi,
+} from "#/stores/browser-store";
+import {
+  createCommandStore,
+  useCommandStore as useGlobalCommandStore,
+  type CommandState,
+  type CommandStoreApi,
+} from "#/stores/command-store";
+import {
+  createConversationStore,
+  useConversationStore as useGlobalConversationStore,
+  type ConversationStore,
+  type ConversationStoreApi,
+} from "#/stores/conversation-store";
+import {
+  createErrorMessageStore,
+  useErrorMessageStore as useGlobalErrorMessageStore,
+  type ErrorMessageStore,
+  type ErrorMessageStoreApi,
+} from "#/stores/error-message-store";
+import {
+  createEventMessageStore,
+  useEventMessageStore as useGlobalEventMessageStore,
+  type EventMessageStore,
+  type EventMessageStoreApi,
+} from "#/stores/event-message-store";
+import {
+  createEventStore,
+  useEventStore as useGlobalEventStore,
+  type EventState,
+  type EventStoreApi,
+} from "#/stores/use-event-store";
+import useGlobalMetricsStore, {
+  createMetricsStore,
+  type MetricsStore,
+  type MetricsStoreApi,
+} from "#/stores/metrics-store";
+import {
+  createOptimisticUserMessageStore,
+  useOptimisticUserMessageStore as useGlobalOptimisticUserMessageStore,
+  type OptimisticUserMessageStore,
+  type OptimisticUserMessageStoreApi,
+} from "#/stores/optimistic-user-message-store";
+import {
+  createSecurityAnalyzerStore,
+  useSecurityAnalyzerStore as useGlobalSecurityAnalyzerStore,
+  type SecurityAnalyzerStore,
+  type SecurityAnalyzerStoreApi,
+} from "#/stores/security-analyzer-store";
+import {
+  createStatusStore,
+  useStatusStore as useGlobalStatusStore,
+  type StatusState,
+  type StatusStoreApi,
+} from "#/stores/status-store";
+import {
+  createV1ConversationStateStore,
+  useV1ConversationStateStore as useGlobalV1ConversationStateStore,
+  type V1ConversationStateStore,
+  type V1ConversationStateStoreApi,
+} from "#/stores/v1-conversation-state-store";
+
+export { ActionSecurityRisk } from "#/stores/security-analyzer-store";
+export type { Command } from "#/stores/command-store";
+export type { OHEvent } from "#/stores/use-event-store";
+export type {
+  ConversationMode,
+  ConversationTab,
+  IMessageToSend,
+} from "#/stores/conversation-store";
+
+export interface ConversationScopedStores {
+  conversation: ConversationStoreApi;
+  status: StatusStoreApi;
+  eventMessage: EventMessageStoreApi;
+  agent: AgentStoreApi;
+  browser: BrowserStoreApi;
+  command: CommandStoreApi;
+  metrics: MetricsStoreApi;
+  securityAnalyzer: SecurityAnalyzerStoreApi;
+  event: EventStoreApi;
+  errorMessage: ErrorMessageStoreApi;
+  optimisticUserMessage: OptimisticUserMessageStoreApi;
+  v1ConversationState: V1ConversationStateStoreApi;
+}
+
+export interface ConversationContextValue {
+  conversationId: string | null;
+  serverConfig?: unknown;
+  stores: ConversationScopedStores;
+}
+
+export interface ConversationProviderProps {
+  children: React.ReactNode;
+  conversationId?: string | null;
+  serverConfig?: unknown;
+}
+
+const ConversationContext = React.createContext<ConversationContextValue | null>(
+  null,
+);
+
+const globalConversationScopedStores: ConversationScopedStores = {
+  conversation: useGlobalConversationStore,
+  status: useGlobalStatusStore,
+  eventMessage: useGlobalEventMessageStore,
+  agent: useGlobalAgentStore,
+  browser: useGlobalBrowserStore,
+  command: useGlobalCommandStore,
+  metrics: useGlobalMetricsStore,
+  securityAnalyzer: useGlobalSecurityAnalyzerStore,
+  event: useGlobalEventStore,
+  errorMessage: useGlobalErrorMessageStore,
+  optimisticUserMessage: useGlobalOptimisticUserMessageStore,
+  v1ConversationState: useGlobalV1ConversationStateStore,
+};
+
+const useConversationScopedStores = () =>
+  React.useContext(ConversationContext)?.stores ?? globalConversationScopedStores;
+
+const createConversationScopedStores = (
+  conversationId?: string | null,
+): ConversationScopedStores => {
+  const globalOptimisticMessage =
+    useGlobalOptimisticUserMessageStore.getState().getOptimisticUserMessage();
+
+  return {
+    conversation: createConversationStore(conversationId),
+    status: createStatusStore(),
+    eventMessage: createEventMessageStore(),
+    agent: createAgentStore(),
+    browser: createBrowserStore(),
+    command: createCommandStore(),
+    metrics: createMetricsStore(),
+    securityAnalyzer: createSecurityAnalyzerStore(),
+    event: createEventStore(),
+    errorMessage: createErrorMessageStore(),
+    optimisticUserMessage:
+      createOptimisticUserMessageStore(globalOptimisticMessage),
+    v1ConversationState: createV1ConversationStateStore(),
+  };
+};
+
+export function ConversationProvider({
+  children,
+  conversationId = null,
+  serverConfig,
+}: ConversationProviderProps) {
+  const storesRef = React.useRef<ConversationScopedStores | null>(null);
+  const previousConversationIdRef = React.useRef<string | null>(conversationId);
+
+  if (
+    !storesRef.current ||
+    previousConversationIdRef.current !== conversationId
+  ) {
+    storesRef.current = createConversationScopedStores(conversationId);
+    previousConversationIdRef.current = conversationId;
+  }
+
+  const value = React.useMemo<ConversationContextValue>(
+    () => ({
+      conversationId,
+      serverConfig,
+      stores: storesRef.current as ConversationScopedStores,
+    }),
+    [conversationId, serverConfig],
+  );
+
+  return (
+    <ConversationContext.Provider value={value}>
+      {children}
+    </ConversationContext.Provider>
+  );
+}
+
+export function useConversationContext(): ConversationContextValue {
+  const context = React.useContext(ConversationContext);
+  if (!context) {
+    throw new Error(
+      "Conversation-scoped state is unavailable. Wrap this UI in <ConversationProvider>.",
+    );
+  }
+  return context;
+}
+
+function useScopedStore<State>(store: StoreApi<State>): State;
+function useScopedStore<State, Selected>(
+  store: StoreApi<State>,
+  selector: (state: State) => Selected,
+): Selected;
+function useScopedStore<State, Selected>(
+  store: StoreApi<State>,
+  selector?: (state: State) => Selected,
+): State | Selected {
+  if (typeof store.getState !== "function") {
+    const legacyHook = store as unknown as (
+      selector?: (state: State) => Selected,
+    ) => State | Selected;
+    return legacyHook(selector);
+  }
+
+  return useStore(
+    store,
+    selector ?? ((state: State) => state as State | Selected),
+  );
+}
+
+export const useConversationStoreApi = () =>
+  useConversationScopedStores().conversation;
+export const useStatusStoreApi = () => useConversationScopedStores().status;
+export const useEventMessageStoreApi = () =>
+  useConversationScopedStores().eventMessage;
+export const useAgentStoreApi = () => useConversationScopedStores().agent;
+export const useBrowserStoreApi = () => useConversationScopedStores().browser;
+export const useCommandStoreApi = () => useConversationScopedStores().command;
+export const useMetricsStoreApi = () => useConversationScopedStores().metrics;
+export const useSecurityAnalyzerStoreApi = () =>
+  useConversationScopedStores().securityAnalyzer;
+export const useEventStoreApi = () => useConversationScopedStores().event;
+export const useErrorMessageStoreApi = () =>
+  useConversationScopedStores().errorMessage;
+export const useOptimisticUserMessageStoreApi = () =>
+  useConversationScopedStores().optimisticUserMessage;
+export const useV1ConversationStateStoreApi = () =>
+  useConversationScopedStores().v1ConversationState;
+
+export function useConversationStore(): ConversationStore;
+export function useConversationStore<Selected>(
+  selector: (state: ConversationStore) => Selected,
+): Selected;
+export function useConversationStore<Selected>(
+  selector?: (state: ConversationStore) => Selected,
+) {
+  const store = useConversationStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useStatusStore(): StatusState;
+export function useStatusStore<Selected>(
+  selector: (state: StatusState) => Selected,
+): Selected;
+export function useStatusStore<Selected>(
+  selector?: (state: StatusState) => Selected,
+) {
+  const store = useStatusStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useEventMessageStore(): EventMessageStore;
+export function useEventMessageStore<Selected>(
+  selector: (state: EventMessageStore) => Selected,
+): Selected;
+export function useEventMessageStore<Selected>(
+  selector?: (state: EventMessageStore) => Selected,
+) {
+  const store = useEventMessageStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useAgentStore(): AgentStore;
+export function useAgentStore<Selected>(
+  selector: (state: AgentStore) => Selected,
+): Selected;
+export function useAgentStore<Selected>(
+  selector?: (state: AgentStore) => Selected,
+) {
+  const store = useAgentStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useBrowserStore(): BrowserStore;
+export function useBrowserStore<Selected>(
+  selector: (state: BrowserStore) => Selected,
+): Selected;
+export function useBrowserStore<Selected>(
+  selector?: (state: BrowserStore) => Selected,
+) {
+  const store = useBrowserStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useCommandStore(): CommandState;
+export function useCommandStore<Selected>(
+  selector: (state: CommandState) => Selected,
+): Selected;
+export function useCommandStore<Selected>(
+  selector?: (state: CommandState) => Selected,
+) {
+  const store = useCommandStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useMetricsStore(): MetricsStore;
+export function useMetricsStore<Selected>(
+  selector: (state: MetricsStore) => Selected,
+): Selected;
+export function useMetricsStore<Selected>(
+  selector?: (state: MetricsStore) => Selected,
+) {
+  const store = useMetricsStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useSecurityAnalyzerStore(): SecurityAnalyzerStore;
+export function useSecurityAnalyzerStore<Selected>(
+  selector: (state: SecurityAnalyzerStore) => Selected,
+): Selected;
+export function useSecurityAnalyzerStore<Selected>(
+  selector?: (state: SecurityAnalyzerStore) => Selected,
+) {
+  const store = useSecurityAnalyzerStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useEventStore(): EventState;
+export function useEventStore<Selected>(
+  selector: (state: EventState) => Selected,
+): Selected;
+export function useEventStore<Selected>(
+  selector?: (state: EventState) => Selected,
+) {
+  const store = useEventStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useErrorMessageStore(): ErrorMessageStore;
+export function useErrorMessageStore<Selected>(
+  selector: (state: ErrorMessageStore) => Selected,
+): Selected;
+export function useErrorMessageStore<Selected>(
+  selector?: (state: ErrorMessageStore) => Selected,
+) {
+  const store = useErrorMessageStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useOptimisticUserMessageStore(): OptimisticUserMessageStore;
+export function useOptimisticUserMessageStore<Selected>(
+  selector: (state: OptimisticUserMessageStore) => Selected,
+): Selected;
+export function useOptimisticUserMessageStore<Selected>(
+  selector?: (state: OptimisticUserMessageStore) => Selected,
+) {
+  const store = useOptimisticUserMessageStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}
+
+export function useV1ConversationStateStore(): V1ConversationStateStore;
+export function useV1ConversationStateStore<Selected>(
+  selector: (state: V1ConversationStateStore) => Selected,
+): Selected;
+export function useV1ConversationStateStore<Selected>(
+  selector?: (state: V1ConversationStateStore) => Selected,
+) {
+  const store = useV1ConversationStateStoreApi();
+  return selector ? useScopedStore(store, selector) : useScopedStore(store);
+}

--- a/src/context/global-store-hooks.ts
+++ b/src/context/global-store-hooks.ts
@@ -1,0 +1,4 @@
+export { useBtwStore } from "#/stores/btw-store";
+export { useHomeStore } from "#/stores/home-store";
+export { useInitialQueryStore } from "#/stores/initial-query-store";
+export { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";

--- a/src/contexts/conversation-websocket-context.tsx
+++ b/src/contexts/conversation-websocket-context.tsx
@@ -10,12 +10,18 @@ import React, {
 import { useQueryClient } from "@tanstack/react-query";
 import { usePostHog } from "posthog-js/react";
 import { useWebSocket, WebSocketHookOptions } from "#/hooks/use-websocket";
-import { useEventStore } from "#/stores/use-event-store";
-import { useErrorMessageStore } from "#/stores/error-message-store";
-import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
-import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
-import { useCommandStore } from "#/stores/command-store";
-import { useBrowserStore } from "#/stores/browser-store";
+import {
+  useBrowserStoreApi,
+  useCommandStore,
+  useConversationStore,
+  useConversationStoreApi,
+  useErrorMessageStore,
+  useErrorMessageStoreApi,
+  useEventStore,
+  useMetricsStoreApi,
+  useOptimisticUserMessageStore,
+  useV1ConversationStateStore,
+} from "#/context/conversation-context";
 import {
   isV1Event,
   isAgentErrorEvent,
@@ -45,11 +51,9 @@ import type {
 } from "#/api/conversation-service/v1-conversation-service.types";
 import EventService from "#/api/event-service/event-service.api";
 import PendingMessageService from "#/api/pending-message-service/pending-message-service.api";
-import { useConversationStore } from "#/stores/conversation-store";
 import { isBudgetOrCreditError, trackError } from "#/utils/error-handler";
 import { useTracking } from "#/hooks/use-tracking";
 import { useReadConversationFile } from "#/hooks/mutation/use-read-conversation-file";
-import useMetricsStore from "#/stores/metrics-store";
 import { I18nKey } from "#/i18n/declaration";
 import { useConversationHistory } from "#/hooks/query/use-conversation-history";
 import { setConversationState } from "#/utils/conversation-local-storage";
@@ -104,6 +108,10 @@ export function ConversationWebSocketProvider({
   const posthog = usePostHog();
   const queryClient = useQueryClient();
   const { addEvent } = useEventStore();
+  const browserStore = useBrowserStoreApi();
+  const conversationStore = useConversationStoreApi();
+  const errorMessageStore = useErrorMessageStoreApi();
+  const metricsStore = useMetricsStoreApi();
   const { setErrorMessage, removeErrorMessage } = useErrorMessageStore();
   const { removeOptimisticUserMessage } = useOptimisticUserMessageStore();
   const { setExecutionStatus } = useV1ConversationStateStore();
@@ -143,7 +151,7 @@ export function ConversationWebSocketProvider({
   // Budget/credit errors persist until an agent event proves the LLM is working.
   const handleNonErrorEvent = useCallback(
     (event: { source?: string }) => {
-      const currentError = useErrorMessageStore.getState().errorMessage;
+      const currentError = errorMessageStore.getState().errorMessage;
       const isBudgetError =
         currentError === I18nKey.STATUS$ERROR_LLM_OUT_OF_CREDITS;
       const isAgentEvent = event.source === "agent";
@@ -155,7 +163,7 @@ export function ConversationWebSocketProvider({
 
       removeErrorMessage();
     },
-    [removeErrorMessage],
+    [errorMessageStore, removeErrorMessage],
   );
 
   // Helper function to update metrics from stats event
@@ -183,10 +191,10 @@ export function ConversationWebSocketProvider({
               }
             : null,
         };
-        useMetricsStore.getState().setMetrics(metrics);
+        metricsStore.getState().setMetrics(metrics);
       }
     },
-    [],
+    [metricsStore],
   );
 
   // Build WebSocket URL from props
@@ -473,13 +481,13 @@ export function ConversationWebSocketProvider({
               const screenshotSrc = screenshotData.startsWith("data:")
                 ? screenshotData
                 : `data:image/png;base64,${screenshotData}`;
-              useBrowserStore.getState().setScreenshotSrc(screenshotSrc);
+              browserStore.getState().setScreenshotSrc(screenshotSrc);
             }
           }
 
           // Handle BrowserNavigateAction events - update browser store with URL
           if (isBrowserNavigateActionEvent(event)) {
-            useBrowserStore.getState().setUrl(event.action.url);
+            browserStore.getState().setUrl(event.action.url);
           }
         }
       } catch (error) {
@@ -500,6 +508,7 @@ export function ConversationWebSocketProvider({
       appendInput,
       appendOutput,
       updateMetricsFromStats,
+      browserStore,
       trackCreditLimitReached,
       posthog,
     ],
@@ -833,7 +842,7 @@ export function ConversationWebSocketProvider({
   // Falls back to REST API queue when WebSocket is not connected
   const sendMessage = useCallback(
     async (message: V1SendMessageRequest): Promise<SendMessageResult> => {
-      const currentMode = useConversationStore.getState().conversationMode;
+      const currentMode = conversationStore.getState().conversationMode;
       const currentSocket =
         currentMode === "plan" ? planningAgentSocket : mainSocket;
 
@@ -875,7 +884,13 @@ export function ConversationWebSocketProvider({
         throw error;
       }
     },
-    [mainSocket, planningAgentSocket, setErrorMessage, conversationId],
+    [
+      mainSocket,
+      planningAgentSocket,
+      conversationStore,
+      setErrorMessage,
+      conversationId,
+    ],
   );
 
   // Track main socket state changes

--- a/src/hooks/chat/use-btw-interceptor.ts
+++ b/src/hooks/chat/use-btw-interceptor.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { askV1Agent } from "#/hooks/mutation/conversation-mutation-utils";
-import { useBtwStore } from "#/stores/btw-store";
+import { useBtwStore } from "#/context/global-store-hooks";
 import { BTW_COMMAND } from "#/utils/constants";
 
 const BTW_PREFIX = `${BTW_COMMAND} `;

--- a/src/hooks/chat/use-chat-input-logic.ts
+++ b/src/hooks/chat/use-chat-input-logic.ts
@@ -4,7 +4,7 @@ import {
   clearEmptyContent,
   getTextContent,
 } from "#/components/features/chat/utils/chat-input.utils";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { useDraftPersistence } from "./use-draft-persistence";
 

--- a/src/hooks/chat/use-grip-resize.ts
+++ b/src/hooks/chat/use-grip-resize.ts
@@ -4,7 +4,7 @@ import { CHAT_INPUT } from "#/utils/constants";
 import {
   IMessageToSend,
   useConversationStore,
-} from "#/stores/conversation-store";
+} from "#/context/conversation-context";
 
 /**
  * Hook for managing grip resize functionality

--- a/src/hooks/mutation/use-unified-start-conversation.ts
+++ b/src/hooks/mutation/use-unified-start-conversation.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Provider } from "#/types/settings";
-import { useErrorMessageStore } from "#/stores/error-message-store";
+import { useErrorMessageStore } from "#/context/conversation-context";
 import {
   resumeV1ConversationSandbox,
   updateConversationSandboxStatusInCache,

--- a/src/hooks/use-agent-state.test.tsx
+++ b/src/hooks/use-agent-state.test.tsx
@@ -1,8 +1,12 @@
+import React from "react";
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAgentState } from "./use-agent-state";
 import { useActiveConversation } from "./query/use-active-conversation";
-import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
+import {
+  ConversationProvider,
+  useV1ConversationStateStoreApi,
+} from "#/context/conversation-context";
 import { AgentState } from "#/types/agent-state";
 import { V1ExecutionStatus } from "#/types/v1/core/base/common";
 
@@ -10,14 +14,18 @@ vi.mock("./query/use-active-conversation", () => ({
   useActiveConversation: vi.fn(),
 }));
 
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <ConversationProvider conversationId="test">
+      {children}
+    </ConversationProvider>
+  );
+}
+
 describe("useAgentState", () => {
   const mockUseActiveConversation = vi.mocked(useActiveConversation);
 
   beforeEach(() => {
-    act(() => {
-      useV1ConversationStateStore.getState().reset();
-    });
-
     mockUseActiveConversation.mockReturnValue({
       data: null,
     } as ReturnType<typeof useActiveConversation>);
@@ -30,16 +38,24 @@ describe("useAgentState", () => {
       },
     } as ReturnType<typeof useActiveConversation>);
 
+    const { result } = renderHook(
+      () => ({
+        agentState: useAgentState(),
+        v1Store: useV1ConversationStateStoreApi(),
+      }),
+      { wrapper },
+    );
+
     act(() => {
-      useV1ConversationStateStore
+      result.current.v1Store
         .getState()
         .setExecutionStatus(V1ExecutionStatus.RUNNING);
     });
 
-    const { result } = renderHook(() => useAgentState());
-
-    expect(result.current.executionStatus).toBe(V1ExecutionStatus.RUNNING);
-    expect(result.current.curAgentState).toBe(AgentState.RUNNING);
+    expect(result.current.agentState.executionStatus).toBe(
+      V1ExecutionStatus.RUNNING,
+    );
+    expect(result.current.agentState.curAgentState).toBe(AgentState.RUNNING);
   });
 
   it("falls back to cached conversation execution status when live state is empty", () => {
@@ -49,7 +65,7 @@ describe("useAgentState", () => {
       },
     } as ReturnType<typeof useActiveConversation>);
 
-    const { result } = renderHook(() => useAgentState());
+    const { result } = renderHook(() => useAgentState(), { wrapper });
 
     expect(result.current.executionStatus).toBe(
       V1ExecutionStatus.WAITING_FOR_CONFIRMATION,

--- a/src/hooks/use-agent-state.ts
+++ b/src/hooks/use-agent-state.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
-import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
+import { useV1ConversationStateStore } from "#/context/conversation-context";
 import { AgentState } from "#/types/agent-state";
 import { V1ExecutionStatus } from "#/types/v1/core/base/common";
 

--- a/src/hooks/use-auto-resize.ts
+++ b/src/hooks/use-auto-resize.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, RefObject, useRef } from "react";
-import { IMessageToSend } from "#/stores/conversation-store";
+import type { IMessageToSend } from "#/context/conversation-context";
 import { EPS } from "#/utils/constants";
 import { getStyleHeightPx, setStyleHeightPx } from "#/utils/utils";
 import { useDragResize } from "./use-drag-resize";

--- a/src/hooks/use-conversation-name-context-menu.ts
+++ b/src/hooks/use-conversation-name-context-menu.ts
@@ -1,13 +1,12 @@
 import { useTranslation } from "react-i18next";
 import React from "react";
 import { useNavigation } from "#/context/navigation-context";
-import useMetricsStore from "#/stores/metrics-store";
+import { useEventStore, useMetricsStore } from "#/context/conversation-context";
 import { useDeleteConversation } from "./mutation/use-delete-conversation";
 import { useUnifiedPauseConversationSandbox } from "./mutation/use-unified-stop-conversation";
 import { useUpdateConversationPublicFlag } from "./mutation/use-update-conversation-public-flag";
 import { displaySuccessToast } from "#/utils/custom-toast-handlers";
 import { I18nKey } from "#/i18n/declaration";
-import { useEventStore } from "#/stores/use-event-store";
 
 import { useActiveConversation } from "./query/use-active-conversation";
 import { useDownloadConversation } from "./use-download-conversation";

--- a/src/hooks/use-filtered-events.ts
+++ b/src/hooks/use-filtered-events.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import { isOpenHandsAction, isActionOrObservation } from "#/types/core/guards";
-import { useEventStore } from "#/stores/use-event-store";
+import { useEventStore } from "#/context/conversation-context";
 import {
   shouldRenderEvent,
   hasUserEvent,

--- a/src/hooks/use-handle-build-plan-click.ts
+++ b/src/hooks/use-handle-build-plan-click.ts
@@ -1,8 +1,10 @@
 import { useCallback } from "react";
-import { useConversationStore } from "#/stores/conversation-store";
+import {
+  useConversationStore,
+  useOptimisticUserMessageStore,
+} from "#/context/conversation-context";
 import { useSendMessage } from "#/hooks/use-send-message";
 import { createChatMessage } from "#/services/chat-service";
-import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
 
 /**
  * Custom hook that encapsulates the logic for handling the Build button click.

--- a/src/hooks/use-handle-plan-click.ts
+++ b/src/hooks/use-handle-plan-click.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
 import { displaySuccessToast } from "#/utils/custom-toast-handlers";

--- a/src/hooks/use-handle-ws-events.ts
+++ b/src/hooks/use-handle-ws-events.ts
@@ -2,7 +2,7 @@ import React from "react";
 import { generateAgentStateChangeEvent } from "#/services/agent-state-service";
 import { AgentState } from "#/types/agent-state";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
-import { useEventStore } from "#/stores/use-event-store";
+import { useEventStore } from "#/context/conversation-context";
 import { useSendMessage } from "#/hooks/use-send-message";
 
 interface ServerError {

--- a/src/hooks/use-select-conversation-tab.ts
+++ b/src/hooks/use-select-conversation-tab.ts
@@ -2,7 +2,7 @@ import { useConversationLocalStorageState } from "#/utils/conversation-local-sto
 import {
   useConversationStore,
   type ConversationTab,
-} from "#/stores/conversation-store";
+} from "#/context/conversation-context";
 import { useConversationId } from "#/hooks/use-conversation-id";
 
 /**

--- a/src/hooks/use-task-list.ts
+++ b/src/hooks/use-task-list.ts
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
-import { useEventStore } from "#/stores/use-event-store";
-import type { OHEvent } from "#/stores/use-event-store";
+import { useEventStore, type OHEvent } from "#/context/conversation-context";
 import { isTaskTrackingObservation } from "#/types/core/guards";
 import type { OpenHandsParsedEvent } from "#/types/core";
 import { isObservationEvent } from "#/types/v1/type-guards";

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -1,7 +1,7 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
 import React from "react";
-import { Command, useCommandStore } from "#/stores/command-store";
+import { Command, useCommandStore } from "#/context/conversation-context";
 import { parseTerminalOutput } from "#/utils/parse-terminal-output";
 
 /*

--- a/src/routes/conversation.tsx
+++ b/src/routes/conversation.tsx
@@ -3,10 +3,15 @@ import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 
 import { useConversationId } from "#/hooks/use-conversation-id";
-import { useCommandStore } from "#/stores/command-store";
-import { useConversationStore } from "#/stores/conversation-store";
-import { useAgentStore } from "#/stores/agent-store";
-import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
+import {
+  ConversationProvider,
+  useAgentStore,
+  useCommandStore,
+  useConversationStore,
+  useErrorMessageStore,
+  useEventStore,
+  useV1ConversationStateStore,
+} from "#/context/conversation-context";
 import { AgentState } from "#/types/agent-state";
 
 import { EventHandler } from "../wrapper/event-handler";
@@ -23,9 +28,7 @@ import { ConversationNameWithStatus } from "#/components/features/conversation/c
 
 import { ConversationTabs } from "#/components/features/conversation/conversation-tabs/conversation-tabs";
 import { WebSocketProviderWrapper } from "#/contexts/websocket-provider-wrapper";
-import { useErrorMessageStore } from "#/stores/error-message-store";
 import { I18nKey } from "#/i18n/declaration";
-import { useEventStore } from "#/stores/use-event-store";
 
 function AppContent() {
   const { t } = useTranslation("openhands");
@@ -118,7 +121,13 @@ function AppContent() {
 }
 
 export function ConversationView() {
-  return <AppContent />;
+  const { conversationId } = useConversationId();
+
+  return (
+    <ConversationProvider conversationId={conversationId}>
+      <AppContent />
+    </ConversationProvider>
+  );
 }
 
 export default ConversationView;

--- a/src/routes/planner-tab.tsx
+++ b/src/routes/planner-tab.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import LessonPlanIcon from "#/icons/lesson-plan.svg?react";
-import { useConversationStore } from "#/stores/conversation-store";
+import { useConversationStore } from "#/context/conversation-context";
 import { useScrollToBottom } from "#/hooks/use-scroll-to-bottom";
 import { MarkdownRenderer } from "#/components/features/markdown/markdown-renderer";
 import { planComponents } from "#/components/features/markdown/plan-components";

--- a/src/stores/agent-store.ts
+++ b/src/stores/agent-store.ts
@@ -1,21 +1,28 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 import { AgentState } from "#/types/agent-state";
 
-interface AgentStateData {
+export interface AgentStateData {
   curAgentState: AgentState;
 }
 
-interface AgentStore extends AgentStateData {
+export interface AgentStore extends AgentStateData {
   setCurrentAgentState: (state: AgentState) => void;
   reset: () => void;
 }
+
+export type AgentStoreApi = StoreApi<AgentStore>;
 
 const initialState: AgentStateData = {
   curAgentState: AgentState.LOADING,
 };
 
-export const useAgentStore = create<AgentStore>((set) => ({
+const createAgentState: StateCreator<AgentStore> = (set) => ({
   ...initialState,
   setCurrentAgentState: (state: AgentState) => set({ curAgentState: state }),
   reset: () => set(initialState),
-}));
+});
+
+export const createAgentStore = (): AgentStoreApi =>
+  createStore<AgentStore>()(createAgentState);
+
+export const useAgentStore = create<AgentStore>()(createAgentState);

--- a/src/stores/browser-store.ts
+++ b/src/stores/browser-store.ts
@@ -1,26 +1,31 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 
-interface BrowserState {
-  // URL of browser window (placeholder for now, will be replaced with the actual URL later)
+export interface BrowserState {
   url: string;
-  // Base64-encoded screenshot of browser window (placeholder for now, will be replaced with the actual screenshot later)
   screenshotSrc: string;
 }
 
-interface BrowserStore extends BrowserState {
+export interface BrowserStore extends BrowserState {
   setUrl: (url: string) => void;
   setScreenshotSrc: (screenshotSrc: string) => void;
   reset: () => void;
 }
+
+export type BrowserStoreApi = StoreApi<BrowserStore>;
 
 const initialState: BrowserState = {
   url: "https://github.com/OpenHands/OpenHands",
   screenshotSrc: "",
 };
 
-export const useBrowserStore = create<BrowserStore>((set) => ({
+const createBrowserState: StateCreator<BrowserStore> = (set) => ({
   ...initialState,
   setUrl: (url: string) => set({ url }),
   setScreenshotSrc: (screenshotSrc: string) => set({ screenshotSrc }),
   reset: () => set(initialState),
-}));
+});
+
+export const createBrowserStore = (): BrowserStoreApi =>
+  createStore<BrowserStore>()(createBrowserState);
+
+export const useBrowserStore = create<BrowserStore>()(createBrowserState);

--- a/src/stores/command-store.ts
+++ b/src/stores/command-store.ts
@@ -1,18 +1,20 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 
 export type Command = {
   content: string;
   type: "input" | "output";
 };
 
-interface CommandState {
+export interface CommandState {
   commands: Command[];
   appendInput: (content: string) => void;
   appendOutput: (content: string) => void;
   clearTerminal: () => void;
 }
 
-export const useCommandStore = create<CommandState>((set) => ({
+export type CommandStoreApi = StoreApi<CommandState>;
+
+const createCommandState: StateCreator<CommandState> = (set) => ({
   commands: [],
   appendInput: (content: string) =>
     set((state) => ({
@@ -23,4 +25,9 @@ export const useCommandStore = create<CommandState>((set) => ({
       commands: [...state.commands, { content, type: "output" }],
     })),
   clearTerminal: () => set({ commands: [] }),
-}));
+});
+
+export const createCommandStore = (): CommandStoreApi =>
+  createStore<CommandState>()(createCommandState);
+
+export const useCommandStore = create<CommandState>()(createCommandState);

--- a/src/stores/conversation-store.ts
+++ b/src/stores/conversation-store.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 import { devtools } from "zustand/middleware";
 import {
   getConversationState,
@@ -21,7 +21,7 @@ export interface IMessageToSend {
   timestamp: number;
 }
 
-interface ConversationState {
+export interface ConversationState {
   isRightPanelShown: boolean;
   selectedTab: ConversationTab | null;
   images: File[];
@@ -38,7 +38,7 @@ interface ConversationState {
   subConversationTaskId: string | null; // Task ID for sub-conversation creation
 }
 
-interface ConversationActions {
+export interface ConversationActions {
   setIsRightPanelShown: (isRightPanelShown: boolean) => void;
   setSelectedTab: (selectedTab: ConversationTab | null) => void;
   setShouldShownAgentLoading: (shouldShownAgentLoading: boolean) => void;
@@ -64,7 +64,8 @@ interface ConversationActions {
   setPlanContent: (planContent: string | null) => void;
 }
 
-type ConversationStore = ConversationState & ConversationActions;
+export type ConversationStore = ConversationState & ConversationActions;
+export type ConversationStoreApi = StoreApi<ConversationStore>;
 
 const getConversationIdFromLocation = (): string | null => {
   if (typeof window === "undefined") {
@@ -87,14 +88,15 @@ const parseStoredBoolean = (value: string | null): boolean | null => {
   }
 };
 
-const getInitialRightPanelState = (): boolean => {
+const getInitialRightPanelState = (conversationId?: string | null): boolean => {
   if (typeof window === "undefined") {
     return true;
   }
 
-  const conversationId = getConversationIdFromLocation();
-  const keysToCheck = conversationId
-    ? [`conversation-right-panel-shown-${conversationId}`]
+  const scopedConversationId =
+    conversationId ?? getConversationIdFromLocation();
+  const keysToCheck = scopedConversationId
+    ? [`conversation-right-panel-shown-${scopedConversationId}`]
     : [];
 
   // Fallback to legacy global key for users who haven't switched tabs yet
@@ -110,199 +112,224 @@ const getInitialRightPanelState = (): boolean => {
   return true;
 };
 
-const getInitialConversationMode = (): ConversationMode => {
+const getInitialConversationMode = (
+  conversationId?: string | null,
+): ConversationMode => {
   if (typeof window === "undefined") {
     return "code";
   }
 
-  const conversationId = getConversationIdFromLocation();
-  if (!conversationId) {
+  const scopedConversationId =
+    conversationId ?? getConversationIdFromLocation();
+  if (!scopedConversationId) {
     return "code";
   }
 
-  const state = getConversationState(conversationId);
+  const state = getConversationState(scopedConversationId);
   return state.conversationMode;
 };
 
-export const useConversationStore = create<ConversationStore>()(
-  devtools(
-    (set) => ({
-      // Initial state
-      isRightPanelShown: getInitialRightPanelState(),
-      selectedTab: "editor" as ConversationTab,
-      images: [],
-      files: [],
-      loadingFiles: [],
-      loadingImages: [],
-      messageToSend: null,
-      shouldShownAgentLoading: false,
-      submittedMessage: null,
-      shouldHideSuggestions: false,
-      hasRightPanelToggled: true,
-      planContent: null,
-      conversationMode: getInitialConversationMode(),
-      subConversationTaskId: null,
+const createConversationState =
+  (
+    conversationId?: string | null,
+  ): StateCreator<
+    ConversationStore,
+    [["zustand/devtools", never]],
+    [],
+    ConversationStore
+  > =>
+  (set) => ({
+    // Initial state
+    isRightPanelShown: getInitialRightPanelState(conversationId),
+    selectedTab: "editor" as ConversationTab,
+    images: [],
+    files: [],
+    loadingFiles: [],
+    loadingImages: [],
+    messageToSend: null,
+    shouldShownAgentLoading: false,
+    submittedMessage: null,
+    shouldHideSuggestions: false,
+    hasRightPanelToggled: true,
+    planContent: null,
+    conversationMode: getInitialConversationMode(conversationId),
+    subConversationTaskId: null,
 
-      // Actions
-      setIsRightPanelShown: (isRightPanelShown) =>
-        set({ isRightPanelShown }, false, "setIsRightPanelShown"),
+    // Actions
+    setIsRightPanelShown: (isRightPanelShown) =>
+      set({ isRightPanelShown }, false, "setIsRightPanelShown"),
 
-      setSelectedTab: (selectedTab) =>
-        set({ selectedTab }, false, "setSelectedTab"),
+    setSelectedTab: (selectedTab) =>
+      set({ selectedTab }, false, "setSelectedTab"),
 
-      setShouldShownAgentLoading: (shouldShownAgentLoading) =>
-        set({ shouldShownAgentLoading }, false, "setShouldShownAgentLoading"),
+    setShouldShownAgentLoading: (shouldShownAgentLoading) =>
+      set({ shouldShownAgentLoading }, false, "setShouldShownAgentLoading"),
 
-      setShouldHideSuggestions: (shouldHideSuggestions) =>
-        set({ shouldHideSuggestions }, false, "setShouldHideSuggestions"),
+    setShouldHideSuggestions: (shouldHideSuggestions) =>
+      set({ shouldHideSuggestions }, false, "setShouldHideSuggestions"),
 
-      addImages: (images) =>
-        set(
-          (state) => ({ images: [...state.images, ...images] }),
-          false,
-          "addImages",
-        ),
+    addImages: (images) =>
+      set(
+        (state) => ({ images: [...state.images, ...images] }),
+        false,
+        "addImages",
+      ),
 
-      addFiles: (files) =>
-        set(
-          (state) => ({ files: [...state.files, ...files] }),
-          false,
-          "addFiles",
-        ),
+    addFiles: (files) =>
+      set(
+        (state) => ({ files: [...state.files, ...files] }),
+        false,
+        "addFiles",
+      ),
 
-      removeImage: (index) =>
-        set(
-          (state) => {
-            const newImages = [...state.images];
-            newImages.splice(index, 1);
-            return { images: newImages };
+    removeImage: (index) =>
+      set(
+        (state) => {
+          const newImages = [...state.images];
+          newImages.splice(index, 1);
+          return { images: newImages };
+        },
+        false,
+        "removeImage",
+      ),
+
+    removeFile: (index) =>
+      set(
+        (state) => {
+          const newFiles = [...state.files];
+          newFiles.splice(index, 1);
+          return { files: newFiles };
+        },
+        false,
+        "removeFile",
+      ),
+
+    clearImages: () => set({ images: [] }, false, "clearImages"),
+
+    clearFiles: () => set({ files: [] }, false, "clearFiles"),
+
+    clearAllFiles: () =>
+      set(
+        {
+          images: [],
+          files: [],
+          loadingFiles: [],
+          loadingImages: [],
+        },
+        false,
+        "clearAllFiles",
+      ),
+
+    addFileLoading: (fileName) =>
+      set(
+        (state) => {
+          if (!state.loadingFiles.includes(fileName)) {
+            return { loadingFiles: [...state.loadingFiles, fileName] };
+          }
+          return state;
+        },
+        false,
+        "addFileLoading",
+      ),
+
+    removeFileLoading: (fileName) =>
+      set(
+        (state) => ({
+          loadingFiles: state.loadingFiles.filter((name) => name !== fileName),
+        }),
+        false,
+        "removeFileLoading",
+      ),
+
+    addImageLoading: (imageName) =>
+      set(
+        (state) => {
+          if (!state.loadingImages.includes(imageName)) {
+            return { loadingImages: [...state.loadingImages, imageName] };
+          }
+          return state;
+        },
+        false,
+        "addImageLoading",
+      ),
+
+    removeImageLoading: (imageName) =>
+      set(
+        (state) => ({
+          loadingImages: state.loadingImages.filter(
+            (name) => name !== imageName,
+          ),
+        }),
+        false,
+        "removeImageLoading",
+      ),
+
+    clearAllLoading: () =>
+      set({ loadingFiles: [], loadingImages: [] }, false, "clearAllLoading"),
+
+    setMessageToSend: (text) =>
+      set(
+        {
+          messageToSend: {
+            text,
+            timestamp: Date.now(),
           },
-          false,
-          "removeImage",
-        ),
+        },
+        false,
+        "setMessageToSend",
+      ),
 
-      removeFile: (index) =>
-        set(
-          (state) => {
-            const newFiles = [...state.files];
-            newFiles.splice(index, 1);
-            return { files: newFiles };
-          },
-          false,
-          "removeFile",
-        ),
+    setSubmittedMessage: (submittedMessage) =>
+      set({ submittedMessage }, false, "setSubmittedMessage"),
 
-      clearImages: () => set({ images: [] }, false, "clearImages"),
+    resetConversationState: () =>
+      set(
+        {
+          shouldHideSuggestions: false,
+          conversationMode: getInitialConversationMode(conversationId),
+          subConversationTaskId: null,
+          planContent: null,
+        },
+        false,
+        "resetConversationState",
+      ),
 
-      clearFiles: () => set({ files: [] }, false, "clearFiles"),
+    setHasRightPanelToggled: (hasRightPanelToggled) =>
+      set({ hasRightPanelToggled }, false, "setHasRightPanelToggled"),
 
-      clearAllFiles: () =>
-        set(
-          {
-            images: [],
-            files: [],
-            loadingFiles: [],
-            loadingImages: [],
-          },
-          false,
-          "clearAllFiles",
-        ),
-
-      addFileLoading: (fileName) =>
-        set(
-          (state) => {
-            if (!state.loadingFiles.includes(fileName)) {
-              return { loadingFiles: [...state.loadingFiles, fileName] };
-            }
-            return state;
-          },
-          false,
-          "addFileLoading",
-        ),
-
-      removeFileLoading: (fileName) =>
-        set(
-          (state) => ({
-            loadingFiles: state.loadingFiles.filter(
-              (name) => name !== fileName,
-            ),
-          }),
-          false,
-          "removeFileLoading",
-        ),
-
-      addImageLoading: (imageName) =>
-        set(
-          (state) => {
-            if (!state.loadingImages.includes(imageName)) {
-              return { loadingImages: [...state.loadingImages, imageName] };
-            }
-            return state;
-          },
-          false,
-          "addImageLoading",
-        ),
-
-      removeImageLoading: (imageName) =>
-        set(
-          (state) => ({
-            loadingImages: state.loadingImages.filter(
-              (name) => name !== imageName,
-            ),
-          }),
-          false,
-          "removeImageLoading",
-        ),
-
-      clearAllLoading: () =>
-        set({ loadingFiles: [], loadingImages: [] }, false, "clearAllLoading"),
-
-      setMessageToSend: (text) =>
-        set(
-          {
-            messageToSend: {
-              text,
-              timestamp: Date.now(),
-            },
-          },
-          false,
-          "setMessageToSend",
-        ),
-
-      setSubmittedMessage: (submittedMessage) =>
-        set({ submittedMessage }, false, "setSubmittedMessage"),
-
-      resetConversationState: () =>
-        set(
-          {
-            shouldHideSuggestions: false,
-            conversationMode: getInitialConversationMode(),
-            subConversationTaskId: null,
-            planContent: null,
-          },
-          false,
-          "resetConversationState",
-        ),
-
-      setHasRightPanelToggled: (hasRightPanelToggled) =>
-        set({ hasRightPanelToggled }, false, "setHasRightPanelToggled"),
-
-      setConversationMode: (conversationMode) => {
-        const conversationId = getConversationIdFromLocation();
-        if (conversationId) {
-          setConversationState(conversationId, { conversationMode });
-        }
-        set({ conversationMode }, false, "setConversationMode");
-      },
-
-      setSubConversationTaskId: (subConversationTaskId) =>
-        set({ subConversationTaskId }, false, "setSubConversationTaskId"),
-
-      setPlanContent: (planContent) =>
-        set({ planContent }, false, "setPlanContent"),
-    }),
-    {
-      name: "conversation-store",
+    setConversationMode: (conversationMode) => {
+      const scopedConversationId =
+        conversationId ?? getConversationIdFromLocation();
+      if (scopedConversationId) {
+        setConversationState(scopedConversationId, { conversationMode });
+      }
+      set({ conversationMode }, false, "setConversationMode");
     },
-  ),
+
+    setSubConversationTaskId: (subConversationTaskId) =>
+      set({ subConversationTaskId }, false, "setSubConversationTaskId"),
+
+    setPlanContent: (planContent) =>
+      set({ planContent }, false, "setPlanContent"),
+  });
+
+const conversationDevtoolsName = (conversationId?: string | null) =>
+  conversationId
+    ? `conversation-store-${conversationId}`
+    : "conversation-store";
+
+export function createConversationStore(
+  conversationId?: string | null,
+): ConversationStoreApi {
+  return createStore<ConversationStore>()(
+    devtools(createConversationState(conversationId), {
+      name: conversationDevtoolsName(conversationId),
+    }),
+  );
+}
+
+export const useConversationStore = create<ConversationStore>()(
+  devtools(createConversationState(), {
+    name: conversationDevtoolsName(),
+  }),
 );

--- a/src/stores/error-message-store.ts
+++ b/src/stores/error-message-store.ts
@@ -1,21 +1,22 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 
-interface ErrorMessageState {
+export interface ErrorMessageState {
   errorMessage: string | null;
 }
 
-interface ErrorMessageActions {
+export interface ErrorMessageActions {
   setErrorMessage: (message: string) => void;
   removeErrorMessage: () => void;
 }
 
-type ErrorMessageStore = ErrorMessageState & ErrorMessageActions;
+export type ErrorMessageStore = ErrorMessageState & ErrorMessageActions;
+export type ErrorMessageStoreApi = StoreApi<ErrorMessageStore>;
 
 const initialState: ErrorMessageState = {
   errorMessage: null,
 };
 
-export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
+const createErrorMessageState: StateCreator<ErrorMessageStore> = (set) => ({
   ...initialState,
 
   setErrorMessage: (message: string) =>
@@ -27,4 +28,11 @@ export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
     set(() => ({
       errorMessage: null,
     })),
-}));
+});
+
+export const createErrorMessageStore = (): ErrorMessageStoreApi =>
+  createStore<ErrorMessageStore>()(createErrorMessageState);
+
+export const useErrorMessageStore = create<ErrorMessageStore>()(
+  createErrorMessageState,
+);

--- a/src/stores/event-message-store.ts
+++ b/src/stores/event-message-store.ts
@@ -1,18 +1,20 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 
-interface EventMessageState {
-  submittedEventIds: number[]; // Avoid the flashing issue of the confirmation buttons
-  v1SubmittedEventIds: string[]; // V1 event IDs (V1 uses string IDs)
+export interface EventMessageState {
+  submittedEventIds: number[];
+  v1SubmittedEventIds: string[];
 }
 
-interface EventMessageStore extends EventMessageState {
+export interface EventMessageStore extends EventMessageState {
   addSubmittedEventId: (id: number) => void;
   removeSubmittedEventId: (id: number) => void;
   addV1SubmittedEventId: (id: string) => void;
   removeV1SubmittedEventId: (id: string) => void;
 }
 
-export const useEventMessageStore = create<EventMessageStore>((set) => ({
+export type EventMessageStoreApi = StoreApi<EventMessageStore>;
+
+const createEventMessageState: StateCreator<EventMessageStore> = (set) => ({
   submittedEventIds: [],
   v1SubmittedEventIds: [],
   addSubmittedEventId: (id: number) =>
@@ -35,4 +37,11 @@ export const useEventMessageStore = create<EventMessageStore>((set) => ({
         (eventId) => eventId !== id,
       ),
     })),
-}));
+});
+
+export const createEventMessageStore = (): EventMessageStoreApi =>
+  createStore<EventMessageStore>()(createEventMessageState);
+
+export const useEventMessageStore = create<EventMessageStore>()(
+  createEventMessageState,
+);

--- a/src/stores/metrics-store.ts
+++ b/src/stores/metrics-store.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 
 export interface MetricsState {
   cost: number | null;
@@ -17,11 +17,18 @@ export interface MetricsStore extends MetricsState {
   setMetrics: (metrics: MetricsState) => void;
 }
 
-const useMetricsStore = create<MetricsStore>((set) => ({
+export type MetricsStoreApi = StoreApi<MetricsStore>;
+
+const createMetricsState: StateCreator<MetricsStore> = (set) => ({
   cost: null,
   max_budget_per_task: null,
   usage: null,
   setMetrics: (metrics) => set(metrics),
-}));
+});
+
+export const createMetricsStore = (): MetricsStoreApi =>
+  createStore<MetricsStore>()(createMetricsState);
+
+const useMetricsStore = create<MetricsStore>()(createMetricsState);
 
 export default useMetricsStore;

--- a/src/stores/optimistic-user-message-store.ts
+++ b/src/stores/optimistic-user-message-store.ts
@@ -1,25 +1,26 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 
-interface OptimisticUserMessageState {
+export interface OptimisticUserMessageState {
   optimisticUserMessage: string | null;
 }
 
-interface OptimisticUserMessageActions {
+export interface OptimisticUserMessageActions {
   setOptimisticUserMessage: (message: string) => void;
   getOptimisticUserMessage: () => string | null;
   removeOptimisticUserMessage: () => void;
 }
 
-type OptimisticUserMessageStore = OptimisticUserMessageState &
+export type OptimisticUserMessageStore = OptimisticUserMessageState &
   OptimisticUserMessageActions;
+export type OptimisticUserMessageStoreApi =
+  StoreApi<OptimisticUserMessageStore>;
 
-const initialState: OptimisticUserMessageState = {
-  optimisticUserMessage: null,
-};
-
-export const useOptimisticUserMessageStore = create<OptimisticUserMessageStore>(
+const createOptimisticUserMessageState =
+  (
+    initialMessage: string | null = null,
+  ): StateCreator<OptimisticUserMessageStore> =>
   (set, get) => ({
-    ...initialState,
+    optimisticUserMessage: initialMessage,
 
     setOptimisticUserMessage: (message: string) =>
       set(() => ({
@@ -32,5 +33,14 @@ export const useOptimisticUserMessageStore = create<OptimisticUserMessageStore>(
       set(() => ({
         optimisticUserMessage: null,
       })),
-  }),
-);
+  });
+
+export const createOptimisticUserMessageStore = (
+  initialMessage: string | null = null,
+): OptimisticUserMessageStoreApi =>
+  createStore<OptimisticUserMessageStore>()(
+    createOptimisticUserMessageState(initialMessage),
+  );
+
+export const useOptimisticUserMessageStore =
+  create<OptimisticUserMessageStore>()(createOptimisticUserMessageState());

--- a/src/stores/security-analyzer-store.ts
+++ b/src/stores/security-analyzer-store.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 
 export enum ActionSecurityRisk {
   UNKNOWN = -1,
@@ -15,11 +15,11 @@ export type SecurityAnalyzerLog = {
   confirmed_changed: boolean;
 };
 
-interface SecurityAnalyzerState {
+export interface SecurityAnalyzerState {
   logs: SecurityAnalyzerLog[];
 }
 
-interface SecurityAnalyzerStore extends SecurityAnalyzerState {
+export interface SecurityAnalyzerStore extends SecurityAnalyzerState {
   appendSecurityAnalyzerInput: (message: {
     id: number;
     args: {
@@ -34,42 +34,51 @@ interface SecurityAnalyzerStore extends SecurityAnalyzerState {
   clearLogs: () => void;
 }
 
+export type SecurityAnalyzerStoreApi = StoreApi<SecurityAnalyzerStore>;
+
 const initialLogs: SecurityAnalyzerLog[] = [];
 
-export const useSecurityAnalyzerStore = create<SecurityAnalyzerStore>(
-  (set) => ({
-    logs: initialLogs,
-    appendSecurityAnalyzerInput: (message) =>
-      set((state) => {
-        const log: SecurityAnalyzerLog = {
-          id: message.id,
-          content:
-            message.args.command ||
-            message.args.code ||
-            message.args.content ||
-            message.message ||
-            "",
-          security_risk: message.args.security_risk,
-          confirmation_state: message.args.confirmation_state,
-          confirmed_changed: false,
-        };
+const createSecurityAnalyzerState: StateCreator<SecurityAnalyzerStore> = (
+  set,
+) => ({
+  logs: initialLogs,
+  appendSecurityAnalyzerInput: (message) =>
+    set((state) => {
+      const log: SecurityAnalyzerLog = {
+        id: message.id,
+        content:
+          message.args.command ||
+          message.args.code ||
+          message.args.content ||
+          message.message ||
+          "",
+        security_risk: message.args.security_risk,
+        confirmation_state: message.args.confirmation_state,
+        confirmed_changed: false,
+      };
 
-        const existingLog = state.logs.find(
-          (stateLog) =>
-            stateLog.id === log.id ||
-            (stateLog.confirmation_state === "awaiting_confirmation" &&
-              stateLog.content === log.content),
-        );
+      const existingLog = state.logs.find(
+        (stateLog) =>
+          stateLog.id === log.id ||
+          (stateLog.confirmation_state === "awaiting_confirmation" &&
+            stateLog.content === log.content),
+      );
 
-        if (existingLog) {
-          if (existingLog.confirmation_state !== log.confirmation_state) {
-            existingLog.confirmation_state = log.confirmation_state;
-            existingLog.confirmed_changed = true;
-          }
-          return { logs: [...state.logs] }; // Return new array to trigger re-render
+      if (existingLog) {
+        if (existingLog.confirmation_state !== log.confirmation_state) {
+          existingLog.confirmation_state = log.confirmation_state;
+          existingLog.confirmed_changed = true;
         }
-        return { logs: [...state.logs, log] };
-      }),
-    clearLogs: () => set({ logs: initialLogs }),
-  }),
+        return { logs: [...state.logs] };
+      }
+      return { logs: [...state.logs, log] };
+    }),
+  clearLogs: () => set({ logs: initialLogs }),
+});
+
+export const createSecurityAnalyzerStore = (): SecurityAnalyzerStoreApi =>
+  createStore<SecurityAnalyzerStore>()(createSecurityAnalyzerState);
+
+export const useSecurityAnalyzerStore = create<SecurityAnalyzerStore>(
+  createSecurityAnalyzerState,
 );

--- a/src/stores/status-store.ts
+++ b/src/stores/status-store.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 import { StatusMessage } from "#/types/message";
 
 const initialStatusMessage: StatusMessage = {
@@ -8,13 +8,20 @@ const initialStatusMessage: StatusMessage = {
   message: "",
 };
 
-interface StatusState {
+export interface StatusState {
   curStatusMessage: StatusMessage;
   setCurStatusMessage: (message: StatusMessage) => void;
 }
 
-export const useStatusStore = create<StatusState>((set) => ({
+export type StatusStoreApi = StoreApi<StatusState>;
+
+const createStatusState: StateCreator<StatusState> = (set) => ({
   curStatusMessage: initialStatusMessage,
   setCurStatusMessage: (message: StatusMessage) =>
     set({ curStatusMessage: message }),
-}));
+});
+
+export const createStatusStore = (): StatusStoreApi =>
+  createStore<StatusState>()(createStatusState);
+
+export const useStatusStore = create<StatusState>()(createStatusState);

--- a/src/stores/use-event-store.ts
+++ b/src/stores/use-event-store.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 import { OpenHandsEvent } from "#/types/v1/core";
 import { handleEventForUI } from "#/utils/handle-event-for-ui";
 import { OpenHandsParsedEvent } from "#/types/core";
@@ -58,7 +58,9 @@ export interface EventState {
   clearEvents: () => void;
 }
 
-export const useEventStore = create<EventState>()((set) => ({
+export type EventStoreApi = StoreApi<EventState>;
+
+const createEventState: StateCreator<EventState> = (set) => ({
   events: [],
   eventIds: new Set(),
   uiEvents: [],
@@ -103,4 +105,9 @@ export const useEventStore = create<EventState>()((set) => ({
       eventIds: new Set(),
       uiEvents: [],
     })),
-}));
+});
+
+export const createEventStore = (): EventStoreApi =>
+  createStore<EventState>()(createEventState);
+
+export const useEventStore = create<EventState>()(createEventState);

--- a/src/stores/v1-conversation-state-store.ts
+++ b/src/stores/v1-conversation-state-store.ts
@@ -1,7 +1,7 @@
-import { create } from "zustand";
+import { create, createStore, type StateCreator, type StoreApi } from "zustand";
 import { V1ExecutionStatus } from "#/types/v1/core/base/common";
 
-interface V1ConversationStateStore {
+export interface V1ConversationStateStore {
   execution_status: V1ExecutionStatus | null;
 
   /**
@@ -15,13 +15,22 @@ interface V1ConversationStateStore {
   reset: () => void;
 }
 
+export type V1ConversationStateStoreApi = StoreApi<V1ConversationStateStore>;
+
+const createV1ConversationState: StateCreator<V1ConversationStateStore> = (
+  set,
+) => ({
+  execution_status: null,
+
+  setExecutionStatus: (execution_status: V1ExecutionStatus) =>
+    set({ execution_status }),
+
+  reset: () => set({ execution_status: null }),
+});
+
+export const createV1ConversationStateStore = (): V1ConversationStateStoreApi =>
+  createStore<V1ConversationStateStore>()(createV1ConversationState);
+
 export const useV1ConversationStateStore = create<V1ConversationStateStore>(
-  (set) => ({
-    execution_status: null,
-
-    setExecutionStatus: (execution_status: V1ExecutionStatus) =>
-      set({ execution_status }),
-
-    reset: () => set({ execution_status: null }),
-  }),
+  createV1ConversationState,
 );


### PR DESCRIPTION
## Summary
- Add `ConversationProvider` and `useConversationContext`-backed hooks that create per-conversation Zustand store instances.
- Convert conversation UI/hooks/routes/websocket handling to use scoped context hooks instead of importing global store singletons directly.
- Keep home/settings/shared global stores routed through a separate global hook barrel.
- Add regression coverage that verifies two `ConversationProvider` instances do not share store state.

Fixes #9.

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9324fdb5-2ee3-4073-b5e3-1a702bc7c040)