### PR TITLE
Fix Vite dev prebundling for CJS deps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,10 @@ export default defineConfig(({ mode }) => {
         "react-icons/fa",
         "clsx",
         "tailwind-merge",
+        // CJS dependencies used by react-transition-group. Without pre-bundling,
+        // Vite can serve them directly to the browser before route hydration.
+        "prop-types",
+        "react-is",
         "@heroui/react",
         "lucide-react",
         "@microlink/react-json-view",


### PR DESCRIPTION
## Summary
- add `prop-types` and `react-is` to Vite `optimizeDeps.include`
- prevent Vite from serving these CJS packages directly to the browser before route hydration
- keep this as a dev-server prebundle change only; no `package.json` dependency changes are needed

## Rationale
These are not new direct Agent Canvas dependencies. They are already present in the existing dependency graph and lockfile:

- `prop-types` is pulled in by `react-transition-group@4.4.5`, which currently comes through the UI stack: `@heroui/react` -> `@heroui/date-input` -> `@react-aria/datepicker` -> `@react-types/dialog` -> `@react-spectrum/dialog` -> `@adobe/react-spectrum` -> `react-transition-group`.
- `react-is` is pulled in by existing transitive dependencies as well. In the current install it is used by `downshift`, and `prop-types` also carries its own nested `react-is` dependency.

The bug is not that these packages are missing from installation. The bug is that they are CommonJS packages that can be reached through ESM client modules during dev. Without pre-bundling, Vite may serve the raw CJS entrypoints to the browser, which then fails before route hydration with errors like:

- `prop-types/index.js` does not provide a `default` export
- `react-is/index.js` does not provide an `isForwardRef` named export

Adding them to `optimizeDeps.include` tells Vite to convert them during dependency optimization, which is the same treatment as the other client-load dependencies already listed here. Since Agent Canvas source does not import these packages directly, adding them to `package.json` would make the dependency relationship less accurate; the important part is forcing Vite's dev optimizer to handle the already-installed transitive CJS modules.

## Verification
- `npm run make-i18n && npm run typecheck`
- loaded `npm run dev:mock` on port 3101 in headless Chromium and confirmed the page rendered without `prop-types` / `react-is` module export errors

## Notes
- The first fresh Vite load can still trigger the existing runtime optimization reload for other dependencies; a second load was clean for this CJS issue.