### PR TITLE
feat(onboarding): update default model and starter prompt

### DIFF
--- a/src/components/features/onboarding/steps/setup-llm-step.tsx
+++ b/src/components/features/onboarding/steps/setup-llm-step.tsx
@@ -18,7 +18,7 @@ interface SetupLlmStepProps {
  * marked dirty so the Next button is enabled immediately.
  */
 const ONBOARDING_LLM_OVERRIDES = {
-  "llm.model": "anthropic/claude-opus-4-5-20251101",
+  "llm.model": "anthropic/claude-opus-4-7",
 } as const;
 
 /**

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -23243,7 +23243,7 @@
     "en": "Send your first message to OpenHands. We'll start a fresh conversation with no workspace."
   },
   "ONBOARDING$HELLO_DEFAULT_MESSAGE": {
-    "en": "hello OpenHands!"
+    "en": "Create a basic webpage explaining what OpenHands can do"
   },
   "ONBOARDING$HELLO_LAUNCH": {
     "en": "Send"


### PR DESCRIPTION
## Changes

- **Default LLM model**: set the onboarding LLM step to pre-fill `anthropic/claude-opus-4-7` (previously `anthropic/claude-opus-4-5-20251101`).
- **Starter prompt**: change the onboarding Say-Hello step default message from `hello OpenHands!` to `Create a basic webpage explaining what OpenHands can do`.

## Files touched
- `src/components/features/onboarding/steps/setup-llm-step.tsx`
- `src/i18n/translation.json` (`ONBOARDING$HELLO_DEFAULT_MESSAGE`)

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._