### PR TITLE
fix(frontend): keep outer container padding consistent across routes

### DIFF
--- a/__tests__/routes/root-layout.test.tsx
+++ b/__tests__/routes/root-layout.test.tsx
@@ -143,36 +143,25 @@ describe("root layout", () => {
     expect(migrateUserConsentMock).toHaveBeenCalled();
   });
 
-  it.each([
-    ["/automations"],
-    ["/automations/abc-123"],
-    ["/conversations"],
-    ["/conversations/abc-123"],
-  ])(
-    "drops the outer layout padding on %s so the page can render flush to the viewport edges",
-    (path) => {
-      render(
+  it("renders an identical root-layout className across routes so navigation never shifts the outer container", () => {
+    const paths = [
+      "/",
+      "/automations/abc-123",
+      "/conversations/abc-123",
+      "/settings",
+    ];
+
+    const classNames = paths.map((path) => {
+      const { unmount } = render(
         <QueryClientProvider client={new QueryClient()}>
           <RouterStub initialEntries={[path]} />
         </QueryClientProvider>,
       );
+      const { className } = screen.getByTestId("root-layout");
+      unmount();
+      return className;
+    });
 
-      const layout = screen.getByTestId("root-layout");
-      expect(layout.className).not.toMatch(/(^|\s)md:p-3(\s|$)/);
-      expect(layout.className).not.toMatch(/(^|\s)md:pl-0(\s|$)/);
-      expect(layout.className).not.toMatch(/(^|\s)md:pr-3(\s|$)/);
-    },
-  );
-
-  it("keeps the outer layout padding on routes other than home and automations", () => {
-    render(
-      <QueryClientProvider client={new QueryClient()}>
-        <RouterStub initialEntries={["/settings"]} />
-      </QueryClientProvider>,
-    );
-
-    const layout = screen.getByTestId("root-layout");
-    expect(layout.className).toMatch(/(^|\s)md:p-3(\s|$)/);
-    expect(layout.className).toMatch(/(^|\s)md:pl-0(\s|$)/);
+    expect(new Set(classNames).size).toBe(1);
   });
 });

--- a/src/routes/root-layout.tsx
+++ b/src/routes/root-layout.tsx
@@ -1,10 +1,5 @@
 import React from "react";
-import {
-  useRouteError,
-  isRouteErrorResponse,
-  Outlet,
-  useLocation,
-} from "react-router";
+import { useRouteError, isRouteErrorResponse, Outlet } from "react-router";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import i18n from "#/i18n";
@@ -13,7 +8,6 @@ import { Sidebar } from "#/components/features/sidebar/sidebar";
 import { useSettings } from "#/hooks/query/use-settings";
 import { useMigrateUserConsent } from "#/hooks/use-migrate-user-consent";
 import { useSyncPostHogConsent } from "#/hooks/use-sync-posthog-consent";
-import { cn } from "#/utils/utils";
 import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { useAppTitle } from "#/hooks/use-app-title";
 import { ReactRouterNavigationProvider } from "./react-router-navigation-provider";
@@ -70,7 +64,6 @@ export function ErrorBoundary() {
 
 export default function MainApp() {
   const appTitle = useAppTitle();
-  const { pathname } = useLocation();
   const { data: settings } = useSettings();
   const { migrateUserConsent } = useMigrateUserConsent();
   const config = useConfig();
@@ -105,23 +98,11 @@ export default function MainApp() {
     );
   }
 
-  let rootLayoutPaddingClass = "p-0 md:p-3 md:pl-0";
-  if (
-    pathname === "/" ||
-    pathname.startsWith("/automations") ||
-    pathname.startsWith("/conversations")
-  ) {
-    rootLayoutPaddingClass = "p-0";
-  }
-
   return (
     <ReactRouterNavigationProvider>
       <div
         data-testid="root-layout"
-        className={cn(
-          "h-screen lg:min-w-5xl flex flex-col md:flex-row bg-base overflow-hidden",
-          rootLayoutPaddingClass,
-        )}
+        className="h-screen lg:min-w-5xl flex flex-col md:flex-row bg-base overflow-hidden p-0"
       >
         <title>{appTitle}</title>
         <Sidebar />


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary
The outer root-layout container in `agent-canvas` applies different padding depending on the current route. As a result, when a user navigates between sidebar pages (e.g. **Conversations → Settings → Automations**), the outer container's box visibly "jumps" on medium-and-wider viewports. The inner page content should be the only thing that changes during navigation — the surrounding chrome should stay still.

### Steps to reproduce
1. Start the GUI: `npm run dev` (runs the agent server in Docker).
2. Open http://localhost:3001 in a browser at a `≥ md` viewport width.
3. Use the sidebar to navigate between **Home**, **Automations**, **Conversations**, and **Settings** in any order.

### Current behavior
- `/`, `/automations*`, `/conversations*` render with `p-0` on the root container.
- All other routes (e.g. `/settings`) render with `p-0 md:p-3 md:pl-0`.
- Switching between the two groups visibly shifts the layout.

### Expected behavior
- The root layout's padding stays consistent across every route — no navigation-induced shift.

### Root cause
`src/routes/root-layout.tsx` derives `rootLayoutPaddingClass` from `useLocation().pathname` and merges it into the container's `className` via `cn(...)`. Because the merged class set differs by route, the container's box model changes on navigation.

### Proposed fix
Pin the root container to a single, route-independent class set ending in `p-0`. The inner pages already own their internal spacing, so the outer padding is no longer needed.

```tsx
className="h-screen lg:min-w-5xl flex flex-col md:flex-row bg-base overflow-hidden p-0"
```

### Acceptance criteria
- [ ] The outer container's class set on `data-testid="root-layout"` is identical across `/`, `/automations*`, `/conversations*`, and `/settings`.
- [ ] Manual smoke at both `< md` and `≥ md` viewport widths shows no shift when navigating between sidebar pages.
- [ ] `__tests__/routes/root-layout.test.tsx` passes and no longer asserts the old route-conditional behavior.
- [ ] `npm run lint` and `tsc --noEmit` are clean.

### Out of scope
- Internal padding of individual pages — each page continues to own its own spacing.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Stop deriving the root layout's padding from `useLocation().pathname`; pin it to a single static class set so navigating between sidebar pages no longer shifts the outer container.
- Drop the now-unused `useLocation` and `cn` imports in `src/routes/root-layout.tsx`.
- Replace the two stale route-conditional padding tests with one functional assertion that the root container's className is identical across representative routes.

### Why
On `≥ md` viewports the root container previously toggled between `p-0` and `p-0 md:p-3 md:pl-0` depending on the route group, so users saw the outer chrome jump on every cross-group navigation (e.g. **Settings → Conversations**). Inner pages already own their spacing, so the route-conditional outer padding wasn't pulling its weight — it was only causing the shift.

### Changes
- `src/routes/root-layout.tsx`
  - Remove the `rootLayoutPaddingClass` variable and its `pathname` branch.
  - Render the container with a single className: `"h-screen lg:min-w-5xl flex flex-col md:flex-row bg-base overflow-hidden p-0"`.
  - Drop unused `useLocation`, `pathname`, and `cn`.
- `__tests__/routes/root-layout.test.tsx`
  - Delete the `it.each([...])` "drops padding on %s" test and the "keeps padding on /settings" test — both encoded the old route-conditional behavior.
  - Add one focused test: render the layout at `/`, `/automations/abc-123`, `/conversations/abc-123`, `/settings`; capture `getByTestId("root-layout").className` for each; assert `new Set(classNames).size === 1`. This captures the functional guarantee (navigation does not mutate the container) without asserting specific CSS values.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #292

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Start the GUI: `npm run dev` (runs the agent server in Docker).
2. Open http://localhost:3001 in a browser at a `≥ md` viewport width.
3. Use the sidebar to navigate between **Home**, **Automations**, **Conversations**, and **Settings** in any order.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/c0324738-c27c-4275-b2ba-5d04fe33eddb

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- No production styling changes outside the root container.
- Inner-page padding is unaffected — each page continues to manage its own internal spacing.