### PR TITLE
fix(agent-status): truncate status text instead of per-character wrap on small screens

### DIFF
--- a/src/components/features/controls/agent-status.tsx
+++ b/src/components/features/controls/agent-status.tsx
@@ -86,7 +86,7 @@ export function AgentStatus({
   return (
     <div className={cn("flex items-center gap-1 min-w-0", className)}>
       <span
-        className="text-[11px] text-white font-normal leading-5 flex-1 min-w-0 max-w-full whitespace-normal break-words"
+        className="text-[11px] text-white font-normal leading-5 min-w-0 max-w-full truncate"
         title={t(statusCode)}
       >
         {t(statusCode)}


### PR DESCRIPTION
## Summary

Fixes the "Running task" status text wrapping one character per line in the chat input on small screens.

![before](attachment-was-described-in-the-task)

before/after
<img width="383" height="145" alt="Screenshot 2026-05-10 at 12 37 14 PM" src="https://github.com/user-attachments/assets/a683af0c-9276-4efd-a131-7a1a7d275190" />
<img width="371" height="314" alt="Screenshot 2026-05-10 at 12 11 11 PM" src="https://github.com/user-attachments/assets/596ca8f7-e97c-4596-aa3d-98852823e63d" />


### Root cause

In `src/components/features/controls/agent-status.tsx`, the status label `<span>` used `flex-1 min-w-0 max-w-full whitespace-normal break-words`. The `AgentStatus` is the right-hand item of a `w-full flex justify-between` row whose left side carries `Tools` + the model name (capped at `max-w-[220px]`). When the row got narrow on small screens, the right column shrank to roughly one character wide and `break-words` happily wrapped "Running task" letter-by-letter into a vertical waterfall.

### Fix

Swap the wrapping classes for `truncate` so the label collapses to a single ellipsized line. The existing `title={t(statusCode)}` already exposes the full status on hover.

```diff
- className="text-[11px] text-white font-normal leading-5 flex-1 min-w-0 max-w-full whitespace-normal break-words"
+ className="text-[11px] text-white font-normal leading-5 min-w-0 max-w-full truncate"
```

### Verification

- `npx vitest run __tests__/components/features/conversation/agent-status.test.tsx __tests__/components/features/chat/components/chat-input-actions.test.tsx` — 7/7 pass.
- `npm run typecheck` — clean.

---

_This PR was opened by an AI agent (OpenHands) on behalf of the user._