### PR TITLE
feat: add VITE_LOAD_PUBLIC_SKILLS config to optionally disable public skills

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,6 +9,7 @@ VITE_BACKEND_BASE_URL="http://127.0.0.1:8000" # Base URL used by browser-side di
 # VITE_WORKING_DIR="/workspace/project/agent-canvas" # Base dir for per-conversation working_dirs. Each conversation's working_dir is <VITE_WORKING_DIR>/<id_hex>. Defaults to <OH_CANVAS_SAFE_STATE_DIR>/workspaces, which is the sibling of the agent server's <state_dir>/conversations/ persistence dir — both share the same <id_hex> per conversation.
 # VITE_WORKER_URLS="" # Optional comma-separated worker URLs for the Browser tab
 # VITE_ENABLE_BROWSER_TOOLS="true" # Set to false to omit BrowserToolSet from new conversations
+# VITE_LOAD_PUBLIC_SKILLS="true" # Set to false to disable loading public skills from https://github.com/OpenHands/extensions
 
 # Frontend dev server
 VITE_FRONTEND_PORT="3001" # Port to run the frontend application

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
   - `VITE_WORKING_DIR` for the default workspace path sent when starting conversations.
   - `VITE_WORKER_URLS` as a comma-separated list of browser worker URLs if you want the Browser tab to probe exposed app hosts.
   - `VITE_ENABLE_BROWSER_TOOLS=false` to omit `BrowserToolSet` from new conversation payloads.
+  - `VITE_LOAD_PUBLIC_SKILLS=false` to disable loading public skills from the OpenHands extensions marketplace (https://github.com/OpenHands/extensions). Defaults to true.
 - Default working-dir fallback is now the relative path `workspace/project` (exported as `DEFAULT_WORKING_DIR` from `src/api/agent-server-config.ts`); git-path heuristics and the default PLAN preview path should reuse that constant instead of hardcoding `/workspace/project`.
 - The UI keeps most OpenHands routes/layout intact, but hosted-only behavior (org, account management, integrations) has been removed via the fabricated OSS config because there is no separate app backend.
 - Verification command: `npm run typecheck && npm run build`.

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -21,6 +21,7 @@ vi.mock("#/api/agent-server-config", () => ({
   getAgentServerSessionApiKey: vi.fn(() => null),
   getAgentServerWorkingDir: mockGetAgentServerWorkingDir,
   getConfiguredWorkerUrls: vi.fn(() => []),
+  shouldLoadPublicSkills: vi.fn(() => true),
 }));
 
 vi.mock("#/api/agent-server-compatibility", () => ({
@@ -88,6 +89,10 @@ describe("buildStartConversationRequest", () => {
       { name: "task_tracker", params: {} },
       { name: "browser_tool_set", params: {} },
     ]);
+    expect(payload.agent.agent_context).toEqual({
+      load_public_skills: true,
+      load_user_skills: true,
+    });
     expect(payload.agent.agent).toBeUndefined();
     expect(payload.workspace.working_dir).toBe(
       "/workspace/project/agent-canvas",

--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -45,6 +45,7 @@ vi.mock("#/api/agent-server-config", () => ({
     (id: string) => `/state/workspaces/${id.replace(/-/g, "")}`,
   ),
   getConfiguredWorkerUrls: vi.fn(() => []),
+  shouldLoadPublicSkills: vi.fn(() => true),
 }));
 
 vi.mock("#/api/settings-service/settings-service.api", () => ({

--- a/__tests__/api/use-create-conversation-metadata.test.ts
+++ b/__tests__/api/use-create-conversation-metadata.test.ts
@@ -32,6 +32,7 @@ vi.mock("#/api/agent-server-config", () => ({
     (id: string) => `/state/workspaces/${id.replace(/-/g, "")}`,
   ),
   getConfiguredWorkerUrls: vi.fn(() => []),
+  shouldLoadPublicSkills: vi.fn(() => true),
 }));
 
 vi.mock("#/api/settings-service/settings-service.api", () => ({

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -526,6 +526,8 @@ function startVite(config) {
       VITE_FRONTEND_PORT: config.vitePort.toString(),
       // Automation API key for frontend to authenticate with automation backend
       VITE_AUTOMATION_API_KEY: config.localApiKey,
+      // Session API key for agent-server auth (when SESSION_API_KEY is set)
+      ...(config.sessionApiKey && { VITE_SESSION_API_KEY: config.sessionApiKey }),
     },
     color: c.magenta,
   });

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -294,6 +294,10 @@ function createAgentFromSettings(agentSettings: SettingsRecord) {
   return {
     kind: "Agent",
     ...agentSettings,
+    agent_context: {
+      load_public_skills: shouldLoadPublicSkills(),
+      load_user_skills: true,
+    },
   };
 }
 

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -2,7 +2,10 @@ import { DEFAULT_SETTINGS } from "#/services/settings";
 import { ExecutionStatus } from "#/types/agent-server/core";
 import { Settings, SettingsValue } from "#/types/settings";
 import { isAgentServerToolAvailable } from "./agent-server-compatibility";
-import { getAgentServerWorkingDir } from "./agent-server-config";
+import {
+  getAgentServerWorkingDir,
+  shouldLoadPublicSkills,
+} from "./agent-server-config";
 import { getEffectiveLocalBackend } from "./backend-registry/active-store";
 import {
   GetHooksResponse,
@@ -533,7 +536,7 @@ export async function loadSkillsForConversation(
     conversation?.workspace?.working_dir ?? getAgentServerWorkingDir();
 
   const response = await createSkillsClient().getSkills({
-    load_public: true,
+    load_public: shouldLoadPublicSkills(),
     load_user: true,
     load_project: true,
     load_org: false,

--- a/src/api/agent-server-config.ts
+++ b/src/api/agent-server-config.ts
@@ -177,3 +177,13 @@ export function getAgentServerHeaders(): Record<string, string> {
   const sessionApiKey = getAgentServerSessionApiKey();
   return sessionApiKey ? { "X-Session-API-Key": sessionApiKey } : {};
 }
+
+/**
+ * Returns whether public skills from the OpenHands extensions marketplace
+ * (https://github.com/OpenHands/extensions) should be loaded.
+ *
+ * Defaults to true. Set VITE_LOAD_PUBLIC_SKILLS=false to disable.
+ */
+export function shouldLoadPublicSkills(): boolean {
+  return import.meta.env.VITE_LOAD_PUBLIC_SKILLS !== "false";
+}

--- a/src/api/skills-service.ts
+++ b/src/api/skills-service.ts
@@ -1,5 +1,8 @@
 import { SkillInfo } from "#/types/settings";
-import { getAgentServerWorkingDir } from "./agent-server-config";
+import {
+  getAgentServerWorkingDir,
+  shouldLoadPublicSkills,
+} from "./agent-server-config";
 import { getActiveBackend } from "./backend-registry/active-store";
 import { fetchCloudSkills } from "./cloud/skills-service.api";
 import { createSkillsClient } from "./typescript-client";
@@ -11,7 +14,7 @@ class SkillsService {
     }
 
     const response = await createSkillsClient().getSkills({
-      load_public: true,
+      load_public: shouldLoadPublicSkills(),
       load_user: true,
       load_project: true,
       load_org: false,


### PR DESCRIPTION
## Summary

Fixes [APP-1645](https://linear.app/all-hands-ai/issue/APP-1645/public-skills-are-loading-inside-conversations)

Add a new environment variable `VITE_LOAD_PUBLIC_SKILLS` that controls whether skills from the [OpenHands extensions marketplace](https://github.com/OpenHands/extensions) are loaded.

**Default behavior:** `load_public: true` (skills from the extensions marketplace are loaded)

**To disable:** Set `VITE_LOAD_PUBLIC_SKILLS=false`

## Critical Fix

**The main change:** Pass `agent_context.load_public_skills` and `agent_context.load_user_skills` in the conversation start request. 

Previously, we were only passing `load_public=true` to the `/api/skills` endpoint (used for UI display), but NOT passing it to the conversation start payload. This meant skills were shown in the UI but **never actually loaded during agent execution**.

The fix adds an `agent_context` block to the agent configuration:
```javascript
agent_context: {
  load_public_skills: shouldLoadPublicSkills(),
  load_user_skills: true,
}
```

## Changes

- Add `shouldLoadPublicSkills()` function in `agent-server-config.ts`
- Update `skills-service.ts` to use the new config function  
- Update `agent-server-adapter.ts` `loadSkillsForConversation` to use the config
- **Add `agent_context` with `load_public_skills` to `createAgentFromSettings()`** - this is the critical fix
- Pass `VITE_SESSION_API_KEY` through to Vite dev server (fixes auth in nested dev mode)
- Document the new env var in `.env.sample` and `AGENTS.md`

## Background

Public skills are loaded by default from https://github.com/OpenHands/extensions via the agent-server SDK's `load_public_skills` parameter. This includes 40+ skills:
- `github`, `gitlab`, `bitbucket`, `azure-devops` - Git provider integrations
- `docker`, `kubernetes` - Container tools
- `code-review`, `code-simplifier` - Code quality tools
- `agent-memory`, `agent-creator`, `skill-creator` - Agent utilities
- And many more...

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1b2c0e06-d827-4568-9a4a-2dec070172e2)