### PR TITLE
feat(chat): add "upload as file" checkbox for attached images

### DIFF
--- a/__tests__/stores/conversation-store.test.ts
+++ b/__tests__/stores/conversation-store.test.ts
@@ -32,6 +32,7 @@ describe("conversation store", () => {
       planContent: null,
       subConversationTaskId: null,
       shouldHideSuggestions: false,
+      uploadImagesAsFiles: false,
     });
   });
 
@@ -43,6 +44,26 @@ describe("conversation store", () => {
       expect(mockSetConversationState).toHaveBeenCalledWith(CONV_ID, {
         conversationMode: "plan",
       });
+    });
+  });
+
+  describe("uploadImagesAsFiles", () => {
+    it("defaults to false and is updated by setUploadImagesAsFiles", () => {
+      expect(useConversationStore.getState().uploadImagesAsFiles).toBe(false);
+
+      useConversationStore.getState().setUploadImagesAsFiles(true);
+      expect(useConversationStore.getState().uploadImagesAsFiles).toBe(true);
+
+      useConversationStore.getState().setUploadImagesAsFiles(false);
+      expect(useConversationStore.getState().uploadImagesAsFiles).toBe(false);
+    });
+
+    it("is reset to false by clearAllFiles", () => {
+      useConversationStore.getState().setUploadImagesAsFiles(true);
+      expect(useConversationStore.getState().uploadImagesAsFiles).toBe(true);
+
+      useConversationStore.getState().clearAllFiles();
+      expect(useConversationStore.getState().uploadImagesAsFiles).toBe(false);
     });
   });
 

--- a/src/components/features/chat/interactive-chat-box.tsx
+++ b/src/components/features/chat/interactive-chat-box.tsx
@@ -24,6 +24,7 @@ export function InteractiveChatBox({
   const {
     images,
     files,
+    uploadImagesAsFiles,
     addImages,
     addFiles,
     clearAllFiles,
@@ -141,7 +142,14 @@ export function InteractiveChatBox({
   const handleSubmit = useBtwInterceptor(
     conversation?.id ?? null,
     (message) => {
-      onSubmit(message, images, files);
+      // When the user opts in via the "upload as file" checkbox, route
+      // the attached images through the normal file-upload path instead
+      // of embedding them in the message sent to the LLM.
+      if (uploadImagesAsFiles) {
+        onSubmit(message, [], [...files, ...images]);
+      } else {
+        onSubmit(message, images, files);
+      }
       clearAllFiles();
     },
   );

--- a/src/components/features/chat/upload-as-file-checkbox.tsx
+++ b/src/components/features/chat/upload-as-file-checkbox.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from "react-i18next";
+import { I18nKey } from "#/i18n/declaration";
+import { useConversationStore } from "#/stores/conversation-store";
+
+export function UploadAsFileCheckbox() {
+  const { t } = useTranslation("openhands");
+  const { uploadImagesAsFiles, setUploadImagesAsFiles } =
+    useConversationStore();
+
+  return (
+    <label
+      htmlFor="upload-images-as-files-checkbox"
+      className="flex items-center gap-2 text-xs text-[#A7A7A7] cursor-pointer select-none whitespace-nowrap"
+    >
+      <input
+        id="upload-images-as-files-checkbox"
+        data-testid="upload-images-as-files-checkbox"
+        type="checkbox"
+        checked={uploadImagesAsFiles}
+        onChange={(e) => setUploadImagesAsFiles(e.target.checked)}
+        className="h-3.5 w-3.5 flex-shrink-0"
+      />
+      <span>{t(I18nKey.CHAT_INTERFACE$UPLOAD_IMAGES_AS_FILES)}</span>
+    </label>
+  );
+}

--- a/src/components/features/chat/uploaded-files.tsx
+++ b/src/components/features/chat/uploaded-files.tsx
@@ -1,5 +1,6 @@
 import { UploadedFile } from "./uploaded-file";
 import { UploadedImage } from "./uploaded-image";
+import { UploadAsFileCheckbox } from "./upload-as-file-checkbox";
 import { useConversationStore } from "#/stores/conversation-store";
 
 export function UploadedFiles() {
@@ -11,6 +12,8 @@ export function UploadedFiles() {
     removeFile,
     removeImage,
   } = useConversationStore();
+
+  const hasImages = images.length > 0 || loadingImages.length > 0;
 
   const handleRemoveFile = (index: number) => {
     removeFile(index);
@@ -31,54 +34,58 @@ export function UploadedFiles() {
   }
 
   return (
-    <div className="flex items-center gap-4 w-full overflow-x-auto custom-scrollbar">
-      {/* Regular files */}
-      {files.map((file, index) => (
-        <UploadedFile
-          key={`file-${index}-${file.name}`}
-          file={file}
-          onRemove={() => handleRemoveFile(index)}
-          isLoading={loadingFiles.includes(file.name)}
-        />
-      ))}
-
-      {/* Loading files (files currently being processed) */}
-      {loadingFiles.map((fileName, index) => {
-        // Create a temporary File object for display purposes
-        const tempFile = new File([], fileName);
-        return (
+    <div className="flex flex-col gap-2 w-full">
+      <div className="flex items-center gap-4 w-full overflow-x-auto custom-scrollbar">
+        {/* Regular files */}
+        {files.map((file, index) => (
           <UploadedFile
-            key={`loading-file-${index}-${fileName}`}
-            file={tempFile}
-            onRemove={() => {}} // No remove action during loading
-            isLoading
+            key={`file-${index}-${file.name}`}
+            file={file}
+            onRemove={() => handleRemoveFile(index)}
+            isLoading={loadingFiles.includes(file.name)}
           />
-        );
-      })}
+        ))}
 
-      {/* Regular images */}
-      {images.map((image, index) => (
-        <UploadedImage
-          key={`image-${index}-${image.name}`}
-          image={image}
-          onRemove={() => handleRemoveImage(index)}
-          isLoading={loadingImages.includes(image.name)}
-        />
-      ))}
+        {/* Loading files (files currently being processed) */}
+        {loadingFiles.map((fileName, index) => {
+          // Create a temporary File object for display purposes
+          const tempFile = new File([], fileName);
+          return (
+            <UploadedFile
+              key={`loading-file-${index}-${fileName}`}
+              file={tempFile}
+              onRemove={() => {}} // No remove action during loading
+              isLoading
+            />
+          );
+        })}
 
-      {/* Loading images (images currently being processed) */}
-      {loadingImages.map((imageName, index) => {
-        // Create a temporary File object for display purposes
-        const tempImage = new File([], imageName);
-        return (
+        {/* Regular images */}
+        {images.map((image, index) => (
           <UploadedImage
-            key={`loading-image-${index}-${imageName}`}
-            image={tempImage}
-            onRemove={() => {}} // No remove action during loading
-            isLoading
+            key={`image-${index}-${image.name}`}
+            image={image}
+            onRemove={() => handleRemoveImage(index)}
+            isLoading={loadingImages.includes(image.name)}
           />
-        );
-      })}
+        ))}
+
+        {/* Loading images (images currently being processed) */}
+        {loadingImages.map((imageName, index) => {
+          // Create a temporary File object for display purposes
+          const tempImage = new File([], imageName);
+          return (
+            <UploadedImage
+              key={`loading-image-${index}-${imageName}`}
+              image={tempImage}
+              onRemove={() => {}} // No remove action during loading
+              isLoading
+            />
+          );
+        })}
+      </div>
+
+      {hasImages && <UploadAsFileCheckbox />}
     </div>
   );
 }

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -9638,6 +9638,9 @@
     "uk": "Надіслати повідомлення",
     "ca": "Envia el missatge"
   },
+  "CHAT_INTERFACE$UPLOAD_IMAGES_AS_FILES": {
+    "en": "upload as file"
+  },
   "CHAT_INTERFACE$TOOLTIP_UPLOAD_IMAGE": {
     "en": "Upload image",
     "zh-CN": "上传图片",

--- a/src/stores/conversation-store.ts
+++ b/src/stores/conversation-store.ts
@@ -26,6 +26,7 @@ interface ConversationState {
   selectedTab: ConversationTab | null;
   images: File[];
   files: File[];
+  uploadImagesAsFiles: boolean; // If true, attached images are sent through the file-upload path instead of being embedded in the LLM message
   loadingFiles: string[]; // File names currently being processed
   loadingImages: string[]; // Image names currently being processed
   messageToSend: IMessageToSend | null;
@@ -45,6 +46,7 @@ interface ConversationActions {
   setShouldHideSuggestions: (shouldHideSuggestions: boolean) => void;
   addImages: (images: File[]) => void;
   addFiles: (files: File[]) => void;
+  setUploadImagesAsFiles: (uploadImagesAsFiles: boolean) => void;
   removeImage: (index: number) => void;
   removeFile: (index: number) => void;
   clearImages: () => void;
@@ -132,6 +134,7 @@ export const useConversationStore = create<ConversationStore>()(
       selectedTab: "editor" as ConversationTab,
       images: [],
       files: [],
+      uploadImagesAsFiles: false,
       loadingFiles: [],
       loadingImages: [],
       messageToSend: null,
@@ -170,6 +173,9 @@ export const useConversationStore = create<ConversationStore>()(
           "addFiles",
         ),
 
+      setUploadImagesAsFiles: (uploadImagesAsFiles) =>
+        set({ uploadImagesAsFiles }, false, "setUploadImagesAsFiles"),
+
       removeImage: (index) =>
         set(
           (state) => {
@@ -201,6 +207,7 @@ export const useConversationStore = create<ConversationStore>()(
           {
             images: [],
             files: [],
+            uploadImagesAsFiles: false,
             loadingFiles: [],
             loadingImages: [],
           },


### PR DESCRIPTION
## Summary

When the user attaches an image to the message input, a checkbox labeled **"upload as file"** now appears below the previews. When checked, the attached images are routed through the **normal file-upload path** (the same path that handles non-image attachments) instead of being converted to base64 and embedded in the message sent to the LLM.

## Changes

- `src/stores/conversation-store.ts` — new `uploadImagesAsFiles` boolean (default `false`) + `setUploadImagesAsFiles` action; `clearAllFiles` resets it so each new message starts unchecked.
- `src/components/features/chat/upload-as-file-checkbox.tsx` — new component rendering the labeled checkbox bound to the store (i18n via `CHAT_INTERFACE$UPLOAD_IMAGES_AS_FILES`).
- `src/components/features/chat/uploaded-files.tsx` — wraps the existing previews row in a flex-column and renders the checkbox underneath whenever at least one image is attached/loading.
- `src/components/features/chat/interactive-chat-box.tsx` — at submit time, when `uploadImagesAsFiles` is true, attached images are appended to the `files` array (and the `images` array passed to `onSubmit` is empty). The existing `handleSendMessage` in `chat-interface.tsx` then routes them through `useUnifiedUploadFiles` (the normal file upload path) instead of base64-embedding them in the LLM message.
- `src/i18n/translation.json` — new `CHAT_INTERFACE$UPLOAD_IMAGES_AS_FILES` key (en).
- `__tests__/stores/conversation-store.test.ts` — covers default state, setter behaviour, and `clearAllFiles` resetting the new flag.

## Verification

- `npm run typecheck` ✅
- `npx eslint src` ✅ (no new errors)
- `npx vitest run __tests__/stores/conversation-store.test.ts` ✅ (4/4 pass)

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._