### PR TITLE
chore: update automation entrypoint to openhands.automation namespace

### DIFF
--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -29,7 +29,7 @@ describe("buildAutomationCommand", () => {
       `git+${DEFAULT_AUTOMATION_REPO}@${DEFAULT_AUTOMATION_GIT_REF}`,
     );
     expect(cmd.args).toContain("uvicorn");
-    expect(cmd.args).toContain("automation.app:app");
+    expect(cmd.args).toContain("openhands.automation.app:app");
     expect(cmd.source).toBe(`git (${DEFAULT_AUTOMATION_GIT_REF})`);
   });
 

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -181,7 +181,7 @@ function buildAutomationCommand(env = process.env) {
   const gitUrl = `git+${repoUrl}@${gitRef}`;
 
   // Use --refresh to ensure latest commit is fetched for git refs
-  const args = ["--refresh", "--from", gitUrl, "uvicorn", "automation.app:app"];
+  const args = ["--refresh", "--from", gitUrl, "uvicorn", "openhands.automation.app:app"];
 
   return {
     command: "uvx",


### PR DESCRIPTION
## Summary

Updates the uvicorn entrypoint for the automation service from `automation.app:app` to `openhands.automation.app:app` to align with the namespace restructuring in OpenHands/automation#101.

## Changes

- Update `scripts/dev-with-automation.mjs` to use `openhands.automation.app:app` entrypoint
- Update corresponding test expectation in `__tests__/scripts/dev-with-automation.test.ts`

## Context

The automation package is being restructured to use the `openhands.automation` namespace to:
- Align with other OpenHands packages (`openhands-sdk`, `openhands-workspace`)
- Avoid conflicts with the generic `automation` package name
- Follow PEP 420 namespace package conventions

## Related

- Closes after OpenHands/automation#104 is merged

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b33b5123-22ea-492c-8d60-d7e3bfd980fd)