### PR TITLE
fix(frontend): hide Suggested Tasks section for local backends

### DIFF
--- a/__tests__/components/features/home/task-suggestions.test.tsx
+++ b/__tests__/components/features/home/task-suggestions.test.tsx
@@ -1,10 +1,17 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRoutesStub } from "react-router";
 import { TaskSuggestions } from "#/components/features/home/tasks/task-suggestions";
 import { SuggestionsService } from "#/api/suggestions-service/suggestions-service.api";
 import { MOCK_TASKS } from "#/mocks/task-suggestions-handlers";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
 
 // Mock the translation function
 vi.mock("react-i18next", async () => {
@@ -46,6 +53,14 @@ vi.mock("#/hooks/use-user-providers", () => ({
   useUserProviders: () => useUserProvidersMock(),
 }));
 
+const cloudBackend: Backend = {
+  id: "prod",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "k",
+  kind: "cloud",
+};
+
 const renderTaskSuggestions = () => {
   const RouterStub = createRoutesStub([
     {
@@ -65,7 +80,7 @@ const renderTaskSuggestions = () => {
   return render(<RouterStub />, {
     wrapper: ({ children }) => (
       <QueryClientProvider client={new QueryClient()}>
-        {children}
+        <ActiveBackendProvider>{children}</ActiveBackendProvider>
       </QueryClientProvider>
     ),
   });
@@ -77,13 +92,31 @@ describe("TaskSuggestions", () => {
     "getSuggestedTasks",
   );
 
+  beforeEach(() => {
+    window.localStorage.clear();
+    __resetActiveStoreForTests();
+    setRegisteredBackends([cloudBackend]);
+    setActiveSelection({ backendId: cloudBackend.id });
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
+    __resetActiveStoreForTests();
   });
 
   it("should render the task suggestions section", () => {
     renderTaskSuggestions();
     screen.getByTestId("task-suggestions");
+  });
+
+  it("renders nothing when the active backend is local", () => {
+    setRegisteredBackends([]);
+    setActiveSelection(null);
+
+    renderTaskSuggestions();
+
+    expect(screen.queryByTestId("task-suggestions")).not.toBeInTheDocument();
   });
 
   it("should render an empty message if there are no tasks", async () => {

--- a/src/components/features/home/tasks/task-suggestions.tsx
+++ b/src/components/features/home/tasks/task-suggestions.tsx
@@ -7,6 +7,7 @@ import { cn, getDisplayedTaskGroups, getTotalTaskCount } from "#/utils/utils";
 import { I18nKey } from "#/i18n/declaration";
 import { GitRepository } from "#/types/git";
 import { Typography } from "#/ui/typography";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 
 interface TaskSuggestionsProps {
   filterFor?: GitRepository | null;
@@ -15,8 +16,11 @@ interface TaskSuggestionsProps {
 export function TaskSuggestions({ filterFor }: TaskSuggestionsProps) {
   const { t } = useTranslation("openhands");
   const [isExpanded, setIsExpanded] = useState(false);
+  const isCloud = useActiveBackend().backend.kind === "cloud";
 
   const { data: tasks, isLoading } = useSuggestedTasks();
+
+  if (!isCloud) return null;
 
   const suggestedTasks = filterFor
     ? tasks?.filter(


### PR DESCRIPTION
Resolves #218 

### Demo Video

https://github.com/user-attachments/assets/e614fa39-e7f3-4b40-bdd0-e5ddb5790cbd

### Description

The home screen renders the **Suggested Tasks** section for both local and cloud backends. Local backends have no Git connection, so the section is functionally meaningless — it always shows the empty-state heading and "No tasks available" copy, taking up valuable real estate next to **Recent Conversations**.

### Steps to reproduce

1. Open `agent-server-gui` at `http://localhost:3001`.
2. Hover the user avatar → **Add Backend** → enter Hostname / Host / API Key (kind: **local**) → **Save**.
3. From the avatar menu, switch to a cloud workspace (e.g. **Production - Personal Workspace**).
4. Switch back to the local backend.

### Expected

* **Local backend:** "Suggested Tasks" is **not displayed** (no Git → nothing to suggest).
* **Cloud backend:** "Suggested Tasks" is displayed as today.

### Actual

* "Suggested Tasks" is displayed in **both** local and cloud environments.

### Root cause

`src/routes/home.tsx` mounts `<TaskSuggestions />` unconditionally, and `src/components/features/home/tasks/task-suggestions.tsx` renders its `<section>` chrome regardless of backend kind. The data fetch in `useSuggestedTasks` is gated by `useShouldShowUserFeatures()` (auth + Git providers present), but the surrounding UI (heading + "No tasks available" copy) is not.

### Acceptance criteria

* [x] On a local backend (bundled or user-added with `kind: "local"`), the Suggested Tasks section is fully removed from the DOM.
* [x] On a cloud backend, the section renders unchanged (loading skeletons, task groups, empty-state copy, expand/collapse).
* [x] No new component is introduced; the gate uses the existing `useActiveBackend()` helper, matching `RepoConnector`'s pattern.
* [x] Unit test coverage for the new local-mode behavior, extending the existing `task-suggestions.test.tsx`.

### Summary

* The home screen used to render the **Suggested Tasks** section in both local and cloud environments. Local backends have no Git connection, so the section only ever showed an empty-state heading and "No tasks available" copy.
* `TaskSuggestions` now self-gates on `useActiveBackend().backend.kind === "cloud"` and returns `null` for local backends — same pattern `RepoConnector` already uses.
* Cloud behavior is unchanged.

### Changes

* `src/components/features/home/tasks/task-suggestions.tsx`

  * Read `useActiveBackend().backend.kind` and early-return `null` when not `"cloud"`.
* `__tests__/components/features/home/task-suggestions.test.tsx`

  * Wrap render helper with `ActiveBackendProvider` and seed a cloud backend so existing cases stay green.
  * Add one new test: **"renders nothing when the active backend is local"**.

### Why this location

* Encapsulates the rule in the component that owns it; future callers of `<TaskSuggestions />` inherit the correct behavior.
* Mirrors the `RepoConnector` self-gate pattern (`repo-connector.tsx:14`).
* Lets us extend the existing component test file rather than create a new one.
