### PR TITLE
chore: default to released PyPI versions instead of git branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,28 +78,21 @@
      The `addGitProvider` method stores to server FIRST (must succeed), then updates localStorage. This ensures server-side persistence is the source of truth.
 - Agent server connection settings now live at `Settings > Agent Server` (`/settings/agent-server`). The page reads deployment defaults from `VITE_BACKEND_BASE_URL` / `VITE_SESSION_API_KEY`, saves user overrides in the `openhands-agent-server-config` localStorage key, and must stay reachable even when the backend compatibility probe fails so users can recover from missing or wrong backend configuration.
 
-- **SDK Dependency for Settings Persistence (PR #98)**: The settings persistence API changes depend on [software-agent-sdk PR #3060](https://github.com/OpenHands/software-agent-sdk/pull/3060) which adds:
-  - `/api/settings` GET/PATCH with `X-Expose-Secrets: encrypted` header support
-  - `/api/settings/secrets` CRUD endpoints for custom secrets
-  - `OH_SECRET_KEY` environment variable for encryption
-
-  **IMPORTANT**: Until PR #3060 is merged and released, `npm run dev` must use `OH_AGENT_SERVER_GIT_REF=main` to point at the SDK main branch (or the feature branch), not a released PyPI version. The dev scripts now default to `main` for this reason. Once released, update `dev-safe.mjs` to use the minimum required version.
-
 - README expectation: keep the first section as a concrete, chronological from-scratch quickstart for running this frontend against a real `openhands-agent-server` (clone, install uv, optional `.env`, run `npm run dev`).
 - Keep README user-focused and move contributor/developer-specific workflows (`dev:safe`, mock mode, detailed env vars/build-test notes) into `DEVELOPMENT.md`.
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.18.0")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.21.1")
   - `OH_SECRET_KEY` — secret key for settings encryption; uses a default value for local dev, override for production
-  - Default: latest released version from PyPI
+  - Default: released PyPI version `1.21.1` for agent-server SDK libraries
 - `scripts/dev-safe.mjs` should fail fast if `uvx` cannot be spawned (for example missing PATH entries).
 - `npm run dev` now runs the full stack with automation by default (via `dev:automation`). Use `npm run dev:minimal` for agent-server + Vite only.
 - `scripts/dev-with-automation.mjs` runs the full stack: agent-server, automation backend (both via uvx), Vite dev server, and ingress proxy. Uses a standalone ingress proxy (`scripts/ingress.mjs`) to route traffic:
   - `/api/automation/*` → automation backend (:18001)
   - `/api/*`, `/sockets`, etc. → agent server (:18000)
   - `/*` (default) → Vite dev server (:3001)
-  - Environment variables: `PORT` (ingress port, default: 8000), `OH_AUTOMATION_GIT_REF` (default: `main`)
+  - Environment variables: `PORT` (ingress port, default: 8000), `OH_AUTOMATION_GIT_REF` (git ref, overrides default version), `OH_AUTOMATION_VERSION` (default: `1.0.0a1`)
   - Access points: `http://localhost:8000/` (main UI), `http://localhost:8000/api/automation/docs` (API docs)
 - `scripts/ingress.mjs` is a standalone HTTP reverse proxy that can be used independently to route traffic to multiple backends based on URL path prefix.
 - `scripts/dev-safe.mjs` (now `npm run dev:minimal`) runs just agent-server + Vite without automation.

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -42,35 +42,36 @@ describe("formatMissingUvxGuidance", () => {
 });
 
 describe("buildAgentServerCommand", () => {
-  it("uses main branch by default (until settings APIs are released)", () => {
+  it("uses released PyPI version by default with all packages pinned", () => {
     const cmd = buildAgentServerCommand({});
 
     expect(cmd.command).toBe("uvx");
-    // Currently defaults to main branch due to unreleased settings persistence APIs
+    // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "git+https://github.com/OpenHands/software-agent-sdk@main#subdirectory=openhands-agent-server",
+      "openhands-agent-server==1.21.1",
       "--with",
-      "git+https://github.com/OpenHands/software-agent-sdk@main#subdirectory=openhands-tools",
+      "openhands-tools==1.21.1",
       "--with",
-      "git+https://github.com/OpenHands/software-agent-sdk@main#subdirectory=openhands-workspace",
+      "openhands-workspace==1.21.1",
       "agent-server",
     ]);
-    expect(cmd.source).toBe("git (main, default)");
+    expect(cmd.source).toBe("PyPI (1.21.1, default)");
   });
 
-  it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set", () => {
+  it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {
     const cmd = buildAgentServerCommand({ OH_AGENT_SERVER_VERSION: "1.18.0" });
 
     expect(cmd.command).toBe("uvx");
     // Uses --from syntax because executable name (agent-server) differs from package name (openhands-agent-server)
+    // All SDK packages are pinned to the same version
     expect(cmd.args).toEqual([
       "--from",
       "openhands-agent-server==1.18.0",
       "--with",
-      "openhands-tools",
+      "openhands-tools==1.18.0",
       "--with",
-      "openhands-workspace",
+      "openhands-workspace==1.18.0",
       "agent-server",
     ]);
     expect(cmd.source).toBe("PyPI (1.18.0)");

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -9,7 +9,8 @@ import {
   buildAutomationCommand,
   buildConfig,
   DEFAULT_AUTOMATION_REPO,
-  DEFAULT_AUTOMATION_GIT_REF,
+  DEFAULT_AUTOMATION_PACKAGE,
+  DEFAULT_AUTOMATION_VERSION,
   DEFAULT_BACKEND_PORT,
   DEFAULT_AUTOMATION_PORT,
 } from "../../scripts/dev-with-automation.mjs";
@@ -20,17 +21,17 @@ const repoRoot = path.resolve(
 );
 
 describe("buildAutomationCommand", () => {
-  it("uses main branch by default", () => {
+  it("uses released PyPI version by default", () => {
     const cmd = buildAutomationCommand({});
 
     expect(cmd.command).toBe("uvx");
     expect(cmd.args).toContain("--from");
     expect(cmd.args).toContain(
-      `git+${DEFAULT_AUTOMATION_REPO}@${DEFAULT_AUTOMATION_GIT_REF}`,
+      `${DEFAULT_AUTOMATION_PACKAGE}==${DEFAULT_AUTOMATION_VERSION}`,
     );
     expect(cmd.args).toContain("uvicorn");
     expect(cmd.args).toContain("openhands.automation.app:app");
-    expect(cmd.source).toBe(`git (${DEFAULT_AUTOMATION_GIT_REF})`);
+    expect(cmd.source).toBe(`PyPI (${DEFAULT_AUTOMATION_VERSION}, default)`);
   });
 
   it("uses custom git ref from OH_AUTOMATION_GIT_REF", () => {
@@ -46,14 +47,15 @@ describe("buildAutomationCommand", () => {
     expect(cmd.source).toBe("git (feat/my-feature)");
   });
 
-  it("uses custom repo from OH_AUTOMATION_REPO", () => {
+  it("uses custom repo with git ref", () => {
     const cmd = buildAutomationCommand({
       OH_AUTOMATION_REPO: "https://github.com/MyOrg/my-automation",
+      OH_AUTOMATION_GIT_REF: "main",
     });
 
     expect(cmd.command).toBe("uvx");
     expect(cmd.args).toContain(
-      `git+https://github.com/MyOrg/my-automation@${DEFAULT_AUTOMATION_GIT_REF}`,
+      "git+https://github.com/MyOrg/my-automation@main",
     );
   });
 
@@ -80,6 +82,32 @@ describe("buildAutomationCommand", () => {
       `git+${DEFAULT_AUTOMATION_REPO}@abc123def456`,
     );
     expect(cmd.source).toBe("git (abc123def456)");
+  });
+
+  it("uses specific PyPI version when OH_AUTOMATION_VERSION is set", () => {
+    const cmd = buildAutomationCommand({
+      OH_AUTOMATION_VERSION: "1.0.0",
+    });
+
+    expect(cmd.command).toBe("uvx");
+    expect(cmd.args).toContain(
+      `${DEFAULT_AUTOMATION_PACKAGE}==1.0.0`,
+    );
+    expect(cmd.source).toBe("PyPI (1.0.0)");
+  });
+
+  it("git ref takes precedence over version", () => {
+    const cmd = buildAutomationCommand({
+      OH_AUTOMATION_GIT_REF: "main",
+      OH_AUTOMATION_VERSION: "1.0.0",
+    });
+
+    expect(cmd.command).toBe("uvx");
+    expect(cmd.args).toContain(
+      `git+${DEFAULT_AUTOMATION_REPO}@main`,
+    );
+    expect(cmd.args).not.toContain(`${DEFAULT_AUTOMATION_PACKAGE}==1.0.0`);
+    expect(cmd.source).toBe("git (main)");
   });
 });
 
@@ -219,8 +247,12 @@ describe("default constants", () => {
     );
   });
 
-  it("has expected default automation git ref", () => {
-    expect(DEFAULT_AUTOMATION_GIT_REF).toBe("main");
+  it("has expected default automation package", () => {
+    expect(DEFAULT_AUTOMATION_PACKAGE).toBe("openhands-automation");
+  });
+
+  it("has expected default automation version", () => {
+    expect(DEFAULT_AUTOMATION_VERSION).toBe("1.0.0a1");
   });
 
   it("has expected default backend port", () => {

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -25,9 +25,9 @@ const LOCAL_AGENT_SERVER_SUBDIRS = [
 ];
 // Default secret key for local development (DO NOT use in production)
 const DEFAULT_SECRET_KEY = "openhands-dev-secret-key-change-in-prod";
-// Default to main branch until settings persistence APIs are in a released version.
-// TODO: Once SDK PR #3060 is released, change this to null and let it use PyPI.
-const DEFAULT_GIT_REF = "main";
+// Default agent-server version (released PyPI version)
+// Set OH_AGENT_SERVER_GIT_REF to use a git branch/SHA instead
+const DEFAULT_AGENT_SERVER_VERSION = "1.21.1";
 
 function isEnoentError(error) {
   return Boolean(
@@ -71,10 +71,11 @@ export function formatMissingUvxGuidance(cwd = process.cwd()) {
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.18.0")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.21.1")
  *
- * If none are set, defaults to main branch until settings persistence APIs
- * are released. Set OH_AGENT_SERVER_VERSION to use a released version.
+ * If none are set, defaults to the released version specified by
+ * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a
+ * git branch or commit instead.
  *
  * @param {Record<string, string | undefined>} env
  * @returns {{ command: string, args: string[], source: string }}
@@ -124,42 +125,30 @@ export function buildAgentServerCommand(env = process.env) {
   } else if (version) {
     // Use specific PyPI version: uvx --from openhands-agent-server==version agent-server
     // The package name differs from the executable name, so we need --from syntax
+    // Pin all SDK packages to the same version for consistency
     uvxArgs.push(
       "--from",
       `${DEFAULT_AGENT_SERVER_PACKAGE}==${version}`,
       "--with",
-      "openhands-tools",
+      `openhands-tools==${version}`,
       "--with",
-      "openhands-workspace",
+      `openhands-workspace==${version}`,
       "agent-server",
     );
     source = `PyPI (${version})`;
-  } else if (DEFAULT_GIT_REF) {
-    // Default to git ref when no version specified (until APIs are released)
-    const baseGitUrl = `git+${AGENT_SERVER_GIT_REPO}@${DEFAULT_GIT_REF}`;
-    uvxArgs.push(
-      "--from",
-      `${baseGitUrl}#subdirectory=openhands-agent-server`,
-      "--with",
-      `${baseGitUrl}#subdirectory=openhands-tools`,
-      "--with",
-      `${baseGitUrl}#subdirectory=openhands-workspace`,
-      "agent-server",
-    );
-    source = `git (${DEFAULT_GIT_REF}, default)`;
   } else {
-    // Use latest released version: uvx --from openhands-agent-server agent-server
-    // The package name differs from the executable name, so we need --from syntax
+    // Default to released PyPI version
+    // Pin all SDK packages to the same version for consistency
     uvxArgs.push(
       "--from",
-      DEFAULT_AGENT_SERVER_PACKAGE,
+      `${DEFAULT_AGENT_SERVER_PACKAGE}==${DEFAULT_AGENT_SERVER_VERSION}`,
       "--with",
-      "openhands-tools",
+      `openhands-tools==${DEFAULT_AGENT_SERVER_VERSION}`,
       "--with",
-      "openhands-workspace",
+      `openhands-workspace==${DEFAULT_AGENT_SERVER_VERSION}`,
       "agent-server",
     );
-    source = "PyPI (latest)";
+    source = `PyPI (${DEFAULT_AGENT_SERVER_VERSION}, default)`;
   }
 
   return {

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -58,7 +58,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
 
 const DEFAULT_AUTOMATION_REPO = "https://github.com/OpenHands/automation";
-const DEFAULT_AUTOMATION_GIT_REF = "main";
+const DEFAULT_AUTOMATION_PACKAGE = "openhands-automation";
+// Default automation version (released PyPI version)
+// Set OH_AUTOMATION_GIT_REF to use a git branch/SHA instead
+const DEFAULT_AUTOMATION_VERSION = "1.0.0a1";
 const DEFAULT_BACKEND_PORT = 18000;
 const DEFAULT_AUTOMATION_PORT = 18001;
 // Default local API key for automation backend auth (matches agent-server pattern)
@@ -148,15 +151,17 @@ USAGE:
 
 OPTIONS:
   -p, --port <port>           Ingress port (default: 8000)
-  --automation-ref <ref>      Git ref for automation (branch/tag/SHA, default: main)
+  --automation-ref <ref>      Git ref for automation (branch/tag/SHA)
   --automation-repo <url>     Git repo URL (default: ${DEFAULT_AUTOMATION_REPO})
   -v, --verbose               Show detailed output
   -h, --help                  Show this help
 
 ENVIRONMENT VARIABLES:
   PORT                        Alternative to --port
-  OH_AUTOMATION_GIT_REF       Alternative to --automation-ref
-  OH_AGENT_SERVER_GIT_REF     Git ref for agent-server SDK
+  OH_AUTOMATION_GIT_REF       Git ref for automation (overrides default version)
+  OH_AUTOMATION_VERSION       Specific PyPI version for automation (default: ${DEFAULT_AUTOMATION_VERSION})
+  OH_AGENT_SERVER_GIT_REF     Git ref for agent-server SDK (overrides default version)
+  OH_AGENT_SERVER_VERSION     Specific PyPI version for agent-server
   OH_SECRET_KEY               Secret key for sessions
   AUTOMATION_LOCAL_API_KEY    Custom API key for automation backend auth
 
@@ -172,21 +177,42 @@ ACCESS POINTS:
 
 /**
  * Build the uvx command for running automation backend.
+ *
+ * Environment variables (highest precedence first):
+ * - OH_AUTOMATION_GIT_REF: Git commit SHA or branch name
+ * - OH_AUTOMATION_VERSION: Specific PyPI version (e.g., "1.0.0a1")
+ *
+ * If none are set, defaults to the released version specified by
+ * DEFAULT_AUTOMATION_VERSION. Set OH_AUTOMATION_GIT_REF to use a
+ * git branch or commit instead.
  */
 function buildAutomationCommand(env = process.env) {
-  const gitRef = env.OH_AUTOMATION_GIT_REF || DEFAULT_AUTOMATION_GIT_REF;
+  const gitRef = env.OH_AUTOMATION_GIT_REF;
+  const version = env.OH_AUTOMATION_VERSION;
   const repoUrl = env.OH_AUTOMATION_REPO || DEFAULT_AUTOMATION_REPO;
 
-  // Build git URL with ref
-  const gitUrl = `git+${repoUrl}@${gitRef}`;
+  const uvxArgs = [];
+  let source = "";
 
-  // Use --refresh to ensure latest commit is fetched for git refs
-  const args = ["--refresh", "--from", gitUrl, "uvicorn", "openhands.automation.app:app"];
+  if (gitRef) {
+    // Use git ref - refresh to ensure latest commit is fetched
+    const gitUrl = `git+${repoUrl}@${gitRef}`;
+    uvxArgs.push("--refresh", "--from", gitUrl, "uvicorn", "openhands.automation.app:app");
+    source = `git (${gitRef})`;
+  } else if (version) {
+    // Use specific PyPI version
+    uvxArgs.push("--from", `${DEFAULT_AUTOMATION_PACKAGE}==${version}`, "uvicorn", "openhands.automation.app:app");
+    source = `PyPI (${version})`;
+  } else {
+    // Default to released PyPI version
+    uvxArgs.push("--from", `${DEFAULT_AUTOMATION_PACKAGE}==${DEFAULT_AUTOMATION_VERSION}`, "uvicorn", "openhands.automation.app:app");
+    source = `PyPI (${DEFAULT_AUTOMATION_VERSION}, default)`;
+  }
 
   return {
     command: "uvx",
-    args,
-    source: `git (${gitRef})`,
+    args: uvxArgs,
+    source,
   };
 }
 
@@ -680,7 +706,8 @@ export {
   buildAutomationCommand,
   buildConfig,
   DEFAULT_AUTOMATION_REPO,
-  DEFAULT_AUTOMATION_GIT_REF,
+  DEFAULT_AUTOMATION_PACKAGE,
+  DEFAULT_AUTOMATION_VERSION,
   DEFAULT_BACKEND_PORT,
   DEFAULT_AUTOMATION_PORT,
 };


### PR DESCRIPTION
## Summary

Fixes [APP-1564](https://linear.app/all-hands-ai/issue/APP-1564/milestone-3-local-automations-backend-integration)

This PR changes the dev scripts to default to released PyPI versions instead of git branches for better stability and reproducibility.

## Changes

### Agent Server SDK (`scripts/dev-safe.mjs`)
- Changed default from `git main` to **PyPI `1.21.1`**
- All SDK packages (`openhands-agent-server`, `openhands-tools`, `openhands-workspace`) are now pinned to the same version when using PyPI
- Precedence order (highest to lowest):
  1. `OH_AGENT_SERVER_LOCAL_PATH` - local SDK checkout
  2. `OH_AGENT_SERVER_GIT_REF` - git branch/tag/SHA override
  3. `OH_AGENT_SERVER_VERSION` - specific PyPI version
  4. Default: `1.21.1` (all packages pinned)

### Automation Backend (`scripts/dev-with-automation.mjs`)
- Changed default from `git main` to **PyPI `1.0.0a1`**
- Added `DEFAULT_AUTOMATION_PACKAGE` constant
- Precedence order:
  1. `OH_AUTOMATION_GIT_REF` - git branch/tag/SHA override
  2. `OH_AUTOMATION_VERSION` - specific PyPI version
  3. Default: `1.0.0a1`

### Override Examples

To use a git branch instead of the released version:
```bash
OH_AGENT_SERVER_GIT_REF=main npm run dev
OH_AUTOMATION_GIT_REF=feat/my-feature npm run dev
```

To use a specific version:
```bash
OH_AGENT_SERVER_VERSION=1.20.0 npm run dev
OH_AUTOMATION_VERSION=1.0.0 npm run dev
```

## Testing

- Updated tests in `__tests__/scripts/dev-safe.test.ts` and `__tests__/scripts/dev-with-automation.test.ts`
- All 52 script tests pass
- Full test suite passes (1583 tests)

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a1941d93-f1fe-457e-a43e-cd92315cdde1)