### PR TITLE
Refresh local-workspace git info every 10s

### DIFF
--- a/src/hooks/query/use-local-git-info.ts
+++ b/src/hooks/query/use-local-git-info.ts
@@ -84,7 +84,12 @@ export const useLocalGitInfo = () => {
       !!workingDir &&
       !hasConversationRepo,
     retry: false,
-    staleTime: 1000 * 60,
+    // Re-probe the workspace every 10s so the UI reflects branch/repo
+    // changes (e.g. `git checkout`, adding a remote) without requiring a
+    // manual refresh when there is no `selected_repository` recorded on
+    // the conversation.
+    staleTime: 10_000,
+    refetchInterval: 10_000,
     gcTime: 1000 * 60 * 5,
     meta: { disableToast: true },
   });


### PR DESCRIPTION
For conversations that don't have a `selected_repository` recorded, the conversations UI infers the repo and branch by shelling out to `git remote get-url origin` / `git rev-parse --abbrev-ref HEAD` in the workspace. Poll that probe every 10 seconds so the UI keeps up with branch/remote changes (e.g. `git checkout`, `git remote add`) without requiring a manual refresh.

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
