### PR TITLE
fix how lookupsecrets are sent

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -8,13 +8,23 @@ import {
 } from "#/api/agent-server-adapter";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 
-const { mockGetAgentServerWorkingDir, mockIsAgentServerToolAvailable } =
-  vi.hoisted(() => ({
-    mockGetAgentServerWorkingDir: vi.fn(
-      () => "/workspace/project/agent-canvas",
-    ),
-    mockIsAgentServerToolAvailable: vi.fn(() => true),
-  }));
+const {
+  mockGetAgentServerWorkingDir,
+  mockIsAgentServerToolAvailable,
+  mockGetEffectiveLocalBackend,
+} = vi.hoisted(() => ({
+  mockGetAgentServerWorkingDir: vi.fn(
+    () => "/workspace/project/agent-canvas",
+  ),
+  mockIsAgentServerToolAvailable: vi.fn(() => true),
+  mockGetEffectiveLocalBackend: vi.fn(() => ({
+    id: "default-local",
+    name: "Local backend",
+    host: "http://127.0.0.1:8000",
+    apiKey: "session-key",
+    kind: "local" as const,
+  })),
+}));
 
 vi.mock("#/api/agent-server-config", () => ({
   getAgentServerBaseUrl: vi.fn(() => "http://127.0.0.1:8000"),
@@ -28,10 +38,20 @@ vi.mock("#/api/agent-server-compatibility", () => ({
   isAgentServerToolAvailable: mockIsAgentServerToolAvailable,
 }));
 
+vi.mock("#/api/backend-registry/active-store", () => ({
+  getEffectiveLocalBackend: mockGetEffectiveLocalBackend,
+}));
+
 beforeEach(() => {
   mockIsAgentServerToolAvailable.mockReturnValue(true);
+  mockGetEffectiveLocalBackend.mockReturnValue({
+    id: "default-local",
+    name: "Local backend",
+    host: "http://127.0.0.1:8000",
+    apiKey: "session-key",
+    kind: "local",
+  });
 });
-
 
 describe("buildStartConversationRequest", () => {
   it("uses nested settings as the source of truth and keeps SDK tool names", () => {
@@ -215,6 +235,48 @@ describe("buildStartConversationRequest", () => {
       content: [{ type: "text", text: "Follow the repo conventions." }],
     });
   });
+
+  it("serializes custom secrets as host-relative LookupSecret entries", () => {
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          ...DEFAULT_SETTINGS.agent_settings,
+          llm: { model: "nested-model" },
+        },
+      },
+      customSecrets: [
+        { name: "API_KEY", description: "Primary API key" },
+        { name: "folder/name", description: "Nested secret" },
+      ],
+    }) as {
+      secrets: Record<
+        string,
+        {
+          kind: string;
+          url: string;
+          description?: string;
+          headers?: Record<string, string>;
+        }
+      >;
+    };
+
+    expect(payload.secrets).toEqual({
+      API_KEY: {
+        kind: "LookupSecret",
+        url: "/api/settings/secrets/API_KEY",
+        description: "Primary API key",
+        headers: { "X-Session-API-Key": "session-key" },
+      },
+      "folder/name": {
+        kind: "LookupSecret",
+        url: "/api/settings/secrets/folder%2Fname",
+        description: "Nested secret",
+        headers: { "X-Session-API-Key": "session-key" },
+      },
+    });
+  });
+
 });
 
 describe("getDefaultConversationTitle", () => {

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -461,24 +461,6 @@ export function buildStartConversationRequest(
     const backend = getEffectiveLocalBackend();
     const headers = buildAuthHeaders(backend);
 
-    /* eslint-disable no-console */
-    console.log("[LookupSecret debug] customSecrets =", options.customSecrets);
-    console.log("[LookupSecret debug] backend =", backend);
-    console.log(
-      "[LookupSecret debug] backend.apiKey length =",
-      backend.apiKey?.length ?? 0,
-    );
-    console.log("[LookupSecret debug] buildAuthHeaders(backend) =", headers);
-    try {
-      const rawBackends = window.localStorage.getItem("openhands-backends");
-      const rawActive = window.localStorage.getItem("openhands-active-backend");
-      console.log("[LookupSecret debug] localStorage openhands-backends =", rawBackends);
-      console.log("[LookupSecret debug] localStorage openhands-active-backend =", rawActive);
-    } catch (e) {
-      console.log("[LookupSecret debug] localStorage read failed:", e);
-    }
-    /* eslint-enable no-console */
-
     const secrets: Record<string, LookupSecret> = {};
     for (const secret of options.customSecrets) {
       const lookupSecret: LookupSecret = {
@@ -491,21 +473,10 @@ export function buildStartConversationRequest(
         lookupSecret.headers = headers;
       }
 
-      // eslint-disable-next-line no-console
-      console.log(
-        `[LookupSecret debug] built ${secret.name} =`,
-        JSON.parse(JSON.stringify(lookupSecret)),
-      );
-
       secrets[secret.name] = lookupSecret;
     }
 
     payload.secrets = secrets;
-    // eslint-disable-next-line no-console
-    console.log(
-      "[LookupSecret debug] final payload.secrets =",
-      JSON.parse(JSON.stringify(secrets)),
-    );
   }
 
   return payload;

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -7,6 +7,7 @@ import {
   shouldLoadPublicSkills,
 } from "./agent-server-config";
 import { getEffectiveLocalBackend } from "./backend-registry/active-store";
+import { buildAuthHeaders } from "./backend-registry/auth";
 import {
   GetHooksResponse,
   GetSkillsResponse,
@@ -452,33 +453,59 @@ export function buildStartConversationRequest(
     payload.agent_definitions = conversationSettings.agent_definitions;
   }
 
-  // Add custom secrets as LookupSecret entries
-  // The agent-server will fetch values at runtime from /api/settings/secrets/{name}
+  // Add custom secrets as LookupSecret entries.
+  // The agent-server fetches the value at runtime from
+  // `/api/settings/secrets/{name}` on its own host, so the URL stays
+  // host-relative; auth headers come from the active local backend.
   if (options.customSecrets && options.customSecrets.length > 0) {
     const backend = getEffectiveLocalBackend();
-    const baseUrl = backend.host;
-    const sessionApiKey = backend.apiKey || null;
+    const headers = buildAuthHeaders(backend);
+
+    /* eslint-disable no-console */
+    console.log("[LookupSecret debug] customSecrets =", options.customSecrets);
+    console.log("[LookupSecret debug] backend =", backend);
+    console.log(
+      "[LookupSecret debug] backend.apiKey length =",
+      backend.apiKey?.length ?? 0,
+    );
+    console.log("[LookupSecret debug] buildAuthHeaders(backend) =", headers);
+    try {
+      const rawBackends = window.localStorage.getItem("openhands-backends");
+      const rawActive = window.localStorage.getItem("openhands-active-backend");
+      console.log("[LookupSecret debug] localStorage openhands-backends =", rawBackends);
+      console.log("[LookupSecret debug] localStorage openhands-active-backend =", rawActive);
+    } catch (e) {
+      console.log("[LookupSecret debug] localStorage read failed:", e);
+    }
+    /* eslint-enable no-console */
 
     const secrets: Record<string, LookupSecret> = {};
     for (const secret of options.customSecrets) {
       const lookupSecret: LookupSecret = {
         kind: "LookupSecret",
-        url: `${baseUrl}/api/settings/secrets/${encodeURIComponent(secret.name)}`,
+        url: `/api/settings/secrets/${encodeURIComponent(secret.name)}`,
         description: secret.description,
       };
 
-      // Include session API key header if configured (local agent-server only —
-      // cloud LookupSecrets aren't fetched by the local runtime).
-      if (sessionApiKey) {
-        lookupSecret.headers = {
-          "X-Session-API-Key": sessionApiKey,
-        };
+      if (Object.keys(headers).length > 0) {
+        lookupSecret.headers = headers;
       }
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[LookupSecret debug] built ${secret.name} =`,
+        JSON.parse(JSON.stringify(lookupSecret)),
+      );
 
       secrets[secret.name] = lookupSecret;
     }
 
     payload.secrets = secrets;
+    // eslint-disable-next-line no-console
+    console.log(
+      "[LookupSecret debug] final payload.secrets =",
+      JSON.parse(JSON.stringify(secrets)),
+    );
   }
 
   return payload;


### PR DESCRIPTION
Depends on https://github.com/OpenHands/software-agent-sdk/pull/3181

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

Saved custom secrets are serialized as `LookupSecret` entries in the conversation start payload. This PR keeps those lookups pointed at the local agent-server secrets endpoint and ensures the active local backend auth headers are forwarded correctly.

## Summary

- send custom secrets as host-relative `LookupSecret` URLs with auth headers derived from the effective local backend
- remove temporary `LookupSecret` debug logging from `agent-server-adapter`
- add a regression test covering custom secret serialization and header forwarding

## Issue Number

N/A

## How to Test

- `npm run lint`
- `npx vitest run __tests__/api/agent-server-adapter.test.ts`
- `npm run build`

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Depends on the SDK-side LookupSecret handling fix in `software-agent-sdk` PR 3181.
- _This PR description was updated by an AI agent (OpenHands) on behalf of @rbren._
