### PR TITLE
ci: enable sub-agent delegation for PR reviews

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           llm-model: litellm_proxy/claude-sonnet-4-5-20250929
           llm-base-url: https://llm-proxy.app.all-hands.dev
-          use-sub-agents: "false"
+          use-sub-agents: "true"
           llm-api-key: ${{ secrets.LLM_API_KEY }}
           github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
           lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary

Enables the `use-sub-agents` feature in the PR review workflow (`pr-review-by-openhands.yml`).

## Why

This repo typically has large PRs spanning many files. With sub-agent delegation enabled, the review bot can fan out file-level reviews to dedicated sub-agents, producing better coverage and more thorough feedback on big diffs.

## Change

- `.github/workflows/pr-review-by-openhands.yml`: `use-sub-agents: "false"` → `use-sub-agents: "true"`

Per the [action definition](https://github.com/OpenHands/extensions/blob/main/plugins/pr-review/action.yml), this gives the agent `TaskToolSet` and lets it decide at runtime whether to delegate based on diff size and complexity.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c25e4910-a987-4029-9506-2c6ac670c5fa)