### PR TITLE
fix(frontend): animate sidebar min-width so expand transition is visible

### DIFF
--- a/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -152,6 +152,21 @@ describe("Sidebar", () => {
     expect(remountedSidebar?.dataset.collapsed).toBe("true");
   });
 
+  it("expands the sidebar when the toggle is clicked from the collapsed state", () => {
+    // Arrange: simulate a user whose sidebar was previously collapsed.
+    window.localStorage.setItem("openhands-sidebar-collapsed", "true");
+    renderSidebar("/conversations");
+
+    // Act
+    fireEvent.click(screen.getByTestId("sidebar-collapse-toggle"));
+
+    // Assert: state flips back to expanded and the inline settings submenu
+    // toggle (rendered only when expanded) reappears.
+    const sidebar = screen.getByRole("navigation").parentElement;
+    expect(sidebar?.dataset.collapsed).toBe("false");
+    expect(screen.getByTestId("sidebar-settings-toggle")).toBeInTheDocument();
+  });
+
   it("renders icons for every top-level nav item so they remain meaningful in the collapsed rail", () => {
     renderSidebar("/conversations");
 

--- a/src/components/features/sidebar/sidebar.tsx
+++ b/src/components/features/sidebar/sidebar.tsx
@@ -142,7 +142,7 @@ export function Sidebar() {
         aria-label={t(I18nKey.SIDEBAR$NAVIGATION_LABEL)}
         data-collapsed={collapsed ? "true" : "false"}
         className={cn(
-          "bg-base flex flex-col gap-3 transition-[width] duration-200",
+          "bg-base flex flex-col gap-3 transition-[width,min-width] duration-200",
           // Mobile: top bar; Desktop: vertical column. Width responds to
           // the collapsed state on md+ screens.
           "h-[54px] md:h-full",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

The desktop sidebar uses a CSS width transition to animate between its expanded (300px) and collapsed (64px) states. The animation only plays in the collapsing direction; expanding snaps instantly to the wider size, creating an inconsistent and jarring UX.

### Steps to reproduce

1. Run `npm run dev` and open `http://localhost:3001`.
2. Make sure the viewport is at least the `md:` breakpoint (≥ 768px).
3. Click the chevron on the sidebar header.
   - Collapsing 300px → 64px: smooth ~200ms animation. ✅
   - Expanding 64px → 300px: snaps to 300px instantly. ❌

### Expected behavior

The sidebar should animate smoothly in **both** directions over the same ~200ms width transition.

### Root cause

`src/components/features/sidebar/sidebar.tsx:145` declares `transition-[width] duration-200`, but the rendered size is driven by **both** `width` and `min-width` (`md:w-[64|300]px md:min-w-[64|300]px`). Tailwind's `transition-[width]` only transitions `width`; `min-width` changes instantly.

The effective box width is `max(width, min-width)`:

- **Collapsing (300 → 64):** `min-width` drops to 64 instantly; `width` animates 300 → 64. Since `width(t) ≥ 64` throughout, `max(width(t), 64) = width(t)` and the animation is visible.
- **Expanding (64 → 300):** `min-width` jumps to 300 instantly; this pins the rendered width at 300 for the entire duration, masking the `width` animation.

### Fix

Include `min-width` in the transition property list so it animates in lockstep with `width`:

```diff
- "bg-base flex flex-col gap-3 transition-[width] duration-200",
+ "bg-base flex flex-col gap-3 transition-[width,min-width] duration-200",
```

`min-width` is kept (rather than removed) because the sidebar sits in a `flex flex-row` parent in `src/routes/root-layout.tsx` and needs it to resist flex compression.

### Acceptance criteria

- [ ] Expanding the sidebar animates smoothly over ~200ms.
- [ ] Collapsing still animates smoothly (no regression).
- [ ] Collapsed state persists across reloads (no regression).
- [ ] Sidebar unit tests pass.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The desktop sidebar collapsed with a smooth 200ms width animation but expanded instantly, because `transition-[width]` doesn't cover `min-width` — and the rendered width is pinned by `max(width, min-width)`. On expand, `min-width` snapped to 300px immediately and masked the `width` animation.
- Switched the transition to `transition-[width,min-width]` on the sidebar `<aside>` so both properties animate together. Collapse behavior is unchanged; expand now animates symmetrically.
- Kept `min-width` in place (rather than removing it) — the sidebar lives inside a `flex flex-row` parent and needs `min-width` to resist flex compression.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #300 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Run `npm run dev` and open `http://localhost:3001`.
2. Make sure the viewport is at least the `md:` breakpoint (≥ 768px).
3. Click the chevron on the sidebar header.
   - Collapsing 300px → 64px: smooth ~200ms animation. ✅
   - Expanding 64px → 300px: snaps to 300px instantly. ❌

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/a3daa37c-6a01-4a01-98d8-25e60b80c1d5

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
