### PR TITLE
fix: move TMUX_TMPDIR to /tmp to avoid socket errors on mounted volumes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,7 +23,7 @@ VITE_MOCK_API="false" # Enable/disable API mocking with MSW
 # `npm run dev` (scripts/dev-safe.mjs) — isolated local backend via uvx
 # OH_CANVAS_SAFE_BACKEND_PORT="18000" # Port the spawned agent-server listens on
 # OH_CANVAS_SAFE_VSCODE_PORT="18001" # Port forwarded to the embedded VS Code (defaults to backend port + 1)
-# OH_CANVAS_SAFE_STATE_DIR="$HOME/.openhands/agent-canvas" # Where conversations, tmux sockets, and bash events are stored
+# OH_CANVAS_SAFE_STATE_DIR="$HOME/.openhands/agent-canvas" # Where conversations and bash events are stored (tmux sockets live under /tmp)
 
 # Agent server version selection (uvx) — listed in order of precedence (highest first)
 # OH_AGENT_SERVER_LOCAL_PATH="" # Absolute path to a local software-agent-sdk checkout. Runs the local checkout via uvx with editable openhands-sdk/tools/workspace installs so source edits are picked up on restart. Highest precedence.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ npm run dev
 
 This is an alias for `npm run dev:safe`.
 
-It uses `uvx` to run a temporary `agent-server` installation for this checkout on `127.0.0.1:18000` and points the frontend at it. It isolates tmux state and conversation persistence by setting separate `TMUX_TMPDIR`, `OH_CONVERSATIONS_PATH`, `OH_BASH_EVENTS_DIR`, and `OH_VSCODE_PORT` values under `.openhands-dev/`, so it does not collide with other local or cloud-backed OpenHands sessions.
+It uses `uvx` to run a temporary `agent-server` installation for this checkout on `127.0.0.1:18000` and points the frontend at it. It isolates conversation persistence by setting separate `OH_CONVERSATIONS_PATH`, `OH_BASH_EVENTS_DIR`, and `OH_VSCODE_PORT` values under `.openhands-dev/`, and places tmux sockets under `/tmp` (via `TMUX_TMPDIR`) to avoid filesystem-support issues with mounted volumes, so it does not collide with other local or cloud-backed OpenHands sessions.
 
 ### Environment Variables
 

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -442,7 +442,9 @@ describe("buildSafeDevConfig", () => {
     expect(config.stateDir).toBe(
       path.join(homedir(), ".openhands", "agent-canvas"),
     );
-    expect(config.tmuxTmpDir).toBe(path.join(config.stateDir, "tmux"));
+    expect(config.tmuxTmpDir).toBe(
+      path.join(tmpdir(), "openhands-agent-canvas-tmux"),
+    );
     expect(config.conversationsPath).toBe(
       path.join(config.stateDir, "conversations"),
     );

--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -229,7 +229,6 @@ function startAgentServerDocker(config) {
       "/home/openhands/.openhands/agent-canvas/conversations",
     OH_PERSISTENCE_DIR: "/home/openhands/.openhands",
     OH_BASH_EVENTS_DIR: "/home/openhands/.openhands/agent-canvas/bash_events",
-    TMUX_TMPDIR: "/tmp/openhands-agent-canvas-tmux",
     OH_SECRET_KEY: process.env.OH_SECRET_KEY || DEFAULT_SECRET_KEY,
     // Required so the secret-seeding PUT /api/settings/secrets call from
     // the host can authenticate against the agent-server in the container.

--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -229,7 +229,7 @@ function startAgentServerDocker(config) {
       "/home/openhands/.openhands/agent-canvas/conversations",
     OH_PERSISTENCE_DIR: "/home/openhands/.openhands",
     OH_BASH_EVENTS_DIR: "/home/openhands/.openhands/agent-canvas/bash_events",
-    TMUX_TMPDIR: "/home/openhands/.openhands/agent-canvas/tmux",
+    TMUX_TMPDIR: "/tmp/openhands-agent-canvas-tmux",
     OH_SECRET_KEY: process.env.OH_SECRET_KEY || DEFAULT_SECRET_KEY,
     // Required so the secret-seeding PUT /api/settings/secrets call from
     // the host can authenticate against the agent-server in the container.

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -10,7 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import net from "node:net";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { setTimeout as delay } from "node:timers/promises";
@@ -497,7 +497,7 @@ function buildConfigFromPorts(ports, cwd, env) {
     backendPort,
     vscodePort,
     stateDir,
-    tmuxTmpDir: path.join(stateDir, "tmux"),
+    tmuxTmpDir: path.join(tmpdir(), "openhands-agent-canvas-tmux"),
     conversationsPath,
     workspacesPath,
     bashEventsDir: path.join(stateDir, "bash_events"),

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -580,7 +580,6 @@ async function main() {
   const { mkdirSync } = await import("node:fs");
   for (const dir of [
     config.stateDir,
-    join(config.stateDir, "tmux"),
     join(config.stateDir, "conversations"),
     join(config.stateDir, "workspaces"),
     join(config.stateDir, "bash_events"),

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -332,7 +332,6 @@ function checkPrerequisites() {
 function ensureDirectories(config) {
   const dirs = [
     config.stateDir,
-    join(config.stateDir, "tmux"),
     join(config.stateDir, "conversations"),
     join(config.stateDir, "workspaces"),
     join(config.stateDir, "bash_events"),


### PR DESCRIPTION
## Problem

When running agent-canvas with a Docker backend (`dev-docker.mjs`), the first message to a new conversation fails with:

```
error connecting to /home/openhands/.openhands/agent-canvas/tmux/tmux-10001/openhands (Operation not supported)
```

This happens because `TMUX_TMPDIR` was set to `~/.openhands/agent-canvas/tmux/`, which lives on a Docker bind-mounted volume. Some filesystems used by Docker bind-mounts (NFS, CIFS, certain FUSE/overlay mounts) **do not support Unix domain sockets**, causing tmux to fail when trying to create its control socket.

## Fix

Move `TMUX_TMPDIR` from `~/.openhands/agent-canvas/tmux/` to `/tmp/openhands-agent-canvas-tmux`. The `/tmp` directory is always on a local/tmpfs filesystem that supports Unix sockets. Tmux sockets are ephemeral by nature — they're only meaningful for the lifetime of the process and don't need persistence across restarts.

### Changes

- **`scripts/dev-safe.mjs`**: Use `tmpdir()` (i.e. `/tmp`) instead of `stateDir` for `tmuxTmpDir`. This flows through `buildAgentServerEnv()` to all consumers (`dev-static.mjs`, `dev-with-automation.mjs`, `dev-extra-backend.mjs`).
- **`scripts/dev-docker.mjs`**: Hardcoded container path changed from `/home/openhands/.openhands/agent-canvas/tmux` → `/tmp/openhands-agent-canvas-tmux`.
- **`scripts/dev-static.mjs`**, **`scripts/dev-with-automation.mjs`**: Removed stale `stateDir/tmux` from mkdir lists (no longer needed since tmux dir is under `/tmp`).
- **Tests and docs**: Updated accordingly.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/32eaca87-1a6e-42af-a348-52d3297ff92f)