### PR TITLE
feat(frontend): migrate folder browser to /api/file/search_subdirs

### DIFF
--- a/__tests__/components/features/home/workspace-selection-form.test.tsx
+++ b/__tests__/components/features/home/workspace-selection-form.test.tsx
@@ -83,23 +83,23 @@ describe("WorkspaceSelectionForm", () => {
 
   it("Add Workspaces opens Finder-like modal, navigates, and imports subfolders deduped on repeat", async () => {
     vi.spyOn(FilesService, "getHome").mockResolvedValue({ home: "/Users/me" });
-    const listSpy = vi
-      .spyOn(FilesService, "listSubdirs")
+    const searchSpy = vi
+      .spyOn(FilesService, "searchSubdirs")
       .mockImplementation(async (path: string) => {
         if (path === "/Users/me") {
           return {
-            path,
-            subdirs: [{ name: "dev", path: "/Users/me/dev" }],
+            items: [{ name: "dev", path: "/Users/me/dev" }],
+            next_page_id: null,
           };
         }
         if (path === "/Users/me/dev") {
           return {
-            path,
-            subdirs: [
+            items: [
               { name: "repo1", path: "/Users/me/dev/repo1" },
               { name: "repo2", path: "/Users/me/dev/repo2" },
               { name: "repo3", path: "/Users/me/dev/repo3" },
             ],
+            next_page_id: null,
           };
         }
         throw new Error(`unexpected path ${path}`);
@@ -141,7 +141,7 @@ describe("WorkspaceSelectionForm", () => {
       "/Users/me/dev/repo2",
       "/Users/me/dev/repo3",
     ]);
-    expect(listSpy).toHaveBeenCalledWith("/Users/me/dev");
+    expect(searchSpy).toHaveBeenCalledWith("/Users/me/dev");
   });
 
   it("Launch creates a v1 conversation with the selected workspace path as working_dir", async () => {

--- a/src/api/files-service/files-service.api.ts
+++ b/src/api/files-service/files-service.api.ts
@@ -5,20 +5,32 @@ export interface SubdirectoryEntry {
   path: string;
 }
 
-export interface ListSubdirsResponse {
-  path: string;
-  subdirs: SubdirectoryEntry[];
+export interface SubdirectoryPage {
+  items: SubdirectoryEntry[];
+  next_page_id: string | null;
 }
 
 export interface HomeResponse {
   home: string;
 }
 
+export interface SearchSubdirsOptions {
+  pageId?: string | null;
+  limit?: number;
+}
+
 const FilesService = {
-  async listSubdirs(path: string): Promise<ListSubdirsResponse> {
-    const response = await createHttpClient().get<ListSubdirsResponse>(
-      "/api/file/list_subdirs",
-      { params: { path } },
+  async searchSubdirs(
+    path: string,
+    options: SearchSubdirsOptions = {},
+  ): Promise<SubdirectoryPage> {
+    const params: Record<string, string | number> = { path };
+    if (options.pageId) params.page_id = options.pageId;
+    if (typeof options.limit === "number") params.limit = options.limit;
+
+    const response = await createHttpClient().get<SubdirectoryPage>(
+      "/api/file/search_subdirs",
+      { params },
     );
     return response.data;
   },

--- a/src/components/features/home/workspace-dropdown/folder-browser-modal.tsx
+++ b/src/components/features/home/workspace-dropdown/folder-browser-modal.tsx
@@ -7,8 +7,8 @@ import { I18nKey } from "#/i18n/declaration";
 import { LocalWorkspace } from "#/types/workspace";
 import {
   useHomeDirectory,
-  useListSubdirs,
-} from "#/hooks/query/use-list-subdirs";
+  useSearchSubdirs,
+} from "#/hooks/query/use-search-subdirs";
 import { cn } from "#/utils/utils";
 import FolderIcon from "#/icons/folder.svg?react";
 import ChevronLeft from "#/icons/chevron-left-small.svg?react";
@@ -122,7 +122,7 @@ export function FolderBrowserModal({
     isLoading,
     isError,
     error,
-  } = useListSubdirs(isOpen ? currentPath : null);
+  } = useSearchSubdirs(isOpen ? currentPath : null);
 
   const sidebar = useMemo(
     () => buildSidebar(homeData?.home ?? null),
@@ -131,7 +131,7 @@ export function FolderBrowserModal({
 
   if (!isOpen) return null;
 
-  const subdirs = listing?.subdirs ?? [];
+  const subdirs = listing?.items ?? [];
   const parent = currentPath ? getParentPath(currentPath) : null;
 
   const handleUseThisFolder = () => {

--- a/src/hooks/query/use-search-subdirs.ts
+++ b/src/hooks/query/use-search-subdirs.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import FilesService from "#/api/files-service/files-service.api";
 
-export const useListSubdirs = (path: string | null) =>
+export const useSearchSubdirs = (path: string | null) =>
   useQuery({
-    queryKey: ["file", "list_subdirs", path],
-    queryFn: () => FilesService.listSubdirs(path as string),
+    queryKey: ["file", "search_subdirs", path],
+    queryFn: () => FilesService.searchSubdirs(path as string),
     enabled: !!path,
     retry: false,
     meta: { disableToast: true },


### PR DESCRIPTION
### Description

The agent-server is renaming `GET /api/file/list_subdirs` → `GET /api/file/search_subdirs` and switching its response shape to the standard paginated `{ items, next_page_id }` envelope used by every other `search_<ITEM>` endpoint in the agent-server. The change addresses an unbounded-response concern raised in code review (a directory's immediate-child count is bounded only by the filesystem) and aligns with the existing `search_conversations` / `search_bash_events` pattern.

The GUI's workspace folder picker (the "Add Workspaces" Finder-like modal launched from the Workspaces tab) is the only consumer. It needs to be updated in lock-step with the server merge to avoid a 404 on the first user click.

### Acceptance criteria

- [ ] `FilesService` calls `/api/file/search_subdirs` (not `/api/file/list_subdirs`).
- [ ] The hook used by `FolderBrowserModal` reads `data.items` from the paginated envelope (the `path` echo is gone).
- [ ] Method/hook names follow the new server vocabulary (`searchSubdirs` / `useSearchSubdirs`) so future readers don't have to translate.
- [ ] All existing folder-browser test scenarios still pass (open modal at home, navigate into a subfolder, "Use this folder" imports immediate children, dedup on repeat).
- [ ] Typecheck and lint clean.

### Summary

- Switch the workspace folder browser off `GET /api/file/list_subdirs` and onto the new `GET /api/file/search_subdirs` endpoint.
- Adopt the agent-server's standard paginated `{ items, next_page_id }` envelope and rename the JS surface to match (`searchSubdirs` / `useSearchSubdirs`).
- Update unit tests to the new mock shape.

This client must merge after / alongside [OpenHands/software-agent-sdk#3067](https://github.com/OpenHands/software-agent-sdk/pull/3067) — the old endpoint is removed by that PR, not deprecated.

### Why

`@tofarr` asked on the server PR: *"What if there are a million of them? Should we paginate this endpoint? (And follow our `search_<ITEM>` pattern?"* That landed two coupled changes on the server:

1. The endpoint moved to `GET /api/file/search_subdirs` to align with the `search_<ITEM>` convention used by `search_conversations`, `search_bash_events`, and `search_conversation_events`.
2. The response is now the standard `{ items: SubdirectoryEntry[], next_page_id: string | null }` envelope, with `page_id` + `limit` (1–100) query params.

The `FolderBrowserModal` is the only place in this repo that hits the old endpoint. Without this PR, opening the "Add Workspaces" modal 404s the moment the server PR merges.

### Changes

#### `src/api/files-service/files-service.api.ts`

- `interface ListSubdirsResponse { path; subdirs }` → `interface SubdirectoryPage { items; next_page_id }`. The `path` echo is dropped — the only consumer keeps the input path in `useState`, so we never used the echoed copy.
- `FilesService.listSubdirs(path)` → `FilesService.searchSubdirs(path, { pageId?, limit? })`. The optional second arg is forwarded as `page_id` / `limit` query params; calls without it behave exactly like the old single-page call (server defaults to `limit=100`).
- New `interface SearchSubdirsOptions` to type that second arg.

#### `src/hooks/query/use-search-subdirs.ts` (renamed from `use-list-subdirs.ts`)

- File renamed via `git mv` to keep blame history.
- Hook renamed `useListSubdirs` → `useSearchSubdirs`.
- React Query key updated `["file", "list_subdirs", path]` → `["file", "search_subdirs", path]` so it doesn't share cache state with anything that might still be holding the old key.
- `useHomeDirectory` is unchanged.

#### `src/components/features/home/workspace-dropdown/folder-browser-modal.tsx`

- Import path updated to `#/hooks/query/use-search-subdirs`.
- `useListSubdirs(...)` → `useSearchSubdirs(...)`.
- `listing?.subdirs ?? []` → `listing?.items ?? []`. The local variable name `subdirs` is unchanged — it's a perfectly fine shorthand for "subdirectory entries", and renaming it would have churned ~7 unrelated lines of JSX.

#### `__tests__/components/features/home/workspace-selection-form.test.tsx`

- `vi.spyOn(FilesService, "listSubdirs")` → `vi.spyOn(FilesService, "searchSubdirs")`.
- Mock return values switched from `{ path, subdirs: [...] }` to `{ items: [...], next_page_id: null }`.
- Renamed the local spy variable `listSpy` → `searchSpy` to match the method it stubs.