### PR TITLE
fix(frontend): use SPA navigation for sidebar Automations button

### DIFF
--- a/__tests__/components/shared/buttons/automations-button.test.tsx
+++ b/__tests__/components/shared/buttons/automations-button.test.tsx
@@ -1,14 +1,39 @@
 import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AutomationsButton } from "#/components/shared/buttons/automations-button";
+import {
+  NavigationProvider,
+  type NavigationContextValue,
+} from "#/context/navigation-context";
 
 vi.mock("#/components/shared/buttons/styled-tooltip", () => ({
   StyledTooltip: ({ children }: { children: unknown }) => children,
 }));
 
+function renderAutomationsButton(
+  props: { disabled?: boolean } = {},
+  overrides: Partial<NavigationContextValue> = {},
+) {
+  const value: NavigationContextValue = {
+    currentPath: "/",
+    conversationId: null,
+    isNavigating: false,
+    navigate: vi.fn(),
+    ...overrides,
+  };
+
+  const result = render(
+    <NavigationProvider value={value}>
+      <AutomationsButton {...props} />
+    </NavigationProvider>,
+  );
+
+  return { ...result, navigate: value.navigate };
+}
+
 describe("AutomationsButton", () => {
   it("should render a link to /automations", () => {
-    render(<AutomationsButton />);
+    renderAutomationsButton();
 
     const link = screen.getByTestId("automations-button");
     expect(link).toBeInTheDocument();
@@ -16,15 +41,26 @@ describe("AutomationsButton", () => {
   });
 
   it("should be focusable and accessible when enabled", () => {
-    render(<AutomationsButton />);
+    renderAutomationsButton();
 
     const link = screen.getByTestId("automations-button");
     expect(link).toHaveAttribute("tabIndex", "0");
     expect(link).toHaveAttribute("aria-label", "SIDEBAR$AUTOMATIONS");
   });
 
+  it("should navigate via SPA routing without a full page reload when clicked", () => {
+    const { navigate } = renderAutomationsButton();
+
+    const link = screen.getByTestId("automations-button");
+    const clickEvent = createEvent.click(link);
+    fireEvent(link, clickEvent);
+
+    expect(navigate).toHaveBeenCalledWith("/automations", { replace: false });
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+
   it("should prevent navigation and remove from tab order when disabled", () => {
-    render(<AutomationsButton disabled />);
+    const { navigate } = renderAutomationsButton({ disabled: true });
 
     const link = screen.getByTestId("automations-button");
     expect(link).toHaveAttribute("tabIndex", "-1");
@@ -32,5 +68,6 @@ describe("AutomationsButton", () => {
     const clickEvent = createEvent.click(link);
     fireEvent(link, clickEvent);
     expect(clickEvent.defaultPrevented).toBe(true);
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/src/components/shared/buttons/automations-button.tsx
+++ b/src/components/shared/buttons/automations-button.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
+import { NavigationLink } from "#/components/shared/navigation-link";
 import { StyledTooltip } from "#/components/shared/buttons/styled-tooltip";
 import AutomationsIcon from "#/icons/automations.svg?react";
 import { cn } from "#/utils/utils";
@@ -17,8 +18,8 @@ export function AutomationsButton({
 
   return (
     <StyledTooltip content={label} placement="right">
-      <a
-        href="/automations"
+      <NavigationLink
+        to="/automations"
         data-testid="automations-button"
         aria-label={label}
         tabIndex={disabled ? -1 : 0}
@@ -32,7 +33,7 @@ export function AutomationsButton({
         })}
       >
         <AutomationsIcon width={24} height={24} />
-      </a>
+      </NavigationLink>
     </StyledTooltip>
   );
 }


### PR DESCRIPTION
Resolves #216 

### Demo Video

https://github.com/user-attachments/assets/6c7b5fe9-8364-4b88-ba98-cf6c296aa7ea

### Description

Clicking the **Automations** icon in the sidebar navigates the user to `/automations` correctly, but the navigation is performed as a full browser document request rather than client-side SPA routing. This breaks the expected single-page-app behavior we have on every other sidebar entry point and causes a visible page flash, loss of in-memory React state, and an unnecessary round-trip to the server.

### Steps to Reproduce

1. Run the GUI locally and open `http://localhost:3001`.
2. Open DevTools → **Network** tab and filter by **Doc**.
3. In the sidebar, click the **Automations** icon.

### Current Behavior

- The URL changes to `/automations`.
- A new top-level document request is recorded in the Network tab — the entire SPA reboots.
- React state (open panels, sidebar selection, etc.) is lost.

### Expected Behavior

- The URL changes to `/automations`.
- **No** new top-level document request is made; React Router handles the route in-memory.
- React state is preserved across the navigation.

### Root Cause

`src/components/shared/buttons/automations-button.tsx` renders a plain HTML `<a href="/automations">` element. Native anchor clicks are full-document navigations, so React Router never sees the click. Every other sidebar entry (`NewProjectButton`, `OpenHandsLogoButton`, automations detail `BackLink`) uses the project's custom `NavigationLink` component, which intercepts clicks and routes through `NavigationContext`.

### Fix

Replace the `<a>` in `AutomationsButton` with `<NavigationLink to="/automations">`, mirroring `NewProjectButton`. The disabled-state guard, accessibility attributes, and styling all carry over unchanged because `NavigationLink` accepts standard anchor props.

### Acceptance Criteria

- [ ] Clicking the sidebar Automations icon navigates to `/automations` without a full page reload (no new `Doc` request in DevTools).
- [ ] Modifier-key clicks (Cmd/Ctrl/Shift/Alt) still defer to native browser behavior (e.g. open in new tab).
- [ ] When the button is disabled, clicks are no-ops and the icon is removed from the tab order.
- [ ] Unit tests in `__tests__/components/shared/buttons/automations-button.test.tsx` cover SPA navigation and the disabled-state guard.

### Summary

- The sidebar **Automations** icon was rendered as a plain `<a href="/automations">`, causing a full page reload on click.
- Swapped it for the project's `NavigationLink` component (the same SPA-navigation primitive already used by `NewProjectButton`, `OpenHandsLogoButton`, and the automations detail `BackLink`).
- Disabled-state behavior, accessibility attributes (`aria-label`, `tabIndex`), and styling are preserved; `NavigationLink` calls the user-supplied `onClick` first and skips `navigate()` whenever `event.defaultPrevented` is true.

### Files Changed

- `src/components/shared/buttons/automations-button.tsx` — replace `<a>` with `<NavigationLink to="/automations">`.
- `__tests__/components/shared/buttons/automations-button.test.tsx` — wrap renders in `NavigationProvider`, add SPA-navigation assertion, tighten disabled-state assertion.

### Why `NavigationLink` (not React Router's `<Link>`)?

`NavigationLink` is the codebase's standard navigation primitive. It wraps `<a>`, intercepts left-clicks (no modifier keys), calls `event.preventDefault()`, and delegates to the `navigate()` function exposed by `NavigationContext` (backed by React Router's `useNavigate`). This keeps navigation centralized, preserves `target="_blank"` and modifier-key semantics, and enables the existing context-driven loading state and active-link styling.

### Risk / Rollback

Low risk — change is isolated to a single sidebar button and follows an established pattern in the codebase. Revert is a one-file rollback of `automations-button.tsx`.