### PR TITLE
chore: update agent-server Docker tag to use main-python

### DIFF
--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -68,8 +68,13 @@ const CONTAINER_LOCAL_SDK_DIR = "/agent-server-src";
 
 // Docker image for the agent-server.
 const AGENT_SERVER_REPO = "ghcr.io/openhands/agent-server";
-// Default tag used when OH_AGENT_SERVER_GIT_REF is not set. Update to upgrade.
-const DEFAULT_AGENT_SERVER_TAG = "0924962-python";
+// Default tag used when OH_AGENT_SERVER_GIT_REF is not set.
+// Uses `main-python` which tracks the latest main branch build. This is
+// rebuilt on every push to main, so it stays current with SDK releases.
+// NOTE: Versioned tags (e.g., `1.21.1-python`) are planned but not yet
+// available — see https://linear.app/all-hands-ai/issue/AGE-1518.
+// Once resolved, update this to use a pinned release version tag.
+const DEFAULT_AGENT_SERVER_TAG = "main-python";
 const CONTAINER_NAME = "agent-canvas-dev-agent-server";
 
 // Default secret key matches dev-safe.mjs so persisted settings stay


### PR DESCRIPTION
## Summary

Updates the default agent-server Docker image tag from a stale commit-based tag (`0924962-python`) to `main-python`, which tracks the latest main branch build.

## Changes

- **`scripts/dev-docker.mjs`**: Update `DEFAULT_AGENT_SERVER_TAG` from `0924962-python` to `main-python`
- Added documentation noting that versioned tags (e.g., `1.21.1-python`) are planned but not yet available due to [AGE-1518](https://linear.app/all-hands-ai/issue/AGE-1518)

## Why `main-python` instead of a versioned tag?

The `software-agent-sdk` repository is [designed to produce versioned Docker tags](https://github.com/OpenHands/software-agent-sdk/blob/main/.github/workflows/server.yml) like `1.21.1-python` on release, but these haven't been built yet due to an issue with the release workflow (see AGE-1518). The `main-python` tag is rebuilt on every push to main, so it stays reasonably current with SDK releases.

Once AGE-1518 is resolved, we should update this to use a pinned versioned tag for better reproducibility.

## Related

- Fixes https://github.com/OpenHands/agent-canvas/issues/323
- Fixes APP-1686
- Blocked by AGE-1518 for versioned tags

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3efa5771-8cb3-4c88-9720-625c8557b2aa)