### PR TITLE
Fix uvx command to use --from syntax for PyPI packages

### DIFF
--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -60,12 +60,15 @@ describe("buildAgentServerCommand", () => {
     const cmd = buildAgentServerCommand({ OH_AGENT_SERVER_VERSION: "1.18.0" });
 
     expect(cmd.command).toBe("uvx");
+    // Uses --from syntax because executable name (agent-server) differs from package name (openhands-agent-server)
     expect(cmd.args).toEqual([
+      "--from",
+      "openhands-agent-server==1.18.0",
       "--with",
       "openhands-tools",
       "--with",
       "openhands-workspace",
-      "openhands-agent-server==1.18.0",
+      "agent-server",
     ]);
     expect(cmd.source).toBe("PyPI (1.18.0)");
   });

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -84,13 +84,16 @@ export function buildAgentServerCommand(env = process.env) {
     );
     source = `git (${gitRef})`;
   } else if (version) {
-    // Use specific PyPI version: uvx --with ... openhands-agent-server==version
+    // Use specific PyPI version: uvx --from openhands-agent-server==version agent-server
+    // The package name differs from the executable name, so we need --from syntax
     uvxArgs.push(
+      "--from",
+      `${DEFAULT_AGENT_SERVER_PACKAGE}==${version}`,
       "--with",
       "openhands-tools",
       "--with",
       "openhands-workspace",
-      `${DEFAULT_AGENT_SERVER_PACKAGE}==${version}`,
+      "agent-server",
     );
     source = `PyPI (${version})`;
   } else if (DEFAULT_GIT_REF) {
@@ -107,13 +110,16 @@ export function buildAgentServerCommand(env = process.env) {
     );
     source = `git (${DEFAULT_GIT_REF}, default)`;
   } else {
-    // Use latest released version: uvx --with ... openhands-agent-server
+    // Use latest released version: uvx --from openhands-agent-server agent-server
+    // The package name differs from the executable name, so we need --from syntax
     uvxArgs.push(
+      "--from",
+      DEFAULT_AGENT_SERVER_PACKAGE,
       "--with",
       "openhands-tools",
       "--with",
       "openhands-workspace",
-      DEFAULT_AGENT_SERVER_PACKAGE,
+      "agent-server",
     );
     source = "PyPI (latest)";
   }


### PR DESCRIPTION
## Summary

Fixes #117

The `openhands-agent-server` package exposes an executable named `agent-server`, not `openhands-agent-server`. When using PyPI versions (either specific or latest), we need to use the `--from` syntax:

```bash
uvx --from openhands-agent-server agent-server
```

Without this fix, users see the error:
```
An executable named `openhands-agent-server` is not provided by package `openhands-agent-server`.
The following executables are available:
- agent-server

Use `uvx --from openhands-agent-server agent-server` instead.
```

## Code Paths Affected

| Scenario | How to Use | Was Affected? |
|----------|------------|---------------|
| Custom git branch/SHA | `OH_AGENT_SERVER_GIT_REF=my-branch npm run dev` | ❌ No - already used `--from` syntax |
| Default (main branch) | `npm run dev` (no env vars) | ❌ No - already used `--from` syntax |
| Specific PyPI version | `OH_AGENT_SERVER_VERSION=1.18.0 npm run dev` | ✅ **Fixed** |
| Latest PyPI release | Only when `DEFAULT_GIT_REF` is set to `null` | ✅ **Fixed** |

**The fix only affects PyPI release paths** (specific version and latest release). The git branch code paths were already correct - they always used `--from git+...#subdirectory=openhands-agent-server agent-server`.

Currently, since `DEFAULT_GIT_REF = "main"`, the default behavior uses the git path (which was already working). The user who reported the bug likely had `OH_AGENT_SERVER_VERSION` set, or was running an older version of the code where the default was to use PyPI.

## Changes

- Updated `scripts/dev-safe.mjs` to use `--from <package> agent-server` syntax for both:
  - Specific PyPI versions (`OH_AGENT_SERVER_VERSION=1.18.0`)
  - Latest PyPI release (when neither git ref nor version is specified)
- Updated corresponding test case in `__tests__/scripts/dev-safe.test.ts`

## Testing

- Verified the new uvx command works: `uvx --from openhands-agent-server agent-server --help` ✅
- Verified the old command produces the reported error: `uvx openhands-agent-server --help` ❌
- All tests pass: `npm run test -- __tests__/scripts/dev-safe.test.ts` ✅
- Typecheck passes: `npm run typecheck` ✅
- Build passes: `npm run build` ✅

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*