### PR TITLE
feat(frontend): always render Workspaces tab regardless of Git PAT

### DIFF
--- a/__tests__/components/features/home/repo-selection-form.test.tsx
+++ b/__tests__/components/features/home/repo-selection-form.test.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RepositorySelectionForm } from "../../../../src/components/features/home/repo-selection-form";
 import { LaunchTabs } from "../../../../src/components/features/home/launch-tabs";
 import GitService from "#/api/git-service/git-service.api";
+import SettingsService from "#/api/settings-service/settings-service.api";
+import { DEFAULT_SETTINGS } from "#/services/settings";
 import { GitRepository } from "#/types/git";
 import { useHomeStore } from "#/stores/home-store";
 import { useWorkspacesStore } from "#/stores/workspaces-store";
@@ -360,5 +362,58 @@ describe("RepositorySelectionForm", () => {
       await screen.findByTestId("workspace-launch-button"),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("git-repo-dropdown")).not.toBeInTheDocument();
+  });
+
+  it("keeps the Workspaces tab reachable when no provider is configured", async () => {
+    mockUseUserProviders.mockReturnValue({ providers: [] });
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      DEFAULT_SETTINGS,
+    );
+    useWorkspacesStore.setState({ workspaces: [] });
+
+    render(<LaunchTabs onRepoSelection={mockOnRepoSelection} />, {
+      wrapper: ({ children }) => (
+        <QueryClientProvider
+          client={
+            new QueryClient({
+              defaultOptions: { queries: { retry: false } },
+            })
+          }
+        >
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    await userEvent.click(screen.getByTestId("workspaces-tab"));
+
+    expect(
+      await screen.findByTestId("workspace-launch-button"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the connect-provider empty state in the Repositories tab when no provider is configured", async () => {
+    mockUseUserProviders.mockReturnValue({ providers: [] });
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      DEFAULT_SETTINGS,
+    );
+
+    render(<LaunchTabs onRepoSelection={mockOnRepoSelection} />, {
+      wrapper: ({ children }) => (
+        <QueryClientProvider
+          client={
+            new QueryClient({
+              defaultOptions: { queries: { retry: false } },
+            })
+          }
+        >
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    expect(
+      await screen.findByTestId("navigate-to-settings-button"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/features/home/launch-tabs.tsx
+++ b/src/components/features/home/launch-tabs.tsx
@@ -4,9 +4,11 @@ import { useTranslation } from "react-i18next";
 import { cn } from "#/utils/utils";
 import { I18nKey } from "#/i18n/declaration";
 import { GitRepository } from "#/types/git";
+import { useUserProviders } from "#/hooks/use-user-providers";
 
 import { RepositorySelectionForm } from "./repo-selection-form";
 import { WorkspaceSelectionForm } from "./workspace-selection-form";
+import { ConnectToProviderMessage } from "./connect-to-provider-message";
 
 type LaunchTab = "repositories" | "workspaces";
 
@@ -47,6 +49,8 @@ export function LaunchTabs({
   isLoadingSettings = false,
 }: LaunchTabsProps) {
   const { t } = useTranslation("openhands");
+  const { providers } = useUserProviders();
+  const providersAreSet = providers.length > 0;
   const [activeTab, setActiveTab] = React.useState<LaunchTab>("repositories");
 
   return (
@@ -73,7 +77,10 @@ export function LaunchTabs({
       </div>
 
       <div className="min-h-[240px]">
-        {activeTab === "repositories" && (
+        {activeTab === "repositories" && !providersAreSet && (
+          <ConnectToProviderMessage />
+        )}
+        {activeTab === "repositories" && providersAreSet && (
           <RepositorySelectionForm
             onRepoSelection={onRepoSelection}
             isLoadingSettings={isLoadingSettings}

--- a/src/components/features/home/repo-connector.tsx
+++ b/src/components/features/home/repo-connector.tsx
@@ -1,4 +1,3 @@
-import { ConnectToProviderMessage } from "./connect-to-provider-message";
 import { LaunchTabs } from "./launch-tabs";
 import { useUserProviders } from "#/hooks/use-user-providers";
 import { GitRepository } from "#/types/git";
@@ -8,22 +7,17 @@ interface RepoConnectorProps {
 }
 
 export function RepoConnector({ onRepoSelection }: RepoConnectorProps) {
-  const { providers, isLoadingSettings } = useUserProviders();
-
-  const providersAreSet = providers.length > 0;
+  const { isLoadingSettings } = useUserProviders();
 
   return (
     <section
       data-testid="repo-connector"
       className="w-full flex flex-col gap-6 rounded-[12px] p-[20px] border border-[#727987] bg-[#26282D] min-h-[263.5px] relative"
     >
-      {!providersAreSet && <ConnectToProviderMessage />}
-      {providersAreSet && (
-        <LaunchTabs
-          onRepoSelection={onRepoSelection}
-          isLoadingSettings={isLoadingSettings}
-        />
-      )}
+      <LaunchTabs
+        onRepoSelection={onRepoSelection}
+        isLoadingSettings={isLoadingSettings}
+      />
     </section>
   );
 }


### PR DESCRIPTION
### Description

On the home screen, two launch tabs exist: **Repositories** and **Workspaces**. The Workspaces tab lets users pick a local folder to start a conversation in — it has nothing to do with Git authentication.

Currently, when no Git Personal Access Token (PAT) is configured, the parent component (`RepoConnector`) swaps the entire `<LaunchTabs>` for a `<ConnectToProviderMessage>` empty state. As a result, the Workspaces tab is unreachable until the user connects a Git provider, even though the feature is independent of Git auth.

### Expected behavior

- The `<LaunchTabs>` UI is always rendered.
- The "Connect to Provider" empty state appears only inside the **Repositories** tab body when no providers are configured.
- The **Workspaces** tab is always reachable and functional, regardless of PAT state.

### Acceptance criteria

- [ ] With no Git providers configured, the user can see and click the Workspaces tab on the home screen.
- [ ] With no Git providers configured, the Repositories tab still shows the "Connect to Provider" CTA pointing to `/settings/integrations`.
- [ ] With at least one Git provider configured, behavior is unchanged: Repositories tab shows the repo dropdown, Workspaces tab shows the workspace dropdown.
- [ ] No visual regression on the home screen.
- [ ] Tests cover both branches (no-provider and provider-set).

### Affected files

- `src/components/features/home/repo-connector.tsx`
- `src/components/features/home/launch-tabs.tsx`
- `__tests__/components/features/home/repo-selection-form.test.tsx`

### Summary

- The Workspaces tab on the home screen is now always rendered, even when no Git Personal Access Token is configured.
- Moves the "Connect to Provider" empty state from the parent `RepoConnector` into the Repositories tab body — it only blocks the Repositories content, not the whole tab UI.
- The Workspaces feature is unrelated to Git auth, so gating it on a PAT was a UX bug.

### Changes

- `src/components/features/home/repo-connector.tsx` — remove the `providersAreSet` gate; `<LaunchTabs>` always renders.
- `src/components/features/home/launch-tabs.tsx` — call `useUserProviders()` and render `<ConnectToProviderMessage>` inside the Repositories tab content area when no providers are set; otherwise render `<RepositorySelectionForm>`. The Workspaces branch is unconditional.
- `__tests__/components/features/home/repo-selection-form.test.tsx` — add two TDD tests:
  - Workspaces tab is reachable when no provider is configured (regression lock).
  - Repositories tab shows the connect-provider CTA when no provider is configured.