### PR TITLE
Fix Windows dev script startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
+      - name: Set up Node.js with npm cache
+        if: runner.os != 'Windows'
         uses: actions/setup-node@v6
         with:
           node-version: 22.12.0
           cache: npm
+
+      - name: Set up Node.js
+        if: runner.os == 'Windows'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.12.0
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,15 @@ permissions:
 
 jobs:
   test-and-build:
-    runs-on: ubuntu-24.04
+    name: Test and build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - windows-2025
 
     steps:
       - name: Check out repository

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Static-frontend Development Stack
  *
@@ -37,10 +36,10 @@
  *   - OH_SECRET_KEY: Session secret key
  */
 
-import { spawn, spawnSync, execSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
 import process from "node:process";
 
@@ -178,12 +177,12 @@ NOTES:
 // ═══════════════════════════════════════════════════════════════════════════
 
 function commandExists(cmd) {
-  try {
-    execSync(`command -v ${cmd}`, { stdio: "pipe" });
-    return true;
-  } catch {
-    return false;
-  }
+  const result =
+    process.platform === "win32"
+      ? spawnSync("where.exe", [cmd], { stdio: "pipe" })
+      : spawnSync("sh", ["-c", `command -v ${cmd}`], { stdio: "pipe" });
+
+  return result.status === 0;
 }
 
 function checkPrerequisites() {
@@ -653,7 +652,8 @@ export { buildFrontend, startStaticServer };
 // Main entry point (only when run directly, not when imported)
 // ═══════════════════════════════════════════════════════════════════════════
 
-const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+const isMainModule =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMainModule) {
   main().catch((err) => {

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Development Stack with Automation Service
  *
@@ -38,10 +37,10 @@
  *   as OPENHANDS_AUTOMATION_API_KEY, making it available to agents in conversations.
  */
 
-import { spawn, execSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { homedir } from "node:os";
 import { setTimeout as delay } from "node:timers/promises";
 import process from "node:process";
@@ -271,12 +270,12 @@ function buildConfig(args, env = process.env) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 function commandExists(cmd) {
-  try {
-    execSync(`command -v ${cmd}`, { stdio: "pipe" });
-    return true;
-  } catch {
-    return false;
-  }
+  const result =
+    process.platform === "win32"
+      ? spawnSync("where.exe", [cmd], { stdio: "pipe" })
+      : spawnSync("sh", ["-c", `command -v ${cmd}`], { stdio: "pipe" });
+
+  return result.status === 0;
 }
 
 function checkPrerequisites() {
@@ -717,7 +716,8 @@ export {
 // ═══════════════════════════════════════════════════════════════════════════
 
 // Check if this module is the main entry point
-const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+const isMainModule =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMainModule) {
   main().catch((err) => {

--- a/scripts/static-server.mjs
+++ b/scripts/static-server.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Combined static file server + reverse proxy.
  *
@@ -32,6 +31,7 @@ import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import { extname, normalize, resolve } from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // MIME types
@@ -408,7 +408,8 @@ export function startStaticServer(config) {
 // Main
 // ─────────────────────────────────────────────────────────────────────────────
 
-const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+const isMainModule =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMainModule) {
   try {


### PR DESCRIPTION
## Summary
- fix Windows entrypoint detection in dev orchestration scripts by using pathToFileURL
- make prerequisite checks use where.exe on Windows instead of POSIX-only command -v
- apply the same startup guard fix to the static dev helper
- run the existing CI test/build job on both Ubuntu and Windows
- keep npm caching on Ubuntu but disable setup-node npm cache on Windows to avoid post-job cache cleanup failures

## Verification
- npm test -- --run __tests__/scripts/dev-with-automation.test.ts __tests__/scripts/dev-safe.test.ts
- node --check scripts/dev-with-automation.mjs; node --check scripts/dev-static.mjs; node --check scripts/static-server.mjs
- controlled npm run dev startup reached the stack banner and served /server_info through ingress
- CI run 25581923676 passed on ubuntu-24.04 and windows-2025