### PR TITLE
[codex] Prototype add backend with agent flow

### DIFF
--- a/.agents/skills/configure-remote-vm-agent.md
+++ b/.agents/skills/configure-remote-vm-agent.md
@@ -1,0 +1,50 @@
+---
+name: configure-remote-vm-agent
+description: Configure a remote VM to run Agent Canvas, openhands-agent-server, and the automation backend using the user's existing SSH access.
+triggers:
+  - Configure Remote VM with Agent
+  - Add Remote Machine
+  - remote agent-server
+  - remote VM
+---
+
+# Configure Remote VM With Agent
+
+Help the user configure a remote machine as an Agent Canvas backend. Work interactively and use the user's existing SSH setup from the local machine; do not ask them to paste private keys or passwords into chat.
+
+## Default Workflow
+
+1. Ask for the SSH target if the user did not provide one.
+2. Confirm whether they want a temporary dev stack or a long-running setup.
+3. Verify SSH connectivity, OS, architecture, shell, package manager, and relevant ports before installing anything.
+4. Check for `git`, `curl`, Node.js `>=22.12`, `npm`, and `uvx`.
+5. Ask before using `sudo` or changing firewall, service, or reverse-proxy configuration.
+6. Clone or update `https://github.com/OpenHands/agent-canvas.git` on the remote VM.
+7. Configure `.env` with stable, strong API keys for the remote stack. Keep secrets out of git.
+8. Start with `npm run dev` unless the user asks for a production process manager. For long-running operation, propose `tmux`, `systemd`, or another explicit supervisor before applying it.
+9. Verify `/server_info`, `/api/automation/docs`, and the frontend URL.
+10. Give the user the backend URL and session API key needed by Agent Canvas Manage Backends, or set up an SSH tunnel when direct exposure is inappropriate.
+
+## Target Layout
+
+Unless the user requests a different location, keep all target-machine files under `~/.openhands/agent-canvas`:
+
+- `repo/` - git checkout of `https://github.com/OpenHands/agent-canvas.git`.
+- `env/.env` - stable runtime environment and generated API keys. Use `chmod 600` and never commit it.
+- `bin/agent-canvas-stack` - fixed idempotent maintenance script with `setup`, `start`, `stop`, `status`, `logs`, `update`, and `print-connection` commands.
+- `metadata/backend.json` - non-secret machine/backend metadata such as hostname, OS, architecture, install path, repo ref/sha, ports, endpoint notes, agent-server version, and timestamps.
+- `metadata/connection.md` - human-readable connection instructions for adding the backend to this UI.
+- `metadata/setup-log.md` - setup/update log and decisions made.
+
+Keep metadata files non-secret. Do not store private keys, raw passwords, or unnecessary API key values in metadata.
+
+## Security Rules
+
+- Never expose an unauthenticated agent-server to the public internet.
+- Prefer SSH tunnels or TLS behind a reverse proxy for untrusted networks.
+- Summarize risky commands before running them.
+- Do not print generated secrets unless the user needs them for a specific local configuration step.
+
+## Final Response
+
+End with a compact status table covering prerequisites, repository location, running processes, exposed URLs, auth state, and remaining manual steps.

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   toAppConversation,
   type DirectConversationInfo,
 } from "#/api/agent-server-adapter";
+import { renderApplicationPrompt } from "#/prompts/registry";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 
 const { mockGetAgentServerWorkingDir, mockIsAgentServerToolAvailable } =
@@ -31,7 +32,6 @@ vi.mock("#/api/agent-server-compatibility", () => ({
 beforeEach(() => {
   mockIsAgentServerToolAvailable.mockReturnValue(true);
 });
-
 
 describe("buildStartConversationRequest", () => {
   it("uses nested settings as the source of truth and keeps SDK tool names", () => {
@@ -101,6 +101,26 @@ describe("buildStartConversationRequest", () => {
     expect(payload.initial_message.content[0]?.text).toBe("hello");
   });
 
+  it("starts backend-agent setup conversations with the current LLM profile model", () => {
+    const setupPrompt = renderApplicationPrompt("configure-remote-vm-agent");
+
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          ...DEFAULT_SETTINGS.agent_settings,
+          llm: { model: "current-profile-model" },
+        },
+      },
+      query: setupPrompt,
+    }) as {
+      agent: { llm: { model: string } };
+      initial_message: { content: Array<{ text: string }> };
+    };
+
+    expect(payload.agent.llm.model).toBe("current-profile-model");
+    expect(payload.initial_message.content[0]?.text).toBe(setupPrompt);
+  });
 
   it("omits browser_tool_set when the server does not advertise browser support", () => {
     mockIsAgentServerToolAvailable.mockReturnValue(false);

--- a/__tests__/components/backends/backend-selector.test.tsx
+++ b/__tests__/components/backends/backend-selector.test.tsx
@@ -12,15 +12,22 @@ import { createRoutesStub, MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAxiosError } from "test-utils";
 import { __resetActiveStoreForTests } from "#/api/backend-registry/active-store";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import {
   ActiveBackendProvider,
   useActiveBackendContext,
 } from "#/contexts/active-backend-context";
+import {
+  NavigationProvider,
+  type NavigationContextValue,
+} from "#/context/navigation-context";
 import { BackendSelector } from "#/components/features/backends/backend-selector";
 import {
   __resetEnvironmentSwitchOverlayForTests,
   EnvironmentSwitchOverlay,
 } from "#/components/features/backends/environment-switch-overlay";
+import { renderApplicationPrompt } from "#/prompts/registry";
+import { useConversationStore } from "#/stores/conversation-store";
 
 import {
   getCloudOrganizations,
@@ -29,6 +36,16 @@ import {
   getCurrentCloudApiKey,
 } from "#/api/cloud/organization-service.api";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
+
+const { createServerClientMock, getServerInfoMock } = vi.hoisted(() => {
+  const getServerInfoMock = vi.fn();
+  return {
+    getServerInfoMock,
+    createServerClientMock: vi.fn((options: unknown) => ({
+      getServerInfo: () => getServerInfoMock(options),
+    })),
+  };
+});
 
 vi.mock("#/api/cloud/organization-service.api", () => ({
   getCloudOrganizations: vi.fn(),
@@ -41,14 +58,56 @@ vi.mock("#/utils/custom-toast-handlers", () => ({
   displayErrorToast: vi.fn(),
 }));
 
-function renderWithProviders(ui: React.ReactElement) {
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual("react-i18next");
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) =>
+        key === "BACKEND$VERSION_LABEL"
+          ? `v${String(options?.version ?? "")}`
+          : key,
+      i18n: { language: "en" },
+    }),
+  };
+});
+
+vi.mock("#/hooks/use-tracking", () => ({
+  useTracking: () => ({
+    trackConversationCreated: vi.fn(),
+  }),
+}));
+
+vi.mock("#/api/typescript-client", async () => {
+  const actual = await vi.importActual<
+    typeof import("#/api/typescript-client")
+  >("#/api/typescript-client");
+  return {
+    ...actual,
+    createServerClient: (...args: unknown[]) => createServerClientMock(args[0]),
+  };
+});
+
+function renderWithProviders(
+  ui: React.ReactElement,
+  navigation: Partial<NavigationContextValue> = {},
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  const navigationValue: NavigationContextValue = {
+    currentPath: "/",
+    conversationId: null,
+    isNavigating: false,
+    navigate: vi.fn(),
+    ...navigation,
+  };
   return render(
     <MemoryRouter>
       <QueryClientProvider client={queryClient}>
-        <ActiveBackendProvider>{ui}</ActiveBackendProvider>
+        <NavigationProvider value={navigationValue}>
+          <ActiveBackendProvider>{ui}</ActiveBackendProvider>
+        </NavigationProvider>
       </QueryClientProvider>
     </MemoryRouter>,
   );
@@ -76,9 +135,38 @@ async function openDropdown() {
   return user;
 }
 
+const makeStartTask = (conversationId: string) => ({
+  id: "task-id",
+  created_by_user_id: null,
+  status: "READY" as const,
+  detail: null,
+  app_conversation_id: conversationId,
+  agent_server_url: "http://agent-server.local",
+  request: {
+    initial_message: null,
+    processors: [],
+    llm_model: null,
+    selected_repository: null,
+    selected_branch: null,
+    git_provider: "github" as const,
+    suggested_task: null,
+    title: null,
+    trigger: null,
+    pr_number: [],
+    parent_conversation_id: null,
+    agent_type: "default" as const,
+  },
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+});
+
 beforeEach(() => {
   window.localStorage.clear();
+  useConversationStore.setState({ messageToSend: null });
   __resetActiveStoreForTests();
+  createServerClientMock.mockClear();
+  getServerInfoMock.mockReset();
+  getServerInfoMock.mockResolvedValue({ version: "1.0.0" });
   vi.mocked(getCloudOrganizations).mockReset();
   vi.mocked(switchCloudOrganization).mockReset();
   vi.mocked(switchCloudOrganization).mockResolvedValue(undefined);
@@ -99,7 +187,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   window.localStorage.clear();
+  useConversationStore.setState({ messageToSend: null });
   __resetActiveStoreForTests();
   __resetEnvironmentSwitchOverlayForTests();
 });
@@ -139,6 +229,36 @@ describe("BackendSelector", () => {
     expect(screen.getByText("BACKEND$LOCAL_ROW")).toBeInTheDocument();
     expect(screen.getByText("Local 1")).toBeInTheDocument();
     expect(screen.getByText("Production")).toBeInTheDocument();
+  });
+
+  it("shows backend host and agent-server version in dropdown rows", async () => {
+    getServerInfoMock.mockImplementation(
+      async (options: { host?: string }) => ({
+        version:
+          options.host === "http://remote.example:8000" ? "2.3.4" : "1.0.0",
+      }),
+    );
+
+    renderWithProviders(
+      <TestSeed
+        onMount={(ctx) => {
+          ctx.addBackend({
+            name: "Remote Mac",
+            host: "http://remote.example:8000",
+            apiKey: "k",
+            kind: "local",
+          });
+        }}
+      >
+        <BackendSelector />
+      </TestSeed>,
+    );
+
+    await openDropdown();
+
+    expect(screen.getByText("Remote Mac")).toBeInTheDocument();
+    expect(screen.getByText("http://remote.example:8000")).toBeInTheDocument();
+    expect(await screen.findByText("v2.3.4")).toBeInTheDocument();
   });
 
   it("expands a cloud backend into one row per org and fires switch-org on select", async () => {
@@ -441,6 +561,11 @@ describe("BackendSelector", () => {
   });
 
   it("does not open backend modals on mouse down alone", async () => {
+    const createSpy = vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    );
+
     renderWithProviders(<BackendSelector />);
 
     await openDropdown();
@@ -452,6 +577,9 @@ describe("BackendSelector", () => {
     expect(
       screen.queryByTestId("manage-backends-modal"),
     ).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByTestId("add-backend-with-agent-menu-item"));
+    expect(createSpy).not.toHaveBeenCalled();
   });
 
   it("shows an error toast, dismisses the overlay, and does not switch to the failing cloud backend", async () => {
@@ -599,6 +727,9 @@ describe("BackendSelector", () => {
 
     const user = await openDropdown();
     expect(screen.getByTestId("add-backend-menu-item")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("add-backend-with-agent-menu-item"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("manage-backends-menu-item")).toBeInTheDocument();
 
     await user.click(screen.getByTestId("add-backend-menu-item"));
@@ -607,6 +738,35 @@ describe("BackendSelector", () => {
     await user.click(screen.getByTestId("add-backend-cancel"));
     await waitFor(() => {
       expect(screen.queryByTestId("add-backend-modal")).not.toBeInTheDocument();
+    });
+  });
+
+  it("starts a conversation with the backend-agent setup prompt", async () => {
+    const createSpy = vi
+      .spyOn(AgentServerConversationService, "createConversation")
+      .mockResolvedValue(makeStartTask("conv-remote"));
+    const prompt = renderApplicationPrompt("configure-remote-vm-agent");
+    const navigate = vi.fn();
+
+    renderWithProviders(<BackendSelector />, { navigate });
+
+    const user = await openDropdown();
+    await user.click(screen.getByTestId("add-backend-with-agent-menu-item"));
+
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(
+        prompt,
+        undefined,
+        undefined,
+        null,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+    expect(useConversationStore.getState().messageToSend).toBeNull();
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith("/conversations/conv-remote");
     });
   });
 

--- a/__tests__/components/features/conversation-panel/new-conversation-button.test.tsx
+++ b/__tests__/components/features/conversation-panel/new-conversation-button.test.tsx
@@ -141,9 +141,10 @@ describe("NewConversationButton", () => {
         path: "/workspace/project/repo1",
       },
     ]);
-    vi.spyOn(AgentServerConversationService, "createConversation").mockImplementation(
-      () => new Promise(() => {}),
-    );
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockImplementation(() => new Promise(() => {}));
 
     const user = userEvent.setup();
     renderWithProviders(<NewConversationButton />);

--- a/__tests__/components/features/home/new-conversation.test.tsx
+++ b/__tests__/components/features/home/new-conversation.test.tsx
@@ -1,14 +1,14 @@
 import { screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "test-utils";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { NewConversation } from "#/components/features/home/new-conversation/new-conversation";
 
 vi.mock("#/hooks/query/use-settings", async () => {
-  const actual = await vi.importActual<typeof import("#/hooks/query/use-settings")>(
-    "#/hooks/query/use-settings",
-  );
+  const actual = await vi.importActual<
+    typeof import("#/hooks/query/use-settings")
+  >("#/hooks/query/use-settings");
   return {
     ...actual,
     getSettingsQueryFn: vi.fn().mockResolvedValue({}),
@@ -41,35 +41,41 @@ const renderNewConversation = (navigate = vi.fn()) =>
     navigation: { navigate },
   });
 
+const makeStartTask = (conversationId: string) => ({
+  id: "task-id",
+  created_by_user_id: null,
+  status: "READY" as const,
+  detail: null,
+  app_conversation_id: conversationId,
+  agent_server_url: "http://agent-server.local",
+  request: {
+    initial_message: null,
+    processors: [],
+    llm_model: null,
+    selected_repository: null,
+    selected_branch: null,
+    git_provider: "github" as const,
+    suggested_task: null,
+    title: null,
+    trigger: null,
+    pr_number: [],
+    parent_conversation_id: null,
+    agent_type: "default" as const,
+  },
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+});
+
 describe("NewConversation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("should create an empty conversation and navigate when pressing the launch from scratch button", async () => {
     const navigate = vi.fn();
     const createConversationSpy = vi
       .spyOn(AgentServerConversationService, "createConversation")
-      .mockResolvedValue({
-        id: "task-id",
-        created_by_user_id: null,
-        status: "READY",
-        detail: null,
-        app_conversation_id: "conv-123",
-        agent_server_url: "http://agent-server.local",
-        request: {
-          initial_message: null,
-          processors: [],
-          llm_model: null,
-          selected_repository: null,
-          selected_branch: null,
-          git_provider: "github",
-          suggested_task: null,
-          title: null,
-          trigger: null,
-          pr_number: [],
-          parent_conversation_id: null,
-          agent_type: "default",
-        },
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      });
+      .mockResolvedValue(makeStartTask("conv-123"));
 
     renderNewConversation(navigate);
 
@@ -84,9 +90,10 @@ describe("NewConversation", () => {
 
   it("should change the launch button text to 'Loading...' when creating a conversation", async () => {
     // Mock V1 API to never resolve, keeping the mutation in loading state
-    vi.spyOn(AgentServerConversationService, "createConversation").mockImplementation(
-      () => new Promise(() => {}),
-    );
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockImplementation(() => new Promise(() => {}));
 
     renderNewConversation();
 

--- a/__tests__/prompts/application-prompts.test.ts
+++ b/__tests__/prompts/application-prompts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { renderApplicationPrompt } from "#/prompts/registry";
+
+describe("application prompts", () => {
+  it("renders the backend-agent setup prompt with SSH, network, and first-response guidance", () => {
+    const prompt = renderApplicationPrompt("configure-remote-vm-agent");
+
+    expect(prompt).toContain("Use the currently configured LLM profile/model");
+    expect(prompt).toContain("a working SSH connection");
+    expect(prompt).toContain("same LAN/private network");
+    expect(prompt).toContain("Tailscale");
+    expect(prompt).toContain(
+      "Your first response must NOT start running setup commands",
+    );
+    expect(prompt).toContain("do I authorize you to connect via SSH");
+    expect(prompt).toContain("~/.openhands/agent-canvas");
+    expect(prompt).toContain("metadata/backend.json");
+    expect(prompt).toContain("bin/agent-canvas-stack");
+    expect(prompt).toContain("setup");
+    expect(prompt).toContain("print-connection");
+    expect(prompt).toContain("SESSION_API_KEY / OH_SESSION_API_KEYS_0");
+    expect(prompt).toContain("/api/automation/docs");
+  });
+});

--- a/src/components/features/backends/backend-selector.tsx
+++ b/src/components/features/backends/backend-selector.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import axios from "axios";
 import { useTranslation } from "react-i18next";
 import { useMatch, useNavigate } from "react-router";
-import { Plus, Settings } from "lucide-react";
+import { Plus, ServerCog, Settings } from "lucide-react";
 import { Dropdown } from "#/ui/dropdown/dropdown";
 import { DropdownOption } from "#/ui/dropdown/types";
 import { useActiveBackendContext } from "#/contexts/active-backend-context";
@@ -16,8 +16,10 @@ import {
   ENVIRONMENT_SWITCH_SETACTIVE_DELAY_MS,
   triggerEnvironmentSwitch,
 } from "#/components/features/backends/environment-switch-overlay";
+import { useBackendServerInfo } from "#/hooks/query/use-backend-server-info";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { retrieveAxiosErrorMessage } from "#/utils/retrieve-axios-error-message";
+import { useRunApplicationPrompt } from "#/prompts/hooks/use-run-application-prompt";
 import { AddBackendModal } from "./add-backend-modal";
 import { ManageBackendsModal } from "./manage-backends-modal";
 
@@ -40,24 +42,46 @@ function buildOptions(
   registered: Backend[],
   bundledLabel: string,
   personalWorkspaceLabel: string,
+  backendServerInfo: ReturnType<typeof useBackendServerInfo>,
+  formatVersionLabel: (version: string) => string,
   cloudOrgs: ReturnType<typeof useAllCloudOrganizations>,
   currentUserIds: ReturnType<typeof useCloudCurrentUserId>,
 ): DropdownOption[] {
+  const makeBackendMetadata = (backend: Backend) => {
+    const version = backendServerInfo[backend.id]?.version;
+    return {
+      description: backend.host,
+      ...(version ? { rightLabel: formatVersionLabel(version) } : {}),
+    };
+  };
+
   const options: DropdownOption[] = [
-    { value: makeOptionValue(bundled.id, null), label: bundledLabel },
+    {
+      value: makeOptionValue(bundled.id, null),
+      label: bundledLabel,
+      ...makeBackendMetadata(bundled),
+    },
   ];
 
   const locals = registered.filter((b) => b.kind === "local");
   const clouds = registered.filter((b) => b.kind === "cloud");
 
   for (const b of locals) {
-    options.push({ value: makeOptionValue(b.id, null), label: b.name });
+    options.push({
+      value: makeOptionValue(b.id, null),
+      label: b.name,
+      ...makeBackendMetadata(b),
+    });
   }
 
   for (const b of clouds) {
     const entry = cloudOrgs[b.id];
     if (!entry || entry.orgs.length === 0) {
-      options.push({ value: makeOptionValue(b.id, null), label: b.name });
+      options.push({
+        value: makeOptionValue(b.id, null),
+        label: b.name,
+        description: b.host,
+      });
     } else {
       // Personal-workspace rule (per the SaaS contract): the org whose
       // id matches the calling user's id is the user's personal
@@ -71,6 +95,7 @@ function buildOptions(
         options.push({
           value: makeOptionValue(b.id, org.id),
           label: `${b.name} – ${orgLabel}`,
+          description: b.host,
         });
       }
     }
@@ -95,6 +120,8 @@ export function BackendSelector({
   const { mutateAsync: switchOrg, isPending: isSwitching } =
     useSwitchCloudOrganization();
   const navigate = useNavigate();
+  const { runApplicationPrompt, isPending: isRunningApplicationPrompt } =
+    useRunApplicationPrompt();
   const conversationMatch = useMatch("/conversations/:conversationId");
   const automationDetailMatch = useMatch("/automations/:automationId");
   const [addBackendModalOpen, setAddBackendModalOpen] = React.useState(false);
@@ -103,6 +130,15 @@ export function BackendSelector({
 
   const bundledLabel = t(I18nKey.BACKEND$LOCAL_ROW);
   const personalWorkspaceLabel = t(I18nKey.BACKEND$PERSONAL_WORKSPACE);
+  const selectableBackends = React.useMemo(
+    () => [bundledBackend, ...backends],
+    [bundledBackend, backends],
+  );
+  const backendServerInfo = useBackendServerInfo(selectableBackends);
+  const formatVersionLabel = React.useCallback(
+    (version: string) => t(I18nKey.BACKEND$VERSION_LABEL, { version }),
+    [t],
+  );
 
   const options = React.useMemo(
     () =>
@@ -111,6 +147,8 @@ export function BackendSelector({
         backends,
         bundledLabel,
         personalWorkspaceLabel,
+        backendServerInfo,
+        formatVersionLabel,
         cloudOrgs,
         currentUserIds,
       ),
@@ -119,6 +157,8 @@ export function BackendSelector({
       backends,
       bundledLabel,
       personalWorkspaceLabel,
+      backendServerInfo,
+      formatVersionLabel,
       cloudOrgs,
       currentUserIds,
     ],
@@ -211,6 +251,24 @@ export function BackendSelector({
       >
         <Plus width={16} height={16} className="text-white shrink-0" />
         {t(I18nKey.BACKEND$ADD)}
+      </button>
+      <button
+        type="button"
+        data-testid="add-backend-with-agent-menu-item"
+        disabled={isRunningApplicationPrompt}
+        onMouseDown={preventDropdownMenuClose}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          void runApplicationPrompt({
+            promptId: "configure-remote-vm-agent",
+            mode: "new-conversation-initial-message",
+          });
+        }}
+        className="flex w-full items-center gap-2 px-2 py-2 rounded-md text-sm cursor-pointer text-white hover:bg-[#5C5D62] disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        <ServerCog width={16} height={16} className="text-white shrink-0" />
+        {t(I18nKey.BACKEND$ADD_WITH_AGENT)}
       </button>
       <button
         type="button"

--- a/src/components/features/backends/manage-backends-modal.tsx
+++ b/src/components/features/backends/manage-backends-modal.tsx
@@ -1,33 +1,24 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
 
 import { type Backend } from "#/api/backend-registry/types";
-import { createServerClient } from "#/api/typescript-client";
 import { BrandButton } from "#/components/features/settings/brand-button";
 import { ConfirmationModal } from "#/components/shared/modals/confirmation-modal";
 import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
 import { useActiveBackendContext } from "#/contexts/active-backend-context";
+import { useBackendServerInfo } from "#/hooks/query/use-backend-server-info";
 import CloseIcon from "#/icons/close.svg?react";
 import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";
 
-function BackendVersion({ backend }: { backend: Backend }) {
+function BackendVersion({
+  backend,
+  version,
+}: {
+  backend: Backend;
+  version: string | null;
+}) {
   const { t } = useTranslation("openhands");
-  const { data: version } = useQuery({
-    queryKey: ["backend-version", backend.host, backend.apiKey],
-    queryFn: async () => {
-      const info = await createServerClient({
-        host: backend.host,
-        sessionApiKey: backend.apiKey || null,
-        timeout: 5000,
-      }).getServerInfo();
-      return info.version ?? null;
-    },
-    retry: false,
-    staleTime: 60_000,
-    enabled: backend.kind === "local",
-  });
 
   if (!version) return null;
 
@@ -53,6 +44,7 @@ interface PendingRemoval {
 export function ManageBackendsModal({ onClose }: ManageBackendsModalProps) {
   const { t } = useTranslation("openhands");
   const { backends, removeBackend } = useActiveBackendContext();
+  const backendServerInfo = useBackendServerInfo(backends);
   const [pendingRemoval, setPendingRemoval] =
     React.useState<PendingRemoval | null>(null);
 
@@ -104,7 +96,10 @@ export function ManageBackendsModal({ onClose }: ManageBackendsModalProps) {
                       <span className="text-xs text-[#A3A3A3] truncate">
                         {backend.host}
                       </span>
-                      <BackendVersion backend={backend} />
+                      <BackendVersion
+                        backend={backend}
+                        version={backendServerInfo[backend.id]?.version ?? null}
+                      />
                     </div>
                     <span className="px-2 py-1 rounded-full text-[11px] uppercase tracking-wide text-[#D6D6D6] bg-[#1F1F1F] border border-[#4B4E57]">
                       {backend.kind === "cloud"

--- a/src/hooks/query/use-backend-server-info.ts
+++ b/src/hooks/query/use-backend-server-info.ts
@@ -1,0 +1,49 @@
+import React from "react";
+import { useQueries } from "@tanstack/react-query";
+
+import type { Backend } from "#/api/backend-registry/types";
+import { createServerClient } from "#/api/typescript-client";
+
+interface BackendServerInfoState {
+  version: string | null;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export type BackendServerInfoById = Record<string, BackendServerInfoState>;
+
+export function useBackendServerInfo(
+  backends: Backend[],
+): BackendServerInfoById {
+  const queries = useQueries({
+    queries: backends.map((backend) => ({
+      queryKey: ["backend-server-info", backend.host, backend.apiKey],
+      queryFn: async () => {
+        const info = await createServerClient({
+          host: backend.host,
+          sessionApiKey: backend.apiKey || null,
+          timeout: 5000,
+        }).getServerInfo();
+        return { version: info.version ?? null };
+      },
+      retry: false,
+      staleTime: 60_000,
+      enabled: backend.kind === "local",
+    })),
+  });
+
+  return React.useMemo(
+    () =>
+      Object.fromEntries(
+        backends.map((backend, index) => [
+          backend.id,
+          {
+            version: queries[index]?.data?.version ?? null,
+            isLoading: queries[index]?.isLoading ?? false,
+            isError: queries[index]?.isError ?? false,
+          },
+        ]),
+      ),
+    [backends, queries],
+  );
+}

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -22189,6 +22189,11 @@
     "uk": "Додати бекенд",
     "ca": "Afegir backend"
   },
+  "BACKEND$ADD_WITH_AGENT": {
+    "en": "Add Backend with Agent",
+    "zh-CN": "用 Agent 添加后端",
+    "zh-TW": "用 Agent 新增後端"
+  },
   "BACKEND$MANAGE": {
     "en": "Manage Backends",
     "ja": "バックエンドを管理",

--- a/src/prompts/hooks/use-run-application-prompt.ts
+++ b/src/prompts/hooks/use-run-application-prompt.ts
@@ -1,0 +1,56 @@
+import React from "react";
+
+import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
+import { useNavigation } from "#/context/navigation-context";
+import { useConversationStore } from "#/stores/conversation-store";
+import { renderApplicationPrompt } from "#/prompts/registry";
+import type { RunApplicationPromptOptions } from "#/prompts/types";
+
+export function useRunApplicationPrompt() {
+  const { navigate } = useNavigation();
+  const setMessageToSend = useConversationStore(
+    (state) => state.setMessageToSend,
+  );
+  const {
+    mutateAsync: createConversation,
+    isPending,
+    isSuccess,
+  } = useCreateConversation();
+
+  const runApplicationPrompt = React.useCallback(
+    async (options: RunApplicationPromptOptions) => {
+      const prompt = renderApplicationPrompt(options.promptId, options.context);
+
+      if (options.mode === "current-conversation-draft") {
+        setMessageToSend(prompt);
+        options.onSuccess?.();
+        return;
+      }
+
+      if (options.mode === "new-conversation-initial-message") {
+        const data = await createConversation({ query: prompt }).catch(
+          () => null,
+        );
+        if (!data) return;
+        options.onSuccess?.();
+        (options.navigate ?? navigate)(
+          `/conversations/${data.conversation_id}`,
+        );
+        return;
+      }
+
+      const data = await createConversation({}).catch(() => null);
+      if (!data) return;
+      setMessageToSend(prompt);
+      options.onSuccess?.();
+      (options.navigate ?? navigate)(`/conversations/${data.conversation_id}`);
+    },
+    [createConversation, navigate, setMessageToSend],
+  );
+
+  return {
+    runApplicationPrompt,
+    isPending,
+    isSuccess,
+  };
+}

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -1,0 +1,30 @@
+import { configureRemoteVmAgentPrompt } from "#/prompts/templates/configure-remote-vm-agent";
+import type {
+  ApplicationPrompt,
+  ApplicationPromptContextById,
+  ApplicationPromptId,
+} from "#/prompts/types";
+
+export const APPLICATION_PROMPTS = {
+  "configure-remote-vm-agent": configureRemoteVmAgentPrompt,
+} satisfies {
+  [TId in ApplicationPromptId]: ApplicationPrompt<
+    ApplicationPromptContextById[TId]
+  >;
+};
+
+export function getApplicationPrompt<TId extends ApplicationPromptId>(
+  promptId: TId,
+) {
+  return APPLICATION_PROMPTS[promptId];
+}
+
+export function renderApplicationPrompt<TId extends ApplicationPromptId>(
+  promptId: TId,
+  context?: ApplicationPromptContextById[TId],
+): string {
+  const prompt = getApplicationPrompt(promptId) as ApplicationPrompt<
+    ApplicationPromptContextById[TId]
+  >;
+  return prompt.render(context as ApplicationPromptContextById[TId]);
+}

--- a/src/prompts/templates/configure-remote-vm-agent.ts
+++ b/src/prompts/templates/configure-remote-vm-agent.ts
@@ -1,0 +1,82 @@
+import { I18nKey } from "#/i18n/declaration";
+import type {
+  ApplicationPrompt,
+  ApplicationPromptContextById,
+} from "#/prompts/types";
+
+const PROMPT = `You are helping me add a new Agent Canvas backend by configuring a target machine to run Agent Canvas, an OpenHands agent-server, and the automation backend.
+
+Use the currently configured LLM profile/model for this conversation. Do not ask me to choose a model unless the current profile fails because it is missing or invalid.
+
+Context you should know before asking me anything:
+- Goal: configure a target machine so this local Agent Canvas UI can connect to it as another backend.
+- Required access: a working SSH connection from this local machine to the target machine is mandatory. Without SSH, you cannot directly set up the target machine.
+- Preferred credential handling: use my existing local SSH config, SSH agent, keychain, or already configured host aliases. Do not ask me to paste private keys or passwords into chat.
+- Agent-server setup path: once SSH works, inspect the target OS and install or verify git, curl, Node.js >= 22.12, npm, and uv/uvx. Then clone or update https://github.com/OpenHands/agent-canvas.git on the target machine, configure stable secrets, and start the stack.
+- Local connection path: after the target stack is running, this local UI needs a reachable backend URL and its session API key. Direct LAN access, a VPN-style private IP, an SSH tunnel, or a public TLS endpoint can work.
+- Network caveat: if this local machine and the target machine are not on the same LAN or private network, direct connection may fail. In that case, recommend that I configure a Tailscale-like private IP, an SSH tunnel, or a secure public endpoint. Prefer letting me configure the SSH connection details locally instead of pasting secrets into chat.
+- Target-machine filesystem convention: unless I explicitly ask for a different location, keep all files under ~/.openhands/agent-canvas on the target machine. Do not scatter files in arbitrary directories.
+
+Use this target-machine layout:
+- ~/.openhands/agent-canvas/repo: git checkout of https://github.com/OpenHands/agent-canvas.git.
+- ~/.openhands/agent-canvas/env/.env: stable runtime environment and generated API keys. chmod 600. Do not commit this file.
+- ~/.openhands/agent-canvas/bin/agent-canvas-stack: the fixed maintenance script for this installation.
+- ~/.openhands/agent-canvas/metadata/backend.json: non-secret machine/backend metadata.
+- ~/.openhands/agent-canvas/metadata/connection.md: human-readable connection instructions for this local UI.
+- ~/.openhands/agent-canvas/metadata/setup-log.md: concise setup/update log and decisions made.
+
+The fixed maintenance script ~/.openhands/agent-canvas/bin/agent-canvas-stack should be idempotent, use set -euo pipefail, and support these commands:
+- setup: verify/install prerequisites, clone/update the repo, create missing directories, and create env/.env if absent.
+- start: start the stack from the repo using env/.env.
+- stop: stop the running stack if it is managed by the script.
+- status: show process status and probe /server_info plus /api/automation/docs.
+- logs: show or tail the relevant logs.
+- update: pull/update the repo and restart only after confirmation.
+- print-connection: print the backend URL and instructions for adding the backend to this UI, but avoid printing secrets unless I explicitly need them.
+
+Keep metadata files non-secret. backend.json should include useful maintenance data such as hostname, OS, architecture, install_dir, repo_dir, repo URL, current git ref/sha, chosen ports, LAN/private/public endpoint notes, agent-server version after verification, created_at, updated_at, and script version. Do not store private keys, raw passwords, or unnecessary API key values in metadata.
+
+Your first response must NOT start running setup commands. First ask me these questions clearly:
+1. What target machine do I want to connect to, and what connection method should be used? Ask for an SSH target such as a host alias, user@host, or an SSH config entry.
+2. Is SSH from this local machine to the target machine already configured and working?
+3. Are this local machine and the target machine on the same LAN/private network?
+4. If SSH is configured, do I authorize you to connect via SSH and perform the setup on the target machine, including generating and writing the final secret configuration files?
+5. Should the target stack be temporary for development, or should it be long-running?
+
+After I answer, follow this setup flow:
+1. If SSH is not configured, guide me to configure it locally first. Do not ask for private keys or passwords in chat.
+2. If the machines are not on the same LAN/private network, explain the connection risk and recommend Tailscale, another private network overlay, an SSH tunnel, or a secure public endpoint before proceeding.
+3. Verify SSH connectivity with the provided target.
+4. Identify the target OS, architecture, shell, package manager, and relevant ports.
+5. Check for prerequisites: git, curl, Node.js >= 22.12, npm, and uv/uvx.
+6. Ask before using sudo, changing firewall rules, changing reverse-proxy config, or installing system packages.
+7. Install missing prerequisites in the least invasive way that fits the target OS.
+8. Create or reuse the standard ~/.openhands/agent-canvas directory layout.
+9. Clone or update https://github.com/OpenHands/agent-canvas.git under ~/.openhands/agent-canvas/repo.
+10. Write or update the fixed ~/.openhands/agent-canvas/bin/agent-canvas-stack maintenance script.
+11. Configure ~/.openhands/agent-canvas/env/.env with stable, strong values for SESSION_API_KEY / OH_SESSION_API_KEYS_0, VITE_SESSION_API_KEY, and AUTOMATION_LOCAL_API_KEY. Never commit these secrets.
+12. Write or update the non-secret metadata files in ~/.openhands/agent-canvas/metadata.
+13. Start the full stack through the maintenance script unless I request a different process manager. For a long-running setup, propose tmux, systemd, or another suitable supervisor before changing anything.
+14. Verify /server_info, /api/automation/docs, and the Agent Canvas frontend URL on the target.
+15. Give me the backend URL and session API key to add through Manage Backends in this UI, or help set up an SSH tunnel if direct exposure is inappropriate.
+16. After I confirm the connection details, start a test conversation against the new backend.
+
+Security constraints:
+- Do not expose an unauthenticated agent-server to the public internet.
+- Prefer SSH tunnels, Tailscale-style private networking, or TLS behind a reverse proxy when the target machine is not on a trusted network.
+- Summarize commands before running risky changes.
+- Do not print generated secrets unless I need them for a specific local configuration step.
+
+Expected output:
+- A concise status table for the remote VM setup.
+- The final connection details I need for Agent Canvas.
+- Any remaining manual steps or risks.`;
+
+export const configureRemoteVmAgentPrompt = {
+  id: "configure-remote-vm-agent",
+  labelKey: I18nKey.BACKEND$ADD_WITH_AGENT,
+  category: "backend",
+  render: () => PROMPT,
+} satisfies ApplicationPrompt<
+  ApplicationPromptContextById["configure-remote-vm-agent"]
+>;

--- a/src/prompts/types.ts
+++ b/src/prompts/types.ts
@@ -1,0 +1,32 @@
+import type { I18nKey } from "#/i18n/declaration";
+
+export type ApplicationPromptId = "configure-remote-vm-agent";
+
+export type ApplicationPromptCategory = "backend" | "git" | "repo" | "planning";
+
+export interface ApplicationPromptContextById {
+  "configure-remote-vm-agent": undefined;
+}
+
+export interface ApplicationPrompt<TContext = undefined> {
+  id: ApplicationPromptId;
+  labelKey: I18nKey;
+  descriptionKey?: I18nKey;
+  category: ApplicationPromptCategory;
+  render: (context: TContext) => string;
+}
+
+export type ApplicationPromptRunMode =
+  | "current-conversation-draft"
+  | "new-conversation-draft"
+  | "new-conversation-initial-message";
+
+export interface RunApplicationPromptOptions<
+  TId extends ApplicationPromptId = ApplicationPromptId,
+> {
+  promptId: TId;
+  mode: ApplicationPromptRunMode;
+  context?: ApplicationPromptContextById[TId];
+  onSuccess?: () => void;
+  navigate?: (to: string) => void;
+}

--- a/src/stores/conversation-store.ts
+++ b/src/stores/conversation-store.ts
@@ -87,8 +87,22 @@ const parseStoredBoolean = (value: string | null): boolean | null => {
   }
 };
 
-const getInitialRightPanelState = (): boolean => {
+const getBrowserLocalStorage = (): Storage | null => {
   if (typeof window === "undefined") {
+    return null;
+  }
+
+  const storage = window.localStorage;
+  if (!storage || typeof storage.getItem !== "function") {
+    return null;
+  }
+
+  return storage;
+};
+
+const getInitialRightPanelState = (): boolean => {
+  const storage = getBrowserLocalStorage();
+  if (!storage) {
     return true;
   }
 
@@ -101,7 +115,7 @@ const getInitialRightPanelState = (): boolean => {
   keysToCheck.push("conversation-right-panel-shown");
 
   for (const key of keysToCheck) {
-    const parsed = parseStoredBoolean(localStorage.getItem(key));
+    const parsed = parseStoredBoolean(storage.getItem(key));
     if (parsed !== null) {
       return parsed;
     }

--- a/src/ui/dropdown/dropdown-menu.tsx
+++ b/src/ui/dropdown/dropdown-menu.tsx
@@ -45,24 +45,49 @@ export function DropdownMenu({
           </li>
         )}
         {isOpen &&
-          filteredOptions.map((option, index) => (
-            <li
-              key={option.value}
-              {...getItemProps({
-                item: option,
-                index,
-                className: cn(
-                  "px-2 py-2 cursor-pointer text-sm rounded-md",
-                  "text-white focus:outline-none font-normal",
-                  selectedItem?.value === option.value
-                    ? "bg-[#C9B974] text-black"
-                    : "hover:bg-[#5C5D62]",
-                ),
-              })}
-            >
-              {option.label}
-            </li>
-          ))}
+          filteredOptions.map((option, index) => {
+            const isSelected = selectedItem?.value === option.value;
+            return (
+              <li
+                key={option.value}
+                {...getItemProps({
+                  item: option,
+                  index,
+                  className: cn(
+                    "px-2 py-2 cursor-pointer text-sm rounded-md",
+                    "flex items-center gap-3 focus:outline-none font-normal",
+                    isSelected
+                      ? "bg-[#C9B974] text-black"
+                      : "text-white hover:bg-[#5C5D62]",
+                  ),
+                })}
+              >
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="truncate">{option.label}</span>
+                  {option.description ? (
+                    <span
+                      className={cn(
+                        "truncate text-xs",
+                        isSelected ? "text-black/70" : "text-[#A3A3A3]",
+                      )}
+                    >
+                      {option.description}
+                    </span>
+                  ) : null}
+                </div>
+                {option.rightLabel ? (
+                  <span
+                    className={cn(
+                      "shrink-0 text-xs",
+                      isSelected ? "text-black/70" : "text-[#A3A3A3]",
+                    )}
+                  >
+                    {option.rightLabel}
+                  </span>
+                ) : null}
+              </li>
+            );
+          })}
       </ul>
       {isOpen && footer ? (
         <div className="border-t border-[#242424] p-1">{footer}</div>

--- a/src/ui/dropdown/dropdown.tsx
+++ b/src/ui/dropdown/dropdown.tsx
@@ -41,7 +41,9 @@ export function Dropdown({
   const [searchTerm, setSearchTerm] = useState("");
 
   const filteredOptions = options.filter((option) =>
-    option.label.toLowerCase().includes(searchTerm.toLowerCase()),
+    [option.label, option.description, option.rightLabel]
+      .filter((value): value is string => Boolean(value))
+      .some((value) => value.toLowerCase().includes(searchTerm.toLowerCase())),
   );
 
   const {

--- a/src/ui/dropdown/types.ts
+++ b/src/ui/dropdown/types.ts
@@ -1,4 +1,6 @@
 export interface DropdownOption {
   value: string;
   label: string;
+  description?: string;
+  rightLabel?: string;
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -19,6 +19,41 @@ const windowStub =
 vi.stubGlobal("window", windowStub);
 windowStub.scrollTo = vi.fn();
 
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => store.delete(key),
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+};
+
+const hasUsableStorage = (storage: Storage | undefined): storage is Storage =>
+  !!storage &&
+  typeof storage.getItem === "function" &&
+  typeof storage.setItem === "function" &&
+  typeof storage.removeItem === "function" &&
+  typeof storage.clear === "function";
+
+if (!hasUsableStorage(windowStub.localStorage)) {
+  Object.defineProperty(windowStub, "localStorage", {
+    value: createMemoryStorage(),
+    configurable: true,
+  });
+}
+
+if (!hasUsableStorage(globalThis.localStorage)) {
+  vi.stubGlobal("localStorage", windowStub.localStorage);
+}
+
 if (typeof requestAnimationFrame === "undefined") {
   vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
     setTimeout(() => callback(0), 0),


### PR DESCRIPTION
## Summary

This is a draft prototype for the `Add Backend with Agent` flow. It is intentionally marked as draft because the remote bootstrap design is still open and tracked in #233.

What this prototype includes:

- Adds an `Add Backend with Agent` action to the backend selector footer.
- Starts a new conversation with a backend setup prompt as the initial message, then navigates to the new conversation.
- Introduces a small application prompt registry so future app-owned prompts are not scattered across UI components.
- Shows backend host and local agent-server version in backend dropdown rows.
- Shares backend server-info probing between the selector and Manage Backends modal.
- Adds focused tests for the prompt registry, backend selector action, navigation, current LLM profile usage, and backend version display.

## Design Status

This is not the final implementation direction yet. The current prompt is useful for prototyping, but #233 proposes moving the detailed remote-machine contract into a repo-owned bootstrap script and keeping the prompt much shorter.

Open design questions include:

- Whether to add a `scripts/remote-bootstrap.sh` first or eventually publish a CLI/package.
- Whether the UI should offer an explicit `Agent can SSH` vs `I will run a command manually` choice.
- How much of the remote setup should be auto-added to Manage Backends vs user-confirmed.
- What process manager story should be used for long-running remote installs.

## Validation

- `npm test -- __tests__/components/backends/backend-selector.test.tsx __tests__/prompts/application-prompts.test.ts __tests__/api/agent-server-adapter.test.ts`
- `npm run typecheck`
- `npm run build`
- Browser smoke check: clicking `Add Backend with Agent` creates a conversation, sends the setup prompt as `initial_message`, and navigates to the created conversation.

Related to #233.
