### PR TITLE
feat(sidebar): always show automations icon in sidebar

### DIFF
--- a/src/components/features/sidebar/sidebar.tsx
+++ b/src/components/features/sidebar/sidebar.tsx
@@ -15,7 +15,6 @@ import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { I18nKey } from "#/i18n/declaration";
 import { useNavigation } from "#/context/navigation-context";
 import { cn } from "#/utils/utils";
-import { ENABLE_AUTOMATIONS } from "#/utils/feature-flags";
 
 export function Sidebar() {
   const { t } = useTranslation("openhands");
@@ -88,11 +87,9 @@ export function Sidebar() {
               }
               disabled={settings?.email_verified === false}
             />
-            {ENABLE_AUTOMATIONS() && (
-              <AutomationsButton
-                disabled={settings?.email_verified === false}
-              />
-            )}
+            <AutomationsButton
+              disabled={settings?.email_verified === false}
+            />
           </div>
 
           <div className="flex flex-row md:flex-col md:items-center gap-[26px]">

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -16,4 +16,3 @@ export const HIDE_LLM_SETTINGS = () => loadFeatureFlag("HIDE_LLM_SETTINGS");
 export const VSCODE_IN_NEW_TAB = () => loadFeatureFlag("VSCODE_IN_NEW_TAB");
 export const ENABLE_TRAJECTORY_REPLAY = () =>
   loadFeatureFlag("TRAJECTORY_REPLAY");
-export const ENABLE_AUTOMATIONS = () => loadFeatureFlag("AUTOMATIONS");


### PR DESCRIPTION
## Summary
This PR adds the automations icon (gear with play symbol) to the sidebar, making it always visible and providing navigation to the `/automations` page.

Fixes [APP-1562](https://linear.app/all-hands-ai/issue/APP-1562/milestone-3-add-automations-as-a-first-class-navigation-item)

## Changes
- **`src/components/features/sidebar/sidebar.tsx`**: Removed the `ENABLE_AUTOMATIONS` feature flag condition so the `AutomationsButton` is always rendered in the sidebar
- **`src/utils/feature-flags.ts`**: Removed the now-unused `ENABLE_AUTOMATIONS` feature flag export

## Result
The sidebar now displays the automations icon (gear with play symbol) below the conversation panel button. The icon navigates to `/automations` where users can view and manage their automations.

**Sidebar order (top to bottom):**
1. OpenHands logo (home)
2. New project button (+)
3. Conversation panel button (list icon)
4. **Automations button (gear with play icon)** ← Now always visible
5. User actions (bottom)

## Testing
- ✅ TypeScript type checking passes
- ✅ Build completes successfully
- ✅ Automations button tests pass (3/3 tests)

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e066015d-5945-48b8-b0fe-70a142b37d32)