### PR TITLE
fix(frontend): show pointer cursor on NewConversationButton popover items

### DIFF
--- a/__tests__/components/features/conversation-panel/new-conversation-button-cloud.test.tsx
+++ b/__tests__/components/features/conversation-panel/new-conversation-button-cloud.test.tsx
@@ -221,6 +221,34 @@ describe("NewConversationButton (cloud)", () => {
     expect(screen.getByTestId("cloud-provider-tab-gitlab")).toBeInTheDocument();
   });
 
+  it("applies the pointer-cursor affordance to every interactive popover item", async () => {
+    mockUseGitRepositories.mockReturnValue({
+      data: {
+        pages: [
+          {
+            items: [makeRepo("octo/cat", { main_branch: "main" })],
+            next_page_id: "page-2",
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      hasNextPage: true,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      onLoadMore: vi.fn(),
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<NewConversationButton />);
+
+    await user.click(screen.getByTestId("new-conversation-button"));
+
+    for (const testId of ["launch-repository", "cloud-repo-load-more"]) {
+      expect(screen.getByTestId(testId)).toHaveClass("cursor-pointer");
+    }
+  });
+
   it("shows an empty state when no repositories are returned", async () => {
     mockUseGitRepositories.mockReturnValue({
       data: { pages: [{ items: [], next_page_id: null }] },

--- a/__tests__/components/features/conversation-panel/new-conversation-button.test.tsx
+++ b/__tests__/components/features/conversation-panel/new-conversation-button.test.tsx
@@ -188,6 +188,29 @@ describe("NewConversationButton", () => {
     expect(screen.getByTestId("new-conversation-popover")).toBeInTheDocument();
   });
 
+  it("applies the pointer-cursor affordance to every interactive popover item", async () => {
+    useWorkspacesStore.getState().addWorkspaces([
+      {
+        id: "/workspace/project/repo1",
+        name: "repo1",
+        path: "/workspace/project/repo1",
+      },
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<NewConversationButton />);
+
+    await user.click(screen.getByTestId("new-conversation-button"));
+
+    for (const testId of [
+      "launch-no-workspace",
+      "launch-workspace",
+      "add-workspaces-button",
+      "manage-workspaces-button",
+    ]) {
+      expect(screen.getByTestId(testId)).toHaveClass("cursor-pointer");
+    }
+  });
+
   it("keeps the popover open when conversation creation fails", async () => {
     const navigate = vi.fn();
     const createSpy = vi

--- a/src/components/features/conversation-panel/new-conversation-button-cloud.tsx
+++ b/src/components/features/conversation-panel/new-conversation-button-cloud.tsx
@@ -170,7 +170,7 @@ export function CloudNewConversationButton({
   };
 
   const itemClass = cn(
-    "flex items-center gap-2 w-full px-2 py-2 text-sm text-white text-left",
+    "flex items-center gap-2 w-full px-2 py-2 text-sm text-white text-left cursor-pointer",
     "hover:bg-[#5C5D62] rounded-md transition-colors duration-150 font-normal",
     "disabled:opacity-60 disabled:cursor-not-allowed",
   );

--- a/src/components/features/conversation-panel/new-conversation-button-local.tsx
+++ b/src/components/features/conversation-panel/new-conversation-button-local.tsx
@@ -101,7 +101,7 @@ export function LocalNewConversationButton({
   };
 
   const itemClass = cn(
-    "flex items-center gap-2 w-full px-2 py-2 text-sm text-white text-left",
+    "flex items-center gap-2 w-full px-2 py-2 text-sm text-white text-left cursor-pointer",
     "hover:bg-[#5C5D62] rounded-md transition-colors duration-150 font-normal",
     "disabled:opacity-60 disabled:cursor-not-allowed",
   );


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

In the sidebar, clicking `<NewConversationButton />` opens an inline popover listing workspace entries (local backend) or git repositories (cloud backend), plus footer actions like **Add Workspace** and **Manage Workspaces**. Each row is a real `<button>` that either starts a new conversation or opens a modal, but the cursor stays as the default arrow on hover, so users can't tell the rows are interactive.

The popover's trigger button already uses `cursor-pointer`, which makes the inconsistency more obvious once the popover is open. The reusable `DropdownItem` component used elsewhere in the app (`src/components/features/home/shared/dropdown-item.tsx`) already applies `cursor-pointer`, so this is a missed affordance specifically in the popover variants of `NewConversationButton`.

### Steps to reproduce

1. `npm run dev` and open `http://localhost:3001`.
2. Click the sidebar `+ New Conversation` button to open the popover.
3. Hover the workspace rows, "Add Workspace", and "Manage Workspaces".
4. Observe the cursor stays as the default arrow instead of switching to a hand.

### Expected behavior

Every interactive row in the popover shows `cursor: pointer` on hover. Disabled rows (while a conversation is being created) continue to show `cursor: not-allowed`.

### Acceptance criteria

- [ ] Workspace rows, "No workspace" row, "Add Workspace", and "Manage Workspaces" all show a pointer cursor on hover (local backend).
- [ ] Repository rows and "Load more" show a pointer cursor on hover (cloud backend).
- [ ] Disabled rows still show `not-allowed` while `useIsCreatingConversation` is true.
- [ ] Existing tests for `NewConversationButton` continue to pass.

### Root cause (notes for reviewers)

The shared `itemClass` Tailwind string in both popover variants was missing `cursor-pointer`:

- `src/components/features/conversation-panel/new-conversation-button-local.tsx:103-107`
- `src/components/features/conversation-panel/new-conversation-button-cloud.tsx:172-176`

Adding the utility once per file fixes every row that reuses `itemClass`.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add `cursor-pointer` to the shared `itemClass` in both `new-conversation-button-local.tsx` and `new-conversation-button-cloud.tsx` so every interactive row in the popover shows the hand cursor on hover.
- The existing `disabled:cursor-not-allowed` variant continues to override the pointer while a conversation is being created.
- Add one test per file asserting the cursor affordance class is applied to every interactive popover item (`launch-no-workspace`, `launch-workspace`, `add-workspaces-button`, `manage-workspaces-button`, `launch-repository`, `cloud-repo-load-more`).

### Why

The popover's trigger already uses `cursor-pointer`, and the reusable `DropdownItem` component elsewhere in the app does too — the inline popovers in `NewConversationButton` were the only surfaces that hadn't picked up the project convention, which made the rows feel non-interactive.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #296 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev` and open `http://localhost:3001`.
2. Click the sidebar `+ New Conversation` button to open the popover.
3. Hover the workspace rows, "Add Workspace", and "Manage Workspaces".
4. Observe the cursor stays as the default arrow instead of switching to a hand.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/ee6702f5-8bde-40b0-9256-8c0a4d173d19

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

Scope is intentionally limited to the two `NewConversationButton` popovers reported in the issue. The `WorkspaceDropdown` sticky-footer buttons on the home page have the same missing utility and can be addressed in a follow-up if needed.
