### PR TITLE
fix: always send  param to git branches search

### DIFF
--- a/__tests__/api/cloud/git-service.test.ts
+++ b/__tests__/api/cloud/git-service.test.ts
@@ -1,0 +1,71 @@
+import axios from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import { getCloudRepositoryBranches } from "#/api/cloud/git-service.api";
+
+vi.mock("axios");
+
+const cloudBackend: Backend = {
+  id: "prod",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "bearer-token",
+  kind: "cloud",
+};
+
+const emptyBranchPage = {
+  data: { items: [], next_page_id: null },
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  setRegisteredBackends([cloudBackend]);
+  setActiveSelection({ backendId: cloudBackend.id });
+  vi.mocked(axios.post).mockReset();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+});
+
+describe("getCloudRepositoryBranches", () => {
+  it("includes an empty query parameter when listing all branches so the upstream schema is satisfied", async () => {
+    // Arrange
+    vi.mocked(axios.post).mockResolvedValueOnce(emptyBranchPage);
+
+    // Act
+    await getCloudRepositoryBranches({
+      provider: "github",
+      repository: "hieptl/hieptl",
+    });
+
+    // Assert
+    const [, body] = vi.mocked(axios.post).mock.calls[0]!;
+    const path = (body as { path: string }).path;
+    expect(path).toMatch(/[?&]query=(&|$)/);
+  });
+
+  it("forwards a non-empty query parameter when searching branches", async () => {
+    // Arrange
+    vi.mocked(axios.post).mockResolvedValueOnce(emptyBranchPage);
+
+    // Act
+    await getCloudRepositoryBranches({
+      provider: "github",
+      repository: "hieptl/hieptl",
+      query: "feature/login",
+    });
+
+    // Assert
+    const [, body] = vi.mocked(axios.post).mock.calls[0]!;
+    const path = (body as { path: string }).path;
+    expect(path).toContain("query=feature%2Flogin");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6625,6 +6625,64 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",

--- a/src/api/cloud/git-service.api.ts
+++ b/src/api/cloud/git-service.api.ts
@@ -85,7 +85,7 @@ export async function getCloudRepositoryBranches(args: {
   params.set("provider", args.provider);
   params.set("repository", args.repository);
   params.set("limit", String(args.limit ?? 30));
-  if (args.query) params.set("query", args.query);
+  params.set("query", args.query ?? "");
   if (args.pageId) params.set("page_id", args.pageId);
 
   const data = await callCloudProxy<{


### PR DESCRIPTION
Resolves #156 

**Description**

After switching the active backend to a cloud environment (e.g. *Production – Personal Workspace*) and selecting a repository in `<RepositorySelectionForm />`, the branch dropdown fails to load. The cloud-proxy returns the upstream's **422 Unprocessable Entity** because the required `query` field is missing from the forwarded request.

### Steps to reproduce

1. Open `agent-server-gui` at <http://localhost:3001>.
2. Hover over the user avatar → **Add Backend**, fill in *Hostname / Host / API Key*, click **Save**.
3. From the avatar menu, switch to a cloud environment (e.g. *Production – Personal Workspace*).
4. Confirm the environment switch succeeds.
5. In `<RepositorySelectionForm />`, select a repository (e.g. `hieptl/hieptl`).
6. Open the branch dropdown.

### Current behaviour

Browser sends:

```
POST http://127.0.0.1:8000/api/cloud-proxy
{
  "host":   "https://app.all-hands.dev",
  "method": "GET",
  "path":   "/api/v1/git/branches/search?provider=github&repository=hieptl%2Fhieptl&limit=30",
  "headers":{ "Authorization": "Bearer sk-oh-…" },
  "body":   null
}
```

Upstream responds **422**:

```json
{
  "detail": [
    { "type": "missing", "loc": ["query", "query"], "msg": "Field required", "input": null }
  ]
}
```

The branch list never loads.

### Expected behaviour

The branch list loads successfully and the user can pick a branch.

### Root cause

The upstream `GET /api/v1/git/branches/search` endpoint declares `query` as a **required** parameter (no default). The OpenHands frontend always sends it via axios `params`, even when empty (`query=""`), which satisfies the schema.

In `agent-server-gui`'s cloud path, the URL is constructed manually and the `query` key is **dropped entirely** when the value is empty:

`src/api/cloud/git-service.api.ts:88`
```ts
if (args.query) params.set("query", args.query);
```

So when `useRepositoryBranchesPaginated` calls `getRepositoryBranches(repo, provider, "")` to list all branches, the forwarded URL has no `query` at all, and FastAPI rejects it.

### Fix

Always include `query` (defaulting to empty string) in `getCloudRepositoryBranches`, matching the OpenHands behaviour for the same endpoint.

### Acceptance criteria

- [ ] On a cloud backend, opening the branch dropdown loads branches without errors.
- [ ] Typing a search string in the dropdown still filters branches correctly.
- [ ] Local-backend branch listing remains unaffected.
- [ ] Regression test for the empty-query case is added under `__tests__/api/cloud/`.

## Summary

- The upstream `GET /api/v1/git/branches/search` endpoint declares `query` as a **required** field.
- Our cloud-proxy URL builder dropped the `query` key when the value was empty (`if (args.query) params.set(...)`), so listing all branches on a cloud backend returned **422 Unprocessable Entity**.
- Always set `query` (defaulting to `""`) so the upstream schema is satisfied — same behaviour as the OpenHands frontend for the same endpoint.

## Root cause

`useRepositoryBranchesPaginated` calls `GitService.getRepositoryBranches(repo, provider, "")` to list all branches. That empty string flows through `getRepositoryBranches` (`query: query || undefined`) into `getCloudRepositoryBranches`, where the previous code only added the `query` param when truthy — so the forwarded request had no `query=` at all, and upstream FastAPI rejected it with:

\`\`\`json
{ "detail": [ { "type": "missing", "loc": ["query", "query"], "msg": "Field required" } ] }
\`\`\`

## Changes

- `src/api/cloud/git-service.api.ts` — replace `if (args.query) params.set("query", args.query);` with `params.set("query", args.query ?? "");` inside `getCloudRepositoryBranches` (one-line change, scoped to the endpoint that requires the field).
- `__tests__/api/cloud/git-service.test.ts` — new file with two regression tests: empty-query call still emits `query=`, and non-empty query is forwarded verbatim.