### PR TITLE
feat: pin default SDK and automation versions to PyPI releases

### DIFF
--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -9,7 +9,8 @@ import {
   buildAutomationCommand,
   buildConfig,
   DEFAULT_AUTOMATION_REPO,
-  DEFAULT_AUTOMATION_GIT_REF,
+  DEFAULT_AUTOMATION_VERSION,
+  DEFAULT_AUTOMATION_PACKAGE,
   DEFAULT_BACKEND_PORT,
   DEFAULT_AUTOMATION_PORT,
 } from "../../scripts/dev-with-automation.mjs";
@@ -20,25 +21,26 @@ const repoRoot = path.resolve(
 );
 
 describe("buildAutomationCommand", () => {
-  it("uses main branch by default", () => {
+  it("uses pinned PyPI version by default", () => {
     const cmd = buildAutomationCommand({});
 
     expect(cmd.command).toBe("uvx");
     expect(cmd.args).toContain("--from");
     expect(cmd.args).toContain(
-      `git+${DEFAULT_AUTOMATION_REPO}@${DEFAULT_AUTOMATION_GIT_REF}`,
+      `${DEFAULT_AUTOMATION_PACKAGE}==${DEFAULT_AUTOMATION_VERSION}`,
     );
     expect(cmd.args).toContain("uvicorn");
     expect(cmd.args).toContain("openhands.automation.app:app");
-    expect(cmd.source).toBe(`git (${DEFAULT_AUTOMATION_GIT_REF})`);
+    expect(cmd.source).toBe(`PyPI (${DEFAULT_AUTOMATION_VERSION})`);
   });
 
-  it("uses custom git ref from OH_AUTOMATION_GIT_REF", () => {
+  it("uses custom git ref from OH_AUTOMATION_GIT_REF (overrides default)", () => {
     const cmd = buildAutomationCommand({
       OH_AUTOMATION_GIT_REF: "feat/my-feature",
     });
 
     expect(cmd.command).toBe("uvx");
+    expect(cmd.args).toContain("--refresh");
     expect(cmd.args).toContain("--from");
     expect(cmd.args).toContain(
       `git+${DEFAULT_AUTOMATION_REPO}@feat/my-feature`,
@@ -46,18 +48,30 @@ describe("buildAutomationCommand", () => {
     expect(cmd.source).toBe("git (feat/my-feature)");
   });
 
-  it("uses custom repo from OH_AUTOMATION_REPO", () => {
+  it("uses custom version from OH_AUTOMATION_VERSION", () => {
     const cmd = buildAutomationCommand({
-      OH_AUTOMATION_REPO: "https://github.com/MyOrg/my-automation",
+      OH_AUTOMATION_VERSION: "2.0.0",
     });
 
     expect(cmd.command).toBe("uvx");
-    expect(cmd.args).toContain(
-      `git+https://github.com/MyOrg/my-automation@${DEFAULT_AUTOMATION_GIT_REF}`,
-    );
+    expect(cmd.args).toContain("--from");
+    expect(cmd.args).toContain(`${DEFAULT_AUTOMATION_PACKAGE}==2.0.0`);
+    expect(cmd.source).toBe("PyPI (2.0.0)");
   });
 
-  it("uses both custom repo and ref together", () => {
+  it("git ref takes precedence over version", () => {
+    const cmd = buildAutomationCommand({
+      OH_AUTOMATION_GIT_REF: "my-branch",
+      OH_AUTOMATION_VERSION: "2.0.0",
+    });
+
+    expect(cmd.args).toContain(
+      `git+${DEFAULT_AUTOMATION_REPO}@my-branch`,
+    );
+    expect(cmd.source).toBe("git (my-branch)");
+  });
+
+  it("uses custom repo with git ref", () => {
     const cmd = buildAutomationCommand({
       OH_AUTOMATION_REPO: "https://github.com/MyOrg/my-automation",
       OH_AUTOMATION_GIT_REF: "v1.0.0",
@@ -219,8 +233,12 @@ describe("default constants", () => {
     );
   });
 
-  it("has expected default automation git ref", () => {
-    expect(DEFAULT_AUTOMATION_GIT_REF).toBe("main");
+  it("has expected default automation version", () => {
+    expect(DEFAULT_AUTOMATION_VERSION).toBe("1.0.0a1");
+  });
+
+  it("has expected default automation package name", () => {
+    expect(DEFAULT_AUTOMATION_PACKAGE).toBe("openhands-automation");
   });
 
   it("has expected default backend port", () => {

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -25,9 +25,8 @@ const LOCAL_AGENT_SERVER_SUBDIRS = [
 ];
 // Default secret key for local development (DO NOT use in production)
 const DEFAULT_SECRET_KEY = "openhands-dev-secret-key-change-in-prod";
-// Default to main branch until settings persistence APIs are in a released version.
-// TODO: Once SDK PR #3060 is released, change this to null and let it use PyPI.
-const DEFAULT_GIT_REF = "main";
+// Default agent-server version from PyPI. Set OH_AGENT_SERVER_GIT_REF to override with a branch/commit.
+const DEFAULT_AGENT_SERVER_VERSION = "1.21.1";
 
 function isEnoentError(error) {
   return Boolean(
@@ -134,19 +133,18 @@ export function buildAgentServerCommand(env = process.env) {
       "agent-server",
     );
     source = `PyPI (${version})`;
-  } else if (DEFAULT_GIT_REF) {
-    // Default to git ref when no version specified (until APIs are released)
-    const baseGitUrl = `git+${AGENT_SERVER_GIT_REPO}@${DEFAULT_GIT_REF}`;
+  } else if (DEFAULT_AGENT_SERVER_VERSION) {
+    // Use pinned PyPI version
     uvxArgs.push(
       "--from",
-      `${baseGitUrl}#subdirectory=openhands-agent-server`,
+      `${DEFAULT_AGENT_SERVER_PACKAGE}==${DEFAULT_AGENT_SERVER_VERSION}`,
       "--with",
-      `${baseGitUrl}#subdirectory=openhands-tools`,
+      `openhands-tools==${DEFAULT_AGENT_SERVER_VERSION}`,
       "--with",
-      `${baseGitUrl}#subdirectory=openhands-workspace`,
+      `openhands-workspace==${DEFAULT_AGENT_SERVER_VERSION}`,
       "agent-server",
     );
-    source = `git (${DEFAULT_GIT_REF}, default)`;
+    source = `PyPI (${DEFAULT_AGENT_SERVER_VERSION})`;
   } else {
     // Use latest released version: uvx --from openhands-agent-server agent-server
     // The package name differs from the executable name, so we need --from syntax

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -58,7 +58,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
 
 const DEFAULT_AUTOMATION_REPO = "https://github.com/OpenHands/automation";
-const DEFAULT_AUTOMATION_GIT_REF = "main";
+// Default automation version from PyPI. Set OH_AUTOMATION_GIT_REF to override with a branch/commit.
+const DEFAULT_AUTOMATION_VERSION = "1.0.0a1";
+const DEFAULT_AUTOMATION_PACKAGE = "openhands-automation";
 const DEFAULT_BACKEND_PORT = 18000;
 const DEFAULT_AUTOMATION_PORT = 18001;
 // Default local API key for automation backend auth (matches agent-server pattern)
@@ -172,21 +174,44 @@ ACCESS POINTS:
 
 /**
  * Build the uvx command for running automation backend.
+ * 
+ * Priority:
+ * 1. OH_AUTOMATION_GIT_REF - Use git ref (branch/tag/commit)
+ * 2. OH_AUTOMATION_VERSION - Use specific PyPI version
+ * 3. DEFAULT_AUTOMATION_VERSION - Use default PyPI version
+ * 4. Latest PyPI version
  */
 function buildAutomationCommand(env = process.env) {
-  const gitRef = env.OH_AUTOMATION_GIT_REF || DEFAULT_AUTOMATION_GIT_REF;
+  const gitRef = env.OH_AUTOMATION_GIT_REF;
+  const version = env.OH_AUTOMATION_VERSION;
   const repoUrl = env.OH_AUTOMATION_REPO || DEFAULT_AUTOMATION_REPO;
 
-  // Build git URL with ref
-  const gitUrl = `git+${repoUrl}@${gitRef}`;
+  const args = [];
+  let source = "";
 
-  // Use --refresh to ensure latest commit is fetched for git refs
-  const args = ["--refresh", "--from", gitUrl, "uvicorn", "openhands.automation.app:app"];
+  if (gitRef) {
+    // Use git ref with refresh to ensure latest commit is fetched
+    const gitUrl = `git+${repoUrl}@${gitRef}`;
+    args.push("--refresh", "--from", gitUrl, "uvicorn", "openhands.automation.app:app");
+    source = `git (${gitRef})`;
+  } else if (version) {
+    // Use specific PyPI version
+    args.push("--from", `${DEFAULT_AUTOMATION_PACKAGE}==${version}`, "uvicorn", "openhands.automation.app:app");
+    source = `PyPI (${version})`;
+  } else if (DEFAULT_AUTOMATION_VERSION) {
+    // Use pinned PyPI version
+    args.push("--from", `${DEFAULT_AUTOMATION_PACKAGE}==${DEFAULT_AUTOMATION_VERSION}`, "uvicorn", "openhands.automation.app:app");
+    source = `PyPI (${DEFAULT_AUTOMATION_VERSION})`;
+  } else {
+    // Use latest PyPI version
+    args.push("--from", DEFAULT_AUTOMATION_PACKAGE, "uvicorn", "openhands.automation.app:app");
+    source = "PyPI (latest)";
+  }
 
   return {
     command: "uvx",
     args,
-    source: `git (${gitRef})`,
+    source,
   };
 }
 
@@ -680,7 +705,8 @@ export {
   buildAutomationCommand,
   buildConfig,
   DEFAULT_AUTOMATION_REPO,
-  DEFAULT_AUTOMATION_GIT_REF,
+  DEFAULT_AUTOMATION_VERSION,
+  DEFAULT_AUTOMATION_PACKAGE,
   DEFAULT_BACKEND_PORT,
   DEFAULT_AUTOMATION_PORT,
 };


### PR DESCRIPTION
## Summary

Updates the dev scripts to use pinned PyPI versions by default instead of git branches.

## Changes

### Default Versions
| Package | Default Version |
|---------|-----------------|
| `openhands-agent-server` | `1.21.1` |
| `openhands-tools` | `1.21.1` |
| `openhands-workspace` | `1.21.1` |
| `openhands-automation` | `1.0.0a1` |

### Override Options

Git refs can still be used to override defaults for development:

```bash
# Use a specific git branch for agent-server
OH_AGENT_SERVER_GIT_REF=feat/my-feature npm run dev

# Use a specific git branch for automation
OH_AUTOMATION_GIT_REF=feat/my-feature npm run dev

# Use a different PyPI version
OH_AGENT_SERVER_VERSION=1.22.0 npm run dev
OH_AUTOMATION_VERSION=1.0.0 npm run dev
```

### Priority Order

**Agent Server:**
1. `OH_AGENT_SERVER_LOCAL_PATH` - Local development path
2. `OH_AGENT_SERVER_GIT_REF` - Git branch/tag/commit
3. `OH_AGENT_SERVER_VERSION` - Specific PyPI version
4. `DEFAULT_AGENT_SERVER_VERSION` (1.21.1) - Pinned default

**Automation:**
1. `OH_AUTOMATION_GIT_REF` - Git branch/tag/commit  
2. `OH_AUTOMATION_VERSION` - Specific PyPI version
3. `DEFAULT_AUTOMATION_VERSION` (1.0.0a1) - Pinned default

## Testing

```bash
npm test -- --run __tests__/scripts/dev-with-automation.test.ts
```

All 31 tests pass ✅

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b33b5123-22ea-492c-8d60-d7e3bfd980fd)