### PR TITLE
Fix Vite build hygiene warnings

### DIFF
--- a/__tests__/vite-config.test.ts
+++ b/__tests__/vite-config.test.ts
@@ -22,6 +22,50 @@ describe("vite optimizeDeps", () => {
   });
 });
 
+describe("vite path resolution", () => {
+  it("uses Vite's native tsconfig paths support", async () => {
+    const config = await viteConfig({ mode: "development", command: "serve" });
+
+    expect(config.resolve?.tsconfigPaths).toBe(true);
+    expect(config.plugins).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "vite-tsconfig-paths" }),
+      ]),
+    );
+  });
+});
+
+describe("vite app build", () => {
+  it("configures Rolldown code splitting for large vendor chunks", async () => {
+    const config = await viteConfig({ mode: "production", command: "build" });
+    const appBuild = config as {
+      build?: {
+        rolldownOptions?: {
+          output?: {
+            codeSplitting?: {
+              groups?: Array<{
+                name?: string;
+                maxSize?: number;
+                entriesAware?: boolean;
+              }>;
+            };
+          };
+        };
+      };
+    };
+
+    expect(appBuild.build?.rolldownOptions?.output?.codeSplitting?.groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "vendor",
+          maxSize: 450 * 1024,
+          entriesAware: true,
+        }),
+      ]),
+    );
+  });
+});
+
 describe("vite library build", () => {
   it("configures a dual-format preserved-module library build", async () => {
     process.env.BUILD_LIB = "true";

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
         "tailwindcss": "4.2.4",
         "typescript": "6.0.3",
         "vite-plugin-svgr": "5.2.0",
-        "vite-tsconfig-paths": "6.1.1",
         "vitest": "4.1.5"
       },
       "engines": {
@@ -11170,13 +11169,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/goober": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
@@ -17811,58 +17803,6 @@
       },
       "peerDependencies": {
         "vite": ">=3.0.0"
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
-      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      }
-    },
-    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3",
     "vite-plugin-svgr": "5.2.0",
-    "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.5"
   },
   "packageManager": "npm@10.5.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@
 /// <reference types="vite-plugin-svgr/client" />
 import { fileURLToPath } from "node:url";
 import { defineConfig, loadEnv } from "vite";
-import viteTsconfigPaths from "vite-tsconfig-paths";
 import svgr from "vite-plugin-svgr";
 import { reactRouter } from "@react-router/dev/vite";
 import { configDefaults } from "vitest/config";
@@ -21,6 +20,25 @@ const LIB_EXTERNALS = [
   "react/jsx-dev-runtime",
   "react-router",
 ];
+const APP_CHUNK_MAX_BYTES = 450 * 1024;
+
+const appBuildConfig = {
+  rolldownOptions: {
+    output: {
+      codeSplitting: {
+        groups: [
+          {
+            name: "vendor",
+            test: /node_modules[\\/]/,
+            maxSize: APP_CHUNK_MAX_BYTES,
+            minSize: 20 * 1024,
+            entriesAware: true,
+          },
+        ],
+      },
+    },
+  },
+};
 
 export default defineConfig(({ mode }) => {
   const {
@@ -43,10 +61,12 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       !process.env.VITEST && !isLibraryBuild && reactRouter(),
-      viteTsconfigPaths(),
       svgr(),
       tailwindcss(),
     ],
+    resolve: {
+      tsconfigPaths: true,
+    },
     css: {
       postcss: {
         plugins: [
@@ -99,7 +119,7 @@ export default defineConfig(({ mode }) => {
             ],
           },
         }
-      : undefined,
+      : appBuildConfig,
     copyPublicDir: !isLibraryBuild,
     optimizeDeps: {
       include: [


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

Fixes #254. Vite builds were warning about the deprecated `vite-tsconfig-paths` plugin and large minified chunks.

## Summary

- Removed `vite-tsconfig-paths` and switched to Vite's native `resolve.tsconfigPaths` support.
- Added Rolldown app-build vendor code splitting to keep generated chunks below the warning threshold.
- Added Vite config regression coverage for native path resolution and chunk splitting.

## Issue Number

Closes #254

## How to Test

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run build:lib`

## Video/Screenshots

N/A — configuration/build hygiene change only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The target `vite-tsconfig-paths` and `Some chunks are larger than 500 kB` warnings are absent from the validated app and library builds.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/08fd152b-ee51-4d07-af70-68c424db2a9d)