### PR TITLE
fix(frontend): hide in-page settings navigation on desktop

### DIFF
--- a/__tests__/components/features/settings/settings-navigation.test.tsx
+++ b/__tests__/components/features/settings/settings-navigation.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router";
 import { SettingsNavigation } from "#/components/features/settings/settings-navigation";
@@ -28,5 +29,41 @@ describe("SettingsNavigation", () => {
     expect(screen.getAllByText("SETTINGS$TITLE").length).toBeGreaterThan(0);
     expect(screen.getByText("SETTINGS$NAV_LLM")).toBeInTheDocument();
     expect(screen.getByText("SETTINGS$NAV_CONDENSER")).toBeInTheDocument();
+  });
+
+  it("closes the mobile drawer when the close button is clicked", async () => {
+    const onCloseMobileMenu = vi.fn();
+    render(
+      <MemoryRouter>
+        <SettingsNavigation
+          isMobileMenuOpen
+          onCloseMobileMenu={onCloseMobileMenu}
+          navigationItems={baseItems}
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /close navigation menu/i }),
+    );
+
+    expect(onCloseMobileMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the mobile drawer after a navigation item is selected", async () => {
+    const onCloseMobileMenu = vi.fn();
+    render(
+      <MemoryRouter>
+        <SettingsNavigation
+          isMobileMenuOpen
+          onCloseMobileMenu={onCloseMobileMenu}
+          navigationItems={baseItems}
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByText("SETTINGS$NAV_LLM"));
+
+    expect(onCloseMobileMenu).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/features/settings/settings-navigation.tsx
+++ b/src/components/features/settings/settings-navigation.tsx
@@ -34,9 +34,8 @@ export function SettingsNavigation({
         data-testid="settings-navbar"
         className={cn(
           "flex flex-col gap-6 transition-transform duration-300 ease-in-out",
-          "fixed inset-0 z-50 w-full bg-[#050505] p-4 transform md:transform-none",
+          "fixed inset-0 z-50 w-full bg-[#050505] p-4 transform md:hidden",
           isMobileMenuOpen ? "translate-x-0" : "-translate-x-full",
-          "md:relative md:translate-x-0 md:w-64 md:p-0 md:bg-transparent",
         )}
       >
         <div className="flex items-center justify-between">


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

<img width="1440" height="799" alt="issue" src="https://github.com/user-attachments/assets/0497221d-3be4-4ff5-93e7-e69b16762c15" />

### Description

On `agent-canvas` (`http://localhost:3001/settings`), desktop users see the same Settings menu items rendered twice — once in the global left `Sidebar` (expandable Settings submenu) and once again in the in-page `SettingsNavigation` column. This creates visual redundancy and wastes horizontal space that should belong to the section content.

### Steps to Reproduce

1. Open `agent-canvas` at `http://localhost:3001`.
2. Navigate to the **Settings** page from the home page.
3. Observe a viewport ≥ 1024px wide.

### Current Behavior

Both `sidebar.tsx` and `settings-navigation.tsx` render the same nav items (LLM, Condenser, Verification, MCP, Application, Secrets) on desktop.

### Expected Behavior

- On desktop (≥ 1024px), Settings navigation should be rendered only by `sidebar.tsx`.
- On mobile (< 1024px), `settings-navigation.tsx` continues to function as a slide-in drawer toggled by `MobileHeader`.

### Root Cause

The `<nav>` in `src/components/features/settings/settings-navigation.tsx` carried desktop-sidebar Tailwind classes (`md:relative md:translate-x-0 md:w-64 md:p-0 md:bg-transparent md:transform-none`) that turned the mobile drawer into a permanent desktop sidebar. The global `Sidebar` was later extended to expose Settings sub-items inline, making the in-page sidebar a duplicate that was never removed.

### Acceptance Criteria

- [x] On desktop, only the global `Sidebar` renders Settings sub-items.
- [x] On mobile, the in-page `SettingsNavigation` drawer continues to slide in/out via the `MobileHeader` hamburger.
- [x] Clicking a nav item or the drawer's close button still dismisses the drawer on mobile.
- [x] Existing tests for `Sidebar`, `SettingsNavigation`, and the `/settings` route continue to pass.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Removes the duplicate Settings navigation column that was shown alongside the global Sidebar on desktop (`/settings`).
- `SettingsNavigation` is now mobile-only; on desktop the global `Sidebar`'s expandable Settings submenu is the single source of navigation.
- Mobile drawer behavior (slide-in via `MobileHeader` hamburger, close on backdrop/close-button/nav-item click) is preserved.

### Why

`src/components/features/settings/settings-navigation.tsx` historically served two roles: a slide-in drawer on mobile and a permanent left sidebar on desktop. After `sidebar.tsx` was extended to expose the Settings sub-items inline (LLM, Condenser, Verification, MCP, Application, Secrets), the desktop role became a visible duplicate. This PR removes it.

### Changes

- **`src/components/features/settings/settings-navigation.tsx`** — single `className` change on the `<nav>`:
  - Removed: `md:transform-none`, `md:relative`, `md:translate-x-0`, `md:w-64`, `md:p-0`, `md:bg-transparent`
  - Added: `md:hidden`
- **`__tests__/components/features/settings/settings-navigation.test.tsx`** — added two behavioral tests covering the preserved mobile drawer interactions (close-button click and nav-item click both invoke `onCloseMobileMenu`).

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #265 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Open `agent-canvas` at `http://localhost:3001`.
2. Navigate to the **Settings** page from the home page.
3. Observe a viewport ≥ 1024px wide.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/48995fb0-203c-4563-a262-8663e50f72cb


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore