### PR TITLE
fix(frontend): default v1 conversation title

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { buildStartConversationRequest } from "#/api/agent-server-adapter";
+import {
+  buildStartConversationRequest,
+  getDefaultConversationTitle,
+  toV1AppConversation,
+  type DirectConversationInfo,
+} from "#/api/agent-server-adapter";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 
 const { mockGetAgentServerWorkingDir } = vi.hoisted(() => ({
@@ -168,5 +173,49 @@ describe("buildStartConversationRequest", () => {
       role: "user",
       content: [{ type: "text", text: "Follow the repo conventions." }],
     });
+  });
+});
+
+describe("getDefaultConversationTitle", () => {
+  it("formats the title using the first 5 characters of the conversation id", () => {
+    expect(getDefaultConversationTitle("372eb-1234-5678-9abc")).toBe(
+      "Conversation 372eb",
+    );
+  });
+});
+
+describe("toV1AppConversation", () => {
+  const baseInfo: DirectConversationInfo = {
+    id: "372eb-1234-5678-9abc",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+
+  it("falls back to the default title when the backend returns null", () => {
+    const result = toV1AppConversation({ ...baseInfo, title: null });
+    expect(result.title).toBe("Conversation 372eb");
+  });
+
+  it("falls back to the default title when the backend returns undefined", () => {
+    const result = toV1AppConversation({ ...baseInfo });
+    expect(result.title).toBe("Conversation 372eb");
+  });
+
+  it("falls back to the default title when the backend returns an empty string", () => {
+    const result = toV1AppConversation({ ...baseInfo, title: "" });
+    expect(result.title).toBe("Conversation 372eb");
+  });
+
+  it("falls back to the default title when the backend returns whitespace only", () => {
+    const result = toV1AppConversation({ ...baseInfo, title: "   " });
+    expect(result.title).toBe("Conversation 372eb");
+  });
+
+  it("preserves a backend-provided title when one is set", () => {
+    const result = toV1AppConversation({
+      ...baseInfo,
+      title: "My real title",
+    });
+    expect(result.title).toBe("My real title");
   });
 });

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -55,6 +55,13 @@ export function toConversationUrl(conversationId: string): string {
   return `${getAgentServerBaseUrl()}/api/conversations/${conversationId}`;
 }
 
+// TODO(i18n): extract "Conversation" once we add CONVERSATION$DEFAULT_TITLE
+// with `{{shortId}}` interpolation. Kept as a literal for now to keep the
+// fallback inside this pure adapter rather than fanning out to display sites.
+export function getDefaultConversationTitle(conversationId: string): string {
+  return `Conversation ${conversationId.slice(0, 5)}`;
+}
+
 export function toV1AppConversation(
   info: DirectConversationInfo,
 ): V1AppConversation {
@@ -64,7 +71,7 @@ export function toV1AppConversation(
     selected_repository: null,
     selected_branch: null,
     git_provider: null,
-    title: info.title ?? null,
+    title: info.title?.trim() ? info.title : getDefaultConversationTitle(info.id),
     trigger: null,
     pr_number: [],
     llm_model: info.agent?.llm?.model ?? DEFAULT_SETTINGS.llm_model,

--- a/src/api/conversation-service/v1-conversation-service.api.ts
+++ b/src/api/conversation-service/v1-conversation-service.api.ts
@@ -10,6 +10,7 @@ import {
   buildStartConversationRequest,
   downloadTextFile,
   emptyHooksResponse,
+  getDefaultConversationTitle,
   loadSkillsForConversation,
   toV1AppConversation,
   toV1ConversationPage,
@@ -259,7 +260,7 @@ class V1ConversationService {
 
     return {
       id: data.id,
-      title: data.title ?? null,
+      title: data.title?.trim() ? data.title : getDefaultConversationTitle(data.id),
       metrics: data.metrics
         ? {
             accumulated_cost: data.metrics.accumulated_cost ?? null,


### PR DESCRIPTION
### Description

When a user creates a new v1 conversation from the home page and opens it, the conversation title is empty everywhere it is rendered: the conversation header, the recent‑conversations card, the browser tab, the rename input default value, and the delete‑confirmation modal.

The backend's `AutoTitleSubscriber` only generates a title asynchronously after the first user `MessageEvent` is processed, so a freshly created (and untouched) conversation can sit at `title = null` indefinitely. The frontend renders the value through with no fallback.

### Steps to reproduce

1. Navigate to the home page.
2. Click **New Conversation**.
3. Open the newly created conversation.

### Current behaviour

- Conversation title is empty in the header, the home‑page "Recent" card, the browser tab title, and the rename input.

### Expected behaviour

- The title defaults to `Conversation <first 5 chars of conversation ID>` (e.g. `Conversation 372eb`).
- When the user renames the conversation, the user‑set title takes over.
- When the backend's `AutoTitleSubscriber` later writes a generated title, that title takes over (the existing 30‑second polling already picks this up).

### Summary

- New v1 conversations now show `Conversation <first 5 chars of id>` (e.g. `Conversation 372eb`) instead of an empty title in the header, recent‑conversations card, browser tab, rename input default, and delete‑confirmation modal.
- The fallback lives in the central `toV1AppConversation` adapter (and `getRuntimeConversation` for symmetry), so every consumer of `V1AppConversation` benefits without per‑site edits. Non‑empty backend titles — both user renames and `AutoTitleSubscriber`‑generated titles — continue to pass through unchanged.
- Internationalising the literal "Conversation" is intentionally deferred; a `TODO(i18n)` marks the migration point so we can extract `CONVERSATION$DEFAULT_TITLE` with `{{shortId}}` interpolation later without expanding this PR's blast radius.

### Root cause

`buildStartConversationRequest` does not send a `title`, and the backend `StartConversationRequest` does not accept one. The backend stores `title: None` and only generates one asynchronously after the first user `MessageEvent` (`AutoTitleSubscriber`). `GET /api/conversations/{id}` therefore returns `title: null` for fresh conversations, the adapter passes the null through (`title: info.title ?? null`), and every UI consumer renders empty.

### Changes

- `src/api/agent-server-adapter.ts` — add `getDefaultConversationTitle(id)`; replace `title: info.title ?? null` with `title: info.title?.trim() ? info.title : getDefaultConversationTitle(info.id)`.
- `src/api/conversation-service/v1-conversation-service.api.ts` — apply the same fallback inside `getRuntimeConversation` for consistency.
- `__tests__/api/agent-server-adapter.test.ts` — add `getDefaultConversationTitle` and `toV1AppConversation` test blocks covering null / undefined / empty / whitespace / non‑empty cases.

Resolves #87