### PR TITLE
feat(frontend): run OpenVSCode Server in Docker for npm run dev

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,11 +1,26 @@
 # OpenHands Agent Server target
 # These defaults assume you are manually pointing the frontend at a backend on
 # 127.0.0.1:8000. The recommended local workflow is `npm run dev`, which starts
-# an isolated local backend for this checkout. Use `npm run dev:frontend` only
-# when you intentionally want to point at a separately managed backend.
+# an isolated local backend for this checkout AND a Docker container running
+# OpenVSCode Server (since gitpod-io publishes no native macOS binary). The
+# script auto-generates a shared dev token persisted at
+# <state_dir>/.dev-vscode-token and propagates it to the agent-server
+# (OH_SESSION_API_KEYS_0), the frontend (VITE_SESSION_API_KEY), and the
+# container (--connection-token). Docker Desktop must be running.
+#
+# Expected log line under this setup:
+#   "VSCode server binary not found, VSCode will be disabled"
+# That warning is benign — the agent-server's local binary check fails on
+# macOS by design; the Code tab is served by the Docker container, and
+# /api/vscode/url still returns a working URL because the connection token is
+# injected via OH_SESSION_API_KEYS_0.
+#
+# Use `npm run dev:frontend` only when you intentionally want to point at a
+# separately managed backend.
 VITE_BACKEND_HOST="127.0.0.1:8000" # Host:port used by the Vite dev proxy
 VITE_BACKEND_BASE_URL="http://127.0.0.1:8000" # Base URL used by browser-side direct requests
-# VITE_SESSION_API_KEY="" # Set to the same value as backend SESSION_API_KEY or OH_SESSION_API_KEYS_0 when auth is enabled
+# VITE_SESSION_API_KEY="" # Set to the same value as backend SESSION_API_KEY or OH_SESSION_API_KEYS_0 when auth is enabled. `npm run dev` sets this automatically; only needed manually for `npm run dev:frontend` against an external backend.
+# VITE_VSCODE_BASE_URL="http://localhost:8001" # Browser-reachable URL of openvscode-server. Required when VS Code is on a different port/host than the GUI (e.g. local dev or Docker). `npm run dev` sets this automatically. Falls back to window.location.origin (correct only for path-based-routing prod deploys).
 # VITE_WORKING_DIR="/workspace/project/agent-server-gui" # Base dir for per-conversation working_dirs. Each conversation's working_dir is <VITE_WORKING_DIR>/<id_hex>. Defaults to <OH_GUI_SAFE_STATE_DIR>/workspaces, which is the sibling of the agent server's <state_dir>/conversations/ persistence dir — both share the same <id_hex> per conversation.
 # VITE_WORKER_URLS="" # Optional comma-separated worker URLs for the Browser tab
 # VITE_ENABLE_BROWSER_TOOLS="true" # Set to false to omit BrowserToolSet from new conversations
@@ -19,7 +34,8 @@ VITE_INSECURE_SKIP_VERIFY="false" # Skip TLS certificate verification for proxie
 VITE_MOCK_API="false" # Enable/disable API mocking with MSW
 # VITE_GITHUB_TOKEN="" # GitHub token for repository access (used in some tests)
 
-# `npm run dev` (scripts/dev-safe.mjs) — isolated local backend
+# `npm run dev` (scripts/dev-safe.mjs) — isolated local backend + Dockerized VSCode
 # OH_GUI_SAFE_BACKEND_PORT="18000" # Port the spawned agent-server listens on
-# OH_GUI_SAFE_VSCODE_PORT="18001" # Port forwarded to the embedded VS Code (defaults to backend port + 1)
-# OH_GUI_SAFE_STATE_DIR="$HOME/.openhands/agent-server-gui" # Where conversations, tmux sockets, and bash events are stored
+# OH_GUI_SAFE_VSCODE_PORT="18001" # Host port forwarded to the VSCode container (defaults to backend port + 1)
+# OH_GUI_SAFE_STATE_DIR="$HOME/.openhands/agent-server-gui" # Where conversations, tmux sockets, bash events, and the dev VSCode token are stored. On macOS keep this under your home dir so Docker Desktop file sharing can see it.
+# OH_GUI_DISABLE_VSCODE_DOCKER="" # Set to 1 to skip the VSCode Docker container entirely (the Code tab will be unavailable). Useful on Linux where openvscode-server is installed natively, or for debugging without Docker. NOTE: if openvscode-server is on PATH the agent-server will try to bind OH_VSCODE_PORT itself; either uninstall the local binary or change the port.

--- a/__tests__/api/v1-conversation-service.test.ts
+++ b/__tests__/api/v1-conversation-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import V1ConversationService from "#/api/conversation-service/v1-conversation-service.api";
+import { getVSCodeBaseUrl } from "#/api/agent-server-config";
 
 const {
   mockHttpGet,
@@ -8,6 +9,7 @@ const {
   mockCreateHttpClient,
   mockCreateRemoteWorkspace,
   mockGetSettings,
+  mockCreateVSCodeClient,
 } = vi.hoisted(() => ({
   mockHttpGet: vi.fn(),
   mockHttpPost: vi.fn(),
@@ -15,12 +17,13 @@ const {
   mockCreateHttpClient: vi.fn(),
   mockCreateRemoteWorkspace: vi.fn(),
   mockGetSettings: vi.fn(),
+  mockCreateVSCodeClient: vi.fn(),
 }));
 
 vi.mock("#/api/typescript-client", () => ({
   createHttpClient: mockCreateHttpClient,
   createRemoteWorkspace: mockCreateRemoteWorkspace,
-  createVSCodeClient: vi.fn(),
+  createVSCodeClient: mockCreateVSCodeClient,
 }));
 
 vi.mock("#/api/agent-server-config", () => ({
@@ -32,6 +35,7 @@ vi.mock("#/api/agent-server-config", () => ({
     (id: string) => `/state/workspaces/${id.replace(/-/g, "")}`,
   ),
   getConfiguredWorkerUrls: vi.fn(() => []),
+  getVSCodeBaseUrl: vi.fn(() => undefined),
 }));
 
 vi.mock("#/api/settings-service/settings-service.api", () => ({
@@ -190,6 +194,46 @@ describe("V1ConversationService", () => {
       expect(mockCreateRemoteWorkspace).toHaveBeenCalledWith({
         sessionApiKey: "my-session-key",
       });
+    });
+  });
+
+  describe("getVSCodeUrl", () => {
+    // Regression: previously the GUI passed window.location.origin (port 3001
+    // in dev), so the backend returned an URL pointing at the GUI itself
+    // instead of openvscode-server (port 8001). The fix routes the baseUrl
+    // through getVSCodeBaseUrl(), which honors VITE_VSCODE_BASE_URL.
+    it("forwards the configured VS Code base URL to the typescript client", async () => {
+      // Arrange
+      const mockGetUrl = vi.fn().mockResolvedValue("http://localhost:8001/?tkn=abc");
+      mockCreateVSCodeClient.mockReturnValue({ getUrl: mockGetUrl });
+      vi.mocked(getVSCodeBaseUrl).mockReturnValue("http://localhost:8001");
+      mockHttpGet.mockResolvedValue({
+        data: [
+          {
+            id: "conv-123",
+            created_at: "2024-01-01",
+            updated_at: "2024-01-01",
+            workspace: { working_dir: "/workspace/agent-server-gui/conv-123" },
+          },
+        ],
+      });
+
+      // Act
+      const result = await V1ConversationService.getVSCodeUrl(
+        "conv-123",
+        null,
+        "test-api-key",
+      );
+
+      // Assert
+      expect(mockCreateVSCodeClient).toHaveBeenCalledWith({
+        sessionApiKey: "test-api-key",
+      });
+      expect(mockGetUrl).toHaveBeenCalledWith({
+        baseUrl: "http://localhost:8001",
+        workspaceDir: "/workspace/agent-server-gui/conv-123",
+      });
+      expect(result.vscode_url).toBe("http://localhost:8001/?tkn=abc");
     });
   });
 });

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -62,6 +62,22 @@ describe("buildSafeDevConfig", () => {
     expect(config.bashEventsDir).toBe(
       path.join(config.stateDir, "bash_events"),
     );
+    expect(config.tokenFile).toBe(
+      path.join(config.stateDir, ".dev-vscode-token"),
+    );
+    expect(config.composeFile).toBe(path.join(cwd, "docker-compose.dev.yml"));
+    expect(config.disableVscodeDocker).toBe(false);
+    if (process.platform !== "win32") {
+      expect(typeof config.hostUid).toBe("number");
+      expect(typeof config.hostGid).toBe("number");
+    }
+  });
+
+  it("disables the VSCode docker preflight when OH_GUI_DISABLE_VSCODE_DOCKER is set", () => {
+    const config = buildSafeDevConfig("/workspace/project/agent-server-gui", {
+      OH_GUI_DISABLE_VSCODE_DOCKER: "1",
+    });
+    expect(config.disableVscodeDocker).toBe(true);
   });
 
   it("honors environment overrides", () => {
@@ -142,6 +158,9 @@ describe("dev-safe CLI startup", () => {
       env: {
         ...process.env,
         PATH: "/usr/bin:/bin",
+        // Skip the Docker preflight so this test continues to exercise the
+        // agent-server-missing path even when docker isn't on PATH.
+        OH_GUI_DISABLE_VSCODE_DOCKER: "1",
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -179,5 +198,46 @@ describe("dev-safe CLI startup", () => {
     expect(output).toContain("README.md");
     expect(output).toContain("npm run dev:mock");
     expect(output).toContain("spawn agent-server ENOENT");
+  });
+
+  it("fails fast with Docker guidance when docker is unavailable", async () => {
+    const child = spawn(process.execPath, ["scripts/dev-safe.mjs"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        // No OH_GUI_DISABLE_VSCODE_DOCKER → preflight runs.
+        // Empty PATH ensures `docker` cannot be found.
+        PATH: "/usr/bin:/bin",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+
+    const exitResult = await Promise.race([
+      once(child, "exit").then(([code, signal]) => ({
+        code,
+        signal,
+        timedOut: false,
+      })),
+      delay(4_000).then(() => ({ code: null, signal: null, timedOut: true })),
+    ]);
+
+    if (exitResult.timedOut) {
+      child.kill("SIGKILL");
+    }
+
+    expect(exitResult.timedOut).toBe(false);
+    expect(exitResult.code).toBe(1);
+    expect(output).toContain("Docker Desktop is required");
+    expect(output).toContain("OH_GUI_DISABLE_VSCODE_DOCKER");
+    // Must fail before attempting to spawn agent-server.
+    expect(output).not.toContain("spawn agent-server ENOENT");
   });
 });

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -206,8 +206,10 @@ describe("dev-safe CLI startup", () => {
       env: {
         ...process.env,
         // No OH_GUI_DISABLE_VSCODE_DOCKER → preflight runs.
-        // Empty PATH ensures `docker` cannot be found.
-        PATH: "/usr/bin:/bin",
+        // Use a PATH that definitely contains no `docker` binary so the
+        // preflight fails fast on every platform (CI Linux ships docker in
+        // /usr/bin, so "/usr/bin:/bin" would still find it).
+        PATH: "/__oh_gui_dev_safe_no_docker__",
       },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,25 @@
+name: "agent-server-gui-${OH_GUI_SAFE_BACKEND_PORT:-18000}"
+
+services:
+  vscode:
+    image: gitpod/openvscode-server:1.98.2
+    container_name: "agent-server-gui-vscode-${OH_GUI_SAFE_BACKEND_PORT:-18000}"
+    restart: unless-stopped
+    ports:
+      - "${OH_GUI_SAFE_VSCODE_PORT:-18001}:3000"
+    volumes:
+      - "${OH_GUI_WORKSPACES_DIR}:${OH_GUI_WORKSPACES_DIR}"
+      - openvscode-server-data:/home/workspace/.openvscode-server
+    entrypoint:
+      - /home/.openvscode-server/bin/openvscode-server
+    command:
+      - --host
+      - 0.0.0.0
+      - --port
+      - "3000"
+      - --connection-token
+      - "${OH_VSCODE_DEV_TOKEN}"
+      - --disable-workspace-trust
+
+volumes:
+  openvscode-server-data:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
   "scripts": {
     "dev": "npm run dev:safe",
     "dev:safe": "node --env-file-if-exists=.env scripts/dev-safe.mjs",
+    "dev:vscode": "docker compose -f docker-compose.dev.yml up -d",
+    "dev:vscode:down": "docker compose -f docker-compose.dev.yml down",
     "dev:frontend": "npm run make-i18n && cross-env VITE_MOCK_API=false react-router dev",
     "dev:mock": "npm run make-i18n && cross-env VITE_MOCK_API=true react-router dev",
     "build": "npm run build:app",

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -1,5 +1,6 @@
-import { spawn } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -8,6 +9,9 @@ import { pathToFileURL } from "node:url";
 
 const DEFAULT_BACKEND_PORT = 18000;
 const DEFAULT_WAIT_TIMEOUT_MS = 30_000;
+const DEV_TOKEN_FILENAME = ".dev-vscode-token";
+const DEV_TOKEN_BYTES = 32;
+const COMPOSE_FILE = "docker-compose.dev.yml";
 
 function isEnoentError(error) {
   return Boolean(
@@ -42,6 +46,17 @@ export function formatMissingAgentServerGuidance(cwd = process.cwd()) {
   ].join("\n");
 }
 
+export function formatMissingDockerGuidance() {
+  return [
+    "Docker Desktop is required for `npm run dev` (it provides the VSCode Server container).",
+    "",
+    "To fix this:",
+    "- Start Docker Desktop and re-run `npm run dev`.",
+    "- Or set OH_GUI_DISABLE_VSCODE_DOCKER=1 to skip Docker (the Code tab will be unavailable).",
+    "- Or run `npm run dev:frontend` against a separately managed backend.",
+  ].join("\n");
+}
+
 function parsePort(value, fallback) {
   if (value == null || value === "") {
     return fallback;
@@ -53,6 +68,11 @@ function parsePort(value, fallback) {
   }
 
   return parsed;
+}
+
+function parseBoolean(value) {
+  if (value == null || value === "") return false;
+  return /^(1|true|yes|on)$/i.test(String(value));
 }
 
 export function buildSafeDevConfig(cwd = process.cwd(), env = process.env) {
@@ -68,6 +88,10 @@ export function buildSafeDevConfig(cwd = process.cwd(), env = process.env) {
   );
   const conversationsPath = path.join(stateDir, "conversations");
   const workspacesPath = path.join(stateDir, "workspaces");
+  const hostUid =
+    typeof process.getuid === "function" ? process.getuid() : null;
+  const hostGid =
+    typeof process.getgid === "function" ? process.getgid() : null;
 
   return {
     cwd,
@@ -81,6 +105,11 @@ export function buildSafeDevConfig(cwd = process.cwd(), env = process.env) {
     backendBaseUrl: `http://127.0.0.1:${backendPort}`,
     backendHost: `127.0.0.1:${backendPort}`,
     workingDir: env.VITE_WORKING_DIR || workspacesPath,
+    tokenFile: path.join(stateDir, DEV_TOKEN_FILENAME),
+    composeFile: path.join(cwd, COMPOSE_FILE),
+    hostUid,
+    hostGid,
+    disableVscodeDocker: parseBoolean(env.OH_GUI_DISABLE_VSCODE_DOCKER),
   };
 }
 
@@ -110,12 +139,12 @@ export function buildNpmScriptCommand(
   };
 }
 
-async function waitForServer(url, timeoutMs = DEFAULT_WAIT_TIMEOUT_MS) {
+async function waitForServer(url, timeoutMs = DEFAULT_WAIT_TIMEOUT_MS, headers) {
   const startedAt = Date.now();
 
   while (Date.now() - startedAt < timeoutMs) {
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { headers });
       if (response.ok) {
         return;
       }
@@ -147,6 +176,59 @@ function spawnProcess(command, args, options) {
   return child;
 }
 
+function readOrCreateDevToken(tokenFile) {
+  try {
+    const raw = readFileSync(tokenFile, "utf8").trim();
+    if (/^[0-9a-f]{64,}$/i.test(raw)) {
+      return raw;
+    }
+  } catch (error) {
+    if (!isEnoentError(error)) {
+      throw error;
+    }
+  }
+
+  const token = randomBytes(DEV_TOKEN_BYTES).toString("hex");
+  writeFileSync(tokenFile, `${token}\n`, { mode: 0o600 });
+  return token;
+}
+
+function checkDockerAvailable() {
+  const result = spawnSync("docker", ["info"], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  if (result.error || result.status !== 0) {
+    return {
+      ok: false,
+      message:
+        result.error?.message ||
+        (result.stderr ? result.stderr.toString().trim() : "docker info failed"),
+    };
+  }
+  return { ok: true };
+}
+
+function runComposeCommand(args, config, env, options = {}) {
+  const composeArgs = ["compose", "-f", config.composeFile, ...args];
+  return spawnSync("docker", composeArgs, {
+    cwd: config.cwd,
+    env,
+    stdio: options.silent ? "pipe" : "inherit",
+  });
+}
+
+function buildComposeEnv(config, token) {
+  return {
+    ...process.env,
+    OH_GUI_SAFE_BACKEND_PORT: String(config.backendPort),
+    OH_GUI_SAFE_VSCODE_PORT: String(config.vscodePort),
+    OH_GUI_HOST_UID: config.hostUid != null ? String(config.hostUid) : "0",
+    OH_GUI_HOST_GID: config.hostGid != null ? String(config.hostGid) : "0",
+    OH_GUI_WORKSPACES_DIR: config.workspacesPath,
+    OH_VSCODE_DEV_TOKEN: token,
+  };
+}
+
 async function main() {
   const config = buildSafeDevConfig();
 
@@ -160,30 +242,120 @@ async function main() {
     mkdirSync(dir, { recursive: true });
   }
 
+  if (
+    process.platform === "darwin" &&
+    !config.disableVscodeDocker &&
+    !config.stateDir.startsWith(homedir() + path.sep) &&
+    config.stateDir !== homedir()
+  ) {
+    console.warn(
+      `[dev-safe] OH_GUI_SAFE_STATE_DIR (${config.stateDir}) is outside ${homedir()}.`,
+    );
+    console.warn(
+      "[dev-safe] Docker Desktop for Mac may not see this path; the Code tab can fail.",
+    );
+    console.warn(
+      "[dev-safe] Add the path to Docker Desktop > Settings > Resources > File Sharing, or move it under your home directory.",
+    );
+  }
+
+  let token = null;
+  let composeStarted = false;
+
+  if (!config.disableVscodeDocker) {
+    const dockerCheck = checkDockerAvailable();
+    if (!dockerCheck.ok) {
+      console.error(formatMissingDockerGuidance());
+      if (dockerCheck.message) {
+        console.error(`(docker info: ${dockerCheck.message})`);
+      }
+      process.exit(1);
+    }
+
+    token = readOrCreateDevToken(config.tokenFile);
+    try {
+      const stat = statSync(config.tokenFile);
+      if ((stat.mode & 0o077) !== 0) {
+        // Tighten perms if a previous version wrote them more permissively.
+        writeFileSync(config.tokenFile, `${token}\n`, { mode: 0o600 });
+      }
+    } catch {
+      // Already created above; ignore.
+    }
+
+    const composeEnv = buildComposeEnv(config, token);
+    const upResult = runComposeCommand(
+      ["up", "-d", "--wait"],
+      config,
+      composeEnv,
+    );
+    if (upResult.error || upResult.status !== 0) {
+      console.error(
+        "[dev-safe] Failed to start the VSCode Server container via docker compose.",
+      );
+      if (upResult.error) {
+        console.error(upResult.error.message);
+      }
+      process.exit(upResult.status ?? 1);
+    }
+    composeStarted = true;
+  }
+
   console.log("Starting isolated agent-server + frontend dev stack...");
   console.log(`- backend: ${config.backendBaseUrl}`);
   console.log(`- vscode port: ${config.vscodePort}`);
   console.log(`- working dir: ${config.workingDir}`);
   console.log(`- isolated state dir: ${config.stateDir}`);
+  if (composeStarted) {
+    console.log(`- vscode container: agent-server-gui-vscode-${config.backendPort}`);
+  } else {
+    console.log("- vscode container: disabled (OH_GUI_DISABLE_VSCODE_DOCKER set)");
+  }
   console.log("");
+
+  const backendEnv = {
+    ...process.env,
+    TMUX_TMPDIR: config.tmuxTmpDir,
+    OH_CONVERSATIONS_PATH: config.conversationsPath,
+    OH_BASH_EVENTS_DIR: config.bashEventsDir,
+    OH_VSCODE_PORT: String(config.vscodePort),
+  };
+  if (token) {
+    backendEnv.OH_SESSION_API_KEYS_0 = token;
+  }
 
   const backend = spawnProcess(
     "agent-server",
     ["--host", "127.0.0.1", "--port", String(config.backendPort)],
     {
       cwd: config.cwd,
-      env: {
-        ...process.env,
-        TMUX_TMPDIR: config.tmuxTmpDir,
-        OH_CONVERSATIONS_PATH: config.conversationsPath,
-        OH_BASH_EVENTS_DIR: config.bashEventsDir,
-        OH_VSCODE_PORT: String(config.vscodePort),
-      },
+      env: backendEnv,
     },
   );
 
   let shuttingDown = false;
   let frontend = null;
+
+  const composeDown = () => {
+    if (!composeStarted) return;
+    try {
+      const result = runComposeCommand(
+        ["down"],
+        config,
+        buildComposeEnv(config, token ?? ""),
+        { silent: true },
+      );
+      if (result.error) {
+        console.warn(
+          `[dev-safe] docker compose down failed: ${result.error.message}`,
+        );
+      }
+    } catch (error) {
+      console.warn(
+        `[dev-safe] docker compose down failed: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+  };
 
   const shutdown = (signal = "SIGTERM") => {
     if (shuttingDown) {
@@ -193,6 +365,7 @@ async function main() {
     shuttingDown = true;
     frontend?.kill(signal);
     backend.kill(signal);
+    composeDown();
   };
 
   process.on("SIGINT", () => shutdown("SIGINT"));
@@ -214,8 +387,9 @@ async function main() {
   });
 
   try {
+    const waitHeaders = token ? { "X-Session-API-Key": token } : undefined;
     await Promise.race([
-      waitForServer(`${config.backendBaseUrl}/server_info`),
+      waitForServer(`${config.backendBaseUrl}/server_info`, undefined, waitHeaders),
       backendErrored,
       backendExited,
     ]);
@@ -225,14 +399,20 @@ async function main() {
   }
 
   const frontendCommand = buildNpmScriptCommand("dev:frontend");
+  const frontendEnv = {
+    ...process.env,
+    VITE_BACKEND_HOST: config.backendHost,
+    VITE_BACKEND_BASE_URL: config.backendBaseUrl,
+    VITE_WORKING_DIR: config.workingDir,
+  };
+  if (token) {
+    frontendEnv.VITE_SESSION_API_KEY = token;
+    frontendEnv.VITE_VSCODE_BASE_URL = `http://localhost:${config.vscodePort}`;
+  }
+
   frontend = spawnProcess(frontendCommand.command, frontendCommand.args, {
     cwd: config.cwd,
-    env: {
-      ...process.env,
-      VITE_BACKEND_HOST: config.backendHost,
-      VITE_BACKEND_BASE_URL: config.backendBaseUrl,
-      VITE_WORKING_DIR: config.workingDir,
-    },
+    env: frontendEnv,
   });
 
   frontend.once("exit", (code) => {

--- a/src/api/agent-server-config.ts
+++ b/src/api/agent-server-config.ts
@@ -157,6 +157,15 @@ export function getAgentServerWorkingDir(): string {
   return DEFAULT_WORKING_DIR;
 }
 
+export function getVSCodeBaseUrl(): string | undefined {
+  const envBaseUrl = import.meta.env.VITE_VSCODE_BASE_URL?.trim();
+  if (envBaseUrl) return envBaseUrl;
+
+  if (typeof window !== "undefined") return window.location.origin;
+
+  return undefined;
+}
+
 export function buildConversationWorkingDir(conversationId: string): string {
   const base = getAgentServerWorkingDir().replace(/\/+$/, "");
   const hex = conversationId.replace(/-/g, "");

--- a/src/api/conversation-service/conversation-service.api.ts
+++ b/src/api/conversation-service/conversation-service.api.ts
@@ -1,4 +1,7 @@
-import { getAgentServerWorkingDir } from "../agent-server-config";
+import {
+  getAgentServerWorkingDir,
+  getVSCodeBaseUrl,
+} from "../agent-server-config";
 import {
   GetVSCodeUrlResponse,
   GetTrajectoryResponse,
@@ -50,8 +53,7 @@ class ConversationService {
     const vscode_url = await createVSCodeClient(
       this.getClientOverrides(),
     ).getUrl({
-      baseUrl:
-        typeof window !== "undefined" ? window.location.origin : undefined,
+      baseUrl: getVSCodeBaseUrl(),
       workspaceDir,
     });
 

--- a/src/api/conversation-service/v1-conversation-service.api.ts
+++ b/src/api/conversation-service/v1-conversation-service.api.ts
@@ -4,6 +4,7 @@ import {
   buildConversationWorkingDir,
   getAgentServerBaseUrl,
   getAgentServerWorkingDir,
+  getVSCodeBaseUrl,
 } from "../agent-server-config";
 import {
   DirectConversationInfo,
@@ -112,8 +113,7 @@ class V1ConversationService {
     const workspaceDir =
       await this.resolveConversationWorkingDir(conversationId);
     const vscode_url = await createVSCodeClient({ sessionApiKey }).getUrl({
-      baseUrl:
-        typeof window !== "undefined" ? window.location.origin : undefined,
+      baseUrl: getVSCodeBaseUrl(),
       workspaceDir,
     });
 


### PR DESCRIPTION
### Description

Clicking the **Code** tab on a v1 conversation in local dev shows "VS Code URL not available" (or, with manual workarounds, a misrouted iframe that loads the GUI itself or "localhost refused to connect").

Three independent failures combined to break the flow on macOS:

1. The agent-server's `VSCodeService` hardcoded the OpenVSCode Server install to `/openhands/.openvscode-server`, a path that only exists inside the agent-server Docker image.
2. gitpod-io publishes no native macOS binary for OpenVSCode Server, so even with a configurable root there's no binary to point at on a Mac.
3. The frontend passed `window.location.origin` (port 3001 in dev) as the VSCode base URL, so even when the backend produced a token-bearing URL it pointed at the GUI itself.

### Goals

- `npm run dev` brings up frontend + agent-server (locally) + a containerized openvscode-server in a single command.
- The Code tab loads VS Code against the per-conversation working dir.
- Existing conversation state and workspace contents survive across restarts.
- No SDK forks: SDK gains a configurable server root + PATH fallback so it works in Docker, in this dev setup, and for any future host installation.

### Acceptance criteria

- On macOS with Docker Desktop running, `npm run dev` (no manual env tweaks) starts the stack; the Code tab in a v1 conversation loads VS Code in the iframe pointing at `localhost:18001`.
- `curl http://127.0.0.1:18000/server_info` requires the dev session API key (auth is now active by default in dev).
- A second checkout on a different `OH_GUI_SAFE_BACKEND_PORT` coexists without container-name collisions.
- Existing conversations in `~/.openhands/agent-server-gui/workspaces/<id>/` remain visible after the upgrade.
- Docker Desktop offline path: `npm run dev` exits with a clear message pointing at the `dev:frontend` and `OH_GUI_DISABLE_VSCODE_DOCKER` escape hatches.
- All existing tests still pass; new tests cover the SDK PATH fallback, the frontend base-URL plumbing, and the `dev-safe` Docker preflight.

### Summary

- Add `docker-compose.dev.yml` running gitpod/openvscode-server:1.98.2, with an identical-path bind mount of the workspaces dir, named volume for VS Code settings persistence, and a project name keyed on the backend port (for multi-checkout coexistence).
- Make `npm run dev` orchestrate the container: persist a 32-byte dev token at `<state_dir>/.dev-vscode-token`, preflight `docker info`, `docker compose up -d --wait` before the agent-server, and `compose down` on Ctrl+C.
- Plumb the same dev token to both the agent-server (`OH_SESSION_API_KEYS_0`) and the frontend (`VITE_SESSION_API_KEY` + `VITE_VSCODE_BASE_URL`) so the existing `/api/vscode/url` endpoint returns a URL that the browser can actually reach.
- Frontend: route `baseUrl` through a new `getVSCodeBaseUrl()` helper (honors `VITE_VSCODE_BASE_URL`, falls back to `window.location.origin` for path-based-routing prod deploys) in both v1 and v0 conversation services.
- `package.json`: `dev:vscode` and `dev:vscode:down` scripts for manual container control.
- `.env.sample`: documents the flow, the shared token, the benign "VSCode binary not found" warning, and the `OH_GUI_DISABLE_VSCODE_DOCKER` opt-out for Linux devs with a native install.

### Why

OpenVSCode Server ships Linux-only binaries, so the agent-server's local VS Code spawn never succeeds on macOS. Even after fixing that, the GUI passed `window.location.origin` (port 3001 in dev) as the VSCode base URL, so the iframe loaded the GUI itself instead of VS Code. This PR closes the gap end-to-end so the **Code** tab works on `npm run dev` without any manual env wiring.

The agent-server's existing constructor injection of `session_api_keys[0]` as the VS Code connection token (in the SDK)
means we do not need any SDK contract change beyond the `OH_VSCODE_SERVER_ROOT` + PATH-fallback fix that ships separately.

### Architecture

```
+---------------+        +-----------------+
|  Browser      |        |  agent-server   |
|  localhost:   | <----> |  (local, macOS) |
|  3001         |        |  127.0.0.1:18000|
+-------+-------+        +--------+--------+
        |                         |
        | iframe http://localhost:18001
        v
+---------------+      bind mount     +------------------+
|  Docker:      |  /Users/.../        |  macOS host      |
|  gitpod/      |  workspaces/        |  ~/.openhands/   |
|  openvscode-  | <-----------------> |  agent-server-   |
|  server:      |  identical paths    |  gui/workspaces/ |
|  1.98.2       |                     +------------------+
+---------------+
```

Both sides share the same connection token: `dev-safe.mjs` reads it from `<state_dir>/.dev-vscode-token`, passes it to the agent-server as `OH_SESSION_API_KEYS_0` (which the SDK injects into VSCodeService as the connection token) and to the container as `--connection-token <token>`.

### Behavior changes

- `npm run dev` now requires Docker Desktop. If Docker is not running, the script fails fast with `Docker Desktop is required for npm run dev` and points at `OH_GUI_DISABLE_VSCODE_DOCKER` and `npm run dev:frontend`.
- `npm run dev` enables session API key auth on the agent-server (since `OH_SESSION_API_KEYS_0` is now set). The frontend automatically uses the same key. Manual `curl` against the dev backend now needs an `X-Session-API-Key` header.
- The agent-server log line `VSCode server binary not found, VSCode will be disabled` is now expected on macOS — the URL is generated from the constructor-injected token, not from a local binary launch.

### Tests

- `__tests__/scripts/dev-safe.test.ts`: 10 cases (8 existing + 2 new).
  - New: `buildSafeDevConfig` exposes `tokenFile`, `composeFile`, `disableVscodeDocker`, `hostUid`, `hostGid`.
  - New: CLI fails fast with Docker guidance when `docker` is not on PATH (does not reach agent-server spawn).
  - Existing CLI test sets `OH_GUI_DISABLE_VSCODE_DOCKER=1` so it continues to exercise the agent-server-missing path.
- `__tests__/api/v1-conversation-service.test.ts`: new regression test that asserts `getVSCodeUrl` forwards `getVSCodeBaseUrl()` to the typescript-client (instead of `window.location.origin`).
- `npx tsc --noEmit` clean.

### Failure points addressed

| Risk | Mitigation |
| --- | --- |
| Token mismatch between agent-server and Docker | Single source of truth: `<state_dir>/.dev-vscode-token`, read once per run, propagated to both. |
| HTTP/websocket auth breaks because `OH_SESSION_API_KEYS_0` activates auth | Always sets `VITE_SESSION_API_KEY` to the same token. |
| Path mismatch host vs container | Identical absolute path bind mount. |
| Image entrypoint hardcodes `--without-connection-token` | Override `entrypoint:` to call the binary directly. |
| Image expects uid 1000 with `HOME=/home/workspace` | Run as the image's native user; Docker Desktop for Mac handles UID translation across bind mounts. |
| Multiple checkouts collide on container name | Compose `name:` and `container_name:` keyed on `OH_GUI_SAFE_BACKEND_PORT`. |
| Linux dev with native `openvscode-server` on PATH | Documented opt-out via `OH_GUI_DISABLE_VSCODE_DOCKER`. |
| State dir outside `$HOME` on darwin | Warn loudly (Docker Desktop file sharing won't see it). |

### Issue

Resolves #93 