### PR TITLE
fix(frontend): revert HeroUI v3 to v2 and scope body for portal'd popovers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,12 +98,10 @@
 - GitHub PR-review automation should stay aligned with the current OpenHands repo conventions: keep the review workflow at `.github/workflows/pr-review-by-openhands.yml`, keep the companion `.github/workflows/pr-review-evaluation.yml`, auto-run on newly opened non-draft PRs and `ready_for_review` events from established contributors, still support the `review-this` label / `openhands-agent` / `all-hands-bot` reviewer triggers, use the OpenHands app LLM proxy defaults, and use the dual-trigger pattern (`pull_request` for same-repo PRs, `pull_request_target` for forks) so workflow changes can self-verify without widening fork secret exposure.
 - The repo now includes `.agents/skills/custom-codereview-guide.md`, adapted from `OpenHands/software-agent-sdk`, to force PR reviews to always leave either an APPROVE or COMMENT review instead of silently finishing with no review object.
 
-- HeroUI v3 migration notes:
-  - The repo now uses `@heroui/react@3.0.3` plus `@heroui/styles@3.0.3`.
-  - `src/tailwind.css` should import `@heroui/styles`; the old `hero.ts` Tailwind plugin file was removed and should not be reintroduced.
-  - Settings selectors no longer use the v2 `Autocomplete` APIs. `settings-dropdown-input.tsx` and `model-selector.tsx` now use HeroUI v3 `ComboBox` + `ListBox` patterns, and the model/provider comboboxes must keep their `name` attributes so `FormData` submission still populates settings diffs.
-  - Tooltip consumers that used the old monolithic `Tooltip` props should prefer the shared `StyledTooltip` wrapper so HeroUI v3 trigger/content typing stays centralized.
-  - Visual verification artifacts for the migration live under `.pr/issue-44/`; to reproduce the static screenshots, use `npm run build:mock`, serve `build/` (for example with `python -m http.server --directory build`), and navigate client-side before capturing screenshots because a plain static server will not provide SPA deep-link fallbacks.
+- HeroUI rollback / migration notes:
+  - The attempted HeroUI v3 upgrade changed global theme wiring and homepage design tokens enough that the repo currently prefers `@heroui/react@2.8.10` until a broader visual validation pass is done.
+  - Keep the v2 Tailwind integration active via `@plugin '../hero.ts'` in `src/tailwind.css` and source HeroUI classes from `node_modules/@heroui/theme/dist/**/*`.
+  - The settings UI currently relies on the v2 `Autocomplete` + `AutocompleteItem`/`AutocompleteSection` APIs in `settings-dropdown-input.tsx` and `model-selector.tsx`; a future v3 retry will need to replace those controls again.
 - Library i18n is now namespace-scoped under `openhands`: `src/i18n/index.ts` exports `OPENHANDS_I18N_NAMESPACE`, `translationResources`, and `waitForI18n()`, `scripts/make-i18n-translations.cjs` emits `public/locales/<lang>/openhands.json`, standalone `src/entry.client.tsx` explicitly awaits i18n init, and host apps can register bundles via the `@openhands/agent-canvas/i18n` subpath export.
 
 - Route decoupling note: `src/components/` should stay free of direct `react-router` imports. Route state now flows through `src/context/navigation-context.tsx`, the standalone app bridges router state with `src/routes/react-router-navigation-provider.tsx`, and link-like UI should use `src/components/shared/navigation-link.tsx`.

--- a/__tests__/components/features/settings/settings-dropdown-input.test.tsx
+++ b/__tests__/components/features/settings/settings-dropdown-input.test.tsx
@@ -59,7 +59,13 @@ describe("SettingsDropdownInput", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Clear selection" }));
+    const clearButton = screen
+      .getAllByRole("button")
+      .find((button) => button.getAttribute("aria-label") !== "Show suggestions");
+    if (!clearButton) {
+      throw new Error("Clear button not found");
+    }
+    await user.click(clearButton);
 
     expect(screen.getByLabelText("Language")).toHaveValue("");
     expect(onSelectionChange).toHaveBeenCalledWith(null);

--- a/__tests__/components/shared/modals/settings/settings-form.test.tsx
+++ b/__tests__/components/shared/modals/settings/settings-form.test.tsx
@@ -26,6 +26,11 @@ describe("SettingsForm", () => {
       },
     );
 
+    await waitFor(() => {
+      const llmProvider = screen.queryByLabelText(/LLM\$PROVIDER/i);
+      expect(llmProvider?.getAttribute("aria-expanded")).toBe("false");
+    });
+
     await user.click(screen.getByTestId("save-settings-button"));
 
     await waitFor(() => {
@@ -55,6 +60,11 @@ describe("SettingsForm", () => {
         },
       },
     );
+
+    await waitFor(() => {
+      const llmProvider = screen.queryByLabelText(/LLM\$PROVIDER/i);
+      expect(llmProvider?.getAttribute("aria-expanded")).toBe("false");
+    });
 
     await user.click(screen.getByTestId("save-settings-button"));
 

--- a/hero.ts
+++ b/hero.ts
@@ -1,0 +1,18 @@
+import { heroui } from "@heroui/react";
+
+export default heroui({
+  defaultTheme: "dark",
+  layout: {
+    radius: {
+      small: "5px",
+      large: "20px",
+    },
+  },
+  themes: {
+    dark: {
+      colors: {
+        primary: "#4465DB",
+      },
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@heroui/react": "3.0.3",
-        "@heroui/styles": "3.0.3",
+        "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.18",
         "@monaco-editor/react": "4.7.0",
         "@openhands/typescript-client": "github:OpenHands/typescript-client#7d20f119d68893903c3eab7070416e6317f72716",
@@ -151,6 +150,24 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@adobe/react-spectrum/node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@adobe/react-spectrum/node_modules/@react-types/shared": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1435,32 +1452,1169 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@heroui/react": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@heroui/react/-/react-3.0.3.tgz",
-      "integrity": "sha512-UJPOxg3IbS5KtI2GLP7S56KrSBn/r4xQyntCVpnPzgoT7JuciB4dq7IhckuDNHcrdIPO45JrKHGJz2hiYxaRGg==",
+    "node_modules/@heroui/accordion": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/accordion/-/accordion-2.2.29.tgz",
+      "integrity": "sha512-nhCqgZ3ejgRLRM3jJnpZExufn050raxOVyNUR7zo9o5Ed10KKRpD3J/8l6gwrYA7j+Z46dF2YLJzIFWPzYf1Kw==",
       "license": "MIT",
       "dependencies": {
-        "@heroui/styles": "3.0.3",
-        "@radix-ui/react-avatar": "1.1.11",
-        "@react-aria/i18n": "3.13.0",
-        "@react-aria/ssr": "3.10.0",
-        "@react-aria/utils": "3.34.0",
-        "@react-stately/utils": "3.12.0",
-        "@react-types/color": "3.2.0",
-        "@react-types/shared": "3.34.0",
-        "input-otp": "1.4.2",
-        "react-aria-components": "1.17.0",
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/divider": "2.2.24",
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-accordion": "2.2.20",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-stately/tree": "3.9.6",
+        "@react-types/accordion": "3.0.0-alpha.26",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/alert": {
+      "version": "2.2.32",
+      "resolved": "https://registry.npmjs.org/@heroui/alert/-/alert-2.2.32.tgz",
+      "integrity": "sha512-8piby1PXVTTtdwLLV60JMqduRAFLHoiQpFPeSNVHsAaMIphXsmlpvUb9dct4f0wQJqqgFutiWL3RtjdDwEkRQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-stately/utils": "3.11.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/aria-utils": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/aria-utils/-/aria-utils-2.2.29.tgz",
+      "integrity": "sha512-tVc5Rz+u/WMaAoYpx4VNheFqsfxA5i0SAqT8OAFpPX0WiNrylXaAGWsid/ivFdlW4rE1FgI/+wP0KS6c8KSEjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/system": "2.4.28",
+        "@react-aria/utils": "3.33.1",
+        "@react-stately/collections": "3.12.10",
+        "@react-types/overlays": "3.9.4",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/autocomplete": {
+      "version": "2.3.34",
+      "resolved": "https://registry.npmjs.org/@heroui/autocomplete/-/autocomplete-2.3.34.tgz",
+      "integrity": "sha512-DTmztrWMdEtHCIJmgSyO/7QrABsaq/kDqBg6aVw+P30sgLW6k05wYOqe6ctuoNSWaZzr56QPvFpsgbeMy7Ma0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/button": "2.2.32",
+        "@heroui/form": "2.1.32",
+        "@heroui/input": "2.4.33",
+        "@heroui/listbox": "2.3.31",
+        "@heroui/popover": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/scroll-shadow": "2.3.19",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/combobox": "3.15.0",
+        "@react-aria/i18n": "3.12.16",
+        "@react-stately/combobox": "3.13.0",
+        "@react-types/combobox": "3.14.0",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/avatar": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/@heroui/avatar/-/avatar-2.2.26.tgz",
+      "integrity": "sha512-W2z64Da38ZL4Lu9Pokan2frTURcXxUs3bV37WWJjMzCD6mOAlaogWYMQdAeYmeWHyAW18XZSa5OaUCMVrzJ2SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-image": "2.1.14",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/badge": {
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/@heroui/badge/-/badge-2.2.18.tgz",
+      "integrity": "sha512-OfGove8YJ9oDrdugzq05FC15ZKD5nzqe+thPZ+1SY1LZorJQjZvqSD9QnoEH1nG7fu2IdH6pYJy3sZ/b6Vj5Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.23",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/breadcrumbs": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/breadcrumbs/-/breadcrumbs-2.2.25.tgz",
+      "integrity": "sha512-KmUmJiBVzRuKR1tXIvKBqz8rGz4jAPa2FqsDodQ/Z34Eagsw85l3pI6xekKacGcxNQVM+L6KhMRb00QWHT/SmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/breadcrumbs": "3.5.32",
+        "@react-aria/focus": "3.21.5",
+        "@react-types/breadcrumbs": "3.7.19"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/button": {
+      "version": "2.2.32",
+      "resolved": "https://registry.npmjs.org/@heroui/button/-/button-2.2.32.tgz",
+      "integrity": "sha512-i1vx4gEuyjKmz0xVu+U3PgtYrsGt1PVuWBrT/sSbNcH0AGuPSqQPQ/znwkhgZ4ixhNaU9jjVbBfIGCFGNDz7XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/ripple": "2.2.21",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/spinner": "2.2.29",
+        "@heroui/use-aria-button": "2.2.22",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/calendar": {
+      "version": "2.2.32",
+      "resolved": "https://registry.npmjs.org/@heroui/calendar/-/calendar-2.2.32.tgz",
+      "integrity": "sha512-2xzCmM7Sdz04qYr478lcH3GfGi2HWmKZ77PXrxWyRcVys+6GQpJJS712eusQBdoDNoUHUK/qZLTxihwiDC46wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.32",
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-button": "2.2.22",
+        "@internationalized/date": "3.12.0",
+        "@react-aria/calendar": "3.9.5",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/calendar": "3.9.3",
+        "@react-stately/utils": "3.11.0",
+        "@react-types/button": "3.15.1",
+        "@react-types/calendar": "3.8.3",
+        "@react-types/shared": "3.33.1",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/card": {
+      "version": "2.2.28",
+      "resolved": "https://registry.npmjs.org/@heroui/card/-/card-2.2.28.tgz",
+      "integrity": "sha512-njwCocEntWaYyALB+2SHzVzoG4JJMV2rG55vQ0zZIIJoG1+/F9SCfsZQ87ncf+0D7IQx6vw8fWT2VRKojmn9+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/ripple": "2.2.21",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-button": "2.2.22",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/checkbox": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/checkbox/-/checkbox-2.3.32.tgz",
+      "integrity": "sha512-rmFGPTgpG/Uvlr/8KjCSobT3u2Ig4/3p8s0qwTCo37uvtsCIbCYyB1yNAXZkCN2hfg5ZIBofEaYeEmw0OBsQAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-callback-ref": "2.1.8",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/checkbox": "3.16.5",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-stately/checkbox": "3.7.5",
+        "@react-stately/toggle": "3.9.5",
+        "@react-types/checkbox": "3.10.4",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/chip": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/chip/-/chip-2.2.25.tgz",
+      "integrity": "sha512-kACEoF7tP9o/q5HdARaP3veD0Rl4Uxe9fiTVQvus8kN97Jnw9y4JctsUJ/vXgsscKt39qh53TB8fo8I0sJ2FPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/code": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/code/-/code-2.2.25.tgz",
+      "integrity": "sha512-oGaQVktqTNqRPDceuV/egVh442Ap4cbuXxVSqsmT0aNV1KnISo/P7VwLm4QDN5T3MXxN3Cs2Pw6z0+oydPL3mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system-rsc": "2.3.24"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/date-input": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/date-input/-/date-input-2.3.32.tgz",
+      "integrity": "sha512-jk0cPMkfs0lexdJckBZ4qO96tTqT3ZMgb+Z12aS8VW3Hcbvj2vvv2fuHc7LrIg1mdUqZzZwCwUAsUGWSJDTI0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@internationalized/date": "3.12.0",
+        "@react-aria/datepicker": "3.16.1",
+        "@react-aria/i18n": "3.12.16",
+        "@react-stately/datepicker": "3.16.1",
+        "@react-types/datepicker": "3.13.5",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/date-picker": {
+      "version": "2.3.33",
+      "resolved": "https://registry.npmjs.org/@heroui/date-picker/-/date-picker-2.3.33.tgz",
+      "integrity": "sha512-u9N2NToMLg3hwn7WEXljhrtM/DiRrUVBqs35akW9gTQtcz1fGPugrDkJy4OsKEv7c1HuYBO0As6CM+uXERjHWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/button": "2.2.32",
+        "@heroui/calendar": "2.2.32",
+        "@heroui/date-input": "2.3.32",
+        "@heroui/form": "2.1.32",
+        "@heroui/popover": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@internationalized/date": "3.12.0",
+        "@react-aria/datepicker": "3.16.1",
+        "@react-aria/i18n": "3.12.16",
+        "@react-stately/datepicker": "3.16.1",
+        "@react-stately/utils": "3.11.0",
+        "@react-types/datepicker": "3.13.5",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/divider": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/@heroui/divider/-/divider-2.2.24.tgz",
+      "integrity": "sha512-fq7bZFpruws3aC5X2TGMMUhcInyxQS6oWAOYrwgWX5jrmqzg/8CBtIuOehhwcm0HAk+oI55KFidJUFTuA1s7Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-rsc-utils": "2.1.9",
+        "@heroui/system-rsc": "2.3.24",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/dom-animation": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@heroui/dom-animation/-/dom-animation-2.1.10.tgz",
+      "integrity": "sha512-dt+0xdVPbORwNvFT5pnqV2ULLlSgOJeqlg/DMo97s9RWeD6rD4VedNY90c8C9meqWqGegQYBQ9ztsfX32mGEPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1"
+      }
+    },
+    "node_modules/@heroui/drawer": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/drawer/-/drawer-2.2.29.tgz",
+      "integrity": "sha512-zVBKHbcCXZGR79ORw4vQRA/QfHNLoQ9R8q6P1gsjs24uBGdBQAYvQE0F/bfsKZ5JH7asUt+oSIpjqQGmXAbyyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/modal": "2.2.29",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/dropdown": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/dropdown/-/dropdown-2.3.32.tgz",
+      "integrity": "sha512-+ntmjxkBaUVpyGN0pcByeTm2e2RUi5/D5uI9vPFLvJYWCa26bzQRR7EuK7LuGRXVciWl+NODNlLbSUVukkHBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/menu": "2.2.31",
+        "@heroui/popover": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/menu": "3.21.0",
+        "@react-stately/menu": "3.9.11",
+        "@react-types/menu": "3.10.7"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/form": {
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/@heroui/form/-/form-2.1.32.tgz",
+      "integrity": "sha512-gcMnlNq2eI8jIvNIEas4HVmQNdkRuZnhRCx/nZOd/FtO+WQwuqN2xFAfm/nGH3Hq/7yRf2yOozuJsm7iJVaatA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system": "2.4.28",
+        "@heroui/theme": "2.4.26",
+        "@react-stately/form": "3.2.4",
+        "@react-types/form": "3.7.18",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@heroui/framer-utils": {
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/@heroui/framer-utils/-/framer-utils-2.1.28.tgz",
+      "integrity": "sha512-/M2nqHRx4feZx0lgA8QmHDaqu/DgsdynvSnbniptiU/Xi9XgQApCPJ0Qxgk5JZ9g2vemDFgi5AP7C7FqgiMtMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/system": "2.4.28",
+        "@heroui/use-measure": "2.1.8"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/image": {
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/@heroui/image/-/image-2.2.19.tgz",
+      "integrity": "sha512-XdQ1g0kiHl+Kj9Zj1NL1mbKhmzeN0h27dgfegJS2coGM/yrEavYzg1DWUEyVSzPNKFZS8BDGa9DOpWe0vgggBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-image": "2.1.14"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/input": {
+      "version": "2.4.33",
+      "resolved": "https://registry.npmjs.org/@heroui/input/-/input-2.4.33.tgz",
+      "integrity": "sha512-iDKujnKgXDbR4zLVr03Pg3TYKFR2zv0aPZUpjOvtLdB8/wNBQv+rbizqnHQPAYyDwhNQS0WguW0tQVhh4oPy4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/textfield": "3.18.5",
+        "@react-stately/utils": "3.11.0",
+        "@react-types/shared": "3.33.1",
+        "@react-types/textfield": "3.12.8",
+        "react-textarea-autosize": "^8.5.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/input-otp": {
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/@heroui/input-otp/-/input-otp-2.1.32.tgz",
+      "integrity": "sha512-lrByjetK5/9MjqhDXHnhAI/gBnCJjMmR92k2HARjnJjYhljD58j6xYuf41zwp/faYkyspVvmLMPHF8qjKMTAbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-form-reset": "2.0.1",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/form": "3.1.5",
+        "@react-stately/form": "3.2.4",
+        "@react-stately/utils": "3.11.0",
+        "@react-types/textfield": "3.12.8",
+        "input-otp": "1.4.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@heroui/kbd": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/@heroui/kbd/-/kbd-2.2.26.tgz",
+      "integrity": "sha512-Z8XpQwMmNpLGlQlGD7UWRWG2S8veNb9vezfWgEKmtnnzdVM/CKSYTWctkmiruJ7tPn3XPsGTEt3QU8WPVAnpqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system-rsc": "2.3.24"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/link": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/@heroui/link/-/link-2.2.26.tgz",
+      "integrity": "sha512-TPxd87ZP8mB8HG0GVIDTuoDxL2mcpCVUY9sjrxujAtin3781znM6jFO+O/tv0huW90+jxBHiFU1KpeZWwtl6qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-link": "2.2.23",
+        "@react-aria/focus": "3.21.5",
+        "@react-types/link": "3.6.7"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/listbox": {
+      "version": "2.3.31",
+      "resolved": "https://registry.npmjs.org/@heroui/listbox/-/listbox-2.3.31.tgz",
+      "integrity": "sha512-EvYxlama0kDCtgyNfCtz/X7ftYSE0OlPGKrZrv0st0oz790x3E1EQyCEYOaDbHAnGPxJy8pRC88CbzyPWEHeXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/divider": "2.2.24",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-is-mobile": "2.2.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/listbox": "3.15.3",
+        "@react-stately/list": "3.13.4",
+        "@react-types/shared": "3.33.1",
+        "@tanstack/react-virtual": "3.11.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/menu": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/@heroui/menu/-/menu-2.2.31.tgz",
+      "integrity": "sha512-e5VqpMapolo51kJdHdz+tm3a++dGnvPTQtma8bFPfguVzoyzbq4eicFUR9fvbvYjP2jNewwsyaoTqBvxqbueiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/divider": "2.2.24",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-is-mobile": "2.2.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/menu": "3.21.0",
+        "@react-stately/tree": "3.9.6",
+        "@react-types/menu": "3.10.7",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/modal": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/modal/-/modal-2.2.29.tgz",
+      "integrity": "sha512-ke6i2ByLuTE/4OZRZvgKv6A2Vf1GkitL/Lq+Bojq8ovIquphmH7AXrXkWEQ6yq1YdqYRDFcVOX/4p11Qjv4rkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-button": "2.2.22",
+        "@heroui/use-aria-modal-overlay": "2.2.21",
+        "@heroui/use-disclosure": "2.2.19",
+        "@heroui/use-draggable": "2.1.20",
+        "@heroui/use-viewport-size": "2.0.1",
+        "@react-aria/dialog": "3.5.34",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/overlays": "3.31.2",
+        "@react-stately/overlays": "3.6.23"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/navbar": {
+      "version": "2.2.30",
+      "resolved": "https://registry.npmjs.org/@heroui/navbar/-/navbar-2.2.30.tgz",
+      "integrity": "sha512-zGMRuewcjUFZhj3hIyIWOq+iRt0Mcc8FHBDPHAcYtYe0PrfYF2Ti0WLoH5Bbf5kR3S5hYfwabyT7jtf173S7iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-resize": "2.1.8",
+        "@heroui/use-scroll-position": "2.1.8",
+        "@react-aria/button": "3.14.5",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/overlays": "3.31.2",
+        "@react-stately/toggle": "3.9.5",
+        "@react-stately/utils": "3.11.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/number-input": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@heroui/number-input/-/number-input-2.0.23.tgz",
+      "integrity": "sha512-06Glv+X+tqSLt7i7MUJJz2Zf65+kkBaL/Cgx0Sw7iA418WejPDF3KIRee48RdfI+AOHYPAH4AD9PnGAaOJvapQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.32",
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/numberfield": "3.12.5",
+        "@react-stately/numberfield": "3.11.0",
+        "@react-types/button": "3.15.1",
+        "@react-types/numberfield": "3.8.18",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/pagination": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/@heroui/pagination/-/pagination-2.2.27.tgz",
+      "integrity": "sha512-omTpyJwGzw2fmSdfCfJuIgVmTqDaMzs4RmDtjgqEZxZCAldFlVuTWmsR1peOwzZKsrhzbp3eH/E9F6ipwF6Yug==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-intersection-observer": "2.2.14",
+        "@heroui/use-pagination": "2.2.20",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/utils": "3.33.1",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/popover": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/popover/-/popover-2.3.32.tgz",
+      "integrity": "sha512-aVkDt9aITI66x7nS0k2BJ7szQtNm5YV+Q31X9aWrXFkRdJ+zl0sMbo1UpVQdGSif0yH6NvsFTThmCWDQZkX6fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/button": "2.2.32",
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-button": "2.2.22",
+        "@heroui/use-aria-overlay": "2.0.6",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/dialog": "3.5.34",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/overlays": "3.31.2",
+        "@react-stately/overlays": "3.6.23",
+        "@react-types/overlays": "3.9.4"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/progress": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/progress/-/progress-2.2.25.tgz",
+      "integrity": "sha512-0aMuB3RaEheJPiQPUPRvwC1CkBG9qDRzRyUu6GT5QJfkFVmeB09NwQB4wec74qa1Ke+Yhj2KHfCVyBzYNqAifw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-is-mounted": "2.1.8",
+        "@react-aria/progress": "3.4.30",
+        "@react-types/progress": "3.5.18"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/radio": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/radio/-/radio-2.3.32.tgz",
+      "integrity": "sha512-R0Oj8sQ5NA5LqPkouGEHPetgZxa1p7XNf5teVv0nL+8A9tg4R8VDLvL50ezc0yXp18PmfHa61AoK5DSCnyesNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/radio": "3.12.5",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/radio": "3.11.5",
+        "@react-types/radio": "3.9.4",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/@heroui/react/-/react-2.8.10.tgz",
+      "integrity": "sha512-rW5wFxLX3SNusf8Uhq10M5btRplKunU8glU1Gd4gD9AMIV/e7D+DGy/g2ildz2gEcMPny4C5kLcYlwRDea5oNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/accordion": "2.2.29",
+        "@heroui/alert": "2.2.32",
+        "@heroui/autocomplete": "2.3.34",
+        "@heroui/avatar": "2.2.26",
+        "@heroui/badge": "2.2.18",
+        "@heroui/breadcrumbs": "2.2.25",
+        "@heroui/button": "2.2.32",
+        "@heroui/calendar": "2.2.32",
+        "@heroui/card": "2.2.28",
+        "@heroui/checkbox": "2.3.32",
+        "@heroui/chip": "2.2.25",
+        "@heroui/code": "2.2.25",
+        "@heroui/date-input": "2.3.32",
+        "@heroui/date-picker": "2.3.33",
+        "@heroui/divider": "2.2.24",
+        "@heroui/drawer": "2.2.29",
+        "@heroui/dropdown": "2.3.32",
+        "@heroui/form": "2.1.32",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/image": "2.2.19",
+        "@heroui/input": "2.4.33",
+        "@heroui/input-otp": "2.1.32",
+        "@heroui/kbd": "2.2.26",
+        "@heroui/link": "2.2.26",
+        "@heroui/listbox": "2.3.31",
+        "@heroui/menu": "2.2.31",
+        "@heroui/modal": "2.2.29",
+        "@heroui/navbar": "2.2.30",
+        "@heroui/number-input": "2.0.23",
+        "@heroui/pagination": "2.2.27",
+        "@heroui/popover": "2.3.32",
+        "@heroui/progress": "2.2.25",
+        "@heroui/radio": "2.3.32",
+        "@heroui/ripple": "2.2.21",
+        "@heroui/scroll-shadow": "2.3.19",
+        "@heroui/select": "2.4.33",
+        "@heroui/skeleton": "2.2.18",
+        "@heroui/slider": "2.4.29",
+        "@heroui/snippet": "2.2.33",
+        "@heroui/spacer": "2.2.25",
+        "@heroui/spinner": "2.2.29",
+        "@heroui/switch": "2.2.27",
+        "@heroui/system": "2.4.28",
+        "@heroui/table": "2.2.32",
+        "@heroui/tabs": "2.2.29",
+        "@heroui/theme": "2.4.26",
+        "@heroui/toast": "2.0.22",
+        "@heroui/tooltip": "2.2.29",
+        "@heroui/user": "2.2.26",
+        "@react-aria/visually-hidden": "3.8.31"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react-rsc-utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@heroui/react-rsc-utils/-/react-rsc-utils-2.1.9.tgz",
+      "integrity": "sha512-e77OEjNCmQxE9/pnLDDb93qWkX58/CcgIqdNAczT/zUP+a48NxGq2A2WRimvc1uviwaNL2StriE2DmyZPyYW7Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react-utils": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/@heroui/react-utils/-/react-utils-2.1.14.tgz",
+      "integrity": "sha512-hhKklYKy9sRH52C9A8P0jWQ79W4MkIvOnKBIuxEMHhigjfracy0o0lMnAUdEsJni4oZKVJYqNGdQl+UVgcmeDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-rsc-utils": "2.1.9",
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/ripple": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/@heroui/ripple/-/ripple-2.2.21.tgz",
+      "integrity": "sha512-wairSq9LnhbIqTCJmUlJAQURQ1wcRK/L8pjg2s3R/XnvZlPXHy4ZzfphiwIlTI21z/f6tH3arxv/g1uXd1RY0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.23",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/scroll-shadow": {
+      "version": "2.3.19",
+      "resolved": "https://registry.npmjs.org/@heroui/scroll-shadow/-/scroll-shadow-2.3.19.tgz",
+      "integrity": "sha512-y5mdBlhiITVrFnQTDqEphYj7p5pHqoFSFtVuRRvl9wUec2lMxEpD85uMGsfL8OgQTKIAqGh2s6M360+VJm7ajQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-data-scroll-overflow": "2.2.13"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.23",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/select": {
+      "version": "2.4.33",
+      "resolved": "https://registry.npmjs.org/@heroui/select/-/select-2.4.33.tgz",
+      "integrity": "sha512-iWlczBmrHz2lIjyAneiiFtmgM+YWKLNIHL9dQnMghSAZWT9iCES5c3RuiggqE9k7DfPjHmgvVB24qeajnnXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/form": "2.1.32",
+        "@heroui/listbox": "2.3.31",
+        "@heroui/popover": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/scroll-shadow": "2.3.19",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/spinner": "2.2.29",
+        "@heroui/use-aria-button": "2.2.22",
+        "@heroui/use-aria-multiselect": "2.4.21",
+        "@heroui/use-form-reset": "2.0.1",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/form": "3.1.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/overlays": "3.31.2",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/shared-icons": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@heroui/shared-icons/-/shared-icons-2.1.10.tgz",
+      "integrity": "sha512-ePo60GjEpM0SEyZBGOeySsLueNDCqLsVL79Fq+5BphzlrBAcaKY7kUp74964ImtkXvknTxAWzuuTr3kCRqj6jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/shared-utils": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@heroui/shared-utils/-/shared-utils-2.1.12.tgz",
+      "integrity": "sha512-0iCnxVAkIPtrHQo26Qa5g0UTqMTpugTbClNOrEPsrQuyRAq7Syux998cPwGlneTfB5E5xcU3LiEdA9GUyeK2cQ==",
+      "hasInstallScript": true,
+      "license": "MIT"
+    },
+    "node_modules/@heroui/skeleton": {
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/@heroui/skeleton/-/skeleton-2.2.18.tgz",
+      "integrity": "sha512-7AjU5kjk9rqrKP9mWQiAVj0dow4/vbK5/ejh4jqdb3DZm7bM2+DGzfnQPiS0c2eWR606CgOuuoImpwDS82HJtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.23",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/slider": {
+      "version": "2.4.29",
+      "resolved": "https://registry.npmjs.org/@heroui/slider/-/slider-2.4.29.tgz",
+      "integrity": "sha512-JY3uPIShCFLWTbLLYQJJIT5TyLQsyqJHPcM66FprDxwLkf/Ne03jvf+SeieCKAbq/iw+GygTIfwmbSPzrp/yhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/tooltip": "2.2.29",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/slider": "3.8.5",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/slider": "3.7.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/snippet": {
+      "version": "2.2.33",
+      "resolved": "https://registry.npmjs.org/@heroui/snippet/-/snippet-2.2.33.tgz",
+      "integrity": "sha512-BvoqKPRhdZyXvvPLxUoU0Fg5MzxMYdGWmJMS9gLT1Zv9A9ixua7kTFh9Z5NT9aNScRR9vhroaSQi1x39uCp+5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/tooltip": "2.2.29",
+        "@heroui/use-clipboard": "2.1.9",
+        "@react-aria/focus": "3.21.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/spacer": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/spacer/-/spacer-2.2.25.tgz",
+      "integrity": "sha512-XSw54osEkNaBykZXhZcFmvwqwuSKCGPFOd2AIR+vrMqcJg0IxWjpGIsexaT3P/LV1PuoTYkTJ8G3N5Wf4pZTUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system-rsc": "2.3.24"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/spinner": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/spinner/-/spinner-2.2.29.tgz",
+      "integrity": "sha512-08mWpL4+pdACcyzT5MjR0nSkKoWbab0oPzY+JHxIdPSSh3S8JJ7C8dUeV3Kj/15NRzzZlcTM3ClRCV8fdeGmuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system": "2.4.28",
+        "@heroui/system-rsc": "2.3.24"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/switch": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/@heroui/switch/-/switch-2.2.27.tgz",
+      "integrity": "sha512-z23is+gtPkX29EpixY5ZLY1+NQaP+ueshuiXzdgD9SfCQLOSDYDWuFVdR8ZgfdDPyhP8xpOnJf6l9zfgXHD8Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/switch": "3.7.11",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/toggle": "3.9.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/system": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@heroui/system/-/system-2.4.28.tgz",
+      "integrity": "sha512-agtiiMFsCLaBrGWWrGBlFrnwi06ym4uouh61c3/m16CHuYfGm0Hx5oJ1mZVF98SJ91mDyU3e6Rv+8mqV9XVgoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/system-rsc": "2.3.24",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/overlays": "3.31.2",
+        "@react-aria/utils": "3.33.1"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/system-rsc": {
+      "version": "2.3.24",
+      "resolved": "https://registry.npmjs.org/@heroui/system-rsc/-/system-rsc-2.3.24.tgz",
+      "integrity": "sha512-GEP3hh7j8wE56WdSAIdCcPQOMDdAYk9bSuQpGzXnkYSiSCJKroOyXbRmp9KF2VgpiMXGI0OlO51aj9JWoa+5Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/table": {
+      "version": "2.2.32",
+      "resolved": "https://registry.npmjs.org/@heroui/table/-/table-2.2.32.tgz",
+      "integrity": "sha512-cJ+XtBZOonSmkw7jrj0d9c8aIMdSGSZrBKS/1KZ7J9BTFPDW+ZoWwomgJHgZ31FQlr7dkYa7mZ2rf8LoGoOxRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/checkbox": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/table": "3.17.11",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/table": "3.15.4",
+        "@react-stately/virtualizer": "4.4.6",
+        "@react-types/grid": "3.3.8",
+        "@react-types/table": "3.13.6",
+        "@tanstack/react-virtual": "3.11.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/tabs": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/tabs/-/tabs-2.2.29.tgz",
+      "integrity": "sha512-TzCRXDqhdNsUxhO6sPdsbEt8m7KlkGwvJGvs4S/kHvJh1sKCItnnT0Z2FpZr6pLAqmHA6LO6Ow1phR5ACfNmug==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-is-mounted": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/tabs": "3.11.1",
+        "@react-stately/tabs": "3.8.9",
+        "@react-types/shared": "3.33.1",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/theme": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/@heroui/theme/-/theme-2.4.26.tgz",
+      "integrity": "sha512-TYatChq7YyGDcPJytgOMqQwK72qWYb+vIa7mLmX3Cu9+JzFs2VSHu2QqzdhnOHoK0uJr8giDMy0gvJEDuu31vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "color": "^4.2.3",
+        "color2k": "^2.0.3",
+        "deepmerge": "4.3.1",
         "tailwind-merge": "3.4.0",
         "tailwind-variants": "3.2.2"
       },
       "peerDependencies": {
-        "react": ">=19.0.0",
-        "react-dom": ">=19.0.0",
         "tailwindcss": ">=4.0.0"
       }
     },
-    "node_modules/@heroui/react/node_modules/tailwind-merge": {
+    "node_modules/@heroui/theme/node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
       "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
@@ -1470,17 +2624,347 @@
         "url": "https://github.com/sponsors/dcastil"
       }
     },
-    "node_modules/@heroui/styles": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@heroui/styles/-/styles-3.0.3.tgz",
-      "integrity": "sha512-DtN5QWfLVxy6DSDNgtUuHVU/h4G+dfoDHHxGVZRW6plCEh1Rc5Yc7YW7b8JBiYCknSRx/fqLXpas3Fe5Q5XJSw==",
+    "node_modules/@heroui/toast": {
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@heroui/toast/-/toast-2.0.22.tgz",
+      "integrity": "sha512-eaayx0oJW0/imLyOhfjOdMx8FEKbWa8aKVvPNvXr3mXQbgzBEa+e147Xbh2CneG66we9C24JETE7QMLJ00popw==",
       "license": "MIT",
       "dependencies": {
-        "tailwind-variants": "3.2.2",
-        "tw-animate-css": "1.4.0"
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/spinner": "2.2.29",
+        "@heroui/use-is-mobile": "2.2.12",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/toast": "3.0.11",
+        "@react-stately/toast": "3.1.3"
       },
       "peerDependencies": {
-        "tailwindcss": ">=4.0.0"
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/tooltip": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/tooltip/-/tooltip-2.2.29.tgz",
+      "integrity": "sha512-PsHVC9XwjmbZpdu7o8TWSHENiCHCsoQpzpFJ3GYgnUULIhH5k69L/+5jiON9qG6k7+tL4RZS6pQPSbxDCf1acQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-overlay": "2.0.6",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/overlays": "3.31.2",
+        "@react-aria/tooltip": "3.9.2",
+        "@react-stately/tooltip": "3.5.11",
+        "@react-types/overlays": "3.9.4",
+        "@react-types/tooltip": "3.5.2"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-accordion": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-accordion/-/use-aria-accordion-2.2.20.tgz",
+      "integrity": "sha512-HvZhfrsxpCab+m4TrbHWsnA8iLaYdq1G1pjFCswftDRzfioJLmkJ0FMtYDPi792akJO+TWEvPhJibcwVD0bbfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/button": "3.14.5",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/selection": "3.27.2",
+        "@react-stately/tree": "3.9.6",
+        "@react-types/accordion": "3.0.0-alpha.26",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-button": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-button/-/use-aria-button-2.2.22.tgz",
+      "integrity": "sha512-6Y+fWkf/LKKxw3cd9QCSdLVMrMgKv+0AGCzNCfDiZ5kzQGCX4JQD9eK/495opAHV90yhIWzolwdNwtsyhDploA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/utils": "3.33.1",
+        "@react-types/button": "3.15.1",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-link": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-link/-/use-aria-link-2.2.23.tgz",
+      "integrity": "sha512-jpFj9HNCdt+DENPJyrfoN+AzuaMze9xqo5Y1P3KGoT/2pFDmelFgbXAOC5CHpatYFIn3YEELBGlj84zNXq2gjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/utils": "3.33.1",
+        "@react-types/link": "3.6.7",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-modal-overlay": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-modal-overlay/-/use-aria-modal-overlay-2.2.21.tgz",
+      "integrity": "sha512-Qwj5ldLFpfinfGpYUQu92TCpGKzd9Uamhd31ayRvYl6+LwOX124N9ObRYBTXyEiNJ7XFYer3vXQVeaR84xM1Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/use-aria-overlay": "2.0.6",
+        "@react-aria/overlays": "3.31.2",
+        "@react-aria/utils": "3.33.1",
+        "@react-stately/overlays": "3.6.23"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-multiselect": {
+      "version": "2.4.21",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-multiselect/-/use-aria-multiselect-2.4.21.tgz",
+      "integrity": "sha512-f/7YkTfS67OMXXYCO9WTI0Fj9YGPOgdwMIqhaSnFdA2UywA3W71PPeEqpKeuvO6isBW53YOynAPMZXF1NcsuHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/label": "3.7.25",
+        "@react-aria/listbox": "3.15.3",
+        "@react-aria/menu": "3.21.0",
+        "@react-aria/selection": "3.27.2",
+        "@react-aria/utils": "3.33.1",
+        "@react-stately/form": "3.2.4",
+        "@react-stately/list": "3.13.4",
+        "@react-stately/menu": "3.9.11",
+        "@react-types/button": "3.15.1",
+        "@react-types/overlays": "3.9.4",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-overlay": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-overlay/-/use-aria-overlay-2.0.6.tgz",
+      "integrity": "sha512-7q8oj5DZjr9oGYUB1UTOBnnuAapkBmfATCsdUeNOxQdYb2glJp52sTUslO+ykI9xVOAJSGYAmGuWgY5d+8mD6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/overlays": "3.31.2",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@heroui/use-callback-ref": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-callback-ref/-/use-callback-ref-2.1.8.tgz",
+      "integrity": "sha512-D1JDo9YyFAprYpLID97xxQvf86NvyWLay30BeVVZT9kWmar6O9MbCRc7ACi7Ngko60beonj6+amTWkTm7QuY/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/use-safe-layout-effect": "2.1.8"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-clipboard": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@heroui/use-clipboard/-/use-clipboard-2.1.9.tgz",
+      "integrity": "sha512-lkBq5RpXHiPvk1BXKJG8gMM0f7jRMIGnxAXDjAUzZyXKBuWLoM+XlaUWmZHtmkkjVFMX1L4vzA+vxi9rZbenEQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-data-scroll-overflow": {
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/@heroui/use-data-scroll-overflow/-/use-data-scroll-overflow-2.2.13.tgz",
+      "integrity": "sha512-zboLXO1pgYdzMUahDcVt5jf+l1jAQ/D9dFqr7AxWLfn6tn7/EgY0f6xIrgWDgJnM0U3hKxVeY13pAeB4AFTqTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-disclosure": {
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/@heroui/use-disclosure/-/use-disclosure-2.2.19.tgz",
+      "integrity": "sha512-N3CBikg1cxik2xp1UQkPUBbKPGrvtdsRyAlOnGygliyr5wKpZHLZi0R/g8OxTZVk3zUSCl7HZJT13ddM5TqEvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/use-callback-ref": "2.1.8",
+        "@react-aria/utils": "3.33.1",
+        "@react-stately/utils": "3.11.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-draggable": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@heroui/use-draggable/-/use-draggable-2.1.20.tgz",
+      "integrity": "sha512-yXn3jU3qiUx6aUd2osbDfddpnUTTh2wAVzpNyI+BXl2Z3rkVU9jqiJxZa+BXfsqFX17KrlrxwPPBmLNhSdBKHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/interactions": "3.27.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-form-reset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@heroui/use-form-reset/-/use-form-reset-2.0.1.tgz",
+      "integrity": "sha512-6slKWiLtVfgZnVeHVkM9eXgjwI07u0CUaLt2kQpfKPqTSTGfbHgCYJFduijtThhTdKBhdH6HCmzTcnbVlAxBXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-image": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/@heroui/use-image/-/use-image-2.1.14.tgz",
+      "integrity": "sha512-eCxtKOsM1tszBKYqz8qIJwGIxEAUC7ua+6L9vK8JgG6gOC0jEPFGH7keQuPVprzRtG3DmNt90icowqEjnOHdFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/use-safe-layout-effect": "2.1.8"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-intersection-observer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@heroui/use-intersection-observer/-/use-intersection-observer-2.2.14.tgz",
+      "integrity": "sha512-qYJeMk4cTsF+xIckRctazCgWQ4BVOpJu+bhhkB1NrN+MItx19Lcb7ksOqMdN5AiSf85HzDcAEPIQ9w9RBlt5sg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-is-mobile": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@heroui/use-is-mobile/-/use-is-mobile-2.2.12.tgz",
+      "integrity": "sha512-2UKa4v1xbvFwerWKoMTrg4q9ZfP9MVIVfCl1a7JuKQlXq3jcyV6z1as5bZ41pCsTOT+wUVOFnlr6rzzQwT9ZOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/ssr": "3.9.10"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-is-mounted": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-is-mounted/-/use-is-mounted-2.1.8.tgz",
+      "integrity": "sha512-DO/Th1vD4Uy8KGhd17oGlNA4wtdg91dzga+VMpmt94gSZe1WjsangFwoUBxF2uhlzwensCX9voye3kerP/lskg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-measure": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-measure/-/use-measure-2.1.8.tgz",
+      "integrity": "sha512-GjT9tIgluqYMZWfAX6+FFdRQBqyHeuqUMGzAXMTH9kBXHU0U5C5XU2c8WFORkNDoZIg1h13h1QdV+Vy4LE1dEA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-pagination": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/@heroui/use-pagination/-/use-pagination-2.2.20.tgz",
+      "integrity": "sha512-+ZK+vJgLq7JKLJAnIwfbxe/oF1hANtIiCR6H++q7fOw9pxZZQsntmLEu4kvRhpGZRp5C5T10A1GKIK7/xz1ZdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/i18n": "3.12.16"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-resize": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-resize/-/use-resize-2.1.8.tgz",
+      "integrity": "sha512-htF3DND5GmrSiMGnzRbISeKcH+BqhQ/NcsP9sBTIl7ewvFaWiDhEDiUHdJxflmJGd/c5qZq2nYQM/uluaqIkKA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-safe-layout-effect": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-safe-layout-effect/-/use-safe-layout-effect-2.1.8.tgz",
+      "integrity": "sha512-wbnZxVWCYqk10XRMu0veSOiVsEnLcmGUmJiapqgaz0fF8XcpSScmqjTSoWjHIEWaHjQZ6xr+oscD761D6QJN+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-scroll-position": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-scroll-position/-/use-scroll-position-2.1.8.tgz",
+      "integrity": "sha512-NxanHKObxVfWaPpNRyBR8v7RfokxrzcHyTyQfbgQgAGYGHTMaOGkJGqF8kBzInc3zJi+F0zbX7Nb0QjUgsLNUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-viewport-size": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@heroui/use-viewport-size/-/use-viewport-size-2.0.1.tgz",
+      "integrity": "sha512-blv8BEB/QdLePLWODPRzRS2eELJ2eyHbdOIADbL0KcfLzOUEg9EiuVk90hcSUDAFqYiJ3YZ5Z0up8sdPcR8Y7g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/user": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/@heroui/user/-/user-2.2.26.tgz",
+      "integrity": "sha512-3SESvOSYSVysSSwV1SR2QD8cOx6Fv/vVAXry/GmjLl9CSsA6HTlWoLy7TRtteGFqm3XRWVqjzCrcNGlvSmtdnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/avatar": "2.2.26",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1633,9 +3117,9 @@
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
-      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
+      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -2259,156 +3743,203 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@radix-ui/react-avatar": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz",
-      "integrity": "sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==",
-      "license": "MIT",
+    "node_modules/@react-aria/breadcrumbs": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.32.tgz",
+      "integrity": "sha512-S61vh5DJ2PXiXUwD7gk+pvS/b4VPrc3ZJOUZ0yVRLHkVESr5LhIZH+SAVgZkm1lzKyMRG+BH+fiRH/DZRSs7SA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.4",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/link": "^3.8.9",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/breadcrumbs": "^3.7.19",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
-      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
-      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
-      "license": "MIT",
+    "node_modules/@react-aria/button": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.14.5.tgz",
+      "integrity": "sha512-ZuLx+wQj9VQhH9BYe7t0JowmKnns2XrFHFNvIVBb5RwxL+CIycIOL7brhWKg2rGdxvlOom7jhVbcjSmtAaSyaQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.4"
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/toolbar": "3.0.0-beta.24",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
-      "license": "MIT",
+    "node_modules/@react-aria/calendar": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.9.5.tgz",
+      "integrity": "sha512-k0kvceYdZZu+DoeqephtlmIvh1CxqdFyoN52iqVzTz9O0pe5Xfhq7zxPGbeCp4pC61xzp8Lu/6uFA/YNfQQNag==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@internationalized/date": "^3.12.0",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/calendar": "^3.9.3",
+        "@react-types/button": "^3.15.1",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
-      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
-      "license": "MIT",
+    "node_modules/@react-aria/checkbox": {
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.16.5.tgz",
+      "integrity": "sha512-ZhUT7ELuD52hb+Zpzw0ElLQiVOd5sKYahrh+PK3vq13Wk5TedBscALpjuXetI4pwFfdmAM1Lhgcsrd8+6AmyvA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "use-sync-external-store": "^1.5.0"
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/toggle": "^3.12.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/checkbox": "^3.7.5",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
-      "license": "MIT",
+    "node_modules/@react-aria/combobox": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.15.0.tgz",
+      "integrity": "sha512-qSjQTFwKl3x1jCP2NRSJ6doZqAp6c2GTfoiFwWjaWg1IewwLsglaW6NnzqRDFiqFbDGgXPn4MqtC1VYEJ3NEjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/listbox": "^3.15.3",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/menu": "^3.21.0",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/combobox": "^3.13.0",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/combobox": "^3.14.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
       "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@react-aria/color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/color/-/color-3.2.0.tgz",
-      "integrity": "sha512-Qw1TySxXnGlE4L7kzsi8v86U1yFs9FtonqsbySFzLPzsMV1Oar+rtkYHI5vwNSyNNF6TBJJikJNocS9Fi8xXwA==",
+    "node_modules/@react-aria/datepicker": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.16.1.tgz",
+      "integrity": "sha512-6BltCVWt09yefTkGjb2gViGCwoddx9HKJiZbY9u6Es/Q+VhwNJQRtczbnZ3K32p262hIknukNf/5nZaCOI1AKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/spinbutton": "^3.7.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/datepicker": "^3.16.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/datepicker": "^3.13.5",
+        "@react-types/dialog": "^3.5.24",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dialog": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.34.tgz",
+      "integrity": "sha512-/x53Q5ynpW5Kv9637WYu7SrDfj3woSp6jJRj8l6teGnWW/iNZWYJETgzHfbxx+HPKYATCZesRoIeO2LnYIXyEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/dialog": "^3.5.24",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.5.tgz",
+      "integrity": "sha512-V18fwCyf8zqgJdpLQeDU5ZRNd9TeOfBbhLgmX77Zr5ae9XwaoJ1R3SFJG1wCJX60t34AW+aLZSEEK+saQElf3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/form": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.1.5.tgz",
+      "integrity": "sha512-BWlONgHn8hmaMkcS6AgMSLQeNqVBwqPNLhdqjDO/PCfzvV7O8NZw/dFeIzJwfG4aBfSpbHHRdXGdfrk3d8dylQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.15.0.tgz",
+      "integrity": "sha512-GWAQpdvtr+79qYrRT+5e+ZFbo8RYSlfwKwsxiPj+n8W63Tlf/E99WAMUXtWnzieOz0rPwolvyjS/RmvhqTD2fw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -2420,14 +3951,279 @@
       }
     },
     "node_modules/@react-aria/i18n": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.13.0.tgz",
-      "integrity": "sha512-APjw4EwmvlnIyDxixSWfjHvOFFkW2rVTyKZ4l9FV0v7hOerh+FWLE6mF1XnnX3pgz3yARkKWwhSR9xYcRK6tpg==",
+      "version": "3.12.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.16.tgz",
+      "integrity": "sha512-Km2CAz6MFQOUEaattaW+2jBdWOHUF8WX7VQoNbjlqElCP58nSaqi9yxTWUDRhAcn8/xFUnkFh4MFweNgtrHuEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.12.1",
-        "@internationalized/message": "^3.1.9",
-        "@internationalized/string": "^3.2.8",
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/message": "^3.1.8",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.27.1.tgz",
+      "integrity": "sha512-M3wLpTTmDflI0QGNK0PJNUaBXXfeBXue8ZxLMngfc1piHNiH4G5lUvWd9W14XVbqrSCVY8i8DfGrNYpyyZu0tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/label": {
+      "version": "3.7.25",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.25.tgz",
+      "integrity": "sha512-oNK3Pqj4LDPwEbQaoM/uCip4QvQmmwGOh08VeW+vzSi6TAwf+KoWTyH/tiAeB0CHWNDK0k3e1iTygTAt4wzBmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/landmark": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.1.0.tgz",
+      "integrity": "sha512-0218hm9M2IzMpWjW/Sq0+KVmYmH5H4jmfKraLBeeaKsgEHKr9V18EBFT+6DG5P77bB9gjab5AQvZQYwWmoLCeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/link": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.9.0.tgz",
+      "integrity": "sha512-XffSkG7OVZmQDkgFgwGQ6YUE0hxn9rmMTBMz3V7zaJsrkSbsPwUJiXzXF2nFFUaaCCnEUsl+KBkvArZE3tKXYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/listbox": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.15.3.tgz",
+      "integrity": "sha512-C6YgiyrHS5sbS5UBdxGMhEs+EKJYotJgGVtl9l0ySXpBUXERiHJWLOyV7a8PwkUOmepbB4FaLD7Y9EUzGkrGlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/list": "^3.13.4",
+        "@react-types/listbox": "^3.7.6",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/live-announcer": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.5.0.tgz",
+      "integrity": "sha512-1b+Txq00WQ/PJPCsZT+CI5qP86DrfFGPuJL5ifKtdMVXrxNGJWrfu7jTj6q9AbAOOXLG11BJ6blILu7sZeRPxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/menu": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.21.0.tgz",
+      "integrity": "sha512-CKTVZ4izSE1eKIti6TbTtzJAUo+WT8O4JC0XZCYDBpa0f++lD19Kz9aY+iY1buv5xGI20gAfpO474E9oEd4aQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/menu": "^3.9.11",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/tree": "^3.9.6",
+        "@react-types/button": "^3.15.1",
+        "@react-types/menu": "^3.10.7",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/numberfield": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.12.5.tgz",
+      "integrity": "sha512-Fi41IUWXEHLFIeJ/LHuZ9Azs8J/P563fZi37GSBkIq5P1pNt1rPgJJng5CNn4KsHxwqadTRUlbbZwbZraWDtRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/spinbutton": "^3.7.2",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/numberfield": "^3.11.0",
+        "@react-types/button": "^3.15.1",
+        "@react-types/numberfield": "^3.8.18",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.31.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.31.2.tgz",
+      "integrity": "sha512-78HYI08r6LvcfD34gyv19ArRIjy1qxOKuXl/jYnjLDyQzD4pVb634IQWcm0zt10RdKgyuH6HTqvuDOgZTLet7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/button": "^3.15.1",
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/progress": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.30.tgz",
+      "integrity": "sha512-S6OWVGgluSWYSd/A6O8CVjz83eeMUfkuWSra0ewAV9bmxZ7TP9pUmD3bGdqHZEl97nt5vHGjZ3eq/x8eCmzKhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/progress": "^3.5.18",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/radio": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.12.5.tgz",
+      "integrity": "sha512-8CCJKJzfozEiWBPO9QAATG1rBGJEJ+xoqvHf9LKU2sPFGsA2/SRnLs6LB9fCG5R3spvaK1xz0any1fjWPl7x8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/radio": "^3.11.5",
+        "@react-types/radio": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/selection": {
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.27.2.tgz",
+      "integrity": "sha512-GbUSSLX/ciXix95KW1g+SLM9np7iXpIZrFDSXkC6oNx1uhy18eAcuTkeZE25+SY5USVUmEzjI3m/3JoSUcebbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/slider": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.8.5.tgz",
+      "integrity": "sha512-gqkJxznk141mE0JamXF5CXml9PDbPkBz8dyKlihtWHWX4yhEbVYdC9J0otE7iCR3zx69Bm7WHoTGL0BsdpKzVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/slider": "^3.7.5",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/slider": "^3.8.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.8.0.tgz",
+      "integrity": "sha512-acXMvQkhwHwnbCbw6oeTZBCd0D9GiLbxLsBLev6Q8vwhZCuDHds1kSLZhRz64vnj7Q3cjAWQbb5gAA1wd2bbhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "@swc/helpers": "^0.5.0",
         "react-aria": "3.48.0"
       },
@@ -2437,16 +4233,168 @@
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.10.0.tgz",
-      "integrity": "sha512-mnelvACtfNWWKFCT1YHebxJRmfBmmANGwHQhCFPByMVTx1L8RumcaLxChYkE87g2KPuP5xX2il/oRn1DytW+qQ==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/switch": {
+      "version": "3.7.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.11.tgz",
+      "integrity": "sha512-dYVX71HiepBsKyeMaQgHbhqI+MQ3MVoTd5EnTbUjefIBnmQZavYj1/e4NUiUI4Ix+/C0HxL8ibDAv4NlSW3eLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/toggle": "^3.12.5",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/switch": "^3.5.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/table": {
+      "version": "3.17.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.11.tgz",
+      "integrity": "sha512-GkYmWPiW3OM+FUZxdS33teHXHXde7TjHuYgDDaG9phvg6cQTQjGilJozrzA3OfftTOq5VB8XcKTIQW3c0tpYsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/grid": "^3.14.8",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/table": "^3.15.4",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tabs": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.11.1.tgz",
+      "integrity": "sha512-3Ppz7yaEDW9L7p9PE9yNOl5caLwNnnLQqI+MX/dwbWlw9HluHS7uIjb21oswNl6UbSxAWyENOka45+KN4Fkh7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/tabs": "^3.8.9",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tabs": "^3.3.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/textfield": {
+      "version": "3.18.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.18.5.tgz",
+      "integrity": "sha512-ttwVSuwoV3RPaG2k2QzEXKeQNQ3mbdl/2yy6I4Tjrn1ZNkYHfVyJJ26AjenfSmj1kkTQoSAfZ8p+7rZp4n0xoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/textfield": "^3.12.8",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toast": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.11.tgz",
+      "integrity": "sha512-2DjZjBAvm8/CWbnZ6s7LjkYCkULKtjMve6GvhPTq98AthuEDLEiBvM1wa3xdecCRhZyRT1g6DXqVca0EfZ9fJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/landmark": "^3.0.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toast": "^3.1.3",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.13.0.tgz",
+      "integrity": "sha512-fU3r8XGUBjD1yNfxeLkI3I29Z/hR9QqoApA1ctOmcPYXJ2mnO0lf5jKyNSKeImCxVpHS0eMfaoo68a9PsYKb5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
         "react-aria": "3.48.0"
       },
-      "engines": {
-        "node": ">= 12"
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toolbar": {
+      "version": "3.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.24.tgz",
+      "integrity": "sha512-B2Rmpko7Ghi2RbNfsGdbR7I+RQBDhPGVE4bU3/EwHz+P/vNe5LyGPTeSwqaOMsQTF9lKNCkY8424dVTCr6RUMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tooltip": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.9.2.tgz",
+      "integrity": "sha512-VrgkPwHiEnAnBhoQ4W7kfry/RfVuRWrUPaJSp0+wKM6u0gg2tmn7OFRDXTxBAm/omQUguIdIjRWg7sf3zHH82A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/tooltip": "^3.5.11",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tooltip": "^3.5.2",
+        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -2454,14 +4402,33 @@
       }
     },
     "node_modules/@react-aria/utils": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.34.0.tgz",
-      "integrity": "sha512-ZM1ZXIqpwGTJjjL6o3JhlZkEaBpQdxuOCqLEvwEwooaj5GsYI3E9UfOl5vy3UW6bYiEEWl9pNBntrb9CR9kItQ==",
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.1.tgz",
+      "integrity": "sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0",
-        "react-stately": "3.46.0"
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.31",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.31.tgz",
+      "integrity": "sha512-RTOHHa4n56a9A3criThqFHBifvZoV71+MCkSuNP2cKO662SUWjqKkd0tJt/mBRMEJPkys8K7Eirp6T8Wt5FFRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -2605,10 +4572,24 @@
         "react-router": "7.14.1"
       }
     },
-    "node_modules/@react-spectrum/color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@react-spectrum/color/-/color-3.2.0.tgz",
-      "integrity": "sha512-Xg/U8+l1CQdvPRF4Zrv7AvtqsjuYUNkMxJMG0cIug9RKtIfEoyh7VR4Xg3FNd4Y/AwKXNJZZN4l94qz4WlK23Q==",
+    "node_modules/@react-spectrum/dialog": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/dialog/-/dialog-3.10.0.tgz",
+      "integrity": "sha512-U+0rTx1eG+BIpIb3vUAtP/n65CsyGydhtkJSNDTGUzG8yHgc7jGU/siwhY6/C8Y25wU4QggkXhIcn0y6rLvJ4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/react-spectrum": "3.47.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/listbox": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/listbox/-/listbox-3.16.0.tgz",
+      "integrity": "sha512-yYpBUScaF7v2qA6wcUM1D2bGlU63ZvFphkiu5qGeQHd4TdDNqVfmF4tlkUQZIH/PPPoXwvyFpKHwVfbNgqzJ5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum": "3.47.0",
@@ -2635,10 +4616,137 @@
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@react-stately/color": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/color/-/color-3.10.0.tgz",
-      "integrity": "sha512-P4tlvOYFA8hl/NXiMyPxfM+7rXV01hnwlvGCwbZqUK1aRv0Ry0yGCj2AbSzhYHx7i4J4+CVUJUYozNLzhm+6Sw==",
+    "node_modules/@react-spectrum/slider": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/slider/-/slider-3.9.0.tgz",
+      "integrity": "sha512-FTsfWfn6+BkXi8ZDcd7mBQs/KbKYJRHV6aQ64pC4gCnMw54eFcKSuCtlCtdGw3exLPQtGHCNVWGznOjgc8PtGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/react-spectrum": "3.47.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/switch": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/switch/-/switch-3.7.0.tgz",
+      "integrity": "sha512-xr+/6BefcxnuD2OJ8X2/nuz1XQOsHcbR1nnYE2B/KUJhrrTSxKpQcPnU36E1N1U8iQUO3TYn8zwCl3NHxpuByQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/react-spectrum": "3.47.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/tabs": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/tabs/-/tabs-3.9.0.tgz",
+      "integrity": "sha512-gTHgc7pONFCQDlOu9PYn2LueWQd5Oq49YVcRR8UxTM2TwrXf1gHcBnZKPmsfNoZ6FWMsXUG7ByeQJ6gdGoZC1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/react-spectrum": "3.47.0",
+        "@swc/helpers": "^0.5.0",
+        "react-stately": "3.46.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/calendar": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.9.3.tgz",
+      "integrity": "sha512-uw7fCZXoypSBBUsVkbNvJMQWTihZReRbyLIGG3o/ZM630N3OCZhb/h4Uxke4pNu7n527H0V1bAnZgAldIzOYqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/checkbox": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.7.5.tgz",
+      "integrity": "sha512-K5R5ted7AxLB3sDkuVAazUdyRMraFT1imVqij2GuAiOUFvsZvbuocnDuFkBVKojyV3GpqLBvViV8IaCMc4hNIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/collections": {
+      "version": "3.12.10",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.10.tgz",
+      "integrity": "sha512-wmF9VxJDyBujBuQ76vXj2g/+bnnj8fx5DdXgRmyfkkYhPB46+g2qnjbVGEvipo7bJuGxDftCUC4SN7l7xqUWfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/combobox": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.13.0.tgz",
+      "integrity": "sha512-dX9g/cK1hjLRjcbWVF6keHxTQDGhKGB2QAgPhWcBmOK3qJv+2dQqsJ6YCGWn/Y2N2acoEseLrAA7+Qe4HWV9cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/list": "^3.13.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/combobox": "^3.14.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/datepicker": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.16.1.tgz",
+      "integrity": "sha512-BtAMDvxd1OZxkxjqq5tN5TYmp6Hm8+o3+IDA4qmem2/pfQfVbOZeWS2WitcPBImj4n4T+W1A5+PI7mT/6DUBVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/datepicker": "^3.13.5",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.2.0.tgz",
+      "integrity": "sha512-HcfFk5sUpSVUgjOHUSi4izUWbiya+iTt2/PAviW+cKmCJOy507CQ3VG3Yu0Rqs0cr66yt3foDKy0MRNQ2zmGmQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -2647,31 +4755,357 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/form": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.2.4.tgz",
+      "integrity": "sha512-qNBzun8SbLdgahryhKLqL1eqP+MXY6as82sVXYOOvUYLzgU5uuN8mObxYlxJgMI5akSdQJQV3RzyfVobPRE7Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/list": {
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.13.4.tgz",
+      "integrity": "sha512-HHYSjA9VG7FPSAtpXAjQyM/V7qFHWGg88WmMrDt5QDlTBexwPuH0oFLnW0qaVZpAIxuWIsutZfxRAnme/NhhAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/menu": {
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.11.tgz",
+      "integrity": "sha512-vYkpO9uV2OUecsIkrOc+Urdl/s1xw/ibNH/UXsp4PtjMnS6mK9q2kXZTM3WvMAKoh12iveUO+YkYCZQshmFLHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/menu": "^3.10.7",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/numberfield": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.11.0.tgz",
+      "integrity": "sha512-rxfC047vL0LP4tanjinfjKAriAvdVL57Um5RUL5nHML8IOWCB3TBxegQkJ6to6goScC/oZhd0/Y2LSaiRuKbNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.5",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/numberfield": "^3.8.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.23",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.23.tgz",
+      "integrity": "sha512-RzWxots9A6gAzQMP4s8hOAHV7SbJRTFSlQbb6ly1nkWQXacOSZSFNGsKOaS0eIatfNPlNnW4NIkgtGws5UYzfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/overlays": "^3.9.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/radio": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.11.5.tgz",
+      "integrity": "sha512-QxA779S4ea5icQ0ja7CeiNzY1cj7c9G9TN0m7maAIGiTSinZl2Ia8naZJ0XcbRRp+LBll7RFEdekne15TjvS/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/radio": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.21.0.tgz",
+      "integrity": "sha512-SBafuZoJgDr7L9dCgMjat1Mx85xOnRO7E5UCtAj6TF/7yhisJVnrNkfnryOH2CunPyXCUgfUlUebkxeXjbW+lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-stately": "3.46.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/slider": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.7.5.tgz",
+      "integrity": "sha512-OrQMNR5xamLYH52TXtvTgyw3EMwv+JI+1istQgEj1CHBjC9eZZqn5iNCN20tzm+uDPTH0EIGULFjjPIumqYUQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/slider": "^3.8.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/table": {
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.15.4.tgz",
+      "integrity": "sha512-fGaNyw3wv7JgRCNzgyDzpaaTFuSy5f4Qekch4UheMXDJX7dOeaMhUXeOfvnXCVg+BGM4ey/D82RvDOGvPy1Nww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/grid": "^3.11.9",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/table/node_modules/@react-stately/grid": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.12.0.tgz",
+      "integrity": "sha512-MLCN3hyxRpaj4tUnQyc+aFR2/QBP2rmFcXGdADHO1c0kvxd9Vk+bEe88uA9MJTz2VClQ+AN7yRGCTIuME+QvNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-stately": "3.46.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tabs": {
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.9.tgz",
+      "integrity": "sha512-AQ4Xrn6YzIolaVShCV9cnwOjBKPAOGP/PTp7wpSEtQbQ0HZzUDG2RG/M4baMeUB2jZ33b7ifXyPcK78o0uOftg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/list": "^3.13.4",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tabs": "^3.3.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toast": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.3.tgz",
+      "integrity": "sha512-mT9QJKmD523lqFpOp0VWZ6QHZENFK7HrodnNJDVc7g616s5GNmemdlkITV43fSY3tHeThCVvPu+Uzh7RvQ9mpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toggle": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.9.5.tgz",
+      "integrity": "sha512-PVzXc788q3jH98Kvw1LYDL+wpVC14dCEKjOku8cSaqhEof6AJGaLR9yq+EF1yYSL2dxI6z8ghc0OozY8WrcFcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tooltip": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.11.tgz",
+      "integrity": "sha512-o8PnFXbvDCuVZ4Ht9ahfS6KHwIZjXopvoQ2vUPxv920irdgWEeC+4omgDOnJ/xFvcpmmJAmSsrQsTQrTguDUQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/tooltip": "^3.5.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tree": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.6.tgz",
+      "integrity": "sha512-JCuhGyX2A+PAMsx2pRSwArfqNFZJ9JSPkDaOQJS8MFPAsBe5HemvXsdmv9aBIMzlbCYcVq6EsrFnzbVVTBt/6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/utils": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.12.0.tgz",
-      "integrity": "sha512-7q+iHz9cENvro1dVKgdTxNh1i1mtWuLUI6UHp10TAgpxM9DyRDvmuN35zLXYCmMDgx3WLY2xkwqoez8xd+CdxQ==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
+      "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@swc/helpers": "^0.5.0",
-        "react-stately": "3.46.0"
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/virtualizer": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.6.tgz",
+      "integrity": "sha512-9SfXgLFB61/8SXNLfg5ARx9jAK4m03Aw6/Cg8mdZN24SYarL4TKNRpfw8K/HHVU/bi6WHSJypk6Z/z19o/ztrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@react-types/color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@react-types/color/-/color-3.2.0.tgz",
-      "integrity": "sha512-beV3vz80nzZ1EuYUM7296Kyi3AHcMrbQw0qub/9yzHWVTKKc5sy/e4dCMKcWL/ArkeAyc7jDOiui190RQ4l0Fw==",
+    "node_modules/@react-types/accordion": {
+      "version": "3.0.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/@react-types/accordion/-/accordion-3.0.0-alpha.26.tgz",
+      "integrity": "sha512-OXf/kXcD2vFlEnkcZy/GG+a/1xO9BN7Uh3/5/Ceuj9z2E/WwD55YwU3GFM5zzkZ4+DMkdowHnZX37XnmbyD3Mg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/color": "^3.2.0",
-        "@react-spectrum/color": "^3.2.0",
-        "@react-stately/color": "^3.10.0"
+        "@react-types/shared": "^3.27.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/breadcrumbs": {
+      "version": "3.7.19",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.19.tgz",
+      "integrity": "sha512-AnkyYYmzaM2QFi/N0P/kQLM8tHOyFi7p397B/jEMucXDfwMw5Ny1ObCXeIEqbh8KrIa2Xp8SxmQlCV+8FPs4LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/link": "^3.6.7",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.15.1.tgz",
+      "integrity": "sha512-M1HtsKreJkigCnqceuIT22hDJBSStbPimnpmQmsl7SNyqCFY3+DHS7y/Sl3GvqCkzxF7j9UTL0dG38lGQ3K4xQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/calendar": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.8.3.tgz",
+      "integrity": "sha512-fpH6WNXotzH0TlKHXXxtjeLZ7ko0sbyHmwDAwmDFyP7T0Iwn1YQZ+lhceLifvynlxuOgX6oBItyUKmkHQ0FouQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/checkbox": {
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.10.4.tgz",
+      "integrity": "sha512-tYCG0Pd1usEz5hjvBEYcqcA0youx930Rss1QBIse9TgMekA1c2WmPDNupYV8phpO8Zuej3DL1WfBeXcgavK8aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/combobox": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.14.0.tgz",
+      "integrity": "sha512-zmSSS7BcCOD8rGT8eGbVy7UlL5qq1vm88fFn4WgFe+lfK33ne+E7yTzTxcPY2TCGSo5fY6xMj3OG79FfVNGbSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/datepicker": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.13.5.tgz",
+      "integrity": "sha512-j28Vz+xvbb4bj7+9Xbpc4WTvSitlBvt7YEaEGM/8ZQ5g4Jr85H2KwkmDwjzmMN2r6VMQMMYq9JEcemq5wWpfUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.6.0.tgz",
+      "integrity": "sha512-vvxohmsTRZWE/saaJt6mMy3ONA4xbQTSk1okfMUK6OMSp/VpLBRLCz/2/myiMK3UIBCagUnrwzOwbk9whnFx0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/dialog": "^3.6.0",
+        "@react-spectrum/dialog": "^3.10.0"
       },
       "peerDependencies": {
         "@react-spectrum/provider": "^3.0.0",
@@ -2679,11 +5113,326 @@
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@react-types/dialog/node_modules/@react-aria/dialog": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.6.0.tgz",
+      "integrity": "sha512-FL7mInToLqYHCQExAj5fg1kpF5H4q0CvBs9GKZAo0HCWVv9pb5i4SiN1FXm5CJWU62UIhd7JysdW3Jl+TXtSng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/form": {
+      "version": "3.7.18",
+      "resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.18.tgz",
+      "integrity": "sha512-0sBJW0+I9nJcF4SmKrYFEWAlehiebSTy7xqriqAXtqfTEdvzAYLGaAK2/7gx+wlNZeDTdW43CDRJ4XAhyhBqnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/grid": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.8.tgz",
+      "integrity": "sha512-zJvXH8gc1e1VH2H3LRnHH/W2HIkLkZMH3Cu5pLcj0vDuLBSWpcr3Ikh3jZ+VUOZF0G1Jt1lO8pKIaqFzDLNmLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/link": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.7.tgz",
+      "integrity": "sha512-1apXCFJgMC1uydc2KNENrps1qR642FqDpwlNWe254UTpRZn/hEZhA6ImVr8WhomfLJu672WyWA0rUOv4HT+/pQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.8.0.tgz",
+      "integrity": "sha512-6l/P1mYQUQ7hGW6x8cH/EB8YvRzhhoB536G/GI7t2F2FbjcGkA1kNXhzDo24tLTXi9elnehevEEySRsRa9p6VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/listbox": "^3.16.0",
+        "@react-spectrum/listbox": "^3.16.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox/node_modules/@react-aria/listbox": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.16.0.tgz",
+      "integrity": "sha512-Jv6aTJECRntBvG+0ZQtXniAtHEQjvEi2QSm35FxRcsB8kgv7TmcinUOSZuHe5r8RDY2djILwdrqmfy6ApX0MDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/menu": {
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.7.tgz",
+      "integrity": "sha512-+p7ixZdvPDJZhisqdtWiiuJ9pteNfK5i19NB6wzAw5XkljbEzodNhwLv6rI96DY5XpbFso2kcjw7IWi+rAAGGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/numberfield": {
+      "version": "3.8.18",
+      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.18.tgz",
+      "integrity": "sha512-nLzk7YAG9yAUtSv+9R8LgCHsu8hJq8/A+m1KsKxvc8WmNJjIujSFgWvT21MWBiUgPBzJKGzAqpMDDa087mltJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.9.4.tgz",
+      "integrity": "sha512-7Z9HaebMFyYBqtv3XVNHEmVkm7AiYviV7gv0c98elEN2Co+eQcKFGvwBM9Gy/lV57zlTqFX1EX/SAqkMEbCLOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/progress": {
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.18.tgz",
+      "integrity": "sha512-mKeQn+KrHr1y0/k7KtrbeDGDaERH6i4f6yBwj/ZtYDCTNKMO3tPHJY6nzF0w/KKZLplIO+BjUbHXc2RVm8ovwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/radio": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.9.4.tgz",
+      "integrity": "sha512-TkMRY3sA1PcFZhhclu4IUzUTIir6MzNJj8h6WT8vO6Nug2kXJ72qigugVFBWJSE472mltduOErEAo0rtAYWbQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@react-types/shared": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.33.1.tgz",
+      "integrity": "sha512-oJHtjvLG43VjwemQDadlR5g/8VepK56B/xKO2XORPHt9zlW6IZs3tZrYlvH29BMvoqC7RtE7E5UjgbnbFtDGag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.9.0.tgz",
+      "integrity": "sha512-gbQWB8LnucC+jhDi5Imd2ZDPbVuiHt0xzObGHWq6GTZ3slLgTvGQaHNO5h9+h7dZH0iFQOVNb6+TlyTsnjFuAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/slider": "^3.9.0",
+        "@react-spectrum/slider": "^3.9.0",
+        "@react-stately/slider": "^3.8.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider/node_modules/@react-aria/slider": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.9.0.tgz",
+      "integrity": "sha512-FdowBjuYOT1OfAo6iEBGoz/EFJ0paRt3Gk/om+NwBF98yeqjHB7qZAkucGIswpixDfMNLYhGoiwiGYIYerhCxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider/node_modules/@react-stately/slider": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.8.0.tgz",
+      "integrity": "sha512-TonYUZZ9BENheuT1VPL8tJl3ltM3DKzw0aDKpfQudqMz3c9L11Efq+ZrBaIUIwNvA/W0kfrCRJ30byFEkNTyCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-stately": "3.46.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider/node_modules/@react-types/shared": {
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
       "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
       "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.6.0.tgz",
+      "integrity": "sha512-6pjDO5a35ovAAw5xsSJoftmUP1BhFzKazB5IuVBNTbeEvJjz/LC1NGkVV3sQX68ZDSZ0UyYLS7ENIVHKU+hjzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/switch": "^3.8.0",
+        "@react-spectrum/switch": "^3.7.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch/node_modules/@react-aria/switch": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.8.0.tgz",
+      "integrity": "sha512-sGfkuF2P9W6nkwRRHa73ivHbGCYHAfRXL3pZ8fYBOHAttwQKBgYqB+DTg9tD+FNLxB8Kr28nm9u6v6TGgTtWnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/table": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.6.tgz",
+      "integrity": "sha512-eluL+iFfnVmFm7OSZrrFG9AUjw+tcv898zbv+NsZACa8oXG1v9AimhZfd+Mo8q/5+sX/9hguWNXFkSvmTjuVPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.4.0.tgz",
+      "integrity": "sha512-/o2gmSKK9MmXCVL9vs+YYU1fl+u3+p07nbl2KXk0aL0UhVfgev3pKpFMjsWBiF9kUGp3EnVNjEDr8ZlSMIgZqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/tabs": "^3.12.0",
+        "@react-spectrum/tabs": "^3.9.0",
+        "@react-stately/tabs": "^3.9.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs/node_modules/@react-aria/tabs": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.12.0.tgz",
+      "integrity": "sha512-gvilqw9P2bpqc/DQluVA9c01f50d3wyjPMn41KzQBRnJKcsih0KHB5ynSoRxfOXw7TOu5w2ydfTXwZgrseu8/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs/node_modules/@react-stately/tabs": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.9.0.tgz",
+      "integrity": "sha512-BzMb3P90KL5Yezqk29POR0sN7NT40OgovAZTXgo/GBy1wTX239AeFKtEg+w3tIziB1o9rWkEaUIWLf0Y9ayDJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-stately": "3.46.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs/node_modules/@react-types/shared": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/textfield": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.8.tgz",
+      "integrity": "sha512-wt6FcuE5AyntxsnPika/h3nf/DPmeAVbI018L9o6h+B/IL4sMWWdx663wx2KOOeHH8ejKGZQNPLhUKs4s1mVQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tooltip": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.5.2.tgz",
+      "integrity": "sha512-FvSuZ2WP08NEWefrpCdBYpEEZh/5TvqvGjq0wqGzWg2OPwpc14HjD8aE7I3MOuylXkD4MSlMjl7J4DlvlcCs3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
@@ -3982,6 +6731,33 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.11.3.tgz",
+      "integrity": "sha512-vCU+OTylXN3hdC8RKg68tPlBPjjxtzon7Ys46MgrSLE+JhSjSTPvoQifV6DQJeJmA8Q3KT6CphJbejupx85vFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.11.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.11.3.tgz",
+      "integrity": "sha512-v2mrNSnMwnPJtcVqNvV0c5roGCBqeogN8jDtgtuHCphdwBasOZ17x8UV8qpHUh+u0MLfX43c0uUHKje0s+Zb0w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -4238,7 +7014,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5955,6 +8731,12 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -6368,6 +9150,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -8753,9 +11544,9 @@
       "license": "MIT"
     },
     "node_modules/input-otp": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
-      "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.1.tgz",
+      "integrity": "sha512-+yvpmKYKHi9jIGngxagY9oWiiblPB7+nEO75F2l2o4vs+6vpPZZmUl4tBNYuTCvQjhvEIbdNeJu70bhfYP2nbw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
@@ -12392,6 +15183,42 @@
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/react-aria-components/node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/react-aria-components/node_modules/@react-types/shared": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria/node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/react-aria/node_modules/@react-types/shared": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-base16-styling": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.10.0.tgz",
@@ -12571,6 +15398,24 @@
         "@swc/helpers": "^0.5.0",
         "use-sync-external-store": "^1.6.0"
       },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-stately/node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/react-stately/node_modules/@react-types/shared": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
@@ -13131,6 +15976,15 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.0.10.tgz",
+      "integrity": "sha512-t44QCeDKAPf1mtQH3fYpWz8IM/DyvHLjs8wUvvwMYxk5moOqCzrMSxK6HQVD0QVmVjXFavoFIPRVrMuJPKAvtg==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
     },
     "node_modules/semiver": {
       "version": "1.1.0",
@@ -14196,15 +17050,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tw-animate-css": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
-      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Wombosvideo"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "node": ">=22.12.0"
   },
   "dependencies": {
-    "@heroui/react": "3.0.3",
-    "@heroui/styles": "3.0.3",
+    "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.18",
     "@monaco-editor/react": "4.7.0",
     "@openhands/typescript-client": "github:OpenHands/typescript-client#7d20f119d68893903c3eab7070416e6317f72716",

--- a/src/components/features/settings/settings-dropdown-input.tsx
+++ b/src/components/features/settings/settings-dropdown-input.tsx
@@ -1,4 +1,4 @@
-import { ComboBox, Input, ListBox, type Key } from "@heroui/react";
+import { Autocomplete, AutocompleteItem } from "@heroui/react";
 import React, { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { OptionalTag } from "./optional-tag";
@@ -27,36 +27,6 @@ interface SettingsDropdownInputProps {
   inputClassName?: string;
 }
 
-const INPUT_GROUP_CLASS =
-  "bg-tertiary border border-[#717888] h-10 w-full max-w-[680px] rounded-sm px-2 flex items-center gap-2";
-const POPOVER_CLASS =
-  "bg-tertiary rounded-xl border border-[#717888] overflow-hidden";
-const LIST_BOX_CLASS = "max-h-60 overflow-auto py-1";
-const LIST_BOX_ITEM_CLASS =
-  "px-3 py-2 text-sm text-content hover:bg-white/5 cursor-pointer rounded-md mx-1";
-const CLEAR_BUTTON_CLASS =
-  "text-tertiary-light/80 hover:text-content transition-colors text-lg leading-none";
-const TRIGGER_CLASS =
-  "text-tertiary-light/80 hover:text-content transition-colors";
-
-const normalizeKey = (key: React.Key | null | undefined) =>
-  key === null || key === undefined ? null : String(key);
-
-const getItemLabel = (
-  items: { key: React.Key; label: string }[],
-  key: React.Key | null | undefined,
-) => {
-  const normalizedKey = normalizeKey(key);
-
-  if (normalizedKey === null) {
-    return "";
-  }
-
-  return (
-    items.find((item) => normalizeKey(item.key) === normalizedKey)?.label ?? ""
-  );
-};
-
 export function SettingsDropdownInput({
   testId,
   label,
@@ -80,70 +50,6 @@ export function SettingsDropdownInput({
   inputClassName,
 }: SettingsDropdownInputProps) {
   const { t } = useTranslation("openhands");
-  const isControlled = selectedKey !== undefined;
-  const [internalSelectedKey, setInternalSelectedKey] =
-    React.useState<Key | null>(defaultSelectedKey ?? null);
-  const [inputValue, setInputValue] = React.useState(() =>
-    getItemLabel(items, defaultSelectedKey),
-  );
-
-  const effectiveSelectedKey = isControlled
-    ? (selectedKey ?? null)
-    : internalSelectedKey;
-  const effectiveLabel = React.useMemo(
-    () => getItemLabel(items, effectiveSelectedKey),
-    [effectiveSelectedKey, items],
-  );
-
-  React.useEffect(() => {
-    if (!isControlled) {
-      setInternalSelectedKey(defaultSelectedKey ?? null);
-    }
-  }, [defaultSelectedKey, isControlled]);
-
-  React.useEffect(() => {
-    if (effectiveSelectedKey !== null) {
-      setInputValue(effectiveLabel);
-      return;
-    }
-
-    if (!allowsCustomValue) {
-      setInputValue("");
-    }
-  }, [allowsCustomValue, effectiveLabel, effectiveSelectedKey]);
-
-  const clearSelection = () => {
-    if (!isControlled) {
-      setInternalSelectedKey(null);
-    }
-
-    setInputValue("");
-    onSelectionChange?.(null);
-    onInputChange?.("");
-  };
-
-  const handleSelectionChange = (key: Key | null) => {
-    if (!isControlled) {
-      setInternalSelectedKey(key);
-    }
-
-    setInputValue(getItemLabel(items, key));
-    onSelectionChange?.(key);
-  };
-
-  const handleInputChange = (value: string) => {
-    setInputValue(value);
-
-    if (!value && isClearable) {
-      if (!isControlled) {
-        setInternalSelectedKey(null);
-      }
-
-      onSelectionChange?.(null);
-    }
-
-    onInputChange?.(value);
-  };
 
   return (
     <label className={cn("flex flex-col gap-2.5", wrapperClassName)}>
@@ -153,63 +59,41 @@ export function SettingsDropdownInput({
           {showOptionalTag && <OptionalTag />}
         </div>
       )}
-      <ComboBox
+      <Autocomplete
         aria-label={typeof label === "string" ? label : name}
-        allowsCustomValue={allowsCustomValue}
-        className="w-full"
-        defaultFilter={defaultFilter}
-        defaultInputValue={getItemLabel(items, defaultSelectedKey)}
-        defaultSelectedKey={defaultSelectedKey}
-        inputValue={inputValue}
-        isDisabled={isDisabled || isLoading}
-        isRequired={required}
-        items={items}
+        data-testid={testId}
         name={name}
-        onInputChange={handleInputChange}
-        onSelectionChange={handleSelectionChange}
-        selectedKey={effectiveSelectedKey}
+        items={items}
+        defaultSelectedKey={defaultSelectedKey}
+        selectedKey={selectedKey}
+        onSelectionChange={onSelectionChange}
+        onInputChange={onInputChange}
+        isClearable={isClearable}
+        isDisabled={isDisabled || isLoading}
+        isLoading={isLoading}
+        placeholder={isLoading ? t("HOME$LOADING") : placeholder}
+        allowsCustomValue={allowsCustomValue}
+        isRequired={required}
+        className="w-full"
+        classNames={{
+          popoverContent: "bg-tertiary rounded-xl",
+        }}
+        inputProps={{
+          classNames: {
+            inputWrapper: cn(
+              "bg-tertiary border border-[#717888] h-10 w-full max-w-[680px] rounded-sm p-2 placeholder:italic",
+              inputWrapperClassName,
+            ),
+            input: inputClassName,
+          },
+        }}
+        defaultFilter={defaultFilter}
+        startContent={startContent || null}
       >
-        <ComboBox.InputGroup
-          className={cn(INPUT_GROUP_CLASS, inputWrapperClassName)}
-        >
-          {startContent ? (
-            <span className="flex shrink-0 items-center">{startContent}</span>
-          ) : null}
-          <Input
-            aria-label={typeof label === "string" ? label : name}
-            className={cn(
-              "flex-1 bg-transparent text-sm text-content placeholder:italic outline-none",
-              inputClassName,
-            )}
-            data-testid={testId}
-            placeholder={isLoading ? t("HOME$LOADING") : placeholder}
-          />
-          {isClearable && inputValue ? (
-            <button
-              aria-label="Clear selection"
-              className={CLEAR_BUTTON_CLASS}
-              onClick={clearSelection}
-              type="button"
-            >
-              ×
-            </button>
-          ) : null}
-          <ComboBox.Trigger className={TRIGGER_CLASS} />
-        </ComboBox.InputGroup>
-        <ComboBox.Popover className={POPOVER_CLASS}>
-          <ListBox className={LIST_BOX_CLASS} items={items}>
-            {(item) => (
-              <ListBox.Item
-                className={LIST_BOX_ITEM_CLASS}
-                id={String(item.key)}
-                textValue={item.label}
-              >
-                {item.label}
-              </ListBox.Item>
-            )}
-          </ListBox>
-        </ComboBox.Popover>
-      </ComboBox>
+        {(item) => (
+          <AutocompleteItem key={item.key}>{item.label}</AutocompleteItem>
+        )}
+      </Autocomplete>
     </label>
   );
 }

--- a/src/components/shared/buttons/styled-tooltip.tsx
+++ b/src/components/shared/buttons/styled-tooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, type TooltipContentProps } from "@heroui/react";
+import { Tooltip, TooltipProps } from "@heroui/react";
 import React, { ReactNode } from "react";
 import { cn } from "#/utils/utils";
 
@@ -6,7 +6,7 @@ export interface StyledTooltipProps {
   children: ReactNode;
   content: string | ReactNode;
   tooltipClassName?: React.HTMLAttributes<HTMLDivElement>["className"];
-  placement?: TooltipContentProps["placement"];
+  placement?: TooltipProps["placement"];
   showArrow?: boolean;
   closeDelay?: number;
 }
@@ -20,15 +20,14 @@ export function StyledTooltip({
   closeDelay = 100,
 }: StyledTooltipProps) {
   return (
-    <Tooltip closeDelay={closeDelay}>
-      <Tooltip.Trigger className="inline-flex">{children}</Tooltip.Trigger>
-      <Tooltip.Content
-        className={cn("bg-white text-black", tooltipClassName)}
-        placement={placement}
-        showArrow={showArrow}
-      >
-        {content}
-      </Tooltip.Content>
+    <Tooltip
+      content={content}
+      closeDelay={closeDelay}
+      placement={placement}
+      className={cn("bg-white text-black", tooltipClassName)}
+      showArrow={showArrow}
+    >
+      <div className="inline-flex">{children}</div>
     </Tooltip>
   );
 }

--- a/src/components/shared/modals/settings/model-selector.tsx
+++ b/src/components/shared/modals/settings/model-selector.tsx
@@ -1,22 +1,18 @@
 import {
-  ComboBox,
-  Header,
-  Input,
-  ListBox,
-  Separator,
-  Spinner,
-  type Key,
+  Autocomplete,
+  AutocompleteItem,
+  AutocompleteSection,
 } from "@heroui/react";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
-import { extractModelAndProvider } from "#/utils/extract-model-and-provider";
 import { mapProvider } from "#/utils/map-provider";
+import { extractModelAndProvider } from "#/utils/extract-model-and-provider";
 import { cn } from "#/utils/utils";
-import { PRODUCT_URL } from "#/utils/constants";
-import { useProviderModels } from "#/hooks/query/use-provider-models";
-import { useSearchProviders } from "#/hooks/query/use-search-providers";
 import { HelpLink } from "#/ui/help-link";
+import { PRODUCT_URL } from "#/utils/constants";
+import { useSearchProviders } from "#/hooks/query/use-search-providers";
+import { useProviderModels } from "#/hooks/query/use-provider-models";
 
 interface ModelSelectorProps {
   isDisabled?: boolean;
@@ -28,127 +24,6 @@ interface ModelSelectorProps {
   ) => void;
   wrapperClassName?: string;
   labelClassName?: string;
-}
-
-interface ComboBoxSectionItem {
-  key: string;
-  label: string;
-  section: "verified" | "others";
-  testId?: string;
-}
-
-const INPUT_GROUP_CLASS =
-  "bg-tertiary border border-[#717888] h-10 w-full rounded-sm px-2 flex items-center gap-2";
-const POPOVER_CLASS =
-  "bg-tertiary rounded-xl border border-[#717888] overflow-hidden";
-const LIST_BOX_ITEM_CLASS =
-  "px-3 py-2 text-sm text-content hover:bg-white/5 cursor-pointer rounded-md mx-1";
-const TRIGGER_CLASS =
-  "text-tertiary-light/80 hover:text-content transition-colors";
-const SECTION_HEADER_CLASS =
-  "px-3 pt-2 pb-1 text-xs uppercase text-tertiary-light";
-const SECTION_SEPARATOR_CLASS = "my-1 h-px bg-[#717888]/50";
-
-function SectionedComboBox({
-  ariaLabel,
-  testId,
-  items,
-  placeholder,
-  selectedKey,
-  inputValue,
-  isDisabled,
-  isRequired,
-  isLoading,
-  verifiedLabel,
-  othersLabel,
-  onSelectionChange,
-  onInputChange,
-}: {
-  ariaLabel: string;
-  testId: string;
-  items: ComboBoxSectionItem[];
-  placeholder: string;
-  selectedKey: string | null;
-  inputValue: string;
-  isDisabled?: boolean;
-  isRequired?: boolean;
-  isLoading?: boolean;
-  verifiedLabel: string;
-  othersLabel: string;
-  onSelectionChange: (key: Key | null) => void;
-  onInputChange?: (value: string) => void;
-}) {
-  const verifiedItems = React.useMemo(
-    () => items.filter((item) => item.section === "verified"),
-    [items],
-  );
-  const otherItems = React.useMemo(
-    () => items.filter((item) => item.section === "others"),
-    [items],
-  );
-
-  return (
-    <ComboBox
-      aria-label={ariaLabel}
-      className="w-full"
-      inputValue={inputValue}
-      isDisabled={isDisabled}
-      isRequired={isRequired}
-      items={items}
-      name={testId}
-      onInputChange={onInputChange}
-      onSelectionChange={onSelectionChange}
-      selectedKey={selectedKey}
-    >
-      <ComboBox.InputGroup className={INPUT_GROUP_CLASS}>
-        <Input
-          aria-label={ariaLabel}
-          className="flex-1 bg-transparent text-sm text-content placeholder:italic outline-none"
-          data-testid={testId}
-          placeholder={placeholder}
-        />
-        {isLoading ? <Spinner size="sm" /> : null}
-        <ComboBox.Trigger className={TRIGGER_CLASS} />
-      </ComboBox.InputGroup>
-      <ComboBox.Popover className={POPOVER_CLASS}>
-        <ListBox className="max-h-60 overflow-auto py-1">
-          <ListBox.Section>
-            <Header className={SECTION_HEADER_CLASS}>{verifiedLabel}</Header>
-            {verifiedItems.map((item) => (
-              <ListBox.Item
-                className={LIST_BOX_ITEM_CLASS}
-                data-testid={item.testId}
-                id={item.key}
-                key={item.key}
-                textValue={item.label}
-              >
-                {item.label}
-              </ListBox.Item>
-            ))}
-          </ListBox.Section>
-          {otherItems.length > 0 ? (
-            <>
-              <Separator className={SECTION_SEPARATOR_CLASS} />
-              <ListBox.Section>
-                <Header className={SECTION_HEADER_CLASS}>{othersLabel}</Header>
-                {otherItems.map((item) => (
-                  <ListBox.Item
-                    className={LIST_BOX_ITEM_CLASS}
-                    data-testid={item.testId}
-                    id={item.key}
-                    key={item.key}
-                    textValue={item.label}
-                  >
-                    {item.label}
-                  </ListBox.Item>
-                ))}
-              </ListBox.Section>
-            </>
-          ) : null}
-        </ListBox>
-      </ComboBox.Popover>
-    </ComboBox>
-  );
 }
 
 export function ModelSelector({
@@ -164,12 +39,6 @@ export function ModelSelector({
     null,
   );
   const [selectedModel, setSelectedModel] = React.useState<string | null>(null);
-  const [pendingCurrentModel, setPendingCurrentModel] = React.useState<{
-    provider: string | null;
-    model: string | null;
-  } | null>(null);
-  const [providerInputValue, setProviderInputValue] = React.useState("");
-  const [modelInputValue, setModelInputValue] = React.useState("");
 
   const { data: providers = [] } = useSearchProviders();
   const {
@@ -179,143 +48,53 @@ export function ModelSelector({
   } = useProviderModels(selectedProvider);
 
   const verifiedProviders = React.useMemo(
-    () => providers.filter((provider) => provider.verified),
+    () => providers.filter((p) => p.verified),
     [providers],
   );
   const unverifiedProviders = React.useMemo(
-    () => providers.filter((provider) => !provider.verified),
+    () => providers.filter((p) => !p.verified),
     [providers],
   );
 
   const verifiedModels = React.useMemo(
-    () => providerModels.filter((model) => model.verified),
+    () => providerModels.filter((m) => m.verified),
     [providerModels],
   );
   const unverifiedModels = React.useMemo(
-    () => providerModels.filter((model) => !model.verified),
+    () => providerModels.filter((m) => !m.verified),
     [providerModels],
   );
 
-  const providerItems = React.useMemo<ComboBoxSectionItem[]>(
-    () => [
-      ...verifiedProviders.map((provider) => ({
-        key: provider.name,
-        label: mapProvider(provider.name),
-        section: "verified" as const,
-        testId: `provider-item-${provider.name}`,
-      })),
-      ...unverifiedProviders.map((provider) => ({
-        key: provider.name,
-        label: mapProvider(provider.name),
-        section: "others" as const,
-      })),
-    ],
-    [unverifiedProviders, verifiedProviders],
-  );
-
-  const modelItems = React.useMemo<ComboBoxSectionItem[]>(
-    () => [
-      ...verifiedModels.map((model) => ({
-        key: model.name,
-        label: model.name,
-        section: "verified" as const,
-      })),
-      ...unverifiedModels.map((model) => ({
-        key: model.name,
-        label: model.name,
-        section: "others" as const,
-        testId: `model-item-${model.name}`,
-      })),
-    ],
-    [unverifiedModels, verifiedModels],
-  );
-
   React.useEffect(() => {
-    if (!currentModel) {
-      return;
+    if (currentModel) {
+      const { provider, model } = extractModelAndProvider(currentModel);
+
+      setLitellmId(currentModel);
+      setSelectedProvider(provider || null);
+      setSelectedModel(model);
+      onDefaultValuesChanged?.(provider || null, model);
     }
-
-    const { provider, model } = extractModelAndProvider(currentModel);
-
-    setLitellmId(currentModel);
-    setPendingCurrentModel({ provider: provider || null, model });
-    setSelectedProvider(provider || null);
-    setSelectedModel(null);
-    setProviderInputValue(provider ? mapProvider(provider) : "");
-    setModelInputValue(model ?? "");
-    onDefaultValuesChanged?.(provider || null, model);
-  }, [currentModel, onDefaultValuesChanged]);
-
-  React.useEffect(() => {
-    if (!selectedProvider) {
-      setModelInputValue("");
-      setSelectedModel(null);
-      return;
-    }
-
-    const nextProviderLabel = mapProvider(selectedProvider);
-    if (providerInputValue !== nextProviderLabel) {
-      setProviderInputValue(nextProviderLabel);
-    }
-  }, [providerInputValue, selectedProvider]);
-
-  React.useEffect(() => {
-    if (!pendingCurrentModel?.model) {
-      return;
-    }
-
-    if (pendingCurrentModel.provider !== selectedProvider) {
-      return;
-    }
-
-    const matchingModel = providerModels.find(
-      (model) => model.name === pendingCurrentModel.model,
-    );
-
-    if (!matchingModel) {
-      return;
-    }
-
-    setSelectedModel(matchingModel.name);
-    setModelInputValue(matchingModel.name);
-    setPendingCurrentModel(null);
-  }, [pendingCurrentModel, providerModels, selectedProvider]);
-
-  React.useEffect(() => {
-    if (!selectedModel) {
-      return;
-    }
-
-    setModelInputValue(selectedModel);
-  }, [modelItems.length, selectedModel]);
+  }, [currentModel]);
 
   const handleChangeProvider = (provider: string) => {
     setSelectedProvider(provider);
     setSelectedModel(null);
-    setModelInputValue("");
-    setProviderInputValue(mapProvider(provider));
     setLitellmId(`${provider}/`);
     onChange?.(provider, null);
   };
 
   const handleChangeModel = (model: string) => {
     let fullModel = `${selectedProvider}/${model}`;
-
     if (selectedProvider === "openai") {
       fullModel = model;
     }
-
     setLitellmId(fullModel);
     setSelectedModel(model);
-    setModelInputValue(model);
     onChange?.(selectedProvider, model);
   };
 
   const clear = () => {
     setSelectedProvider(null);
-    setSelectedModel(null);
-    setProviderInputValue("");
-    setModelInputValue("");
     setLitellmId(null);
   };
 
@@ -332,29 +111,51 @@ export function ModelSelector({
         <label className={cn("text-sm", labelClassName)}>
           {t(I18nKey.LLM$PROVIDER)}
         </label>
-        <SectionedComboBox
-          ariaLabel={t(I18nKey.LLM$PROVIDER)}
-          inputValue={providerInputValue}
-          isDisabled={isDisabled}
+        <Autocomplete
+          data-testid="llm-provider-input"
           isRequired
-          items={providerItems}
-          onInputChange={(value) => {
-            setProviderInputValue(value);
-            if (!value) {
-              clear();
-            }
-          }}
-          onSelectionChange={(key) => {
-            if (key?.toString()) {
-              handleChangeProvider(key.toString());
-            }
-          }}
-          othersLabel={t(I18nKey.MODEL_SELECTOR$OTHERS)}
+          isVirtualized={false}
+          name="llm-provider-input"
+          isDisabled={isDisabled}
+          aria-label={t(I18nKey.LLM$PROVIDER)}
           placeholder={t(I18nKey.LLM$SELECT_PROVIDER_PLACEHOLDER)}
+          isClearable={false}
+          onSelectionChange={(e) => {
+            if (e?.toString()) handleChangeProvider(e.toString());
+          }}
+          onInputChange={(value) => !value && clear()}
+          defaultSelectedKey={selectedProvider ?? undefined}
           selectedKey={selectedProvider}
-          testId="llm-provider-input"
-          verifiedLabel={t(I18nKey.MODEL_SELECTOR$VERIFIED)}
-        />
+          classNames={{
+            popoverContent: "bg-tertiary rounded-xl border border-[#717888]",
+          }}
+          inputProps={{
+            classNames: {
+              inputWrapper:
+                "bg-tertiary border border-[#717888] h-10 w-full rounded-sm p-2 placeholder:italic",
+            },
+          }}
+        >
+          <AutocompleteSection title={t(I18nKey.MODEL_SELECTOR$VERIFIED)}>
+            {verifiedProviders.map((provider) => (
+              <AutocompleteItem
+                data-testid={`provider-item-${provider.name}`}
+                key={provider.name}
+              >
+                {mapProvider(provider.name)}
+              </AutocompleteItem>
+            ))}
+          </AutocompleteSection>
+          {unverifiedProviders.length > 0 ? (
+            <AutocompleteSection title={t(I18nKey.MODEL_SELECTOR$OTHERS)}>
+              {unverifiedProviders.map((provider) => (
+                <AutocompleteItem key={provider.name}>
+                  {mapProvider(provider.name)}
+                </AutocompleteItem>
+              ))}
+            </AutocompleteSection>
+          ) : null}
+        </Autocomplete>
       </fieldset>
 
       {selectedProvider === "openhands" && (
@@ -363,8 +164,8 @@ export function ModelSelector({
           text={t(I18nKey.SETTINGS$NEED_OPENHANDS_ACCOUNT)}
           linkText={t(I18nKey.SETTINGS$CLICK_HERE)}
           href={PRODUCT_URL.PRODUCTION}
-          linkColor="white"
           size="settings"
+          linkColor="white"
         />
       )}
 
@@ -372,27 +173,51 @@ export function ModelSelector({
         <label className={cn("text-sm", labelClassName)}>
           {t(I18nKey.LLM$MODEL)}
         </label>
-        <SectionedComboBox
-          ariaLabel={t(I18nKey.LLM$MODEL)}
-          inputValue={modelInputValue}
-          isDisabled={isDisabled || !selectedProvider}
-          isLoading={isLoadingModels}
+        <Autocomplete
+          data-testid="llm-model-input"
           isRequired
-          items={modelItems}
-          onInputChange={setModelInputValue}
-          onSelectionChange={(key) => {
-            if (key?.toString()) {
-              handleChangeModel(key.toString());
-            }
-          }}
-          othersLabel={t(I18nKey.MODEL_SELECTOR$OTHERS)}
+          isVirtualized={false}
+          isLoading={isLoadingModels}
+          name="llm-model-input"
+          aria-label={t(I18nKey.LLM$MODEL)}
           placeholder={t(I18nKey.LLM$SELECT_MODEL_PLACEHOLDER)}
+          isClearable={false}
+          onSelectionChange={(e) => {
+            if (e?.toString()) handleChangeModel(e.toString());
+          }}
+          isDisabled={isDisabled || !selectedProvider}
           selectedKey={selectedModel}
-          testId="llm-model-input"
-          verifiedLabel={t(I18nKey.MODEL_SELECTOR$VERIFIED)}
-        />
+          defaultSelectedKey={selectedModel ?? undefined}
+          classNames={{
+            popoverContent: "bg-tertiary rounded-xl border border-[#717888]",
+          }}
+          inputProps={{
+            classNames: {
+              inputWrapper:
+                "bg-tertiary border border-[#717888] h-10 w-full rounded-sm p-2 placeholder:italic",
+            },
+          }}
+        >
+          <AutocompleteSection title={t(I18nKey.MODEL_SELECTOR$VERIFIED)}>
+            {verifiedModels.map((model) => (
+              <AutocompleteItem key={model.name}>{model.name}</AutocompleteItem>
+            ))}
+          </AutocompleteSection>
+          {unverifiedModels.length > 0 ? (
+            <AutocompleteSection title={t(I18nKey.MODEL_SELECTOR$OTHERS)}>
+              {unverifiedModels.map((model) => (
+                <AutocompleteItem
+                  data-testid={`model-item-${model.name}`}
+                  key={model.name}
+                >
+                  {model.name}
+                </AutocompleteItem>
+              ))}
+            </AutocompleteSection>
+          ) : null}
+        </Autocomplete>
         {modelsError && (
-          <p className="text-danger text-xs" data-testid="models-error">
+          <p data-testid="models-error" className="text-danger text-xs">
             {t(I18nKey.CONFIGURATION$ERROR_FETCH_MODELS)}
           </p>
         )}

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -33,7 +33,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body style={{ margin: 0 }}>
+      <body data-agent-server-ui="" style={{ margin: 0 }}>
         <AgentServerUIRoot contentClassName="min-h-screen">
           {children}
           <Toaster />

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,7 +1,8 @@
 @import "tailwindcss";
-@import "@heroui/styles";
 
+@plugin '../hero.ts';
 @config "../tailwind.config.js";
+@source '../node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}';
 
 @plugin 'tailwind-scrollbar' {
   nocompatible: true;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,4 @@
 /** @type {import('tailwindcss').Config} */
-import { heroui } from "@heroui/react";
 import typography from "@tailwindcss/typography";
 export default {
   darkMode: "class",


### PR DESCRIPTION
<img width="1440" height="796" alt="issue" src="https://github.com/user-attachments/assets/fbda98b2-70b3-4114-96b1-f5683db7502a" />

### Description

Following the HeroUI v3 upgrade landed in PR #28 (`6fc9e54`) and re-applied in PR #50 (`2dd6204`), every dropdown on `/settings` (LLM Provider, LLM Model, Condenser, etc.) renders broken: clicking the input shows item labels as raw, unstyled text overflowing the page rather than as a dark popover with readable rows.

The user-visible effect is that the LLM cannot be configured — Provider and Model selection is blocked.

### Steps to reproduce

1. `npm run dev` (or `npm run dev:mock`).
2. Open `http://localhost:3001/settings`.
3. Click the **LLM Provider** dropdown.

### Expected

A dark, rounded popover opens directly under the input, item rows are readable, hovered rows highlight, the list scrolls when long. Visuals match OpenHands `frontend/`.

### Actual

The popover renders as plain transparent text floating over the page, with item labels barely visible.

### Root cause

Two stacked problems:

1. **HeroUI v3 migration broke styling/component contracts.** PR #28 auto-bumped `@heroui/react` 2.8.10 → 3.0.3, and an automated follow-up commit attempted a v3 migration:
   - Deleted `hero.ts`.
   - Replaced `@plugin '../hero.ts'` + `@source '...@heroui/theme/dist...'` in `src/tailwind.css` with `@import "@heroui/styles"` (which does not register HeroUI as a Tailwind v4 source/plugin).
   - Left a dead `import { heroui }` in `tailwind.config.js`.
   - Rewrote `settings-dropdown-input.tsx` and `model-selector.tsx` to use v3's compound `ComboBox` / `ListBox` / `Popover` API, which has different component anatomy and styling tokens than v2.
   - Switched `styled-tooltip.tsx` to v3's compound `Tooltip.Trigger` / `Tooltip.Content` API.

   OpenHands (the canonical UI reference) remains on `@heroui/react: 2.8.7` (v2) — agent-canvas is the only consumer that diverged.

2. **Scoped-styles wrapper hides HeroUI variables from portal'd popovers.** Even after restoring v2 components, the popover still rendered with no contrast. The agent-canvas project ships an embeddable-styles system introduced in PR #55: `vite.config.ts` runs every CSS rule through `postcss-prefix-selector`, rewriting `:root`/`html`/`body` and other selectors to live under `[data-agent-server-ui]`. HeroUI v2 `Autocomplete` opens its popover into a React Aria portal at `document.body`, which was *not* inside the scope — so the portal'd popover received none of HeroUI's CSS variables (`--heroui-default-foreground`, `--heroui-default-100`, etc.), defined only on `[data-agent-server-ui]`. OpenHands has no such prefixer, so the same component works there with no extra wiring.

### Fix

Revert the v3 migration to align with OpenHands' v2 setup, then add `data-agent-server-ui=""` to `<body>` in `src/root.tsx` so portal'd popovers fall within the scope.

### Acceptance criteria

- LLM Provider, LLM Model, Condenser, Verification dropdowns on `/settings` open as dark, anchored popovers with readable, hover-highlighted rows.
- `npm run typecheck` passes.
- `npm run build` succeeds.
- Visual parity with OpenHands `frontend/` `/settings`.

### Summary

`/settings` dropdowns (LLM Provider, LLM Model, Condenser, …) were rendering as unstyled overflowing text — see the issue screenshots. This PR fixes them by reverting the HeroUI v3 migration to v2 (matching OpenHands) and adding `data-agent-server-ui=""` to `<body>` so HeroUI's portal'd popover inherits the scoped CSS variables.

### Root cause

Two stacked regressions:

1. **HeroUI v3 migration was incomplete.** PR #28 auto-bumped `@heroui/react` 2.8.10 → 3.0.3; an automated follow-up commit replaced the v2 `Autocomplete` API with v3 `ComboBox`/`ListBox`/`Tooltip` compound components and rewired `tailwind.config.js` / `src/tailwind.css` for the new `@heroui/styles` contract. The wiring was incomplete (the `heroui()` Tailwind plugin was no longer being registered, `hero.ts` was deleted), so v3's CSS variables for popover/listbox/tooltip never made it into the Tailwind output.
2. **Scoped-styles wrapper hid HeroUI variables from portal'd popovers.** After restoring v2 components, the popover still had no contrast: agent-canvas runs every CSS rule through `postcss-prefix-selector`, scoping it under `[data-agent-server-ui]`. HeroUI v2 `Autocomplete` opens its popover via a React Aria portal at `document.body`. Because `<body>` did not carry `data-agent-server-ui`, the portal'd popover got none of HeroUI's CSS variables and rendered with default-foreground tokens that resolve to nothing. OpenHands has no such prefixer, so the same component works there unchanged.

OpenHands `frontend/` is on `@heroui/react@2.8.7` (v2) and is the visual reference per `AGENTS.md`. v3 was a divergence with no upstream demand.

### Fix

**Revert HeroUI v3 → v2** (surgical, not `git revert`, to preserve unrelated post-v3 work like the `org → surface` rename in PR #83 and i18n namespacing in PR #62):

| File | Change |
|------|--------|
| `package.json` | `@heroui/react`: `3.0.3` → `2.8.10`; remove `@heroui/styles` |
| `hero.ts` (new at root) | Restore v2 `heroui()` config (`defaultTheme: "dark"`) — verbatim match with OpenHands |
| `tailwind.config.js` | Drop the dead `import { heroui } from "@heroui/react"` |
| `src/tailwind.css` | Replace `@import "@heroui/styles"` with `@plugin '../hero.ts'` + `@source '...@heroui/theme/dist...'` |
| `src/components/features/settings/settings-dropdown-input.tsx` | Restore v2 `Autocomplete` / `AutocompleteItem`; keep `useTranslation("openhands")` from PR #62 |
| `src/components/shared/modals/settings/model-selector.tsx` | Restore v2 `Autocomplete` + `AutocompleteSection` |
| `src/components/shared/buttons/styled-tooltip.tsx` | Restore v2 `Tooltip` API (single `content` prop, no `Tooltip.Trigger`/`Tooltip.Content`) |
| `AGENTS.md` | Restore the v2 rollback notes |

**Scope body for portal'd popovers:**

| File | Change |
|------|--------|
| `src/root.tsx` | Add `data-agent-server-ui=""` to `<body>` so body-level portals inherit the prefixed CSS variables. `AgentServerUIRoot` (used in library/embed mode) is unchanged. |

### Why not a plain `git revert 2dd6204`?

Tempting but conflicts: subsequent commits modified the same files for unrelated reasons — `tailwind.config.js` was touched by PR #83 to rename `org → surface`, `settings-dropdown-input.tsx` by PR #62 for i18n namespacing. A raw revert would undo that work.

### Demo Screenshot

<img width="1440" height="796" alt="output" src="https://github.com/user-attachments/assets/55e7b20e-3a10-47b8-af74-ed16fbc6416f" />
