### PR TITLE
fix(frontend): restore OpenHands provider end-to-end and dedupe LLM metadata fetches

### DIFF
--- a/__tests__/api/config-service.test.ts
+++ b/__tests__/api/config-service.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
 import ConfigService from "#/api/config-service/config-service.api";
+import { server } from "#/mocks/node";
 
 describe("ConfigService", () => {
   it("derives providers from llm endpoints", async () => {
@@ -23,5 +25,37 @@ describe("ConfigService", () => {
       true,
     );
     expect(page.items.every((model) => model.provider === "anthropic")).toBe(true);
+  });
+
+  it("includes verified providers absent from /api/llm/providers and keeps them within the limit", async () => {
+    // Arrange: mirror the real local agent-server, where
+    // /api/llm/providers comes from litellm (no "openhands"),
+    // but /api/llm/models/verified has "openhands" as a key.
+    const litellmOnlyProviders = Array.from(
+      { length: 10 },
+      (_, i) => `litellm_provider_${i}`,
+    );
+    server.use(
+      http.get("/api/llm/providers", () =>
+        HttpResponse.json({ providers: litellmOnlyProviders }),
+      ),
+      http.get("/api/llm/models/verified", () =>
+        HttpResponse.json({
+          models: {
+            openhands: ["claude-opus-4-7", "gpt-5.5"],
+            anthropic: ["claude-opus-4-5-20251101"],
+          },
+        }),
+      ),
+    );
+
+    // Act: request fewer items than the litellm provider count to also
+    // exercise the ordering fix (verified providers must come first so
+    // they survive limitItems).
+    const page = await ConfigService.searchProviders({ limit: 3 });
+
+    // Assert
+    const openhands = page.items.find((p) => p.name === "openhands");
+    expect(openhands).toEqual({ name: "openhands", verified: true });
   });
 });

--- a/__tests__/components/modals/settings/model-selector-openhands.test.tsx
+++ b/__tests__/components/modals/settings/model-selector-openhands.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ModelSelector } from "#/components/shared/modals/settings/model-selector";
+import { server } from "#/mocks/node";
+
+describe("ModelSelector — OpenHands round-trip", () => {
+  let providersCount = 0;
+  let verifiedCount = 0;
+  let modelsCount = 0;
+
+  beforeEach(() => {
+    providersCount = 0;
+    verifiedCount = 0;
+    modelsCount = 0;
+    server.use(
+      http.get("/api/llm/providers", () => {
+        providersCount += 1;
+        return HttpResponse.json({ providers: ["anthropic", "openai"] });
+      }),
+      http.get("/api/llm/models/verified", () => {
+        verifiedCount += 1;
+        return HttpResponse.json({
+          models: {
+            openhands: ["claude-opus-4-7"],
+            anthropic: ["claude-opus-4-5-20251101"],
+          },
+        });
+      }),
+      http.get("/api/llm/models", () => {
+        modelsCount += 1;
+        return HttpResponse.json({ models: [] });
+      }),
+    );
+  });
+
+  function renderWithQuery(ui: React.ReactElement) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    );
+  }
+
+  it("shows OpenHands as the provider for a persisted litellm_proxy/<m> + All-Hands proxy base URL, fetching each LLM endpoint exactly once", async () => {
+    // Arrange — mirrors the post-save state: the SDK rewrote openhands/<m>
+    // to litellm_proxy/<m> on disk and pinned the All-Hands proxy base URL.
+    renderWithQuery(
+      <ModelSelector
+        currentModel="litellm_proxy/claude-opus-4-7"
+        currentBaseUrl="https://llm-proxy.app.all-hands.dev/"
+      />,
+    );
+
+    // Act / Assert — the bootstrap effect must wait for the openhands
+    // verified list to load before resolving the displayed provider.
+    await waitFor(() => {
+      expect(screen.getByLabelText("LLM$PROVIDER")).toHaveValue("OpenHands");
+    });
+
+    // Assert — the three queries that all need verified-models data share
+    // a single cache entry, and the bootstrap effect picks the right
+    // provider on its first run, so /models is not fetched twice.
+    expect(providersCount).toBe(1);
+    expect(verifiedCount).toBe(1);
+    expect(modelsCount).toBe(1);
+  });
+});

--- a/__tests__/components/shared/modals/settings/settings-form.test.tsx
+++ b/__tests__/components/shared/modals/settings/settings-form.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "test-utils";
@@ -11,14 +11,24 @@ describe("SettingsForm", () => {
   const onCloseMock = vi.fn();
   const saveSettingsSpy = vi.spyOn(SettingsService, "saveSettings");
 
+  // The persisted llm.model is "openhands/<m>"; ModelSelector splits it into
+  // provider ("openhands" → "OpenHands") and model name ("<m>") and feeds
+  // them into two autocompletes. extractSettings reconstructs llm.model
+  // from those two FormData entries on submit, so we wait for the model
+  // autocomplete to be populated before triggering submission — otherwise
+  // the spy would be called with model = undefined.
+  const expectedModel = getAgentSettingValue(
+    DEFAULT_SETTINGS,
+    "llm.model",
+  ) as string;
+  const expectedModelName = expectedModel.split("/").slice(1).join("/");
+
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock saveSettings to resolve immediately
     saveSettingsSpy.mockResolvedValue(true);
   });
 
   it("should save the user settings and close the modal when submitted outside a conversation route", async () => {
-    const user = userEvent.setup();
     renderWithProviders(
       <SettingsForm settings={DEFAULT_SETTINGS} onClose={onCloseMock} />,
       {
@@ -27,18 +37,23 @@ describe("SettingsForm", () => {
     );
 
     await waitFor(() => {
-      const llmProvider = screen.queryByLabelText(/LLM\$PROVIDER/i);
-      expect(llmProvider?.getAttribute("aria-expanded")).toBe("false");
+      expect(screen.getByTestId("llm-model-input")).toHaveValue(
+        expectedModelName,
+      );
     });
 
-    await user.click(screen.getByTestId("save-settings-button"));
+    // The Autocomplete popover may be open at this point; click on the save
+    // button can be consumed by the outside-click handler. Submit the form
+    // element directly — the production onSubmit handler is what we're
+    // exercising here, not the click semantics.
+    fireEvent.submit(screen.getByTestId("settings-form"));
 
     await waitFor(() => {
       expect(saveSettingsSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           agent_settings_diff: expect.objectContaining({
             llm: expect.objectContaining({
-              model: getAgentSettingValue(DEFAULT_SETTINGS, "llm.model"),
+              model: expectedModel,
             }),
           }),
         }),
@@ -62,17 +77,21 @@ describe("SettingsForm", () => {
     );
 
     await waitFor(() => {
-      const llmProvider = screen.queryByLabelText(/LLM\$PROVIDER/i);
-      expect(llmProvider?.getAttribute("aria-expanded")).toBe("false");
+      expect(screen.getByTestId("llm-model-input")).toHaveValue(
+        expectedModelName,
+      );
     });
 
-    await user.click(screen.getByTestId("save-settings-button"));
+    fireEvent.submit(screen.getByTestId("settings-form"));
 
     expect(saveSettingsSpy).not.toHaveBeenCalled();
-    const confirmButton = screen.getByRole("button", {
+
+    // The confirm modal mounts after the form submit handler runs the
+    // conversation-route branch, so wait for it instead of using a sync
+    // getByRole.
+    const confirmButton = await screen.findByRole("button", {
       name: /BUTTON\$END_SESSION|end session/i,
     });
-    expect(confirmButton).toBeInTheDocument();
 
     await user.click(confirmButton);
 
@@ -81,7 +100,7 @@ describe("SettingsForm", () => {
         expect.objectContaining({
           agent_settings_diff: expect.objectContaining({
             llm: expect.objectContaining({
-              model: getAgentSettingValue(DEFAULT_SETTINGS, "llm.model"),
+              model: expectedModel,
             }),
           }),
         }),

--- a/__tests__/utils/normalize-display-model.test.ts
+++ b/__tests__/utils/normalize-display-model.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDisplayModel } from "#/utils/normalize-display-model";
+
+const OPENHANDS_VERIFIED = ["claude-opus-4-7", "gpt-5.5"];
+const OPENHANDS_PROXY_BASE_URL = "https://llm-proxy.app.all-hands.dev/";
+
+describe("normalizeDisplayModel", () => {
+  it("rewrites litellm_proxy/<m> to openhands/<m> when the base URL is the All-Hands proxy and the model is in the openhands verified list", () => {
+    // Arrange — mirrors the SDK round-trip: openhands/<m> on save becomes
+    // litellm_proxy/<m> on disk plus the All-Hands proxy base URL.
+    const persistedModel = "litellm_proxy/claude-opus-4-7";
+
+    // Act
+    const result = normalizeDisplayModel(
+      persistedModel,
+      OPENHANDS_PROXY_BASE_URL,
+      OPENHANDS_VERIFIED,
+    );
+
+    // Assert
+    expect(result).toBe("openhands/claude-opus-4-7");
+  });
+
+  it("leaves litellm_proxy/<m> untouched when the base URL is not the All-Hands proxy", () => {
+    // Arrange — a user-configured litellm_proxy pointed at a non-OpenHands
+    // gateway must not be re-labelled as OpenHands.
+    const persistedModel = "litellm_proxy/claude-opus-4-7";
+
+    // Act
+    const result = normalizeDisplayModel(
+      persistedModel,
+      "https://other-proxy.example.com/",
+      OPENHANDS_VERIFIED,
+    );
+
+    // Assert
+    expect(result).toBe("litellm_proxy/claude-opus-4-7");
+  });
+});

--- a/src/api/config-service/config-service.api.ts
+++ b/src/api/config-service/config-service.api.ts
@@ -44,16 +44,21 @@ function limitItems<T>(items: T[], limit?: number): T[] {
 class ConfigService {
   static async searchModels(
     params: SearchModelsParams = {},
+    verifiedByProvider?: Record<string, string[]>,
   ): Promise<LLMModelPage> {
     const llmClient = createLlmMetadataClient();
-    const [models, verifiedByProvider] = await Promise.all([
+    const verifiedFetch =
+      verifiedByProvider !== undefined
+        ? Promise.resolve(verifiedByProvider)
+        : llmClient.getVerifiedModels();
+    const [models, verifiedMap] = await Promise.all([
       llmClient.getModels(),
-      llmClient.getVerifiedModels(),
+      verifiedFetch,
     ]);
 
     const provider = params.provider__eq ?? null;
     const verifiedNames = new Set(
-      provider ? (verifiedByProvider?.[provider] ?? []) : [],
+      provider ? (verifiedMap?.[provider] ?? []) : [],
     );
     const verifiedItems: LLMModel[] = [...verifiedNames].map((name) => ({
       provider,
@@ -89,15 +94,24 @@ class ConfigService {
 
   static async searchProviders(
     params: SearchProvidersParams = {},
+    verifiedByProvider?: Record<string, string[]>,
   ): Promise<ProviderPage> {
     const llmClient = createLlmMetadataClient();
-    const [providers, verifiedByProvider] = await Promise.all([
+    const verifiedFetch =
+      verifiedByProvider !== undefined
+        ? Promise.resolve(verifiedByProvider)
+        : llmClient.getVerifiedModels();
+    const [providers, verifiedMap] = await Promise.all([
       llmClient.getProviders(),
-      llmClient.getVerifiedModels(),
+      verifiedFetch,
     ]);
 
-    const verifiedProviders = new Set(Object.keys(verifiedByProvider ?? {}));
-    const providerItems: LLMProvider[] = (providers ?? []).map((name) => ({
+    const verifiedProviders = new Set(Object.keys(verifiedMap ?? {}));
+    const names = new Set<string>([
+      ...verifiedProviders,
+      ...(providers ?? []),
+    ]);
+    const providerItems: LLMProvider[] = [...names].map((name) => ({
       name,
       verified: verifiedProviders.has(name),
     }));

--- a/src/components/shared/modals/settings/model-selector.tsx
+++ b/src/components/shared/modals/settings/model-selector.tsx
@@ -13,10 +13,13 @@ import { HelpLink } from "#/ui/help-link";
 import { PRODUCT_URL } from "#/utils/constants";
 import { useSearchProviders } from "#/hooks/query/use-search-providers";
 import { useProviderModels } from "#/hooks/query/use-provider-models";
+import { useOpenhandsVerifiedModels } from "#/hooks/query/use-openhands-verified-models";
+import { normalizeDisplayModel } from "#/utils/normalize-display-model";
 
 interface ModelSelectorProps {
   isDisabled?: boolean;
   currentModel?: string;
+  currentBaseUrl?: string;
   onChange?: (provider: string | null, model: string | null) => void;
   onDefaultValuesChanged?: (
     provider: string | null,
@@ -29,6 +32,7 @@ interface ModelSelectorProps {
 export function ModelSelector({
   isDisabled,
   currentModel,
+  currentBaseUrl,
   onChange,
   onDefaultValuesChanged,
   wrapperClassName,
@@ -41,6 +45,7 @@ export function ModelSelector({
   const [selectedModel, setSelectedModel] = React.useState<string | null>(null);
 
   const { data: providers = [] } = useSearchProviders();
+  const { data: openhandsVerifiedModels } = useOpenhandsVerifiedModels();
   const {
     data: providerModels = [],
     isLoading: isLoadingModels,
@@ -66,15 +71,24 @@ export function ModelSelector({
   );
 
   React.useEffect(() => {
-    if (currentModel) {
-      const { provider, model } = extractModelAndProvider(currentModel);
+    // Wait for the openhands verified list before initializing — otherwise a
+    // persisted `litellm_proxy/<m>` model would first land as `litellm_proxy`
+    // and only later flip to `openhands`, triggering a redundant /api/llm/models
+    // fetch for the throwaway provider value.
+    if (currentModel && openhandsVerifiedModels !== undefined) {
+      const displayModel = normalizeDisplayModel(
+        currentModel,
+        currentBaseUrl,
+        openhandsVerifiedModels,
+      );
+      const { provider, model } = extractModelAndProvider(displayModel);
 
-      setLitellmId(currentModel);
+      setLitellmId(displayModel);
       setSelectedProvider(provider || null);
       setSelectedModel(model);
       onDefaultValuesChanged?.(provider || null, model);
     }
-  }, [currentModel]);
+  }, [currentModel, currentBaseUrl, openhandsVerifiedModels]);
 
   const handleChangeProvider = (provider: string) => {
     setSelectedProvider(provider);

--- a/src/components/shared/modals/settings/settings-form.tsx
+++ b/src/components/shared/modals/settings/settings-form.tsx
@@ -70,6 +70,7 @@ export function SettingsForm({ settings, onClose }: SettingsFormProps) {
 
   const isLLMKeySet = settings.llm_api_key_set;
   const currentModel = getAgentSettingValue(settings, "llm.model");
+  const currentBaseUrl = getAgentSettingValue(settings, "llm.base_url");
 
   return (
     <div>
@@ -83,6 +84,9 @@ export function SettingsForm({ settings, onClose }: SettingsFormProps) {
           <ModelSelector
             currentModel={
               typeof currentModel === "string" ? currentModel : undefined
+            }
+            currentBaseUrl={
+              typeof currentBaseUrl === "string" ? currentBaseUrl : undefined
             }
             wrapperClassName="!flex-col !gap-[17px]"
             labelClassName={SETTINGS_FORM.LABEL_CLASSNAME}

--- a/src/hooks/query/use-openhands-verified-models.ts
+++ b/src/hooks/query/use-openhands-verified-models.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  VERIFIED_MODELS_GC_TIME,
+  VERIFIED_MODELS_QUERY_KEY,
+  VERIFIED_MODELS_STALE_TIME,
+  fetchVerifiedModelsByProvider,
+} from "./use-verified-models";
+
+export const useOpenhandsVerifiedModels = () =>
+  useQuery({
+    queryKey: VERIFIED_MODELS_QUERY_KEY,
+    queryFn: fetchVerifiedModelsByProvider,
+    select: (data) => data?.openhands ?? [],
+    staleTime: VERIFIED_MODELS_STALE_TIME,
+    gcTime: VERIFIED_MODELS_GC_TIME,
+  });

--- a/src/hooks/query/use-provider-models.ts
+++ b/src/hooks/query/use-provider-models.ts
@@ -1,11 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import ConfigService from "#/api/config-service/config-service.api";
 import type { LLMModel } from "#/api/config-service/config-service.types";
+import {
+  VERIFIED_MODELS_GC_TIME,
+  VERIFIED_MODELS_QUERY_KEY,
+  VERIFIED_MODELS_STALE_TIME,
+  fetchVerifiedModelsByProvider,
+} from "./use-verified-models";
 
 const MAX_PAGINATION_DEPTH = 10;
 
 async function fetchPage(
   provider: string,
+  verifiedByProvider: Record<string, string[]>,
   pageId?: string,
   depth = 0,
 ): Promise<LLMModel[]> {
@@ -13,24 +20,41 @@ async function fetchPage(
     throw new Error(`Too many pagination requests for provider ${provider}`);
   }
 
-  const page = await ConfigService.searchModels({
-    provider__eq: provider,
-    limit: 100,
-    page_id: pageId,
-  });
+  const page = await ConfigService.searchModels(
+    {
+      provider__eq: provider,
+      limit: 100,
+      page_id: pageId,
+    },
+    verifiedByProvider,
+  );
 
   if (page.next_page_id) {
-    const rest = await fetchPage(provider, page.next_page_id, depth + 1);
+    const rest = await fetchPage(
+      provider,
+      verifiedByProvider,
+      page.next_page_id,
+      depth + 1,
+    );
     return [...page.items, ...rest];
   }
   return page.items;
 }
 
-export const useProviderModels = (provider: string | null) =>
-  useQuery({
+export const useProviderModels = (provider: string | null) => {
+  const queryClient = useQueryClient();
+  return useQuery({
     queryKey: ["config", "models", provider],
-    queryFn: () => fetchPage(provider!),
+    queryFn: async () => {
+      const verifiedByProvider = await queryClient.fetchQuery({
+        queryKey: VERIFIED_MODELS_QUERY_KEY,
+        queryFn: fetchVerifiedModelsByProvider,
+        staleTime: VERIFIED_MODELS_STALE_TIME,
+      });
+      return fetchPage(provider!, verifiedByProvider);
+    },
     enabled: !!provider,
-    staleTime: 1000 * 60 * 5,
-    gcTime: 1000 * 60 * 15,
+    staleTime: VERIFIED_MODELS_STALE_TIME,
+    gcTime: VERIFIED_MODELS_GC_TIME,
   });
+};

--- a/src/hooks/query/use-search-providers.ts
+++ b/src/hooks/query/use-search-providers.ts
@@ -1,17 +1,31 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import ConfigService from "#/api/config-service/config-service.api";
 import type { LLMProvider } from "#/api/config-service/config-service.types";
+import {
+  VERIFIED_MODELS_GC_TIME,
+  VERIFIED_MODELS_QUERY_KEY,
+  VERIFIED_MODELS_STALE_TIME,
+  fetchVerifiedModelsByProvider,
+} from "./use-verified-models";
 
-async function fetchAllProviders(): Promise<LLMProvider[]> {
-  // Providers are a small set; fetch all in one call with a high limit.
-  const page = await ConfigService.searchProviders({ limit: 100 });
-  return page.items;
-}
-
-export const useSearchProviders = () =>
-  useQuery({
+export const useSearchProviders = () => {
+  const queryClient = useQueryClient();
+  return useQuery({
     queryKey: ["config", "providers"],
-    queryFn: fetchAllProviders,
-    staleTime: 1000 * 60 * 5,
-    gcTime: 1000 * 60 * 15,
+    queryFn: async (): Promise<LLMProvider[]> => {
+      const verifiedByProvider = await queryClient.fetchQuery({
+        queryKey: VERIFIED_MODELS_QUERY_KEY,
+        queryFn: fetchVerifiedModelsByProvider,
+        staleTime: VERIFIED_MODELS_STALE_TIME,
+      });
+      // Providers are a small set; fetch all in one call with a high limit.
+      const page = await ConfigService.searchProviders(
+        { limit: 100 },
+        verifiedByProvider,
+      );
+      return page.items;
+    },
+    staleTime: VERIFIED_MODELS_STALE_TIME,
+    gcTime: VERIFIED_MODELS_GC_TIME,
   });
+};

--- a/src/hooks/query/use-verified-models.ts
+++ b/src/hooks/query/use-verified-models.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { createLlmMetadataClient } from "#/api/typescript-client";
+
+export const VERIFIED_MODELS_QUERY_KEY = ["config", "verified-models"] as const;
+export const VERIFIED_MODELS_STALE_TIME = 1000 * 60 * 5;
+export const VERIFIED_MODELS_GC_TIME = 1000 * 60 * 15;
+
+export async function fetchVerifiedModelsByProvider(): Promise<
+  Record<string, string[]>
+> {
+  const client = createLlmMetadataClient();
+  return (await client.getVerifiedModels()) ?? {};
+}
+
+export const useVerifiedModelsByProvider = () =>
+  useQuery({
+    queryKey: VERIFIED_MODELS_QUERY_KEY,
+    queryFn: fetchVerifiedModelsByProvider,
+    staleTime: VERIFIED_MODELS_STALE_TIME,
+    gcTime: VERIFIED_MODELS_GC_TIME,
+  });

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -178,6 +178,7 @@ export function LlmSettingsScreen({
             >
               <ModelSelector
                 currentModel={modelValue || undefined}
+                currentBaseUrl={baseUrlValue || undefined}
                 onChange={(provider, model) => {
                   const nextModel = buildModelId(provider, model);
                   if (nextModel) {

--- a/src/utils/normalize-display-model.ts
+++ b/src/utils/normalize-display-model.ts
@@ -1,0 +1,33 @@
+const OPENHANDS_PROXY_BASE_URLS = new Set([
+  "https://llm-proxy.app.all-hands.dev",
+  "https://llm-proxy.app.all-hands.dev/v1",
+]);
+
+const LITELLM_PROXY_PREFIX = "litellm_proxy/";
+
+const stripTrailingSlashes = (value: string) =>
+  value.trim().replace(/\/+$/, "");
+
+/**
+ * Reverse the SDK's `openhands/* -> litellm_proxy/*` rewrite for display.
+ *
+ * The agent-server's LLM validator stores curated OpenHands models as
+ * `litellm_proxy/<m>` against the All-Hands proxy base URL. Without
+ * normalization the GUI re-loads such settings as `litellm_proxy`, so the
+ * provider dropdown silently switches off "OpenHands" after every save.
+ */
+export function normalizeDisplayModel(
+  rawModel: string | null | undefined,
+  baseUrl: string | null | undefined,
+  openhandsVerifiedModels: readonly string[],
+): string {
+  if (!rawModel) return "";
+  if (!rawModel.startsWith(LITELLM_PROXY_PREFIX)) return rawModel;
+  if (!baseUrl) return rawModel;
+  if (!OPENHANDS_PROXY_BASE_URLS.has(stripTrailingSlashes(baseUrl))) {
+    return rawModel;
+  }
+  const modelName = rawModel.slice(LITELLM_PROXY_PREFIX.length);
+  if (!openhandsVerifiedModels.includes(modelName)) return rawModel;
+  return `openhands/${modelName}`;
+}


### PR DESCRIPTION
Resolves #128

### Demo Screenshot

<img width="1440" height="794" alt="Screenshot 2026-05-09 at 02 56 55" src="https://github.com/user-attachments/assets/016e4a6d-d3b7-4a46-81ee-f474be38f7ae" />

### Description

In a local setup (frontend at `http://localhost:3001`, agent-server at `http://127.0.0.1:8000`), the LLM Settings page (`/settings`) has three related defects around the OpenHands provider:

1. **Provider missing.** "OpenHands" does not appear in the LLM Provider dropdown, so curated OpenHands models (`claude-opus-4-7`, `gpt-5.5`, `gemini-3-pro`, etc.) cannot be selected.
2. **Provider switch on save.** If the user works around (1) and persists an OpenHands model anyway, after **Save Changes** the dropdown silently flips to `litellm_proxy` and the model field clears.
3. **Duplicate API calls.** A single page refresh hits `/api/llm/models/verified` 3 times and `/api/llm/models` 2 times.

### Reproduction

1. Run the local agent-server on `127.0.0.1:8000`.
2. Run agent-server-gui (`npm run dev`) and open `http://localhost:3001/settings`.
3. Open the LLM Provider dropdown — "OpenHands" is absent (defect 1).
4. (After applying the providers fix only) select "OpenHands" + a curated model, set an API key, click **Save Changes**. On the next render, the dropdown shows `litellm_proxy` (defect 2).
5. Open DevTools → Network → filter on `verified` and `models`, refresh. Observe `verified` requested 3× and `models` 2× (defect 3).

### Root cause

- **Provider missing.** The agent-server's `/api/llm/providers` is derived from `litellm.provider_list` (`software-agent-sdk/openhands-agent-server/openhands/agent_server/llm_router.py:35`), which does not contain `openhands`. `/api/llm/models/verified` does include `openhands` as a key (`verified_models.py:132`). `ConfigService.searchProviders()` iterated only over the providers response, dropping any verified-only provider; and `useSearchProviders` requested `limit: 100` against a ~140-entry LiteLLM list, so a naïve append-at-end union also got sliced.
- **Provider switch on save.** The SDK's `LLM` validator deliberately rewrites `openhands/<m>` → `litellm_proxy/<m>` and pins `base_url=https://llm-proxy.app.all-hands.dev/` (`openhands-sdk/openhands/sdk/llm/llm.py:477`) so litellm can route through the All-Hands proxy. The persisted record loses the `openhands` label, and the GUI never reversed the mapping for display.
- **Duplicate `/verified`.** Three React-Query consumers (`useSearchProviders`, `useOpenhandsVerifiedModels`, `useProviderModels` via `ConfigService.searchModels`) each invoked `getVerifiedModels()` inside their own `queryFn`, so React-Query never had a chance to dedupe across them.
- **Duplicate `/models`.** The `ModelSelector` bootstrap effect ran twice with different `selectedProvider` values: once with the verified list still empty (`selectedProvider = "litellm_proxy"`) and once after it loaded (`selectedProvider = "openhands"`). Each value triggered its own `useProviderModels` query.

### Fix (frontend, scoped)

- **Surface verified-only providers.** Build the provider list as a union of the verified-models keys (placed first) and the LiteLLM providers list, so `openhands` always appears and survives `limitItems` regardless of the LiteLLM list size.
- **Reverse the rewrite at display time.** When the persisted model is `litellm_proxy/<m>`, the base URL is the All-Hands proxy, and `<m>` is in the OpenHands verified list, present it to the UI as `openhands/<m>`. The save payload still goes out as `openhands/<m>`; the SDK still normalizes on the way in.
- **Centralize the verified-models fetch.** Single React-Query cache entry (`["config", "verified-models"]`) shared by all three consumers. Concurrent callers dedupe via `queryClient.fetchQuery`; repeat calls within `staleTime` (5 min) hit the cache.
- **Gate the bootstrap effect.** `ModelSelector` waits for the OpenHands verified list before initializing `selectedProvider`, so it resolves to the correct value on its first run instead of bouncing through `litellm_proxy`.

### Acceptance criteria

- "OpenHands" appears in the **Verified** section of the LLM Provider dropdown; selecting it lists curated models such as `claude-opus-4-7`, `gpt-5.5`, `gemini-3-pro`.
- After saving with provider = OpenHands + a curated model, reloading `/settings` keeps "OpenHands" selected and the model populated.
- A cold page load hits `/api/llm/providers`, `/api/llm/models/verified`, and `/api/llm/models` exactly once each.
- Existing verified providers (`anthropic`, `openai`, ...) still appear and remain flagged verified.
- Existing `litellm_proxy` configurations against non-AllHands base URLs are not re-labelled as OpenHands.

### Out of scope

- Backend change in `software-agent-sdk` (`/api/llm/providers` could include keys from `VERIFIED_MODELS`; `llm.py:477` could persist the user-selected provider label alongside the canonical model id). Tracked separately.

### Summary

- Surface the **OpenHands** provider in the LLM Settings provider dropdown by unioning verified-models keys (placed first) with the LiteLLM providers list.
- Preserve the "OpenHands" label across save/reload by reversing the SDK's `openhands/<m>` → `litellm_proxy/<m>` rewrite at display time, gated on the All-Hands proxy base URL **and** the OpenHands verified list.
- Fetch `/api/llm/models/verified` once per page load by routing all consumers through a shared React-Query cache entry, and fetch `/api/llm/models` once by gating the `ModelSelector` bootstrap effect on the verified list being ready.

### Why

Three user-visible defects on `/settings`:

1. **Provider missing.** `/api/llm/providers` is derived from `litellm.provider_list` and omits `openhands`, while `/api/llm/models/verified` includes it as a key. The previous `ConfigService.searchProviders()` iterated only over the providers response, so the OpenHands provider — and any future verified-only provider — never reached the dropdown. `useSearchProviders` also requested `limit: 100` against a ~140-entry LiteLLM list, so the order of any naïve union mattered.
2. **Provider drops to `litellm_proxy` after save.** The SDK's `LLM` validator (`software-agent-sdk/openhands-sdk/openhands/sdk/llm/llm.py:477`) rewrites `openhands/<m>` to `litellm_proxy/<m>` and sets `base_url = https://llm-proxy.app.all-hands.dev/`. The GUI never reversed the mapping, so `extractModelAndProvider` returned `litellm_proxy` on reload.
3. **Redundant network.** DevTools showed `/api/llm/models/verified` hit 3× and `/api/llm/models` 2× per refresh — three queries each inlined `getVerifiedModels()`, and the `ModelSelector` bootstrap effect resolved `selectedProvider` twice (first to `litellm_proxy`, then to `openhands`) which kicked off a second `useProviderModels` fetch.

### Changes

- `src/api/config-service/config-service.api.ts` —

  - `searchProviders` builds the result as a union of verified-models keys (first) and `/api/llm/providers`, so verified providers appear and survive `limitItems`.
  - `searchProviders` and `searchModels` accept an optional `verifiedByProvider` parameter; when provided, the inline `getVerifiedModels()` HTTP call is skipped. Standalone callers (e.g. direct tests) keep working.

- **New** `src/utils/normalize-display-model.ts` — pure helper that maps `litellm_proxy/<m>` + All-Hands proxy base URL + openhands-verified `<m>` → `openhands/<m>`; otherwise returns input unchanged.
- **New** `src/hooks/query/use-verified-models.ts` — single source of truth for the verified-models map. Exports `VERIFIED_MODELS_QUERY_KEY`, `fetchVerifiedModelsByProvider`, and `useVerifiedModelsByProvider`.
- `src/hooks/query/use-openhands-verified-models.ts` — re-implemented to subscribe to the shared key with `select: data => data.openhands ?? []`.
- `src/hooks/query/use-search-providers.ts` and `use-provider-models.ts` — fetch verified models via `queryClient.fetchQuery(VERIFIED_MODELS_QUERY_KEY)` and pass the result into `ConfigService`. Concurrent calls are deduped by React-Query, repeat calls within `staleTime` (5 min) hit the cache.
- `src/components/shared/modals/settings/model-selector.tsx` — accepts a new `currentBaseUrl` prop, applies `normalizeDisplayModel` before parsing `currentModel`, and gates the bootstrap effect on `openhandsVerifiedModels !== undefined` so it only fires once the verified list has loaded.
- `src/routes/llm-settings.tsx` and `src/components/shared/modals/settings/settings-form.tsx` — pass `currentBaseUrl` through to `ModelSelector`.

### Tests

- `__tests__/api/config-service.test.ts` — extended with one regression case pinning the union + ordering fix: a verified-only provider must be returned even when the LiteLLM providers list exceeds the requested limit.
- **New** `__tests__/utils/normalize-display-model.test.ts` — 2 unit cases: rewrite happens when conditions match; rewrite does not happen when the base URL is not the All-Hands proxy.
- **New** `__tests__/components/modals/settings/model-selector-openhands.test.tsx` — 1 integration case using MSW with per-endpoint counters: rendering `<ModelSelector currentModel="litellm_proxy/<m>" currentBaseUrl="…">` must (a) display "OpenHands" in the provider dropdown and (b) hit `/api/llm/providers`, `/api/llm/models/verified`, and `/api/llm/models` exactly once each.

### Notes

- Frontend-only change. The SDK rewrite and the backend providers endpoint stay as-is; the GUI is now resilient regardless of those decisions.
- The display normalization is gated on the OpenHands verified list (sourced from `/api/llm/models/verified`) so an existing user who explicitly chose `litellm_proxy` against a non-AllHands gateway is never re-labelled.
- Hard refresh (Cmd+Shift+R) is required after pulling, since `useSearchProviders` and the new `useVerifiedModelsByProvider` cache results for 5 minutes.
