### PR TITLE
fix: hide No conversations found when sidebar is collapsed

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -1,4 +1,9 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import {
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from "@testing-library/react";
 import {
   afterEach,
   beforeAll,
@@ -133,6 +138,39 @@ describe("ConversationPanel", () => {
 
     const emptyState = await screen.findByText("CONVERSATION$NO_CONVERSATIONS");
     expect(emptyState).toBeInTheDocument();
+  });
+
+  it("should not display the empty state when there are no conversations and the panel is compact", async () => {
+    const searchConversationsSpy = vi.spyOn(
+      AgentServerConversationService,
+      "searchConversations",
+    );
+    searchConversationsSpy.mockResolvedValue({
+      items: [],
+      next_page_id: null,
+    });
+
+    const CompactRouterStub = createRoutesStub([
+      {
+        Component: () => <ConversationPanel compact />,
+        path: "/",
+      },
+      {
+        Component: () => null,
+        path: "/conversations/:conversationId",
+      },
+    ]);
+
+    renderWithProviders(<CompactRouterStub />);
+
+    const skeletons = await screen.findAllByTestId(
+      "conversation-card-skeleton",
+    );
+    await waitForElementToBeRemoved(skeletons);
+
+    expect(
+      screen.queryByText("CONVERSATION$NO_CONVERSATIONS"),
+    ).not.toBeInTheDocument();
   });
 
   it("should handle an error when fetching conversations", async () => {

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -301,7 +301,7 @@ export function ConversationPanel({
           </div>
         )}
 
-        {showEmptyState && (
+        {!compact && showEmptyState && (
           <div className="flex flex-col items-center justify-center h-full">
             <p className="text-neutral-400">
               {t(I18nKey.CONVERSATION$NO_CONVERSATIONS)}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

<img width="1440" height="831" alt="issue" src="https://github.com/user-attachments/assets/f7fccef9-6cf8-4231-b194-d34ec03de8ae" />

### Description

When the user has zero conversations and collapses the left-hand sidebar to its icon-rail variant (64 px), the "No conversations found" empty-state message is still rendered inside the conversation list pane. Because the text is wider than the collapsed column, it visibly overflows onto the main canvas, producing the truncated "…iversation nd" artifact shown in the bug screenshot. The message should be hidden entirely in collapsed mode and only displayed when the sidebar is expanded.

### Steps to reproduce

1. Clone `agent-canvas` and run `npm run dev`.
2. Open <http://localhost:3001>.
3. Ensure there are no existing conversations.
4. Click the collapse toggle on the sidebar to switch to the 64 px icon rail.

### Current behavior

The "No conversations found" text continues to render inside the collapsed list and bleeds outside the 64 px column onto the page background.

### Expected behavior

- The empty-state message is rendered only when the sidebar is expanded.
- The collapsed (compact) sidebar shows nothing for the empty conversation list, matching how the in-progress task cards are already suppressed in compact mode.

### Root cause

`src/components/features/conversation-panel/conversation-panel.tsx` already accepts a `compact` prop that the sidebar passes whenever the rail is collapsed. The component correctly gates the in-progress task cards on `!compact`, but the empty-state JSX (around line 304) was rendered unconditionally. As a result the empty-state block ignores the compact variant and leaks outside the 64 px column.

### Acceptance criteria

- Collapsing the sidebar with zero conversations no longer renders the "No conversations found" text anywhere on the page.
- Expanding the sidebar (still with zero conversations) restores the message in its original centered position.
- Behavior with at least one conversation is unchanged in both expanded and collapsed modes.
- An automated test asserts that the empty-state message is not rendered when `ConversationPanel` is mounted with `compact`.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The conversation panel rendered its empty-state block unconditionally, so the "No conversations found" message visibly overflowed the 64px collapsed sidebar onto the main canvas when the user had zero conversations.
- Gated the empty-state block on `!compact` in `src/components/features/conversation-panel/conversation-panel.tsx`, matching the existing `!compact && startTasks?.map(...)` pattern in the same file.
- Added a regression test that mounts `ConversationPanel` with `compact` and asserts the empty-state copy is not rendered after the initial fetch resolves.

## Before / after

| State                               | Before                                                                | After                             |
| ----------------------------------- | --------------------------------------------------------------------- | --------------------------------- |
| Expanded sidebar, no conversations  | "No conversations found" centered in the list                         | Unchanged                         |
| Collapsed sidebar, no conversations | Text rendered + overflowed outside the 64px column ("…iversation nd") | Nothing rendered in the list area |
| Either mode, ≥ 1 conversation       | List renders normally                                                 | Unchanged                         |

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #294 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-canvas` and run `npm run dev`.
2. Open <http://localhost:3001>.
3. Ensure there are no existing conversations.
4. Click the collapse toggle on the sidebar to switch to the 64 px icon rail.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/c68d66d0-8479-4d80-8793-229420eea0ee

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
