### PR TITLE
fix(frontend): always load public skills on global Skills page

### DIFF
--- a/__tests__/api/skills-service.test.ts
+++ b/__tests__/api/skills-service.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import SkillsService from "#/api/skills-service";
+
+const { mockGetSkills, mockCreateSkillsClient } = vi.hoisted(() => ({
+  mockGetSkills: vi.fn(),
+  mockCreateSkillsClient: vi.fn(),
+}));
+
+vi.mock("#/api/typescript-client", () => ({
+  createSkillsClient: mockCreateSkillsClient,
+}));
+
+const localBackend: Backend = {
+  id: "local",
+  name: "Local",
+  host: "http://127.0.0.1:8000",
+  apiKey: "",
+  kind: "local",
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  setRegisteredBackends([localBackend]);
+  setActiveSelection({ backendId: localBackend.id });
+  mockGetSkills.mockReset();
+  mockCreateSkillsClient.mockReset();
+  mockCreateSkillsClient.mockReturnValue({ getSkills: mockGetSkills });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  __resetActiveStoreForTests();
+});
+
+describe("SkillsService.getSkills against the agent-server backend", () => {
+  it("requests load_public:true for the global Skills page even when VITE_LOAD_PUBLIC_SKILLS is unset, so a fresh dev env still shows the public catalog", async () => {
+    // Arrange: the dev-default scenario that shipped the empty Skills page —
+    // VITE_LOAD_PUBLIC_SKILLS is not set, so shouldLoadPublicSkills() would
+    // return false. The agent-server has one public skill it can return.
+    vi.stubEnv("VITE_LOAD_PUBLIC_SKILLS", "");
+    mockGetSkills.mockResolvedValue({
+      skills: [
+        {
+          name: "alpha",
+          type: "knowledge",
+          content: "...",
+          triggers: [],
+          source: "public",
+          is_agentskills_format: false,
+        },
+      ],
+      sources: { sandbox: 0, sdk_base: 1, org: 0, project: 0 },
+    });
+
+    // Act
+    const skills = await SkillsService.getSkills();
+
+    // Assert: the request opts the user into public skills regardless of the
+    // perf-oriented VITE_LOAD_PUBLIC_SKILLS gate, and the page receives them.
+    expect(mockGetSkills).toHaveBeenCalledTimes(1);
+    expect(mockGetSkills.mock.calls[0]?.[0]).toMatchObject({
+      load_public: true,
+      load_user: true,
+      load_project: true,
+      load_org: false,
+    });
+    expect(skills.map((s) => s.name)).toEqual(["alpha"]);
+  });
+});

--- a/src/api/skills-service.ts
+++ b/src/api/skills-service.ts
@@ -1,8 +1,5 @@
 import { SkillInfo } from "#/types/settings";
-import {
-  getAgentServerWorkingDir,
-  shouldLoadPublicSkills,
-} from "./agent-server-config";
+import { getAgentServerWorkingDir } from "./agent-server-config";
 import { getActiveBackend } from "./backend-registry/active-store";
 import { fetchCloudSkills } from "./cloud/skills-service.api";
 import { createSkillsClient } from "./typescript-client";
@@ -13,8 +10,12 @@ class SkillsService {
       return fetchCloudSkills();
     }
 
+    // Always load public skills on the global Skills settings page so the user
+    // sees the available catalog even on a fresh dev environment with no local
+    // user/project skills. Conversation creation paths still gate on
+    // shouldLoadPublicSkills() to keep new-conversation latency low.
     const response = await createSkillsClient().getSkills({
-      load_public: shouldLoadPublicSkills(),
+      load_public: true,
       load_user: true,
       load_project: true,
       load_org: false,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

When the local Dockerized dev stack is started with `npm run dev`, opening `http://localhost:3001/skills` renders the page but shows no skills.

The backend `POST /api/skills` request returns `200 OK` with:

```json
{
  "skills": [],
  "sources": {
    "sandbox": 0,
    "sdk_base": 0,
    "org": 0,
    "project": 0
  }
}
```

This indicates a configuration or payload issue rather than a backend failure. `LOG.txt` also confirms a clean response:

```txt
Returning 0 total skills: []
```

No related errors are present.

---

### Steps to Reproduce

1. From a fresh checkout, run:

   ```bash
   PROJECT_PATH=/path/to/projects npm run dev
   ```

2. Open:

   ```txt
   http://localhost:3001
   ```

3. Click **Skills** in the sidebar, or navigate directly to:

   ```txt
   http://localhost:3001/skills
   ```

---

### Expected Behavior

The Skills page loads and displays the available skills.

---

### Actual Behavior

The Skills page renders, but the skills list is empty.

---

### Root Cause

The frontend gates `load_public` behind `shouldLoadPublicSkills()` in:

```txt
src/api/agent-server-config.ts:187
```

After PR #229 / commit `17ceec7`, this flag defaults to `false`.

That change was introduced to keep **conversation creation** fast because the same flag is also used in:

```txt
agent-server-adapter.ts:299
```

where enabling it triggers a remote clone of the OpenHands extensions repository during new conversation creation.

However, disabling the flag unintentionally emptied the global Skills settings page because all other sources are also empty in the default dev-docker environment.

#### `load_user`

The container searches:

- `~/.openhands/skills`
- `~/.agents/skills`
- `~/.openhands/microagents`

However, `dev-docker.mjs:159-169` only mounts `~/.openhands` if the host directory already exists. On a fresh setup, these directories either do not exist or are empty.

#### `load_project`

The frontend passes:

```txt
project_dir = getAgentServerWorkingDir()
```

In the dev-docker environment, this resolves to the conversation workspace parent directory:

```txt
/home/openhands/.openhands/agent-canvas/workspaces
```

(see `dev-docker.mjs:66-67,209`)

That parent directory does not contain:

- `.openhands/skills`
- `.agents/skills`

#### `load_org`

This source is explicitly disabled in the request payload.

---

### Proposed Fix

Decouple the global Skills settings page from `shouldLoadPublicSkills()` so the page always loads the public skills catalog.

The following flows should continue respecting the existing flag to preserve the performance optimization introduced in PR #229:

- Conversation creation (`agent-server-adapter.ts:299`)
- Per-conversation skills modal (`agent-server-adapter.ts:542`)

This keeps new conversation startup fast while allowing the dedicated Skills page to load public skills when explicitly opened.

The Skills page already uses a 10-minute `staleTime` in:

```txt
src/hooks/query/use-skills.ts:9
```

so a one-time slower fetch is acceptable.

---

### Acceptance Criteria

- Opening `/skills` in a fresh dev environment displays a populated skills list.
- Conversation creation latency from **Start from Scratch** remains unchanged.
- A unit test verifies that `SkillsService.getSkills()` always sends:

  ```json
  {
    "load_public": true
  }
  ```

  even when `VITE_LOAD_PUBLIC_SKILLS` is unset.

## Summary

<!-- 1-3 bullets describing what changed. -->
### What Changed

- Decoupled `src/api/skills-service.ts` from `shouldLoadPublicSkills()`.

- The global Skills page now always requests:

  ```json
  {
    "load_public": true
  }
  ```

- Left the following flows unchanged so PR #229’s performance optimization remains intact:

  - `agent-server-adapter.ts:299` — conversation creation
  - `agent-server-adapter.ts:542` — per-conversation skills modal

### Files Changed

- `src/api/skills-service.ts`

  - Removed the `shouldLoadPublicSkills()` gate.
  - Removed the now-unused import.

- `__tests__/api/skills-service.test.ts`

  - Added a regression test covering the `agent-server-direct` branch of `SkillsService.getSkills()`.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #262

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. From a fresh checkout, run:

   ```bash
   PROJECT_PATH=/path/to/projects npm run dev
   ```

2. Open:

   ```txt
   http://localhost:3001
   ```

3. Click **Skills** in the sidebar, or navigate directly to:

   ```txt
   http://localhost:3001/skills
   ```


## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="799" alt="image" src="https://github.com/user-attachments/assets/771e5f14-0dc6-4bed-88f8-187db6ce1179" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore