### PR TITLE
fix(frontend): remove inner edge gaps in empty and diff states

### DIFF
--- a/__tests__/routes/changes-tab.test.tsx
+++ b/__tests__/routes/changes-tab.test.tsx
@@ -67,4 +67,45 @@ describe("Changes Tab", () => {
       screen.queryByText("DIFF_VIEWER$NO_CHANGES"),
     ).not.toBeInTheDocument();
   });
+
+  it("should render the Protip alongside the empty state when there are no changes", () => {
+    vi.mocked(useUnifiedGetGitChanges).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      isSuccess: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(useAgentState).mockReturnValue({
+      curAgentState: AgentState.RUNNING,
+    });
+
+    render(<GitChanges />, { wrapper });
+
+    expect(screen.getByText("TIPS$PROTIP:")).toBeInTheDocument();
+  });
+
+  it("should hide the Protip when the git changes request errors", () => {
+    vi.mocked(useUnifiedGetGitChanges).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      isSuccess: false,
+      isError: true,
+      error: { message: "fatal: not a git repository" } as unknown as Error,
+      refetch: vi.fn(),
+    });
+    vi.mocked(useAgentState).mockReturnValue({
+      curAgentState: AgentState.RUNNING,
+    });
+
+    render(<GitChanges />, { wrapper });
+
+    expect(screen.queryByText("TIPS$PROTIP:")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("DIFF_VIEWER$NOT_A_GIT_REPO"),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/routes/changes-tab.tsx
+++ b/src/routes/changes-tab.tsx
@@ -67,10 +67,10 @@ function GitChanges() {
   ]);
 
   return (
-    <main className="h-full overflow-y-scroll md:pr-1.5 flex flex-col items-stretch custom-scrollbar-always">
+    <main className="h-full w-full flex flex-col items-stretch">
       {!isSuccess || !gitChanges.length ? (
-        <div className="relative flex h-full w-full items-center">
-          <div className="absolute inset-x-0 top-1/2 -translate-y-1/2">
+        <div className="flex flex-col h-full w-full">
+          <div className="flex-1 flex items-center justify-center">
             {statusMessage && (
               <StatusMessage>
                 {statusMessage.map((msg) => (
@@ -82,25 +82,22 @@ function GitChanges() {
               <EmptyChangesMessage />
             )}
           </div>
-
-          <div className="absolute inset-x-0 bottom-0">
-            {!isError && gitChanges?.length === 0 && (
-              <div className="max-w-2xl mx-4 mb-4 text-m bg-tertiary p-4 text-left md:mx-auto">
-                <RandomTip />
-              </div>
-            )}
-          </div>
+          {!isError && isSuccess && gitChanges.length === 0 && (
+            <div className="w-full text-m bg-tertiary p-4 text-left">
+              <RandomTip />
+            </div>
+          )}
         </div>
       ) : (
-        gitChanges
-          .slice(0, 100)
-          .map((change) => (
+        <div className="h-full overflow-y-auto flex flex-col items-stretch custom-scrollbar-always">
+          {gitChanges.slice(0, 100).map((change) => (
             <FileDiffViewer
               key={change.path}
               path={change.path}
               type={change.status}
             />
-          ))
+          ))}
+        </div>
       )}
     </main>
   );


### PR DESCRIPTION

Resolves #212

### Description

When a user opens a new conversation in `agent-server-gui` and looks at the **Changes** tab in the right-side conversation panel, the panel content does not fill the bordered container — there are visible dark gaps along the inner edges:

- **Empty state** ("OpenHands hasn't made any changes yet" + Protip card): visible gaps on the right and bottom inside the bordered panel.
- **Diff list** (one or more file changes): a small gap on the inner right edge.

### Steps to Reproduce

1. Run the dev server and navigate to `http://localhost:3001`.
2. From the home page, click **New Conversation**.
3. The **Changes** tab is selected by default. Observe gaps on the right and bottom inside the bordered panel (empty state).
4. Trigger a change in the workspace (e.g., have the agent create a file). Observe a small inner-right gap on the diff list.

### Current Behavior

The Changes tab content is inset from the bordered panel by 6–16 px on the right and 16 px on the bottom in the empty state, and by 6 px on the right in the diff-list state.

### Expected Behavior

Content fills the bordered panel edge-to-edge along all four inner edges. The Protip sits flush against the bottom and side borders. The diff list extends to the right border (the scrollbar gutter only appears when content actually overflows).

### Root Cause

In `src/routes/changes-tab.tsx`:

- `<main>` set `overflow-y-scroll` (always reserves a scrollbar gutter even when there is nothing to scroll) and `md:pr-1.5` (6 px right padding).
- The empty state used absolute positioning (`absolute inset-x-0 top-1/2 -translate-y-1/2` for the icon, `absolute inset-x-0 bottom-0` for the Protip), and the Protip card carried `mb-4` plus `max-w-2xl mx-auto`. Together these produced the bottom and side gaps inside the empty-state branch.
- The diff branch kept `md:pr-1.5`, which was the small inner-right gap when changes are present.

The shared layout files (`conversation-main.tsx`, `tab-container.tsx`, etc.) match the upstream OpenHands reference and are not the source of the bug.

### Fix

In `src/routes/changes-tab.tsx`:

- Replace absolute positioning in the empty state with a normal `flex flex-col h-full` layout — `flex-1` icon area on top, full-width Protip wrapper at the bottom.
- Drop the Protip card's `max-w-2xl mx-auto` and the wrapper's outer padding so the card spans full width and is flush with the left, right, and bottom borders.
- Move scroll/scrollbar styling (`overflow-y-auto custom-scrollbar-always`) into the diff branch only and drop `md:pr-1.5` so the diff list is also flush with the right border.

### Acceptance Criteria

- [ ] Empty Changes panel: no visible gaps on the top, right, bottom, or left inner edges (other than the panel border itself).
- [ ] Diff Changes panel: no visible gap on the right inner edge when content does not overflow; scrollbar appears in-flow when content does overflow.
- [ ] `StatusMessage` (loading / not-a-git-repo / runtime-inactive) still centers inside the panel.
- [ ] Existing diff scrolling behavior is preserved when many file changes are present.

## Summary

- The Changes tab on the conversation page rendered content inset from its bordered container — visible dark gaps along the right and bottom in the empty state, and a small right-edge gap once diffs were present.
- Restructured `src/routes/changes-tab.tsx` to fill the panel edge-to-edge in both branches:
  - **Empty state**: swapped absolute positioning for a `flex flex-col h-full` layout (`flex-1` icon area on top, full-width Protip at the bottom). Removed `max-w-2xl mx-auto` and the surrounding `px-4 pb-4` so the Protip card spans full width and is flush with the side and bottom borders.
  - **Diff state**: dropped `md:pr-1.5`, switched `overflow-y-scroll` → `overflow-y-auto`, and moved `custom-scrollbar-always` into this branch only so the scrollbar gutter only appears when content actually overflows.
- Shared layout files (`conversation-main.tsx`, `tab-container.tsx`, `root-layout.tsx`, `conversation.tsx`) are intentionally untouched — they match the upstream OpenHands reference.

## Screenshots

### Before

<img width="1440" height="746" alt="issue" src="https://github.com/user-attachments/assets/f56d6953-9ee3-4a35-b498-c83e6a1cf5c8" />

### After

<img width="1440" height="792" alt="output" src="https://github.com/user-attachments/assets/2133e1b1-402f-4fab-acd0-a6355693c90e" />