### PR TITLE
deps(deps): group related dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,76 @@ updates:
     labels:
       - dependencies
       - npm
+    # Group related packages together so they ship in a single PR.
+    # Packages that aren't matched by any group still get their own PR
+    # (the default behavior), which is what we want for high-impact deps
+    # like vite, react-router, framer-motion, etc.
+    groups:
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "tailwind-merge"
+          - "tailwind-scrollbar"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      i18next:
+        patterns:
+          - "i18next"
+          - "i18next-*"
+          - "react-i18next"
+          - "eslint-plugin-i18next"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@types/react-*"
+          - "eslint-plugin-react"
+          - "eslint-plugin-react-hooks"
+      react-router:
+        patterns:
+          - "react-router"
+          - "@react-router/*"
+          - "@vercel/react-router"
+          - "isbot"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "jsdom"
+          - "@playwright/test"
+          - "msw"
+          - "@mswjs/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-config-*"
+          - "eslint-plugin-*"
+          - "@typescript-eslint/*"
+          - "prettier"
+        exclude-patterns:
+          # These are grouped under their feature area instead.
+          - "eslint-plugin-i18next"
+          - "eslint-plugin-react"
+          - "eslint-plugin-react-hooks"
+      monaco:
+        patterns:
+          - "monaco-editor"
+          - "@monaco-editor/*"
+      xterm:
+        patterns:
+          - "@xterm/*"
+      types:
+        patterns:
+          - "@types/*"
+        exclude-patterns:
+          - "@types/react"
+          - "@types/react-dom"
+          - "@types/react-*"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -34,3 +104,7 @@ updates:
     labels:
       - dependencies
       - github-actions
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

After merging the 10 open dependabot PRs (#72–#81) one-by-one this morning, the workflow showed two clear pain points:

1. **Lockfile races.** `tailwindcss` (#72) and `@tailwindcss/vite` (#73) bumped together but came in as separate PRs. Once #73 was merged, #72 went `DIRTY` / `CONFLICTING` on `package-lock.json` and needed a full rebase + re-run before it could land. Same risk exists for `@tanstack/react-query` + `@tanstack/eslint-plugin-query`, `i18next` + `i18next-http-backend`, and any future `react` / `react-dom` / `@types/react*` updates.
2. **Review noise.** 10 individual PRs for what was conceptually 6 logical updates (tailwind, tanstack, i18next, lucide, posthog, jsdom, vite). Each one runs full CI and accrues review/QA load.

This change adds Dependabot [`groups`](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) so related packages ship in a single grouped PR instead.

## Groups

| Group | Patterns |
| --- | --- |
| `tailwind` | `tailwindcss`, `@tailwindcss/*`, `tailwind-merge`, `tailwind-scrollbar` |
| `tanstack` | `@tanstack/*` |
| `i18next` | `i18next`, `i18next-*`, `react-i18next`, `eslint-plugin-i18next` |
| `react` | `react`, `react-dom`, `@types/react*`, `eslint-plugin-react*` |
| `react-router` | `react-router`, `@react-router/*`, `@vercel/react-router`, `isbot` |
| `testing` | `vitest`, `@vitest/*`, `@testing-library/*`, `jsdom`, `@playwright/test`, `msw`, `@mswjs/*` |
| `eslint` | `eslint`, `eslint-config-*`, `eslint-plugin-*`, `@typescript-eslint/*`, `prettier` (excludes the i18next/react plugins above) |
| `monaco` | `monaco-editor`, `@monaco-editor/*` |
| `xterm` | `@xterm/*` |
| `types` | `@types/*` (excludes the React types covered above) |

GitHub Actions updates are also collapsed into a single weekly PR via `groups: { actions: { patterns: ["*"] } }`.

## What stays as individual PRs

Anything not matched by a group still gets its own PR — that's the dependabot default. We deliberately keep it that way for high-impact / standalone deps so each one can be reviewed in isolation:

- `vite`
- `framer-motion`
- `axios`
- `posthog-js`
- `lucide-react`
- `react-hot-toast`, `react-icons`, `react-markdown`, `remark-*`, `react-syntax-highlighter`
- `socket.io-client`
- `zustand`
- `@openhands/typescript-client`
- `@heroui/react` (kept manually pinned per AGENTS.md notes)
- `husky`, `lint-staged`, `cross-env`, `sirv-cli`, `vite-plugin-svgr`, `vite-tsconfig-paths`, `postcss-prefix-selector`

If any of those start producing weekly PRs that we'd prefer batched, we can grow the groups list incrementally.

## Other limits unchanged

- `versioning-strategy: increase` is preserved — exact pins continue to be respected per the AGENTS.md note.
- `cooldown: { default-days: 7 }` and the weekly Monday 09:00 UTC schedule are unchanged.
- `open-pull-requests-limit: 10` (npm) / `5` (actions) is unchanged.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses cleanly.
- No code paths or tests change, so no CI signal beyond the standard workflow run is needed.

---

_This PR was created by an AI agent (OpenHands) on behalf of the requester._


@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/da8544a3-1e28-4641-9054-cf35faffc2e9)