### PR TITLE
Changes tab: sleeker styling and squared tab container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@
 - `__tests__/vite-config.test.ts` should import `vite.config` directly under `// @vitest-environment node`; spawning plain `node -e 'import ./vite.config.ts'` is not portable across Node patch releases in CI.
 - `vitest.setup.ts` must guard DOM-specific globals (`HTMLCanvasElement`, `HTMLElement`, `window`) because some suites run in the Node environment instead of jsdom.
 - `__tests__/components/providers/posthog-wrapper.test.tsx` must wrap `PostHogWrapper` in a `QueryClientProvider`; the wrapper now reads its client from React Query context instead of importing the global singleton.
+- `src/components/shared/buttons/styled-tooltip.tsx` should keep HeroUI tooltip animations disabled in Vitest (`disableAnimation` when `import.meta.env.MODE === "test"`); otherwise full-suite runs can end with unhandled `window is not defined` rejections from `framer-motion` after jsdom teardown (seen via `recent-conversation` tests in CI).
+- `__tests__/i18n/library-namespace.test.ts` imports the full library entry and can exceed Vitest's default 5s timeout under full-suite load; keep an explicit higher timeout on that case unless the test is substantially narrowed.
+
 
 - `@openhands/typescript-client` is consumed directly from `github:OpenHands/typescript-client#4716d2e`; that package ships the needed subpath exports for `client/http-client`, `events/remote-events-list`, and `workspace/remote-workspace`.
 - Shared TypeScript-client adapters live in `src/api/typescript-client.ts`; prefer those helpers for agent-server-backed REST/workspace/event/VS Code calls before falling back to `open-hands-axios`.

--- a/__tests__/components/features/diff-viewer/file-diff-viewer.test.tsx
+++ b/__tests__/components/features/diff-viewer/file-diff-viewer.test.tsx
@@ -154,12 +154,12 @@ describe("FileDiffViewer", () => {
 
     await expand(user);
 
-    expect(screen.getByTestId("view-mode-diff").className).toContain("bg-neutral-600");
-    expect(screen.getByTestId("view-mode-old").className).not.toContain("bg-neutral-600");
+    expect(screen.getByTestId("view-mode-diff").className).toContain("bg-[#474A54] text-white");
+    expect(screen.getByTestId("view-mode-old").className).not.toContain("bg-[#474A54] text-white");
 
     await user.click(screen.getByTestId("view-mode-old"));
 
-    expect(screen.getByTestId("view-mode-old").className).toContain("bg-neutral-600");
-    expect(screen.getByTestId("view-mode-diff").className).not.toContain("bg-neutral-600");
+    expect(screen.getByTestId("view-mode-old").className).toContain("bg-[#474A54] text-white");
+    expect(screen.getByTestId("view-mode-diff").className).not.toContain("bg-[#474A54] text-white");
   });
 });

--- a/__tests__/i18n/library-namespace.test.ts
+++ b/__tests__/i18n/library-namespace.test.ts
@@ -25,31 +25,35 @@ describe("library i18n namespace scoping", () => {
     expect(instance.options.ns).toContain(OPENHANDS_I18N_NAMESPACE);
   });
 
-  it("does not initialize the global i18next singleton when importing the library entry", async () => {
-    vi.resetModules();
+  it(
+    "does not initialize the global i18next singleton when importing the library entry",
+    async () => {
+      vi.resetModules();
 
-    const { default: globalI18n } = await import("i18next");
+      const { default: globalI18n } = await import("i18next");
 
-    await globalI18n.init({
-      lng: "en",
-      fallbackLng: "en",
-      ns: ["translation"],
-      defaultNS: "translation",
-      resources: {
-        en: {
-          translation: {
-            HOST_ONLY: "Host only",
+      await globalI18n.init({
+        lng: "en",
+        fallbackLng: "en",
+        ns: ["translation"],
+        defaultNS: "translation",
+        resources: {
+          en: {
+            translation: {
+              HOST_ONLY: "Host only",
+            },
           },
         },
-      },
-    });
-    globalI18n.removeResourceBundle("en", "openhands");
+      });
+      globalI18n.removeResourceBundle("en", "openhands");
 
-    expect(globalI18n.hasResourceBundle("en", "openhands")).toBe(false);
+      expect(globalI18n.hasResourceBundle("en", "openhands")).toBe(false);
 
-    await import("../../src/index");
+      await import("../../src/index");
 
-    expect(globalI18n.hasResourceBundle("en", "openhands")).toBe(false);
-    expect(globalI18n.t("HOST_ONLY")).toBe("Host only");
-  });
+      expect(globalI18n.hasResourceBundle("en", "openhands")).toBe(false);
+      expect(globalI18n.t("HOST_ONLY")).toBe("Host only");
+    },
+    15_000,
+  );
 });

--- a/src/components/features/conversation/conversation-tabs/conversation-tab-content/conversation-tab-content.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tab-content/conversation-tab-content.tsx
@@ -63,7 +63,7 @@ export function ConversationTabContent() {
   const conversationTabTitle = t(activeTab.titleKey);
 
   if (shouldShownAgentLoading) {
-    return <ConversationLoading className="rounded-xl" />;
+    return <ConversationLoading />;
   }
 
   return (

--- a/src/components/features/conversation/conversation-tabs/conversation-tab-content/tab-container.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tab-content/tab-container.tsx
@@ -6,7 +6,7 @@ interface TabContainerProps {
 
 export function TabContainer({ children }: TabContainerProps) {
   return (
-    <div className="bg-[#25272D] border border-[#525252] rounded-xl flex flex-col h-full w-full">
+    <div className="bg-[#25272D] border border-[#525252] flex flex-col h-full w-full">
       {children}
     </div>
   );

--- a/src/components/features/conversation/conversation-tabs/conversation-tab-content/tab-content-area.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tab-content/tab-content-area.tsx
@@ -6,7 +6,7 @@ interface TabContentAreaProps {
 
 export function TabContentArea({ children }: TabContentAreaProps) {
   return (
-    <div className="overflow-hidden flex-grow rounded-b-xl h-full w-full relative">
+    <div className="overflow-hidden flex-grow h-full w-full relative">
       {children}
     </div>
   );

--- a/src/components/features/diff-viewer/editor-container.tsx
+++ b/src/components/features/diff-viewer/editor-container.tsx
@@ -9,7 +9,7 @@ export function EditorContainer({ height, children }: EditorContainerProps) {
   return (
     <div
       data-testid="editor-container"
-      className="w-full border border-neutral-600 overflow-hidden h-[var(--editor-height)] rounded-bl-xl rounded-br-xl"
+      className="w-full border-b border-[#474A54] overflow-hidden h-[var(--editor-height)]"
       style={{ "--editor-height": `${height}px` } as React.CSSProperties}
     >
       {children}

--- a/src/components/features/diff-viewer/file-diff-viewer.tsx
+++ b/src/components/features/diff-viewer/file-diff-viewer.tsx
@@ -174,7 +174,7 @@ export function FileDiffViewer({ path, type }: FileDiffViewerProps) {
     if (isMarkdownFile) {
       return (
         <div
-          className="w-full border border-neutral-600 overflow-auto p-4 bg-neutral-900 prose prose-invert max-w-none"
+          className="w-full border-b border-[#474A54] overflow-auto p-4 bg-neutral-900 prose prose-invert max-w-none"
           data-testid="markdown-preview"
         >
           <MarkdownRenderer
@@ -205,15 +205,12 @@ export function FileDiffViewer({ path, type }: FileDiffViewerProps) {
   return (
     <div data-testid="file-diff-viewer-outer" className="w-full flex flex-col">
       <div
-        className={cn(
-          "flex justify-between items-center px-2.5 py-3.5 border border-neutral-600 rounded-xl hover:cursor-pointer",
-          !isCollapsed && !isLoading && "border-b-0 rounded-b-none",
-        )}
+        className="flex justify-between items-center px-3 py-2.5 border-b border-[#474A54] hover:cursor-pointer"
         onClick={() => setIsCollapsed((prev) => !prev)}
       >
         <span className="text-sm w-full text-content flex items-center gap-2">
-          {isFetchingData ? <LoadingSpinner className="w-5 h-5" /> : statusIcon}
-          <strong className="w-full truncate">{filePath}</strong>
+          {isFetchingData ? <LoadingSpinner className="w-4 h-4" /> : statusIcon}
+          <strong className="w-full truncate font-medium">{filePath}</strong>
           {!isCollapsed && (
             <span
               className="flex items-center gap-0.5 shrink-0"
@@ -228,8 +225,8 @@ export function FileDiffViewer({ path, type }: FileDiffViewerProps) {
                   className={cn(
                     "p-1 rounded transition-colors cursor-pointer",
                     viewMode === mode
-                      ? "bg-neutral-600 text-white"
-                      : "text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200",
+                      ? "bg-[#474A54] text-white"
+                      : "text-[#9099ac] hover:bg-[#474A54] hover:text-white",
                   )}
                 >
                   <Icon className="w-4 h-4" />

--- a/src/components/shared/buttons/styled-tooltip.tsx
+++ b/src/components/shared/buttons/styled-tooltip.tsx
@@ -19,6 +19,8 @@ export function StyledTooltip({
   showArrow = false,
   closeDelay = 100,
 }: StyledTooltipProps) {
+  const disableAnimation = import.meta.env.MODE === "test";
+
   return (
     <Tooltip
       content={content}
@@ -26,6 +28,7 @@ export function StyledTooltip({
       placement={placement}
       className={cn("bg-white text-black", tooltipClassName)}
       showArrow={showArrow}
+      disableAnimation={disableAnimation}
     >
       <div className="inline-flex">{children}</div>
     </Tooltip>

--- a/src/routes/changes-tab.tsx
+++ b/src/routes/changes-tab.tsx
@@ -67,7 +67,7 @@ function GitChanges() {
   ]);
 
   return (
-    <main className="h-full overflow-y-scroll p-4 md:pr-1.5 gap-3 flex flex-col items-center custom-scrollbar-always">
+    <main className="h-full overflow-y-scroll md:pr-1.5 flex flex-col items-stretch custom-scrollbar-always">
       {!isSuccess || !gitChanges.length ? (
         <div className="relative flex h-full w-full items-center">
           <div className="absolute inset-x-0 top-1/2 -translate-y-1/2">
@@ -85,7 +85,7 @@ function GitChanges() {
 
           <div className="absolute inset-x-0 bottom-0">
             {!isError && gitChanges?.length === 0 && (
-              <div className="max-w-2xl mb-4 text-m bg-tertiary rounded-xl p-4 text-left mx-auto">
+              <div className="max-w-2xl mx-4 mb-4 text-m bg-tertiary p-4 text-left md:mx-auto">
                 <RandomTip />
               </div>
             )}


### PR DESCRIPTION
Split out from `rb/megachange`. Pure cosmetic tweaks to the Changes tab — tighter file-diff viewer chrome and a squared-off tab container so it lines up with the rest of the right pane.

_This PR was created by an AI agent (OpenHands) on behalf of @rbren as part of splitting the `rb/megachange` branch into reviewable PRs._