### PR TITLE
fix(frontend): keep top padding constant between Conversations and Automations

### DIFF
--- a/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -97,24 +97,16 @@ function renderSidebar(currentPath: string) {
 }
 
 describe("Sidebar", () => {
-  it.each([["/automations"], ["/automations/abc-123"]])(
-    "applies the standalone vertical padding on %s so the sidebar has breathing room when the root layout's padding is dropped",
+  it.each([["/conversations"], ["/automations"], ["/automations/abc-123"], ["/settings"]])(
+    "keeps the sidebar's default top padding on %s so spacing stays consistent with the conversations page",
     (currentPath) => {
       renderSidebar(currentPath);
 
       const sidebar = screen.getByRole("navigation").parentElement;
-      expect(sidebar?.className).toMatch(/(^|\s)md:pt-6\.5(\s|$)/);
-      expect(sidebar?.className).toMatch(/(^|\s)md:pb-3(\s|$)/);
+      expect(sidebar?.className).toMatch(/(^|\s)md:pt-4(\s|$)/);
+      expect(sidebar?.className).not.toMatch(/(^|\s)md:pt-6\.5(\s|$)/);
     },
   );
-
-  it("does not apply the standalone vertical padding on routes that still use the root layout's padding", () => {
-    renderSidebar("/settings");
-
-    const sidebar = screen.getByRole("navigation").parentElement;
-    expect(sidebar?.className).not.toMatch(/(^|\s)md:pt-6\.5(\s|$)/);
-    expect(sidebar?.className).not.toMatch(/(^|\s)md:pb-3(\s|$)/);
-  });
 
   it("renders sidebar nav links and the settings toggle with the default text color shared by the settings page nav (text-[#8C8C8C])", () => {
     renderSidebar("/skills");

--- a/src/components/features/sidebar/sidebar.tsx
+++ b/src/components/features/sidebar/sidebar.tsx
@@ -90,8 +90,7 @@ export function Sidebar() {
           "h-[54px] md:h-full md:w-[300px] md:min-w-[300px]",
           "px-3 py-2 md:px-3 md:pt-4",
           "flex-row md:flex-col",
-          (currentPath === "/" || currentPath.startsWith("/automations")) &&
-            "md:pt-6.5 md:pb-3",
+          currentPath === "/" && "md:pt-6.5 md:pb-3",
         )}
       >
         <div className="flex items-center md:px-2 md:py-1">


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

The left navigation sidebar in `agent-canvas` shifts vertically when the user navigates between the Conversations page (`/conversations`) and the Automations page (`/automations`). The Automations page renders the sidebar with a heavier top padding (`md:pt-6.5` ≈ 26px) while every other route — including Conversations — uses the default `md:pt-4` (16px).

The result: every time the user crosses between these two top-level routes, the entire sidebar contents (logo, nav links, settings tree) visibly jump by ~10px. This is a navigation-chrome stability defect, not a content layout issue.

### Steps to reproduce

1. Run the app locally (`npm run dev`) and open `http://localhost:3001` at desktop width (≥ `md` breakpoint).
2. Navigate to `/conversations`.
3. Navigate to `/automations`.
4. Observe the sidebar contents shift downward.

### Expected behavior

The sidebar's top padding stays constant across both routes (16px / `md:pt-4`).

### Actual behavior

- `/conversations`: `md:pt-4` → 16px
- `/automations`: `md:pt-6.5` → 26px

### Root cause

`src/components/features/sidebar/sidebar.tsx` lines 93–94 contain a conditional that layers `md:pt-6.5 md:pb-3` over the default `md:pt-4` for `/` or `/automations*`, but not for `/conversations*`. The root layout already collapses its outer padding to `p-0` symmetrically for `/`, `/conversations*`, and `/automations*`, so the asymmetric sidebar padding has no functional justification — it's a divergence introduced relative to upstream OpenHands, which only branches on `pathname === "/"`.

### Acceptance criteria

- [ ] Sidebar top padding on `/automations` matches `/conversations` (16px).
- [ ] Existing routes (`/settings`, `/skills`, conversation detail, automation detail) are visually unchanged.
- [ ] Mobile (< `md` breakpoint) layout unaffected.
- [ ] Existing sidebar tests pass; the test that previously asserted the override is reconciled with the new behavior.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Removes `currentPath.startsWith("/automations")` from the sidebar's top-padding override in `src/components/features/sidebar/sidebar.tsx`, so `/automations*` falls through to the default `md:pt-4` (16px) instead of `md:pt-6.5` (26px).
- Sidebar top padding is now identical on `/conversations` and `/automations`, eliminating the ~10px vertical jump observed when switching between the two routes.
- Reconciles `__tests__/components/features/sidebar/sidebar.test.tsx`: the obsolete positive assertions on `/automations*` are replaced by a single parameterized test asserting `md:pt-4` is present (and `md:pt-6.5` absent) across `/conversations`, `/automations`, `/automations/abc-123`, and `/settings`.
- The `currentPath === "/"` arm is intentionally preserved to mirror upstream OpenHands and minimize PR scope. (`/` redirects to `/conversations` synchronously via `index-redirect.tsx`, so that branch is dead code in practice — cleanup deferred.)

### Why

The root layout already collapses to `p-0` for `/`, `/conversations*`, and `/automations*` symmetrically (`src/routes/root-layout.tsx:108-115`), so there is no asymmetry at the layout level that justifies extra sidebar padding only on `/automations`. The divergence was introduced when the `/automations` route was added to the sidebar's override.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #267 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Run the app locally (`npm run dev`) and open `http://localhost:3001` at desktop width (≥ `md` breakpoint).
2. Navigate to `/conversations`.
3. Navigate to `/automations`.
4. Observe the sidebar contents shift downward.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/3cef9ec3-67bb-448e-b451-9757aea80dea

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

### Risk / blast radius

Low. CSS-only change, scoped to a single conditional className branch in the sidebar. No data, network, or auth surfaces are touched. The override that was removed also dropped `md:pb-3`; bottom padding on `/automations` falls back to the default `py-2`'s 8px on desktop, which matches every other route.