### PR TITLE
Enforce canonical settings query keys in frontend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,7 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx"],
+      "excludedFiles": ["src/hooks/query/query-keys.ts"],
       "rules": {
         // Allow state modification in reduce and Redux reducers
         "no-param-reassign": [
@@ -48,8 +49,13 @@
             "ignorePropertyModificationsFor": ["acc", "state"],
           },
         ],
-        // For https://stackoverflow.com/questions/55844608/stuck-with-eslint-error-i-e-separately-loops-should-be-avoided-in-favor-of-arra
-        "no-restricted-syntax": "off",
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "Property[key.name='queryKey'] > ArrayExpression[elements.0.value='settings']",
+            "message": "Use SETTINGS_QUERY_KEYS helpers instead of raw settings query key arrays."
+          }
+        ],
         "react/require-default-props": "off",
         "import/prefer-default-export": "off",
         "no-underscore-dangle": "off",

--- a/src/hooks/mutation/use-add-git-providers.ts
+++ b/src/hooks/mutation/use-add-git-providers.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { SecretsService } from "#/api/secrets-service";
 import { Provider, ProviderToken } from "#/types/settings";
 import { useTracking } from "#/hooks/use-tracking";
+import { SETTINGS_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 export const useAddGitProviders = () => {
   const queryClient = useQueryClient();
@@ -25,7 +26,7 @@ export const useAddGitProviders = () => {
       }
 
       await queryClient.invalidateQueries({
-        queryKey: ["settings", "personal"],
+        queryKey: SETTINGS_QUERY_KEYS.personal(),
       });
     },
     meta: {

--- a/src/hooks/mutation/use-add-mcp-server.ts
+++ b/src/hooks/mutation/use-add-mcp-server.ts
@@ -8,6 +8,7 @@ import {
   MCPStdioServer,
 } from "#/types/settings";
 import { parseMcpConfig, toSdkMcpConfig } from "#/utils/mcp-config";
+import { SETTINGS_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 type MCPServerType = "sse" | "stdio" | "shttp";
 
@@ -67,7 +68,7 @@ export function useAddMcpServer() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["settings", "personal"],
+        queryKey: SETTINGS_QUERY_KEYS.personal(),
       });
     },
   });

--- a/src/hooks/mutation/use-delete-git-providers.ts
+++ b/src/hooks/mutation/use-delete-git-providers.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { SecretsService } from "#/api/secrets-service";
+import { SETTINGS_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 export const useDeleteGitProviders = () => {
   const queryClient = useQueryClient();
@@ -8,7 +9,7 @@ export const useDeleteGitProviders = () => {
     mutationFn: () => SecretsService.deleteGitProviders(),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["settings", "personal"],
+        queryKey: SETTINGS_QUERY_KEYS.personal(),
       });
     },
     meta: {

--- a/src/hooks/mutation/use-delete-mcp-server.ts
+++ b/src/hooks/mutation/use-delete-mcp-server.ts
@@ -3,6 +3,7 @@ import { useSettings } from "#/hooks/query/use-settings";
 import SettingsService from "#/api/settings-service/settings-service.api";
 import { MCPConfig } from "#/types/settings";
 import { parseMcpConfig, toSdkMcpConfig } from "#/utils/mcp-config";
+import { SETTINGS_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 export function useDeleteMcpServer() {
   const queryClient = useQueryClient();
@@ -36,7 +37,7 @@ export function useDeleteMcpServer() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["settings", "personal"],
+        queryKey: SETTINGS_QUERY_KEYS.personal(),
       });
     },
   });

--- a/src/hooks/mutation/use-logout.ts
+++ b/src/hooks/mutation/use-logout.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { usePostHog } from "posthog-js/react";
 import { openHands } from "#/api/open-hands-axios";
+import { SETTINGS_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 export const useLogout = () => {
   const posthog = usePostHog();
@@ -12,7 +13,7 @@ export const useLogout = () => {
     },
     onSuccess: async () => {
       queryClient.removeQueries({ queryKey: ["tasks"] });
-      queryClient.removeQueries({ queryKey: ["settings"] });
+      queryClient.removeQueries({ queryKey: SETTINGS_QUERY_KEYS.all });
       queryClient.removeQueries({ queryKey: ["user"] });
       queryClient.removeQueries({ queryKey: ["secrets"] });
       posthog.reset();

--- a/src/hooks/mutation/use-save-settings.ts
+++ b/src/hooks/mutation/use-save-settings.ts
@@ -8,6 +8,7 @@ import {
   SettingsValue,
 } from "#/types/settings";
 import { useSettings } from "../query/use-settings";
+import { SETTINGS_QUERY_KEYS } from "../query/query-keys";
 
 type SettingsUpdate = Partial<Settings> & Record<string, unknown>;
 
@@ -82,7 +83,7 @@ export const useSaveSettings = (scope: SettingsScope = "personal") => {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["settings", scope],
+        queryKey: SETTINGS_QUERY_KEYS.byScope(scope),
       });
     },
     meta: {

--- a/src/hooks/mutation/use-update-mcp-server.ts
+++ b/src/hooks/mutation/use-update-mcp-server.ts
@@ -8,6 +8,7 @@ import {
   MCPStdioServer,
 } from "#/types/settings";
 import { parseMcpConfig, toSdkMcpConfig } from "#/utils/mcp-config";
+import { SETTINGS_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 type MCPServerType = "sse" | "stdio" | "shttp";
 
@@ -75,7 +76,7 @@ export function useUpdateMcpServer() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["settings", "personal"],
+        queryKey: SETTINGS_QUERY_KEYS.personal(),
       });
     },
   });

--- a/src/hooks/query/query-keys.test.ts
+++ b/src/hooks/query/query-keys.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { SETTINGS_QUERY_KEYS } from "./query-keys";
+
+describe("SETTINGS_QUERY_KEYS", () => {
+  it("returns the canonical root settings key", () => {
+    expect(SETTINGS_QUERY_KEYS.all).toEqual(["settings"]);
+  });
+
+  it("builds scoped settings keys", () => {
+    expect(SETTINGS_QUERY_KEYS.byScope("personal")).toEqual([
+      "settings",
+      "personal",
+    ]);
+  });
+
+  it("builds the canonical personal settings key", () => {
+    expect(SETTINGS_QUERY_KEYS.personal()).toEqual(["settings", "personal"]);
+    expect(SETTINGS_QUERY_KEYS.personal()).toEqual(
+      SETTINGS_QUERY_KEYS.byScope("personal"),
+    );
+  });
+});

--- a/src/hooks/query/query-keys.ts
+++ b/src/hooks/query/query-keys.ts
@@ -3,9 +3,17 @@
  * Using constants ensures type safety and prevents typos.
  */
 
+import { SettingsScope } from "#/types/settings";
+
 export const QUERY_KEYS = {
   /** Web client configuration from the server */
   WEB_CLIENT_CONFIG: ["web-client-config"] as const,
+} as const;
+
+export const SETTINGS_QUERY_KEYS = {
+  all: ["settings"] as const,
+  byScope: (scope: SettingsScope) => ["settings", scope] as const,
+  personal: () => ["settings", "personal"] as const,
 } as const;
 
 /** Cache configuration shared across all config-related queries */

--- a/src/hooks/query/use-settings.ts
+++ b/src/hooks/query/use-settings.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 import { Settings, SettingsScope, SettingsValue } from "#/types/settings";
 import SettingsService from "#/api/settings-service/settings-service.api";
+import { SETTINGS_QUERY_KEYS } from "#/hooks/query/query-keys";
 import {
   pickFirstBoolean,
   pickFirstNumber,
@@ -123,7 +124,7 @@ export const getSettingsQueryFn = async (
 
 export const useSettings = (scope: SettingsScope = "personal") => {
   const query = useQuery({
-    queryKey: ["settings", scope],
+    queryKey: SETTINGS_QUERY_KEYS.byScope(scope),
     queryFn: () => getSettingsQueryFn(scope),
     retry: (_, error) => getErrorStatus(error) !== 404,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
## Why

Mirrors [OpenHands/OpenHands#14011](https://github.com/OpenHands/OpenHands/pull/14011). The OpenHands repo recently hit a settings invalidation bug because a raw settings query key used the wrong shape (`["settings", organizationId]` instead of the canonical personal settings key). agent-canvas has the same pattern of raw `["settings", ...]` query keys scattered across mutation hooks, so the same guardrail is worth applying here.

## Summary

- Add `SETTINGS_QUERY_KEYS` to `src/hooks/query/query-keys.ts` as the shared source of truth for frontend settings query keys (`all`, `byScope(scope)`, `personal()`).
- Migrate all existing settings query/invalidation callsites to the shared helper:
  - `src/hooks/query/use-settings.ts`
  - `src/hooks/mutation/use-save-settings.ts`
  - `src/hooks/mutation/use-add-git-providers.ts`
  - `src/hooks/mutation/use-delete-git-providers.ts`
  - `src/hooks/mutation/use-add-mcp-server.ts`
  - `src/hooks/mutation/use-update-mcp-server.ts`
  - `src/hooks/mutation/use-delete-mcp-server.ts`
  - `src/hooks/mutation/use-logout.ts`
- Add an ESLint `no-restricted-syntax` rule that rejects raw `queryKey: ["settings", ...]` arrays outside the helper module (`src/hooks/query/query-keys.ts` is excluded).
- Add a small Vitest covering the helper.

## How to Test

```bash
npm run lint
npm run build
npx vitest run src/hooks/query/query-keys.test.ts
```

Verify the lint rule fires on raw settings query keys:

```bash
cat > src/hooks/mutation/test-fake.ts <<'EOF'
const query = { queryKey: ["settings", "personal"] };
export default query;
EOF
npx eslint src/hooks/mutation/test-fake.ts
rm src/hooks/mutation/test-fake.ts
```

Expected: ESLint reports `Use SETTINGS_QUERY_KEYS helpers instead of raw settings query key arrays`.

## Notes

- The lint count is unchanged compared to `main` (63 problems before and after on my machine); no new lint issues are introduced.
- This pull request was opened by an AI assistant (OpenHands) on behalf of the user.


@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/045159fe-95a7-476a-9a64-779b2074f0ba)