### PR TITLE
Fix conversation right pane clipping when divider dragged far right

### DIFF
--- a/__tests__/components/features/conversation/conversation-main.test.tsx
+++ b/__tests__/components/features/conversation/conversation-main.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mutable mock state for controlling breakpoint
 let mockIsMobile = false;
+let mockIsRightPanelShown = false;
+let mockLeftWidth = 50;
 
 // Track ChatInterface unmount via vi.fn()
 const chatInterfaceUnmount = vi.fn();
@@ -13,8 +15,8 @@ vi.mock("#/hooks/use-breakpoint", () => ({
 
 vi.mock("#/hooks/use-resizable-panels", () => ({
   useResizablePanels: () => ({
-    leftWidth: 50,
-    rightWidth: 50,
+    leftWidth: mockLeftWidth,
+    rightWidth: 100 - mockLeftWidth,
     isDragging: false,
     containerRef: { current: null },
     handleMouseDown: vi.fn(),
@@ -23,7 +25,7 @@ vi.mock("#/hooks/use-resizable-panels", () => ({
 
 vi.mock("#/stores/conversation-store", () => ({
   useConversationStore: () => ({
-    isRightPanelShown: false,
+    isRightPanelShown: mockIsRightPanelShown,
   }),
 }));
 
@@ -72,6 +74,8 @@ import { ConversationMain } from "#/components/features/conversation/conversatio
 describe("ConversationMain - Layout Transition Stability", () => {
   beforeEach(() => {
     mockIsMobile = false;
+    mockIsRightPanelShown = false;
+    mockLeftWidth = 50;
     chatInterfaceUnmount.mockClear();
   });
 
@@ -113,6 +117,23 @@ describe("ConversationMain - Layout Transition Stability", () => {
     // ChatInterface must NOT have been unmounted and remounted
     expect(chatInterfaceUnmount).not.toHaveBeenCalled();
     expect(screen.getByTestId("chat-interface")).toBeInTheDocument();
+  });
+
+  it("does not give the right pane inner content min-w-max so its content stays visible at narrow widths", () => {
+    // Repro for the bug where dragging the divider very far to the right made
+    // the right pane appear blank: `min-w-max` made the inner div wider than
+    // its `overflow-hidden` wrapper, pushing right-aligned tab content out of
+    // view.
+    mockIsMobile = false;
+    mockIsRightPanelShown = true;
+    mockLeftWidth = 80;
+
+    render(<ConversationMain />);
+
+    const tabsHeader = screen.getByTestId("tabs-pane-header");
+    const tabsInnerWrapper = tabsHeader.parentElement!;
+
+    expect(tabsInnerWrapper.className).not.toMatch(/(^|\s)min-w-max(\s|$)/);
   });
 
   it("survives rapid back-and-forth resize without unmounting ChatInterface", () => {

--- a/__tests__/hooks/use-resizable-panels.test.ts
+++ b/__tests__/hooks/use-resizable-panels.test.ts
@@ -1,0 +1,58 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { useResizablePanels } from "#/hooks/use-resizable-panels";
+
+describe("useResizablePanels", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("clamps a stale persisted width that is below minLeftWidth on read", () => {
+    window.localStorage.setItem("test-panel-width", JSON.stringify(10));
+
+    const { result } = renderHook(() =>
+      useResizablePanels({
+        defaultLeftWidth: 50,
+        minLeftWidth: 30,
+        maxLeftWidth: 80,
+        storageKey: "test-panel-width",
+      }),
+    );
+
+    expect(result.current.leftWidth).toBe(30);
+    expect(result.current.rightWidth).toBe(70);
+  });
+
+  it("clamps a stale persisted width that is above maxLeftWidth on read", () => {
+    window.localStorage.setItem("test-panel-width", JSON.stringify(95));
+
+    const { result } = renderHook(() =>
+      useResizablePanels({
+        defaultLeftWidth: 50,
+        minLeftWidth: 30,
+        maxLeftWidth: 80,
+        storageKey: "test-panel-width",
+      }),
+    );
+
+    expect(result.current.leftWidth).toBe(80);
+    expect(result.current.rightWidth).toBe(20);
+  });
+
+  it("uses the persisted value as-is when within range", () => {
+    window.localStorage.setItem("test-panel-width", JSON.stringify(60));
+
+    const { result } = renderHook(() =>
+      useResizablePanels({
+        defaultLeftWidth: 50,
+        minLeftWidth: 30,
+        maxLeftWidth: 80,
+        storageKey: "test-panel-width",
+      }),
+    );
+
+    expect(result.current.leftWidth).toBe(60);
+    expect(result.current.rightWidth).toBe(40);
+  });
+});

--- a/__tests__/routes/root-layout.test.tsx
+++ b/__tests__/routes/root-layout.test.tsx
@@ -72,6 +72,14 @@ const RouterStub = createRoutesStub([
         Component: () => <div data-testid="outlet-content" />,
       },
       {
+        path: "/conversations",
+        Component: () => <div data-testid="outlet-content" />,
+      },
+      {
+        path: "/conversations/:id",
+        Component: () => <div data-testid="outlet-content" />,
+      },
+      {
         path: "/settings",
         Component: () => <div data-testid="outlet-content" />,
       },
@@ -131,7 +139,12 @@ describe("root layout", () => {
     expect(migrateUserConsentMock).toHaveBeenCalled();
   });
 
-  it.each([["/automations"], ["/automations/abc-123"]])(
+  it.each([
+    ["/automations"],
+    ["/automations/abc-123"],
+    ["/conversations"],
+    ["/conversations/abc-123"],
+  ])(
     "drops the outer layout padding on %s so the page can render flush to the viewport edges",
     (path) => {
       render(
@@ -143,6 +156,7 @@ describe("root layout", () => {
       const layout = screen.getByTestId("root-layout");
       expect(layout.className).not.toMatch(/(^|\s)md:p-3(\s|$)/);
       expect(layout.className).not.toMatch(/(^|\s)md:pl-0(\s|$)/);
+      expect(layout.className).not.toMatch(/(^|\s)md:pr-3(\s|$)/);
     },
   );
 

--- a/src/components/features/conversation/conversation-main/conversation-main.tsx
+++ b/src/components/features/conversation/conversation-main/conversation-main.tsx
@@ -115,7 +115,7 @@ export function ConversationMain() {
             className={cn(
               isMobile
                 ? "h-full flex flex-col gap-3 pb-2 md:pb-0 pt-2"
-                : "flex flex-col flex-1 gap-3 min-w-max h-full",
+                : "flex flex-col gap-3 h-full w-full",
             )}
           >
             <div

--- a/src/hooks/use-resizable-panels.ts
+++ b/src/hooks/use-resizable-panels.ts
@@ -19,14 +19,16 @@ export function useResizablePanels({
     defaultLeftWidth,
   );
 
-  const [leftWidth, setLeftWidth] = useState(persistedWidth);
-  const [isDragging, setIsDragging] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
   const clampWidth = useCallback(
     (width: number) => Math.max(minLeftWidth, Math.min(maxLeftWidth, width)),
     [minLeftWidth, maxLeftWidth],
   );
+
+  // Clamp the persisted value on read so stale localStorage values from older
+  // min/max bounds (or other tabs) can't push the divider out of range.
+  const [leftWidth, setLeftWidth] = useState(() => clampWidth(persistedWidth));
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/routes/root-layout.tsx
+++ b/src/routes/root-layout.tsx
@@ -92,10 +92,12 @@ export default function MainApp() {
   }
 
   let rootLayoutPaddingClass = "p-0 md:p-3 md:pl-0";
-  if (pathname === "/" || pathname.startsWith("/automations")) {
+  if (
+    pathname === "/" ||
+    pathname.startsWith("/automations") ||
+    pathname.startsWith("/conversations")
+  ) {
     rootLayoutPaddingClass = "p-0";
-  } else if (pathname.startsWith("/conversations")) {
-    rootLayoutPaddingClass = "p-0 md:pr-3";
   }
 
   return (


### PR DESCRIPTION
- Remove min-w-max from the right-pane inner wrapper in conversation-main so it can shrink with its container instead of forcing intrinsic width past the visible area.
- Clamp the persisted left-pane width in useResizablePanels against the current min/max so a stale localStorage value can't push the divider out of bounds on load.
- Drop the md:p-3 padding on /conversations* in root-layout, matching the existing /automations* behavior, so the conversation page renders edge-to-edge.

Includes regression tests for all three changes.

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
