### PR TITLE
Fix local conversation export trajectory

### DIFF
--- a/__tests__/hooks/use-download-conversation.test.tsx
+++ b/__tests__/hooks/use-download-conversation.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useDownloadConversation } from "#/hooks/use-download-conversation";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import ConversationService from "#/api/conversation-service/conversation-service.api";
+import { downloadTrajectory } from "#/utils/download-trajectory";
+
+const mockPosthogCapture = vi.fn();
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: mockPosthogCapture }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("#/utils/custom-toast-handlers", () => ({
+  displayErrorToast: vi.fn(),
+}));
+
+vi.mock("#/utils/download-trajectory", () => ({
+  downloadTrajectory: vi.fn(),
+}));
+
+vi.mock("#/utils/utils", () => ({
+  downloadBlob: vi.fn(),
+}));
+
+vi.mock("#/api/conversation-service/conversation-service.api", () => ({
+  default: {
+    getTrajectory: vi.fn(),
+  },
+}));
+
+vi.mock(
+  "#/api/conversation-service/agent-server-conversation-service.api",
+  () => ({
+    default: {
+      downloadConversation: vi.fn(),
+    },
+  }),
+);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: React.PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+};
+
+describe("useDownloadConversation", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exports the trajectory from the events API instead of the server-side zip endpoint", async () => {
+    const trajectory = [{ id: "event-1" }];
+    vi.mocked(ConversationService.getTrajectory).mockResolvedValue({
+      trajectory,
+    });
+    vi.mocked(
+      AgentServerConversationService.downloadConversation,
+    ).mockResolvedValue(new Blob(["zip-bytes"], { type: "application/zip" }));
+
+    const { result } = renderHook(() => useDownloadConversation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("conv-123");
+    });
+
+    expect(mockPosthogCapture).toHaveBeenCalledWith(
+      "download_trajectory_button_clicked",
+    );
+    expect(ConversationService.getTrajectory).toHaveBeenCalledWith("conv-123");
+    expect(downloadTrajectory).toHaveBeenCalledWith("conv-123", trajectory);
+    expect(
+      AgentServerConversationService.downloadConversation,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-download-conversation.ts
+++ b/src/hooks/use-download-conversation.ts
@@ -1,7 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
 import { usePostHog } from "posthog-js/react";
 import { useTranslation } from "react-i18next";
+import { getActiveBackend } from "#/api/backend-registry/active-store";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import ConversationService from "#/api/conversation-service/conversation-service.api";
+import { downloadTrajectory } from "#/utils/download-trajectory";
 import { downloadBlob } from "#/utils/utils";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { I18nKey } from "#/i18n/declaration";
@@ -14,9 +17,19 @@ export const useDownloadConversation = () => {
     mutationKey: ["conversations", "download"],
     mutationFn: async (conversationId: string) => {
       posthog.capture("download_trajectory_button_clicked");
-      const blob =
-        await AgentServerConversationService.downloadConversation(conversationId);
-      downloadBlob(blob, `conversation_${conversationId}.zip`);
+
+      if (getActiveBackend().backend.kind === "cloud") {
+        const blob =
+          await AgentServerConversationService.downloadConversation(
+            conversationId,
+          );
+        downloadBlob(blob, `conversation_${conversationId}.zip`);
+        return;
+      }
+
+      const { trajectory } =
+        await ConversationService.getTrajectory(conversationId);
+      await downloadTrajectory(conversationId, trajectory);
     },
     onError: () => {
       displayErrorToast(t(I18nKey.CONVERSATION$DOWNLOAD_ERROR));


### PR DESCRIPTION
## Summary
- Fixes #205
- Changes local **Export Conversation** to read the trajectory through the events API and download the existing trajectory JSON instead of depending on the agent-server `/api/file/download-trajectory/{conversationId}` zip endpoint.
- Preserves the existing cloud export behavior, which still downloads the cloud app-conversation zip.
- Adds a regression test showing the local export path should use `ConversationService.getTrajectory` + `downloadTrajectory` and avoid the server-side zip endpoint.

## Verification
- `npm test -- --run __tests__/hooks/use-download-conversation.test.tsx`
- `npm test -- --run __tests__/hooks/use-download-conversation.test.tsx __tests__/api/agent-server-conversation-service.test.ts`
- `npm run typecheck`
- `npm run build`

Note: `npm run lint` currently fails on pre-existing lint/prettier issues across unrelated files (for example `src/api/agent-server-compatibility.ts`, `src/api/cloud/secrets-service.api.ts`, and others). The modified source file was formatted with Prettier.

---
This PR was created by an AI agent (OpenHands) on behalf of the user.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1d853e05-b52f-47d6-b61a-3a6ff8a21d1e)