### PR TITLE
fix: drop explicit OH_PERSISTENCE_DIR from dev-docker.mjs, use derived default

### DIFF
--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -227,7 +227,6 @@ function startAgentServerDocker(config) {
   const containerEnv = {
     OH_CONVERSATIONS_PATH:
       "/home/openhands/.openhands/agent-canvas/conversations",
-    OH_PERSISTENCE_DIR: "/home/openhands/.openhands",
     OH_BASH_EVENTS_DIR: "/home/openhands/.openhands/agent-canvas/bash_events",
     OH_SECRET_KEY: process.env.OH_SECRET_KEY || DEFAULT_SECRET_KEY,
     // Required so the secret-seeding PUT /api/settings/secrets call from


### PR DESCRIPTION
## Problem

`dev-docker.mjs` explicitly sets `OH_PERSISTENCE_DIR=/home/openhands/.openhands` in the container environment, but:

1. **The agent-server already derives a suitable default** — when `OH_PERSISTENCE_DIR` is unset, `_get_persistence_dir()` in the SDK falls back to `config.conversations_path.parent / ".openhands"`. Since `OH_CONVERSATIONS_PATH` is set to `/home/openhands/.openhands/agent-canvas/conversations`, the derived default resolves to `/home/openhands/.openhands/agent-canvas/.openhands` — still on the mounted `~/.openhands` volume, so settings and secrets persist across container restarts.

2. **`buildAgentServerEnv()` in `dev-safe.mjs` never sets `OH_PERSISTENCE_DIR`** — the Docker path was the only place this env var was explicitly set, creating an inconsistency between Docker and non-Docker dev workflows.

## Fix

Remove `OH_PERSISTENCE_DIR` from the `containerEnv` object in `dev-docker.mjs`, letting the agent-server use its derived default. This follows the same pattern as the `TMUX_TMPDIR` removal in #325.

### Remaining `containerEnv` vars (and why they stay)

| Env var | Why it's needed |
|---|---|
| `OH_CONVERSATIONS_PATH` | Without it, conversations go to the ephemeral container path `/agent-server/workspace/conversations` |
| `OH_BASH_EVENTS_DIR` | Same — bash events would be lost on restart |
| `OH_SECRET_KEY` | Stable dev encryption key shared across Docker/non-Docker runs |
| `OH_SESSION_API_KEYS_0` | Must match the frontend's `VITE_SESSION_API_KEY` for auth |

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._