### PR TITLE
feat: export buildAgentServerEnv helper for downstream consumers

### DIFF
--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -170,6 +170,25 @@ export function buildSafeDevConfig(cwd = process.cwd(), env = process.env) {
   };
 }
 
+/**
+ * Build the environment variables object for spawning the agent-server process.
+ *
+ * This is exported so downstream consumers (e.g., automation service) can use
+ * the same env vars without duplicating the mapping logic.
+ *
+ * @param {ReturnType<typeof buildSafeDevConfig>} config - Config from buildSafeDevConfig
+ * @returns {Record<string, string>} Environment variables for agent-server
+ */
+export function buildAgentServerEnv(config) {
+  return {
+    TMUX_TMPDIR: config.tmuxTmpDir,
+    OH_CONVERSATIONS_PATH: config.conversationsPath,
+    OH_BASH_EVENTS_DIR: config.bashEventsDir,
+    OH_VSCODE_PORT: String(config.vscodePort),
+    OH_SECRET_KEY: config.secretKey,
+  };
+}
+
 export function buildNpmScriptCommand(
   scriptName,
   platform = process.platform,
@@ -274,11 +293,7 @@ async function main() {
       cwd: config.cwd,
       env: {
         ...process.env,
-        TMUX_TMPDIR: config.tmuxTmpDir,
-        OH_CONVERSATIONS_PATH: config.conversationsPath,
-        OH_BASH_EVENTS_DIR: config.bashEventsDir,
-        OH_VSCODE_PORT: String(config.vscodePort),
-        OH_SECRET_KEY: config.secretKey,
+        ...buildAgentServerEnv(config),
       },
     },
   );


### PR DESCRIPTION
## Summary

Add a new exported function `buildAgentServerEnv(config)` that builds the environment variables object for spawning the agent-server process. This allows downstream consumers (e.g., the automation service) to use the same env vars without duplicating the mapping logic.

## Problem

The automation service needs to start the agent-server with the same environment variables as `dev-safe.mjs`. Currently, it can import `buildAgentServerCommand` and `buildSafeDevConfig` to stay in sync with the configuration logic, but it still needs to duplicate the env var **names** mapping:

```javascript
// In automation's npm-dev-stack.mjs - duplicating the env var keys
env: {
  TMUX_TMPDIR: safeConfig.tmuxTmpDir,
  OH_CONVERSATIONS_PATH: safeConfig.conversationsPath,
  OH_BASH_EVENTS_DIR: safeConfig.bashEventsDir,
  OH_SECRET_KEY: safeConfig.secretKey,
  OH_VSCODE_PORT: safeConfig.vscodePort.toString(),
},
```

If this file adds a new required env var or renames one, downstream consumers would need to update their code too.

## Solution

Export a `buildAgentServerEnv(config)` helper:

```javascript
export function buildAgentServerEnv(config) {
  return {
    TMUX_TMPDIR: config.tmuxTmpDir,
    OH_CONVERSATIONS_PATH: config.conversationsPath,
    OH_BASH_EVENTS_DIR: config.bashEventsDir,
    OH_VSCODE_PORT: String(config.vscodePort),
    OH_SECRET_KEY: config.secretKey,
  };
}
```

Now downstream consumers can just do:

```javascript
const envVars = buildAgentServerEnv(safeConfig);
spawnService('agent-server', ..., {
  env: { ...envVars, CUSTOM_VAR: 'value' },
});
```

## Changes

- Added `buildAgentServerEnv(config)` exported function with JSDoc
- Refactored `main()` to use the new helper internally (dogfooding)

## Testing

- Verified syntax with `node --check scripts/dev-safe.mjs`

Closes #118

---
*This PR was created by an AI agent (OpenHands) on behalf of a developer.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/06e6444b-fd44-4cd1-905a-a02723dea3fe)