### PR TITLE
feat: seed automation API key into agent-server secrets

### DIFF
--- a/__tests__/routes/root-layout-refetch.test.tsx
+++ b/__tests__/routes/root-layout-refetch.test.tsx
@@ -1,10 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRoutesStub } from "react-router";
 import MainApp from "#/routes/root-layout";
-import SettingsService from "#/api/settings-service/settings-service.api";
-import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import { ActiveBackendProvider } from "#/contexts/active-backend-context";
 
 // Hoisted mocks for useIsAuthed and useConfig to allow dynamic control in tests
@@ -52,6 +50,16 @@ const RouterStub = createRoutesStub([
 ]);
 
 describe("MainApp - Auth refetch behavior", () => {
+  afterEach(async () => {
+    // Wait for any pending async operations (e.g., framer-motion LazyMotion async loads)
+    // Use act to flush all pending state updates before cleanup
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    cleanup();
+    vi.clearAllMocks();
+  });
+
   it("should NOT show loading spinner when auth is refetching for an authenticated user", async () => {
     // Setup: Mock hooks to simulate authenticated user CURRENTLY REFETCHING
     // This is the state when the auth cache is invalidated and refetching

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -178,6 +178,38 @@ describe("buildConfig", () => {
 
     expect(config.sessionApiKey).toBe("oh-key");
   });
+
+  it("reads sessionApiKey from SESSION_API_KEY (agent-server V0 env)", () => {
+    const config = buildConfig({}, { SESSION_API_KEY: "v0-session-key" });
+
+    expect(config.sessionApiKey).toBe("v0-session-key");
+  });
+
+  it("reads sessionApiKey from OH_SESSION_API_KEYS_0 (agent-server V1 env)", () => {
+    const config = buildConfig({}, { OH_SESSION_API_KEYS_0: "v1-session-key" });
+
+    expect(config.sessionApiKey).toBe("v1-session-key");
+  });
+
+  it("SESSION_API_KEY takes precedence over OH_SESSION_API_KEYS_0", () => {
+    const config = buildConfig({}, {
+      SESSION_API_KEY: "v0-key",
+      OH_SESSION_API_KEYS_0: "v1-key",
+    });
+
+    expect(config.sessionApiKey).toBe("v0-key");
+  });
+
+  it("SESSION_API_KEY takes precedence over all other session key env vars", () => {
+    const config = buildConfig({}, {
+      SESSION_API_KEY: "v0-key",
+      OH_SESSION_API_KEYS_0: "v1-key",
+      OH_SESSION_API_KEY: "oh-key",
+      VITE_SESSION_API_KEY: "vite-key",
+    });
+
+    expect(config.sessionApiKey).toBe("v0-key");
+  });
 });
 
 describe("default constants", () => {

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -139,6 +139,45 @@ describe("buildConfig", () => {
 
     expect(config.verbose).toBe(true);
   });
+
+  it("uses default local API key", () => {
+    const config = buildConfig({}, {});
+
+    expect(config.localApiKey).toBe("openhands-local-api-key");
+  });
+
+  it("respects custom AUTOMATION_LOCAL_API_KEY from env", () => {
+    const config = buildConfig({}, { AUTOMATION_LOCAL_API_KEY: "my-custom-key" });
+
+    expect(config.localApiKey).toBe("my-custom-key");
+  });
+
+  it("sets sessionApiKey to null by default", () => {
+    const config = buildConfig({}, {});
+
+    expect(config.sessionApiKey).toBeNull();
+  });
+
+  it("reads sessionApiKey from OH_SESSION_API_KEY", () => {
+    const config = buildConfig({}, { OH_SESSION_API_KEY: "my-session-key" });
+
+    expect(config.sessionApiKey).toBe("my-session-key");
+  });
+
+  it("reads sessionApiKey from VITE_SESSION_API_KEY as fallback", () => {
+    const config = buildConfig({}, { VITE_SESSION_API_KEY: "vite-session-key" });
+
+    expect(config.sessionApiKey).toBe("vite-session-key");
+  });
+
+  it("OH_SESSION_API_KEY takes precedence over VITE_SESSION_API_KEY", () => {
+    const config = buildConfig({}, {
+      OH_SESSION_API_KEY: "oh-key",
+      VITE_SESSION_API_KEY: "vite-key",
+    });
+
+    expect(config.sessionApiKey).toBe("oh-key");
+  });
 });
 
 describe("default constants", () => {
@@ -185,6 +224,9 @@ describe("dev-with-automation CLI", () => {
     expect(output).toContain("--automation-ref");
     expect(output).toContain("--automation-repo");
     expect(output).toContain("OH_AUTOMATION_GIT_REF");
+    expect(output).toContain("AUTOMATION_LOCAL_API_KEY");
+    expect(output).toContain("OPENHANDS_AUTOMATION_API_KEY");
+    expect(output).toContain("SECRETS:");
   });
 
   it("exits promptly when uvx is missing", async () => {

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -209,7 +209,12 @@ function buildConfig(args, env = process.env) {
   const localApiKey = env.AUTOMATION_LOCAL_API_KEY || DEFAULT_LOCAL_API_KEY;
   
   // Session API key for agent-server auth (optional)
-  const sessionApiKey = env.OH_SESSION_API_KEY || env.VITE_SESSION_API_KEY || null;
+  // Check multiple env vars that the agent-server may use:
+  // - SESSION_API_KEY: Used by agent-server default config (V0)
+  // - OH_SESSION_API_KEYS_0: Used by agent-server V1 config
+  // - OH_SESSION_API_KEY: Common alias
+  // - VITE_SESSION_API_KEY: Used by frontend config
+  const sessionApiKey = env.SESSION_API_KEY || env.OH_SESSION_API_KEYS_0 || env.OH_SESSION_API_KEY || env.VITE_SESSION_API_KEY || null;
 
   return {
     // Ingress port (main entry point)

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -337,21 +337,27 @@ function spawnService(name, command, args, options = {}) {
 
 async function waitForService(name, url, timeoutMs = 30000) {
   const start = Date.now();
+  let lastError = null;
 
   while (Date.now() - start < timeoutMs) {
     try {
-      const res = await fetch(url);
+      const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
       if (res.ok) {
         logService(name, `Ready at ${url}`, c.green);
         return true;
       }
-    } catch {
+    } catch (err) {
+      lastError = err;
       // Keep trying
     }
     await delay(500);
   }
 
-  logService(name, `Timeout waiting for ${url}`, c.red);
+  const elapsed = Math.round((Date.now() - start) / 1000);
+  logService(name, `Timeout waiting for ${url} after ${elapsed}s`, c.red);
+  if (lastError) {
+    logService(name, `Last error: ${lastError.message}`, c.dim);
+  }
   return false;
 }
 
@@ -502,40 +508,84 @@ function startVite(config) {
 /**
  * Seed the automation API key into agent-server's secrets store.
  * This makes the key available to agents during conversations.
+ *
+ * Includes retry logic to handle slow server startup or transient failures.
+ *
+ * @param {object} config - Configuration object with agentServerPort, localApiKey, sessionApiKey
+ * @param {object} options - Options for retry behavior
+ * @param {number} options.maxRetries - Maximum number of retry attempts (default: 5)
+ * @param {number} options.retryDelayMs - Delay between retries in ms (default: 2000)
+ * @param {number} options.timeoutMs - Request timeout in ms (default: 10000)
+ * @returns {Promise<boolean>} True if seeding succeeded, false otherwise
  */
-async function seedAutomationSecret(config) {
+async function seedAutomationSecret(config, options = {}) {
+  const {
+    maxRetries = 5,
+    retryDelayMs = 2000,
+    timeoutMs = 10000,
+  } = options;
+
   const secretName = "OPENHANDS_AUTOMATION_API_KEY";
   const secretDescription = "API key for authenticating with the automation backend";
-  
+
   logService("secrets", `Seeding ${secretName} into agent-server...`, c.dim);
-  
+
   const url = `http://localhost:${config.agentServerPort}/api/settings/secrets`;
   const body = JSON.stringify({
     name: secretName,
     value: config.localApiKey,
     description: secretDescription,
   });
-  
-  try {
-    const response = await fetch(url, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        // Include session API key if configured
-        ...(config.sessionApiKey && { "X-Session-API-Key": config.sessionApiKey }),
-      },
-      body,
-    });
-    
-    if (!response.ok) {
+
+  const headers = {
+    "Content-Type": "application/json",
+    // Include session API key if configured
+    ...(config.sessionApiKey && { "X-Session-API-Key": config.sessionApiKey }),
+  };
+
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, {
+        method: "PUT",
+        headers,
+        body,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      if (response.ok) {
+        logService("secrets", `${secretName} seeded successfully`, c.green);
+        return true;
+      }
+
       const text = await response.text();
-      logService("secrets", `Warning: Failed to seed secret (${response.status}): ${text}`, c.yellow);
-    } else {
-      logService("secrets", `${secretName} seeded successfully`, c.green);
+      lastError = `HTTP ${response.status}: ${text}`;
+
+      // Don't retry on authentication errors - they won't resolve with retries
+      if (response.status === 401 || response.status === 403) {
+        logService("secrets", `Warning: Failed to seed secret (${response.status}): ${text}`, c.yellow);
+        return false;
+      }
+
+      // Retry on server errors or service unavailable
+      if (attempt < maxRetries) {
+        logService("secrets", `Retry ${attempt}/${maxRetries} after ${response.status}...`, c.dim);
+        await delay(retryDelayMs);
+      }
+    } catch (err) {
+      lastError = err.message;
+
+      // Connection errors likely mean server isn't ready - wait and retry
+      if (attempt < maxRetries) {
+        logService("secrets", `Retry ${attempt}/${maxRetries}: ${err.message}`, c.dim);
+        await delay(retryDelayMs);
+      }
     }
-  } catch (err) {
-    logService("secrets", `Warning: Failed to seed secret: ${err.message}`, c.yellow);
   }
+
+  logService("secrets", `Warning: Failed to seed secret after ${maxRetries} attempts: ${lastError}`, c.yellow);
+  return false;
 }
 
 function printBanner(config) {
@@ -587,14 +637,22 @@ async function main() {
 
   // 1. Start agent-server first (other services depend on it)
   startAgentServer(config);
-  await waitForService(
+
+  // Wait for agent-server to be ready (60s timeout for slow systems)
+  const agentServerReady = await waitForService(
     "agent-server",
-    `http://localhost:${config.agentServerPort}/server_info`
+    `http://localhost:${config.agentServerPort}/server_info`,
+    60000  // 60 second timeout for initial startup
   );
 
   // 2. Seed automation API key into agent-server secrets
   // This makes the key available to agents during conversations
-  await seedAutomationSecret(config);
+  // Note: seedAutomationSecret has its own retry logic if server is still warming up
+  if (agentServerReady) {
+    await seedAutomationSecret(config);
+  } else {
+    logService("secrets", "Skipping secret seeding - agent-server not ready", c.yellow);
+  }
 
   // 3. Start automation backend
   startAutomationBackend(config);

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -31,6 +31,11 @@
  *   - PORT: Ingress port (default: 8000)
  *   - OH_AUTOMATION_GIT_REF: Git ref for automation (default: main)
  *   - OH_AGENT_SERVER_GIT_REF: Git ref for agent-server
+ *   - AUTOMATION_LOCAL_API_KEY: Custom API key for automation backend auth
+ *
+ * Secrets:
+ *   The automation API key is automatically seeded into agent-server secrets
+ *   as OPENHANDS_AUTOMATION_API_KEY, making it available to agents in conversations.
  */
 
 import { spawn, execSync } from "node:child_process";
@@ -153,6 +158,11 @@ ENVIRONMENT VARIABLES:
   OH_AUTOMATION_GIT_REF       Alternative to --automation-ref
   OH_AGENT_SERVER_GIT_REF     Git ref for agent-server SDK
   OH_SECRET_KEY               Secret key for sessions
+  AUTOMATION_LOCAL_API_KEY    Custom API key for automation backend auth
+
+SECRETS:
+  The automation API key is automatically seeded into agent-server secrets
+  as OPENHANDS_AUTOMATION_API_KEY, making it available to agents in conversations.
 
 ACCESS POINTS:
   Main UI:      http://localhost:PORT/
@@ -197,6 +207,9 @@ function buildConfig(args, env = process.env) {
 
   // Local API key for automation backend auth
   const localApiKey = env.AUTOMATION_LOCAL_API_KEY || DEFAULT_LOCAL_API_KEY;
+  
+  // Session API key for agent-server auth (optional)
+  const sessionApiKey = env.OH_SESSION_API_KEY || env.VITE_SESSION_API_KEY || null;
 
   return {
     // Ingress port (main entry point)
@@ -216,6 +229,7 @@ function buildConfig(args, env = process.env) {
 
     // Auth
     localApiKey,
+    sessionApiKey,
 
     verbose: args.verbose,
   };
@@ -480,6 +494,45 @@ function startVite(config) {
   });
 }
 
+/**
+ * Seed the automation API key into agent-server's secrets store.
+ * This makes the key available to agents during conversations.
+ */
+async function seedAutomationSecret(config) {
+  const secretName = "OPENHANDS_AUTOMATION_API_KEY";
+  const secretDescription = "API key for authenticating with the automation backend";
+  
+  logService("secrets", `Seeding ${secretName} into agent-server...`, c.dim);
+  
+  const url = `http://localhost:${config.agentServerPort}/api/settings/secrets`;
+  const body = JSON.stringify({
+    name: secretName,
+    value: config.localApiKey,
+    description: secretDescription,
+  });
+  
+  try {
+    const response = await fetch(url, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        // Include session API key if configured
+        ...(config.sessionApiKey && { "X-Session-API-Key": config.sessionApiKey }),
+      },
+      body,
+    });
+    
+    if (!response.ok) {
+      const text = await response.text();
+      logService("secrets", `Warning: Failed to seed secret (${response.status}): ${text}`, c.yellow);
+    } else {
+      logService("secrets", `${secretName} seeded successfully`, c.green);
+    }
+  } catch (err) {
+    logService("secrets", `Warning: Failed to seed secret: ${err.message}`, c.yellow);
+  }
+}
+
 function printBanner(config) {
   console.log("");
   console.log(
@@ -534,16 +587,20 @@ async function main() {
     `http://localhost:${config.agentServerPort}/server_info`
   );
 
-  // 2. Start automation backend
+  // 2. Seed automation API key into agent-server secrets
+  // This makes the key available to agents during conversations
+  await seedAutomationSecret(config);
+
+  // 3. Start automation backend
   startAutomationBackend(config);
 
-  // 3. Start Vite dev server (no proxy config needed - ingress handles routing)
+  // 4. Start Vite dev server (no proxy config needed - ingress handles routing)
   startVite(config);
 
-  // 4. Wait for services to be ready
+  // 5. Wait for services to be ready
   await delay(2000);
 
-  // 5. Start ingress proxy (routes traffic to all backends)
+  // 6. Start ingress proxy (routes traffic to all backends)
   startIngress(config);
 
   // Wait for ingress to start


### PR DESCRIPTION
## Summary

When running `npm run dev:automation`, the automation API key is now automatically seeded into the agent-server's secrets store. This makes the key available to agents during conversations so they can authenticate with the automation backend.

## Changes

- Add `seedAutomationSecret()` function that calls `PUT /api/settings/secrets` after agent-server is ready
- Store the automation API key as `OPENHANDS_AUTOMATION_API_KEY`
- Add `sessionApiKey` to config for optional auth header support
- Update help text and header documentation

## How It Works

1. Agent-server starts and becomes healthy
2. Dev script calls `PUT /api/settings/secrets` to store the API key
3. Secret is named `OPENHANDS_AUTOMATION_API_KEY`
4. Agents in conversations can access it as an environment variable

## Usage

Agents can now use the secret to authenticate with the automation backend:

```bash
curl -H "Authorization: Bearer $OPENHANDS_AUTOMATION_API_KEY" \
  http://localhost:8000/api/automation/...
```

## Testing

- [ ] Run `npm run dev:automation` and verify "OPENHANDS_AUTOMATION_API_KEY seeded successfully" message appears
- [ ] Start a conversation and verify the agent can access `$OPENHANDS_AUTOMATION_API_KEY`
- [ ] Verify the secret appears in Settings > Secrets in the UI