### PR TITLE
fix(frontend): render Automations pages flush to viewport edges

### DIFF
--- a/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { Sidebar } from "#/components/features/sidebar/sidebar";
+import {
+  NavigationProvider,
+  type NavigationContextValue,
+} from "#/context/navigation-context";
+
+vi.mock("#/hooks/query/use-git-user", () => ({
+  useGitUser: () => ({ data: undefined, isFetching: false }),
+}));
+
+vi.mock("#/hooks/query/use-config", () => ({
+  useConfig: () => ({ data: { feature_flags: {} } }),
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => ({
+    data: { email_verified: true },
+    error: null,
+    isError: false,
+    isFetching: false,
+  }),
+  getErrorStatus: () => undefined,
+}));
+
+vi.mock("#/components/shared/buttons/styled-tooltip", () => ({
+  StyledTooltip: ({ children }: { children: unknown }) => children,
+}));
+
+vi.mock("#/components/shared/buttons/openhands-logo-button", () => ({
+  OpenHandsLogoButton: () => <div data-testid="logo-button" />,
+}));
+
+vi.mock("#/components/shared/buttons/new-project-button", () => ({
+  NewProjectButton: () => <div data-testid="new-project-button" />,
+}));
+
+vi.mock("#/components/shared/buttons/conversation-panel-button", () => ({
+  ConversationPanelButton: () => (
+    <div data-testid="conversation-panel-button" />
+  ),
+}));
+
+vi.mock("#/components/shared/buttons/automations-button", () => ({
+  AutomationsButton: () => <div data-testid="automations-button" />,
+}));
+
+vi.mock("#/components/features/sidebar/user-actions", () => ({
+  UserActions: () => <div data-testid="user-actions" />,
+}));
+
+vi.mock("#/components/features/conversation-panel/conversation-panel", () => ({
+  ConversationPanel: () => null,
+}));
+
+vi.mock(
+  "#/components/features/conversation-panel/conversation-panel-wrapper",
+  () => ({
+    ConversationPanelWrapper: () => null,
+  }),
+);
+
+vi.mock("#/components/shared/modals/settings/settings-modal", () => ({
+  SettingsModal: () => null,
+}));
+
+function renderSidebar(currentPath: string) {
+  const value: NavigationContextValue = {
+    currentPath,
+    conversationId: null,
+    isNavigating: false,
+    navigate: vi.fn(),
+  };
+
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <NavigationProvider value={value}>
+        <Sidebar />
+      </NavigationProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Sidebar", () => {
+  it.each([["/automations"], ["/automations/abc-123"]])(
+    "applies the standalone vertical padding on %s so the sidebar has breathing room when the root layout's padding is dropped",
+    (currentPath) => {
+      renderSidebar(currentPath);
+
+      const sidebar = screen.getByRole("navigation").parentElement;
+      expect(sidebar?.className).toMatch(/(^|\s)md:pt-6\.5(\s|$)/);
+      expect(sidebar?.className).toMatch(/(^|\s)md:pb-3(\s|$)/);
+    },
+  );
+
+  it("does not apply the standalone vertical padding on routes that still use the root layout's padding", () => {
+    renderSidebar("/settings");
+
+    const sidebar = screen.getByRole("navigation").parentElement;
+    expect(sidebar?.className).not.toMatch(/(^|\s)md:pt-6\.5(\s|$)/);
+    expect(sidebar?.className).not.toMatch(/(^|\s)md:pb-3(\s|$)/);
+  });
+});

--- a/__tests__/routes/root-layout.test.tsx
+++ b/__tests__/routes/root-layout.test.tsx
@@ -39,7 +39,9 @@ vi.mock("#/components/features/sidebar/sidebar", () => ({
 }));
 
 vi.mock("#/components/features/analytics/analytics-consent-form-modal", () => ({
-  AnalyticsConsentFormModal: () => <div data-testid="analytics-consent-modal" />,
+  AnalyticsConsentFormModal: () => (
+    <div data-testid="analytics-consent-modal" />
+  ),
 }));
 
 vi.mock("#/components/features/alerts/alert-banner", () => ({
@@ -59,6 +61,18 @@ const RouterStub = createRoutesStub([
     children: [
       {
         path: "/",
+        Component: () => <div data-testid="outlet-content" />,
+      },
+      {
+        path: "/automations",
+        Component: () => <div data-testid="outlet-content" />,
+      },
+      {
+        path: "/automations/:id",
+        Component: () => <div data-testid="outlet-content" />,
+      },
+      {
+        path: "/settings",
         Component: () => <div data-testid="outlet-content" />,
       },
     ],
@@ -115,5 +129,32 @@ describe("root layout", () => {
     expect(screen.getByTestId("outlet-content")).toBeInTheDocument();
     expect(screen.getByTestId("analytics-consent-modal")).toBeInTheDocument();
     expect(migrateUserConsentMock).toHaveBeenCalled();
+  });
+
+  it.each([["/automations"], ["/automations/abc-123"]])(
+    "drops the outer layout padding on %s so the page can render flush to the viewport edges",
+    (path) => {
+      render(
+        <QueryClientProvider client={new QueryClient()}>
+          <RouterStub initialEntries={[path]} />
+        </QueryClientProvider>,
+      );
+
+      const layout = screen.getByTestId("root-layout");
+      expect(layout.className).not.toMatch(/(^|\s)md:p-3(\s|$)/);
+      expect(layout.className).not.toMatch(/(^|\s)md:pl-0(\s|$)/);
+    },
+  );
+
+  it("keeps the outer layout padding on routes other than home and automations", () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <RouterStub initialEntries={["/settings"]} />
+      </QueryClientProvider>,
+    );
+
+    const layout = screen.getByTestId("root-layout");
+    expect(layout.className).toMatch(/(^|\s)md:p-3(\s|$)/);
+    expect(layout.className).toMatch(/(^|\s)md:pl-0(\s|$)/);
   });
 });

--- a/src/components/features/sidebar/sidebar.tsx
+++ b/src/components/features/sidebar/sidebar.tsx
@@ -67,7 +67,8 @@ export function Sidebar() {
         aria-label={t(I18nKey.SIDEBAR$NAVIGATION_LABEL)}
         className={cn(
           "h-[54px] p-3 md:p-0 md:h-[40px] md:h-auto flex flex-row md:flex-col gap-1 bg-base md:w-[75px] md:min-w-[75px] sm:pt-0 sm:px-2 md:pt-[14px] md:px-0",
-          currentPath === "/" && "md:pt-6.5 md:pb-3",
+          (currentPath === "/" || currentPath.startsWith("/automations")) &&
+            "md:pt-6.5 md:pb-3",
         )}
       >
         <nav className="flex flex-row md:flex-col items-center justify-between w-full h-auto md:w-auto md:h-full">

--- a/src/routes/root-layout.tsx
+++ b/src/routes/root-layout.tsx
@@ -97,7 +97,9 @@ export default function MainApp() {
         data-testid="root-layout"
         className={cn(
           "h-screen lg:min-w-5xl flex flex-col md:flex-row bg-base overflow-hidden",
-          pathname === "/" ? "p-0" : "p-0 md:p-3 md:pl-0",
+          pathname === "/" || pathname.startsWith("/automations")
+            ? "p-0"
+            : "p-0 md:p-3 md:pl-0",
         )}
       >
         <title>{appTitle}</title>


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

When opening `http://localhost:3001/automations` (or any `/automations/:id` detail page), a visible black gap appears along the top, right, and bottom of the content area. The expected behavior is for the page background to extend flush to the viewport edges (and to the sidebar on the left), with no visible color discontinuity.

### Steps to reproduce
1. Start `agent-server-gui` and open `http://localhost:3001`.
2. Navigate to `http://localhost:3001/automations`.
3. Observe the gaps surrounding the dark `bg-surface` content area.

### Expected behavior
- No gaps at the top, right, or bottom.
- The sidebar still has comfortable vertical breathing room.
- All other routes (Settings, Conversation, etc.) keep their existing 12 px frame so navigation between them feels unchanged.

### Acceptance criteria
- `/automations` and `/automations/:id` render with the `bg-surface` content area flush to all edges.
- The sidebar on those routes shows the same vertical padding as it does on `/` (home).
- All other routes retain the root layout's `md:p-3 md:pl-0` outer padding.
- TDD coverage protects the route-conditional layout behavior so it can't silently regress.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The Automations list and detail pages were rendering with a visible 12 px gap of `bg-base` along the top, right, and bottom of the `bg-surface` content area.
- The root cause is a color mismatch: `root-layout.tsx` applies `md:p-3 md:pl-0` padding to the outermost container on every non-home route, and the Automations pages are the only routes that paint themselves with a different background (`bg-surface` vs the parent's `bg-base`), making the padding band visible.
- This PR fixes the gap on Automations routes only, without changing the framing on Settings, Conversation, or any other route.

### Changes

- `src/routes/root-layout.tsx` — Extended the existing `pathname === "/"` exception so `/automations` and `/automations/:id` also render with `p-0`. Other routes still use `p-0 md:p-3 md:pl-0`.
- `src/components/features/sidebar/sidebar.tsx` — Reused the existing home-route conditional to also apply `md:pt-6.5 md:pb-3` on `/automations*`, giving the sidebar the same vertical breathing room it has on home now that the root layout's outer padding is gone for those routes.
- `__tests__/routes/root-layout.test.tsx` — Added route stubs for `/automations`, `/automations/:id`, and `/settings`; added two tests asserting the conditional outer-padding behavior.
- `__tests__/components/features/sidebar/sidebar.test.tsx` — New file covering the conditional sidebar padding for Automations routes vs. other routes (mocks the underlying query hooks and heavy children, not the navigation hook).

### Files changed

- `src/routes/root-layout.tsx`
- `src/components/features/sidebar/sidebar.tsx`
- `__tests__/routes/root-layout.test.tsx`
- `__tests__/components/features/sidebar/sidebar.test.tsx`

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #224

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Start `agent-server-gui` and open `http://localhost:3001`.
2. Navigate to `http://localhost:3001/automations`.
3. Observe the gaps surrounding the dark `bg-surface` content area.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/545b7d17-02e6-4d07-8e8f-c2ba751d75ed

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- Background colors are unchanged (`bg-surface` is intentionally preserved on Automations pages).
- Inner content padding (`p-6 max-w-4xl mx-auto`) is unchanged.
- No visual changes to any non-Automations route.