### PR TITLE
Mount dev:docker project path at /projects and auto-list it as a work…

### DIFF
--- a/__tests__/components/features/home/workspace-selection-form.test.tsx
+++ b/__tests__/components/features/home/workspace-selection-form.test.tsx
@@ -85,6 +85,14 @@ describe("WorkspaceSelectionForm", () => {
     vi.restoreAllMocks();
     mockUseIsCreatingConversation.mockReturnValue(false);
     useWorkspacesStore.setState({ workspaces: [], workspaceParents: [] });
+    // `useResolvedWorkspaces` always queries an implicit `/projects` parent
+    // (the dev:docker mount point). Default it to empty so tests that don't
+    // care about it don't hit a real network call. Tests that need specific
+    // behavior can replace this with their own spy.
+    vi.spyOn(FilesService, "searchSubdirs").mockResolvedValue({
+      items: [],
+      next_page_id: null,
+    });
   });
 
   it("Add Workspace adds only the chosen folder (not its subfolders) and dedupes on repeat", async () => {
@@ -341,14 +349,22 @@ describe("WorkspaceSelectionForm", () => {
   });
 
   it("Removing a workspace parent stops listing its children", async () => {
+    // Scope the mock to the user-added parent so the implicit `/projects`
+    // parent (always queried by `useResolvedWorkspaces`) doesn't also get
+    // these entries.
     const searchSpy = vi
       .spyOn(FilesService, "searchSubdirs")
-      .mockResolvedValue({
-        items: [
-          { name: "repoA", path: "/Users/me/dev/repoA" },
-          { name: "repoB", path: "/Users/me/dev/repoB" },
-        ],
-        next_page_id: null,
+      .mockImplementation(async (path: string) => {
+        if (path === "/Users/me/dev") {
+          return {
+            items: [
+              { name: "repoA", path: "/Users/me/dev/repoA" },
+              { name: "repoB", path: "/Users/me/dev/repoB" },
+            ],
+            next_page_id: null,
+          };
+        }
+        return { items: [], next_page_id: null };
       });
 
     renderForm(

--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -10,7 +10,9 @@
  *
  * Required environment variables:
  *   - PROJECT_PATH: Absolute host path to your projects. Mounted into the
- *     container at /workspace/projects so the agent can read/edit your code.
+ *     container at /projects so the agent can read/edit your code. The
+ *     frontend always treats /projects as a "workspace parent", so the
+ *     dropdown lists its immediate subdirectories as workspaces.
  *
  * Optional environment variables:
  *   - OH_AGENT_SERVER_GIT_REF: Git ref (branch/tag/SHA) of the agent-server
@@ -140,7 +142,7 @@ function startAgentServerDocker(config) {
     CONTAINER_NAME,
     "--init",
     "-v",
-    `${process.env.PROJECT_PATH}:/workspace/projects`,
+    `${process.env.PROJECT_PATH}:/projects`,
   ];
 
   // Optional credential / state mounts. Only mount when the host path

--- a/src/hooks/query/use-resolved-workspaces.ts
+++ b/src/hooks/query/use-resolved-workspaces.ts
@@ -3,7 +3,7 @@ import { useQueries } from "@tanstack/react-query";
 
 import FilesService from "#/api/files-service/files-service.api";
 import { useWorkspacesStore } from "#/stores/workspaces-store";
-import { LocalWorkspace } from "#/types/workspace";
+import { LocalWorkspace, LocalWorkspaceParent } from "#/types/workspace";
 
 interface UseResolvedWorkspacesResult {
   workspaces: LocalWorkspace[];
@@ -12,17 +12,42 @@ interface UseResolvedWorkspacesResult {
 }
 
 /**
+ * Implicit workspace parents that are always considered when resolving
+ * workspaces. The `dev:docker` script mounts the host's PROJECT_PATH at
+ * `/projects` inside the agent-server container, so this directory is
+ * effectively the user's projects root in the dockerized dev stack. We
+ * surface its immediate subdirectories as workspaces automatically.
+ *
+ * In environments where `/projects` doesn't exist (e.g. dockerless dev),
+ * `searchSubdirs` simply errors and contributes no entries -- the implicit
+ * parent stays silent rather than user-visible, which is safe.
+ */
+const IMPLICIT_WORKSPACE_PARENTS: LocalWorkspaceParent[] = [
+  { id: "implicit:/projects", name: "/projects", path: "/projects" },
+];
+
+/**
  * Returns the merged list of workspaces to display:
- *   - workspaces explicitly added by the user (from the persisted store), and
+ *   - workspaces explicitly added by the user (from the persisted store),
  *   - the immediate subdirectories of every saved "workspace parent",
- *     fetched dynamically.
+ *     fetched dynamically, and
+ *   - the immediate subdirectories of any implicit, built-in parents
+ *     (currently just `/projects`, the dockerized dev mount point).
  *
  * Static workspaces always take precedence over a dynamic child with the
  * same path so that user-selected names/ids are preserved.
  */
 export function useResolvedWorkspaces(): UseResolvedWorkspacesResult {
   const workspaces = useWorkspacesStore((s) => s.workspaces);
-  const workspaceParents = useWorkspacesStore((s) => s.workspaceParents);
+  const storedParents = useWorkspacesStore((s) => s.workspaceParents);
+
+  // Merge stored parents with the implicit ones, deduping on path so a
+  // user-added `/projects` doesn't trigger a second query.
+  const workspaceParents = useMemo(() => {
+    const seen = new Set(storedParents.map((p) => p.path));
+    const extras = IMPLICIT_WORKSPACE_PARENTS.filter((p) => !seen.has(p.path));
+    return extras.length === 0 ? storedParents : [...storedParents, ...extras];
+  }, [storedParents]);
 
   const parentQueries = useQueries({
     queries: workspaceParents.map((parent) => ({

--- a/src/hooks/query/use-resolved-workspaces.ts
+++ b/src/hooks/query/use-resolved-workspaces.ts
@@ -48,7 +48,13 @@ export function useResolvedWorkspaces(): UseResolvedWorkspacesResult {
   // user-added `/projects` doesn't trigger a second query.
   const workspaceParents = useMemo(() => {
     const seen = new Set(storedParents.map((p) => p.path));
+  const workspaceParents = useMemo(() => {
+    const seen = new Set(storedParents.map((p) => p.path));
+    // Filter out implicit parents that conflict with user-added ones (by path)
+    // so custom names/ids are preserved
     const extras = IMPLICIT_WORKSPACE_PARENTS.filter((p) => !seen.has(p.path));
+    return extras.length === 0 ? storedParents : [...storedParents, ...extras];
+  }, [storedParents]);
     return extras.length === 0 ? storedParents : [...storedParents, ...extras];
   }, [storedParents]);
 

--- a/src/hooks/query/use-resolved-workspaces.ts
+++ b/src/hooks/query/use-resolved-workspaces.ts
@@ -21,7 +21,10 @@ interface UseResolvedWorkspacesResult {
  * In environments where `/projects` doesn't exist (e.g. dockerless dev),
  * `searchSubdirs` simply errors and contributes no entries -- the implicit
  * parent stays silent rather than user-visible, which is safe.
- */
+ * In environments where `/projects` doesn't exist (e.g. dockerless dev),
+ * the `searchSubdirs` call will fail and the implicit parent contributes
+ * no entries. This is safe and intentional — the implicit parent stays
+ * silent rather than user-visible.
 const IMPLICIT_WORKSPACE_PARENTS: LocalWorkspaceParent[] = [
   { id: "implicit:/projects", name: "/projects", path: "/projects" },
 ];


### PR DESCRIPTION
…space parent

The dev:docker script previously mounted PROJECT_PATH at /workspace/projects inside the agent-server container. Move the mount to /projects to match the shorter, more conventional path used elsewhere in our dockerized setup.

To keep that change useful out of the box, useResolvedWorkspaces now always treats /projects as an implicit workspace parent in addition to any parents saved in the workspaces store. Its immediate subdirectories show up in the workspace dropdown automatically. In dockerless dev the search request simply errors and contributes nothing, so the implicit parent stays silent.

Tests:
- workspace-selection-form.test.tsx now installs an empty default searchSubdirs spy in beforeEach so the implicit /projects query doesn't hit the network in tests that don't care about it.
- The 'remove parent' test scopes its mock to the user-added parent so the implicit /projects query doesn't echo the same children back.

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
