### PR TITLE
feat(frontend): temporarily disable planning agent UI and drop /new from slash menu

### DIFF
--- a/__tests__/components/features/chat/components/chat-input-actions.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-actions.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders } from "test-utils";
+
+vi.mock("#/components/features/controls/agent-status", () => ({
+  AgentStatus: () => <div data-testid="agent-status-stub" />,
+}));
+
+vi.mock("#/components/features/controls/tools", () => ({
+  Tools: () => <div data-testid="tools-stub" />,
+}));
+
+// Sentinel: this stub only renders if a future change re-imports
+// ChangeAgentButton in ChatInputActions, which would fail the assertion below.
+vi.mock("#/components/features/chat/change-agent-button", () => ({
+  ChangeAgentButton: () => <div data-testid="change-agent-button-stub" />,
+}));
+
+// Mock the underlying mutation service module that the pause/resume hooks call.
+vi.mock("#/hooks/mutation/conversation-mutation-utils", () => ({
+  pauseV1Conversation: vi.fn(),
+  resumeV1Conversation: vi.fn(),
+  askV1Agent: vi.fn(),
+  updateConversationExecutionStatusInCache: vi.fn(),
+  invalidateConversationQueries: vi.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { ChatInputActions } from "#/components/features/chat/components/chat-input-actions";
+
+describe("ChatInputActions", () => {
+  it("does not render the Change Agent button while the planning agent feature is disabled", () => {
+    // Arrange + Act
+    renderWithProviders(<ChatInputActions disabled={false} />);
+
+    // Assert
+    expect(
+      screen.queryByTestId("change-agent-button-stub"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/hooks/chat/use-slash-command.test.ts
+++ b/__tests__/hooks/chat/use-slash-command.test.ts
@@ -39,16 +39,19 @@ describe("useSlashCommand", () => {
     mockConversation.data = undefined;
   });
 
-  it("includes /new built-in command for V1 conversations", () => {
+  it("excludes /new from the built-in commands while the planning agent is disabled", () => {
+    // Arrange
     mockConversation.data = { conversation_version: "V1" };
     mockSkills.isLoading = false;
     mockSkills.data = [makeSkill("code-search", ["/code-search"])];
 
+    // Act
     const ref = makeChatInputRef();
     const { result } = renderHook(() => useSlashCommand(ref));
 
+    // Assert
     const commands = result.current.filteredItems.map((i) => i.command);
-    expect(commands).toContain("/new");
-    expect(commands).toContain("/code-search");
+    expect(commands).not.toContain("/new");
+    expect(commands).toEqual(expect.arrayContaining(["/btw", "/code-search"]));
   });
 });

--- a/src/components/features/chat/components/chat-input-actions.tsx
+++ b/src/components/features/chat/components/chat-input-actions.tsx
@@ -4,7 +4,6 @@ import { useUnifiedPauseConversation } from "#/hooks/mutation/use-unified-stop-c
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { useV1PauseConversation } from "#/hooks/mutation/use-v1-pause-conversation";
 import { useV1ResumeConversation } from "#/hooks/mutation/use-v1-resume-conversation";
-import { ChangeAgentButton } from "../change-agent-button";
 
 interface ChatInputActionsProps {
   disabled: boolean;
@@ -35,7 +34,6 @@ export function ChatInputActions({ disabled }: ChatInputActionsProps) {
       <div className="flex items-center gap-1">
         <div className="flex items-center gap-4">
           <Tools />
-          <ChangeAgentButton />
         </div>
       </div>
       <AgentStatus

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -78,15 +78,6 @@ export const BTW_COMMAND = "/btw";
 export const BUILT_IN_COMMANDS: SlashCommandItem[] = [
   {
     skill: {
-      name: "new",
-      type: "agentskills",
-      content: "Creates a new conversation using the same runtime",
-      triggers: ["/new"],
-    },
-    command: "/new",
-  },
-  {
-    skill: {
       name: "btw",
       type: "agentskills",
       content: "Ask the agent a side question without derailing the main task",


### PR DESCRIPTION
### Description

The planning agent feature is being temporarily paused. While it is disabled, the **Change Agent** button (Code/Plan toggle) should not be visible in the chat input toolbar, and the `Shift+Tab` shortcut that switches modes should not be active.

Separately, the built-in `/new` slash command should be removed from the autocomplete suggestion list shown when a user types `/` in the chat input. The submit-side handler that processes a typed-and-sent `/new` message remains unchanged — only the visible suggestion is removed.

### Scope

- Remove `<ChangeAgentButton />` from the chat input toolbar (`chat-input-actions.tsx`).
- Remove the `/new` entry from `BUILT_IN_COMMANDS` in `src/utils/constants.ts`.
- Update / add unit tests.

### Out of scope

- Deleting `change-agent-button.tsx`, `change-agent-context-menu.tsx`, or any of the planning-agent-related hooks. They stay so the feature can be restored with a single import + JSX line.
- Changing the `/new` submit handler in `chat-interface.tsx` — typing and sending `/new` still clears the conversation; the command just no longer shows in the autocomplete popover.

### Acceptance criteria

- [ ] The Code/Plan toggle button no longer appears next to the Tools button in the chat input toolbar.
- [ ] Pressing `Shift+Tab` in the chat input has no effect on conversation mode.
- [ ] Typing `/` in the chat input does not show `/new` in the suggestion popover.
- [ ] `/btw` and any user-defined skills still appear in the suggestion popover.
- [ ] Type-checking and the existing test suite stay green.

### Summary

- Removed `<ChangeAgentButton />` (Code/Plan toggle) from the chat input toolbar so it no longer renders, which also disables the `Shift+Tab` shortcut and the sub-conversation polling that the button mounts.
- Removed the `/new` entry from `BUILT_IN_COMMANDS` so it no longer appears in the slash command suggestion popover. The handler that processes a submitted `/new` message is intentionally left in place.
- Updated the existing slash-command test that asserted `/new` was present and added a regression test that `ChatInputActions` does not render the Change Agent button.

### Files changed

- `src/components/features/chat/components/chat-input-actions.tsx` — removed `ChangeAgentButton` import and JSX usage.
- `src/utils/constants.ts` — removed the `/new` object from `BUILT_IN_COMMANDS`.
- `__tests__/hooks/chat/use-slash-command.test.ts` — flipped the `/new` assertion and tightened it to also confirm `/btw` and user skills still appear.
- `__tests__/components/features/chat/components/chat-input-actions.test.tsx` — new file; sentinel-mocks `ChangeAgentButton` and asserts it is not rendered.

### Files intentionally left alone

- `src/components/features/chat/change-agent-button.tsx` — component preserved for easy re-enablement.
- `src/components/features/chat/chat-interface.tsx` — `/new` submit handler still clears the conversation when typed and sent.

### Demo Screenshot

<img width="1440" height="796" alt="output" src="https://github.com/user-attachments/assets/e827d968-6c09-4a42-a01a-5f10fb4be493" />

