### PR TITLE
fix(frontend): preserve per_turn_token when combining metrics from a dormant condenser LLM

### DIFF
--- a/__tests__/hooks/query/use-conversation-metrics.test.tsx
+++ b/__tests__/hooks/query/use-conversation-metrics.test.tsx
@@ -71,4 +71,75 @@ describe("useConversationMetrics", () => {
       null,
     );
   });
+
+  it("preserves an active LLM's per_turn_token when combined with a dormant condenser entry", async () => {
+    // Arrange
+    const multiLlmRuntimeInfo = {
+      id: "conv-multi",
+      title: "Test",
+      metrics: null,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      status: ExecutionStatus.IDLE,
+      stats: {
+        usage_to_metrics: {
+          agent: {
+            model_name: "test-model",
+            accumulated_cost: 0.07,
+            max_budget_per_task: null,
+            accumulated_token_usage: {
+              prompt_tokens: 37802,
+              completion_tokens: 1024,
+              cache_read_tokens: 24686,
+              cache_write_tokens: 12764,
+              context_window: 1_000_000,
+              per_turn_token: 38826,
+            },
+            costs: [],
+            response_latencies: [],
+            token_usages: [],
+          },
+          condenser: {
+            model_name: "test-model",
+            accumulated_cost: 0,
+            max_budget_per_task: null,
+            accumulated_token_usage: {
+              prompt_tokens: 0,
+              completion_tokens: 0,
+              cache_read_tokens: 0,
+              cache_write_tokens: 0,
+              context_window: 0,
+              per_turn_token: 0,
+            },
+            costs: [],
+            response_latencies: [],
+            token_usages: [],
+          },
+        },
+      },
+    };
+    vi.spyOn(
+      AgentServerConversationService,
+      "getRuntimeConversation",
+    ).mockResolvedValue(multiLlmRuntimeInfo);
+
+    // Act
+    const { result } = renderHook(
+      () =>
+        useConversationMetrics(
+          "conv-multi",
+          "http://localhost:8888/api/conversations/conv-multi",
+          null,
+          true,
+        ),
+      { wrapper: makeWrapper() },
+    );
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        result.current.data?.accumulated_token_usage?.per_turn_token,
+      ).toBe(38826);
+    });
+  });
 });

--- a/src/utils/conversation-metrics.ts
+++ b/src/utils/conversation-metrics.ts
@@ -57,7 +57,10 @@ export function getCombinedMetrics(
             combinedTokenUsage.context_window,
             metrics.accumulated_token_usage.context_window,
           ),
-          per_turn_token: metrics.accumulated_token_usage.per_turn_token, // Use the latest per_turn_token
+          per_turn_token: Math.max(
+            combinedTokenUsage.per_turn_token,
+            metrics.accumulated_token_usage.per_turn_token,
+          ),
         };
       }
     }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

When a user opens **Display Cost** from `<ConversationNameContextMenu />` in `agent-server-gui`, the **Context Window** section in the Conversation Metrics dialog renders as `0 / 1,000,000 (0.00% used)` with an empty progress bar — even though the rows above clearly show real token consumption (e.g. Input: 37,802 / Output: 1,024 / Total: 38,826). The bar misleads the user into thinking no context has been consumed.

### Steps to reproduce

1. Clone `agent-server-gui` and run `npm run dev` (starts the agent-server in Docker).
2. Open `http://localhost:3001`.
3. Create a new conversation and send a short message so the agent completes at least one LLM call.
4. Open the conversation context menu and click **Display Cost**.

### Current behavior

- Context Window shows `0 / 1,000,000 (0.00% used)` with an empty bar.

### Expected behavior

- Context Window shows the latest turn's `prompt_tokens + completion_tokens` over the model's context window (e.g. `38,826 / 1,000,000 (3.88% used)`) with the bar partially filled.

### Root cause

The default agent registers two LLMs with the conversation:

1. The main agent LLM
2. A condenser LLM (`usage_id: "condenser"`, `src/api/agent-server-adapter.ts:236`) — enabled by default via `DEFAULT_SETTINGS.enable_default_condenser = true` (`src/services/settings.ts:18`).

On a fresh conversation, the condenser is never invoked. The backend's Pydantic validator (`openhands-sdk/openhands/sdk/llm/utils/metrics.py:121-134`) auto-initializes its `accumulated_token_usage` to a `TokenUsage` with every field set to `0`, including `per_turn_token`.

`getCombinedMetrics()` in `src/utils/conversation-metrics.ts` correctly uses `Math.max(...)` to combine `context_window` across `usage_to_metrics` entries, but used "last entry wins" for `per_turn_token`. When the condenser entry is iterated last, its `0` clobbers the main agent's real per-turn token count, leaving the dialog showing `0 / 1,000,000`.

### Fix

Combine `per_turn_token` with `Math.max()`, matching how `context_window` is combined. A dormant LLM's zero can no longer override an active LLM's value.

### Acceptance criteria

- With default condenser enabled, the Context Window section displays the latest turn's `prompt_tokens + completion_tokens` over the model's context window after the agent makes at least one LLM call.
- The progress bar fills proportionally (visible `width`).
- Cost, Input, Output, Cache Hit, Cache Write, and Total rows are unchanged.
- A regression test in `__tests__/hooks/query/use-conversation-metrics.test.tsx` covers the multi-LLM combine path (active + dormant condenser) and would fail under the old "last entry wins" implementation.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Context Window section in the Conversation Metrics dialog rendered as `0 / 1,000,000 (0.00% used)` after the agent had consumed tokens, because `getCombinedMetrics()` used "last entry wins" semantics for `per_turn_token`. With the default condenser enabled, the never-invoked condenser's zeroed `accumulated_token_usage` clobbered the active agent LLM's value.
- Switch the `per_turn_token` combine to `Math.max()`, matching the existing `context_window` combine on the lines just above. A dormant LLM's zero can no longer override an active LLM's value.
- Add a TDD test covering the multi-LLM combine path (active agent + dormant condenser) in `__tests__/hooks/query/use-conversation-metrics.test.tsx`.

### Changes

- `src/utils/conversation-metrics.ts` — combine `per_turn_token` with `Math.max()` (one-line change in the multi-entry branch of `getCombinedMetrics`).
- `__tests__/hooks/query/use-conversation-metrics.test.tsx` — add a regression test that mocks `AgentServerConversationService.getRuntimeConversation` with an active agent entry (`per_turn_token=38826`) and a dormant condenser entry (all zeros), and asserts the combined `per_turn_token` is `38826`.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #309 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-server-gui` and run `npm run dev` (starts the agent-server in Docker).
2. Open `http://localhost:3001`.
3. Create a new conversation and send a short message so the agent completes at least one LLM call.
4. Open the conversation context menu and click **Display Cost**.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="827" alt="app-1679" src="https://github.com/user-attachments/assets/9b06bf54-27cc-4c0c-8692-f5ce6433b65e" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- A parallel latent bug exists in the Python SDK's `TokenUsage.__add__` (`openhands-sdk/openhands/sdk/llm/utils/metrics.py:71`), where the same "last value wins" semantic would re-surface this issue in any consumer that uses `ConversationStats.get_combined_metrics()`. Out of scope for this ticket; track separately.