### PR TITLE
fix(frontend): forward disabled_skills to cloud proxy on skills toggle save

### DIFF
--- a/__tests__/api/cloud/settings-service.test.ts
+++ b/__tests__/api/cloud/settings-service.test.ts
@@ -10,6 +10,7 @@ import {
   fetchCloudSettings,
   saveCloudSettings,
 } from "#/api/cloud/settings-service.api";
+import SettingsService from "#/api/settings-service/settings-service.api";
 
 vi.mock("axios");
 
@@ -108,6 +109,29 @@ describe("cloud settings via local proxy", () => {
     });
     expect(proxiedBody).not.toHaveProperty("agent_settings");
     expect(proxiedBody).not.toHaveProperty("conversation_settings");
+  });
+
+  it("SettingsService.saveSettings forwards disabled_skills to the cloud proxy when active backend is cloud", async () => {
+    // Arrange: cloud backend already active via beforeEach; mock proxy response.
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
+
+    // Act: save a skills-only update — previously this short-circuited and
+    // sent nothing at all, leaving the toggle un-persisted.
+    await SettingsService.saveSettings({
+      disabled_skills: ["SSH Microagent"],
+    });
+
+    // Assert: a single proxied POST /api/v1/settings reached the wire with
+    // disabled_skills as a top-level field on the upstream body.
+    expect(vi.mocked(axios.post)).toHaveBeenCalledTimes(1);
+    const [, envelope] = vi.mocked(axios.post).mock.calls[0]!;
+    expect(envelope).toMatchObject({
+      method: "POST",
+      path: "/api/v1/settings",
+    });
+    expect((envelope as { body: Record<string, unknown> }).body).toEqual({
+      disabled_skills: ["SSH Microagent"],
+    });
   });
 
   it("saveCloudSettings omits an empty conversation_settings_diff (LLM-only save)", async () => {

--- a/__tests__/api/settings-service.test.ts
+++ b/__tests__/api/settings-service.test.ts
@@ -104,6 +104,26 @@ describe("SettingsService", () => {
     fetchSpy.mockRestore();
   });
 
+  it("skips PATCH for a skills-only save against a local backend", async () => {
+    // Arrange: skills are a cloud-only feature. The local agent-server's
+    // PATCH /api/settings rejects payloads without agent/conversation diffs
+    // (the MSW handler returns 400 in that case), so a successful no-op here
+    // also confirms disabled_skills is not leaked to the local backend.
+    const fetchSpy = vi.spyOn(SettingsService, "fetchSettingsFromApi");
+
+    // Act
+    const result = await SettingsService.saveSettings({
+      disabled_skills: ["SSH Microagent"],
+    });
+
+    // Assert: returns true and never fires the PATCH (no fetch invalidation
+    // either, because the cache wasn't cleared).
+    expect(result).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+
   it("derives provider_tokens_set from locally stored git provider tokens", async () => {
     // Arrange: simulate post-save state. SecretsService.addGitProvider writes to
     // this localStorage key after the server PUT /api/settings/secrets succeeds.

--- a/src/api/cloud/settings-service.api.ts
+++ b/src/api/cloud/settings-service.api.ts
@@ -149,6 +149,7 @@ export async function fetchCloudSettings(): Promise<Partial<Settings>> {
 export async function saveCloudSettings(diff: {
   agent_settings_diff?: Record<string, SettingsValue>;
   conversation_settings_diff?: Record<string, SettingsValue>;
+  disabled_skills?: string[];
 }): Promise<void> {
   const backend = getActiveCloudBackend();
   const body: Record<string, unknown> = {};
@@ -163,6 +164,10 @@ export async function saveCloudSettings(diff: {
     Object.keys(diff.conversation_settings_diff).length > 0
   ) {
     body.conversation_settings_diff = diff.conversation_settings_diff;
+  }
+  // Use !== undefined so re-enabling every skill (empty array) round-trips.
+  if (diff.disabled_skills !== undefined) {
+    body.disabled_skills = diff.disabled_skills;
   }
   await callCloudProxy<unknown>({
     backend,

--- a/src/api/settings-service/settings-service.api.ts
+++ b/src/api/settings-service/settings-service.api.ts
@@ -31,6 +31,7 @@ export interface SettingsApiResponse {
 export interface SettingsUpdateRequest {
   agent_settings_diff?: Record<string, SettingsValue>;
   conversation_settings_diff?: Record<string, SettingsValue>;
+  disabled_skills?: string[];
 }
 
 /**
@@ -337,16 +338,40 @@ class SettingsService {
       payload.conversation_settings_diff = conversationSettingsDiff;
     }
 
+    // Extract disabled_skills (cloud-only — local agent-server has no skills concept)
+    const disabledSkills = settings.disabled_skills as string[] | undefined;
+    if (Array.isArray(disabledSkills)) {
+      payload.disabled_skills = disabledSkills;
+    }
+
     // Only call API if we have something to update
-    if (!payload.agent_settings_diff && !payload.conversation_settings_diff) {
+    if (
+      !payload.agent_settings_diff &&
+      !payload.conversation_settings_diff &&
+      payload.disabled_skills === undefined
+    ) {
       return true;
     }
 
     if (getActiveBackend().backend.kind === "cloud") {
       await withRetry(() => saveCloudSettings(payload));
     } else {
+      // The local agent-server PATCH /api/settings rejects unknown fields and
+      // requires at least one of the two diff fields. Strip disabled_skills
+      // and skip the request entirely if nothing else was changed.
+      const { disabled_skills: _droppedDisabledSkills, ...localPayload } =
+        payload;
+      if (
+        !localPayload.agent_settings_diff &&
+        !localPayload.conversation_settings_diff
+      ) {
+        return true;
+      }
       await withRetry(() =>
-        createHttpClient().patch<SettingsApiResponse>("/api/settings", payload),
+        createHttpClient().patch<SettingsApiResponse>(
+          "/api/settings",
+          localPayload,
+        ),
       );
     }
 


### PR DESCRIPTION
Resolves #172 

### Description

When a user is on a cloud backend (e.g. *Production – Personal Workspace*) and toggles a skill on/off at `http://localhost:3001/settings/skills`, clicking **Save Changes** has no effect — the change is not persisted, and re-loading the page reverts the toggle.

### Repro

1. Open `agent-server-gui` at `http://localhost:3001`.
2. From the user-avatar context menu, **Add Backend** → enter a cloud host (`https://app.all-hands.dev`) and API key → **Save**.
3. Switch to that cloud environment.
4. Navigate to `/settings/skills`.
5. Toggle any skill, click **Save Changes**.
6. Reload — toggle is back to its original state.

### Current Behavior

No `POST /api/v1/settings` (or `POST /api/cloud-proxy`) request is made on save. Only the unrelated initial-load `GET` is observed. The save is a silent no-op.

### Expected Behavior

Clicking **Save Changes** sends `POST /api/cloud-proxy` with envelope `{ method: "POST", path: "/api/v1/settings", body: { disabled_skills: [...] } }`, the cloud persists it, and the toggle survives a reload.

### Root Cause

`SettingsService.saveSettings` (`src/api/settings-service/settings-service.api.ts:316-357`) builds its outbound payload from only `agent_settings_diff` and `conversation_settings_diff` and short-circuits with `return true` when both are absent. A skills-only save therefore makes no HTTP request at all.

`saveCloudSettings` (`src/api/cloud/settings-service.api.ts:149-173`) likewise only forwards those two diff fields and ignores `disabled_skills`.

Skills are a **cloud-only** feature — the local agent-server's `PATCH /api/settings` endpoint (`software-agent-sdk/.../settings_router.py:222-247`) explicitly rejects payloads without one of the two diff fields, and there is no `disabled_skills` reference anywhere in the local SDK.

### Fix Summary

Wire `disabled_skills` through the save pipeline, but only forward it to the cloud:

* `saveCloudSettings` accepts `disabled_skills` and includes it as a top-level field in the proxied body.
* `SettingsService.saveSettings` extracts `disabled_skills`, includes it in the early-return guard, and strips it from the local PATCH payload (the local backend has no skills concept and would 400 on an unknown field).
* Local backend with a skills-only save → no-op (returns `true`) instead of failing.

### Acceptance Criteria

* [ ] Toggling a skill on a cloud backend and clicking **Save Changes** fires `POST /api/cloud-proxy` with the correct envelope and persists.
* [ ] Reloading the page preserves the toggle state from the server.
* [ ] An empty `disabled_skills: []` (re-enabling everything) is persisted correctly (not dropped as falsy).
* [ ] On a local backend, a skills-only save is a no-op — no `PATCH /api/settings` request, no error toast.
* [ ] Existing local saves (LLM/agent/conversation settings) are unchanged.
* [ ] Unit tests cover both the cloud-forwarding and local-skip paths.

### Summary

* Toggling a skill at `/settings/skills` against a cloud backend silently failed: the save click made no network request and the change was lost on reload.
* The save pipeline dropped `disabled_skills` because `SettingsService.saveSettings` built its payload from only `agent_settings_diff` / `conversation_settings_diff` and short-circuited when both were empty.
* Wired `disabled_skills` through the cloud path and skip it for the local PATCH (skills are a cloud-only feature; the local agent-server has no concept of `disabled_skills` and rejects unknown payload fields).

### Root Cause

`SettingsService.saveSettings`:

```ts
if (!payload.agent_settings_diff && !payload.conversation_settings_diff) {
  return true; // skills-only save bailed out here
}
```

`saveCloudSettings` also only forwarded the two diff fields, so `disabled_skills` was dropped even when present.

The skills feature is cloud-only — local `PATCH /api/settings` requires at least one diff field and rejects unknown keys.

### Changes

| File                            | Change                                             |
| ------------------------------- | -------------------------------------------------- |
| `cloud/settings-service.api.ts` | Accept and forward `disabled_skills`               |
| `settings-service.api.ts`       | Add field, include in guard, strip for local PATCH |
| cloud test                      | verifies proxy includes `disabled_skills`          |
| local test                      | verifies no PATCH request for skills-only save     |