### PR TITLE
fix: pass container workspaces path as VITE_WORKING_DIR

### DIFF
--- a/__tests__/scripts/dev-docker.test.ts
+++ b/__tests__/scripts/dev-docker.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { CONTAINER_WORKSPACES_DIR } from "../../scripts/dev-docker.mjs";
+
+describe("CONTAINER_WORKSPACES_DIR", () => {
+  it("points at the dockerized agent-server's in-container persistence dir so the working_dir the GUI sends is one the container can mkdir (regression guard for the host-path leak that caused 500 on POST /api/conversations)", () => {
+    expect(CONTAINER_WORKSPACES_DIR).toBe(
+      "/home/openhands/.openhands/agent-canvas/workspaces",
+    );
+  });
+});

--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -57,6 +57,15 @@ const CONTAINER_NAME = "agent-canvas-dev-agent-server";
 // decryptable across docker / non-docker runs.
 const DEFAULT_SECRET_KEY = "openhands-dev-secret-key-change-in-prod";
 
+// Path inside the container where the agent-server stores per-conversation
+// workspace directories. Mirrors dev-with-automation.mjs's host-side
+// `${stateDir}/workspaces`, but rooted under the container's persistence
+// dir (which is `~/.openhands` on the host, mounted in below). The frontend
+// receives this via VITE_WORKING_DIR so the working_dir it sends to the
+// agent-server is one the container can actually mkdir.
+const CONTAINER_WORKSPACES_DIR =
+  "/home/openhands/.openhands/agent-canvas/workspaces";
+
 /**
  * Resolve the docker image to use based on environment.
  *
@@ -197,6 +206,7 @@ if (isMainModule) {
     bannerTitle: "Agent Canvas + Automation Development Stack (Docker)",
     extraPrereqs: checkDockerPrereqs,
     startAgentServer: startAgentServerDocker,
+    viteWorkingDir: CONTAINER_WORKSPACES_DIR,
   }).catch((err) => {
     logError(`Fatal error: ${err.message}`);
     if (err.stack) {
@@ -209,6 +219,7 @@ if (isMainModule) {
 export {
   AGENT_SERVER_REPO,
   CONTAINER_NAME,
+  CONTAINER_WORKSPACES_DIR,
   DEFAULT_AGENT_SERVER_TAG,
   checkDockerPrereqs,
   resolveAgentServerImage,

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -556,7 +556,7 @@ function startVite(config) {
       // Point Vite at the ingress (so client-side fetches work)
       VITE_BACKEND_HOST: `127.0.0.1:${config.ingressPort}`,
       VITE_BACKEND_BASE_URL: `http://127.0.0.1:${config.ingressPort}`,
-      VITE_WORKING_DIR: join(config.stateDir, "workspaces"),
+      VITE_WORKING_DIR: config.viteWorkingDir ?? join(config.stateDir, "workspaces"),
       VITE_FRONTEND_PORT: config.vitePort.toString(),
       // Session API key for frontend to authenticate with agent-server
       VITE_SESSION_API_KEY: config.sessionApiKey,
@@ -689,6 +689,7 @@ async function main(options = {}) {
     bannerTitle = "Agent Canvas + Automation Development Stack",
     startAgentServer: startAgentServerOverride,
     extraPrereqs,
+    viteWorkingDir,
   } = options;
 
   const args = parseArgs();
@@ -704,6 +705,7 @@ async function main(options = {}) {
 
   // Build config with dynamic port allocation
   const config = await buildConfig(args);
+  if (viteWorkingDir) config.viteWorkingDir = viteWorkingDir;
   ensureDirectories(config);
   if (typeof extraPrereqs === "function") {
     extraPrereqs(config);


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary

Creating a new conversation from the home page at `http://localhost:3001` fails with `500 Internal Server Error` immediately after running `npm run dev`. The dockerized agent-server logs a `PermissionError: [Errno 13] Permission denied: '/Users'` while trying to `mkdir` the conversation's `working_dir`.

### Steps to reproduce

1. Run `PROJECT_PATH=/some/path npm run dev` (which resolves to `npm run dev:docker`).
2. Open `http://localhost:3001`.
3. Click **Launch** on the home page (with or without selecting a workspace).

### Current behavior

`POST http://127.0.0.1:8000/api/conversations` returns `500`. Agent-server stderr (per `LOG.txt`) shows:

```
File "openhands/agent_server/event_service.py", line 549, in start
File "pathlib/_local.py", line 726, in mkdir
PermissionError: [Errno 13] Permission denied: '/Users'
```

### Expected behavior

Conversation is created successfully, browser navigates to `/conversations/<id>`.

### Root cause

`scripts/dev-with-automation.mjs:559` hard-codes the GUI's `VITE_WORKING_DIR` env var to a **host filesystem path**:

```js
VITE_WORKING_DIR: join(config.stateDir, "workspaces"),
// = /Users/<user>/.openhands/agent-canvas/workspaces
```

`scripts/dev-docker.mjs` reuses `main()` from `dev-with-automation.mjs`, so the same host path leaks into Vite even though the agent-server is now in a container. The GUI then builds `working_dir = ${VITE_WORKING_DIR}/${conv_hex}` (`src/api/agent-server-config.ts:160-164`) and POSTs that host path to the agent-server. Inside the container, `/Users/<user>` does not exist, and `Path.mkdir(parents=True)` walks up to `/Users` — unwritable — and aborts.

The container-equivalent of that host directory already exists inside the container via the volume mount declared in `dev-docker.mjs:138-148` (`-v ~/.openhands:/home/openhands/.openhands`), so the GUI just needs to send the **container path**: `/home/openhands/.openhands/agent-canvas/workspaces`.

### Fix

- `scripts/dev-with-automation.mjs`: `main()` now accepts an optional `viteWorkingDir`; `startVite()` prefers `config.viteWorkingDir` over the host-path default. Behavior in `dev-safe.mjs` / `dev-with-automation.mjs` / `dev-static.mjs` is unchanged when the option is omitted.
- `scripts/dev-docker.mjs`: defines `CONTAINER_WORKSPACES_DIR = "/home/openhands/.openhands/agent-canvas/workspaces"` and passes it as `viteWorkingDir` into `main()`.

### Acceptance criteria

- [x] Running `npm run dev` (docker mode) and creating a conversation returns 2xx and the chat page loads.
- [x] DevTools network tab shows the request payload's `workspace.working_dir` starts with `/home/openhands/.openhands/agent-canvas/workspaces/`.
- [x] On the host, `~/.openhands/agent-canvas/workspaces/<conv_id_hex>/` exists after creation (mount round-trip works).
- [x] Non-docker dev modes (`dev:dangerously-dockerless`, etc.) still resolve `VITE_WORKING_DIR` to the host `~/.openhands/agent-canvas/workspaces` and conversation creation still works.
- [x] New unit test in `__tests__/scripts/dev-docker.test.ts` passes (regression guard for the constant).

## Summary

<!-- 1-3 bullets describing what changed. -->
- Fixes a hard 500 on `POST /api/conversations` whenever a developer runs `npm run dev` (docker mode) and tries to create a conversation. The agent-server, running inside the `agent-canvas-dev-agent-server` container, was being asked to `mkdir` a host filesystem path (`/Users/<user>/.openhands/agent-canvas/workspaces/<conv_hex>`), which it cannot do — `parents=True` walked up to `/Users` and hit `PermissionError`.
- Threads an optional `viteWorkingDir` override from `scripts/dev-docker.mjs` through `main()` into `startVite()` so docker mode passes the **container** path. Non-docker dev scripts (`dev-safe.mjs`, `dev-static.mjs`, `dev-with-automation.mjs` invoked directly) keep their existing host-path default.

### Why this is the right fix

- The agent-server's `LocalWorkspace.working_dir` contract trusts the path it is given by design. Adding host-vs-container path translation server-side would be a much larger, cross-repo change for the same effect.
- `dev-docker.mjs` already takes responsibility for container-vs-host path mapping for every other persistence env var (`OH_CONVERSATIONS_PATH`, `OH_PERSISTENCE_DIR`, `OH_BASH_EVENTS_DIR`, `TMUX_TMPDIR`). `VITE_WORKING_DIR` was a one-line gap in the same family.
- The container path `/home/openhands/.openhands/agent-canvas/workspaces` already exists inside the container via the `~/.openhands → /home/openhands/.openhands` volume mount, so writes round-trip back to the host with no extra plumbing.

### Changes

| File | Change |
| --- | --- |
| `scripts/dev-with-automation.mjs` | `main()` accepts optional `viteWorkingDir`; `startVite()` prefers `config.viteWorkingDir` over `join(config.stateDir, "workspaces")`. |
| `scripts/dev-docker.mjs` | Adds `CONTAINER_WORKSPACES_DIR = "/home/openhands/.openhands/agent-canvas/workspaces"` and passes it as `viteWorkingDir` to `main()`. Re-exports the constant for tests. |
| `__tests__/scripts/dev-docker.test.ts` | New file. One AAA test asserting the constant equals the container path — regression guard for the host-path leak. |

Total diff: ~14 net lines across two scripts plus one test file.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #258 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Manual end-to-end (the failing scenario from the bug report):

1. `PROJECT_PATH=/some/path npm run dev`
2. Open `http://localhost:3001`.
3. Click **Launch** on the home page.
4. **Expected:** `POST /api/conversations` → 2xx, browser navigates to `/conversations/<id>`, no `PermissionError: [Errno 13]` in agent-server logs.
5. DevTools network tab: request payload `workspace.working_dir` starts with `/home/openhands/.openhands/agent-canvas/workspaces/` (container path), not `/Users/...`.
6. `~/.openhands/agent-canvas/workspaces/<conv_id_hex>/` exists on the host after creation (proof the volume mount round-trips).

Regression check on the non-docker path:

7. `npm run dev:dangerously-dockerless` (or another non-docker dev script) — `VITE_WORKING_DIR` still resolves to the host `~/.openhands/agent-canvas/workspaces` and conversation creation still works.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/cc7ba551-fde1-472c-8aa3-c43a7b0dd134

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

### Risk / blast radius

Low. Two-file dev-script change, no production code paths touched. Backward compatible: `viteWorkingDir` is optional; non-docker dev scripts behave exactly as before.

### Out of scope / non-goals

- No changes to the agent-server (`software-agent-sdk`). The host-vs-container path responsibility is intentionally kept in the dev-orchestration layer that already owns volume mounts.
- No refactor of the literal `/home/openhands/.openhands/...` strings already present in `dev-docker.mjs`'s `containerEnv` block — kept surgical.
- No changes to GUI / TS code; the existing `getAgentServerWorkingDir()` reading of `VITE_WORKING_DIR` is correct as-is.