### PR TITLE
chore: bump default agent-server image tag to 1916bb4-python

### DIFF
--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -50,7 +50,7 @@ import {
 // Docker image for the agent-server.
 const AGENT_SERVER_REPO = "ghcr.io/openhands/agent-server";
 // Default tag used when OH_AGENT_SERVER_GIT_REF is not set. Update to upgrade.
-const DEFAULT_AGENT_SERVER_TAG = "d3f4851-python";
+const DEFAULT_AGENT_SERVER_TAG = "1916bb4-python";
 const CONTAINER_NAME = "agent-canvas-dev-agent-server";
 
 // Default secret key matches dev-safe.mjs so persisted settings stay


### PR DESCRIPTION
Updates the default `agent-server` Docker image tag used by `npm run dev` (via `scripts/dev-docker.mjs`) from `d3f4851-python` to `1916bb4-python`.

_This PR was created by an AI agent (OpenHands) on behalf of the user._