### PR TITLE
fix: use versioned release tags for agent-server Docker images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,11 @@
   - `OH_SECRET_KEY` — secret key for settings encryption; uses a static default for local dev since it's needed for reading persisted encrypted values across restarts
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
   - Default: released PyPI version `1.22.0` for agent-server SDK libraries
+- `scripts/dev-docker.mjs` runs the agent-server inside a Docker container instead of via `uvx`. The default image uses versioned release tags:
+  - `DEFAULT_AGENT_SERVER_TAG` — uses format `v{version}-python` (e.g., `v1.22.0-python`) for reproducibility
+  - Should stay in sync with `DEFAULT_AGENT_SERVER_VERSION` in `dev-safe.mjs` for consistency between Docker and non-Docker dev modes
+  - `OH_AGENT_SERVER_GIT_REF` — override to use a git ref-based tag (e.g., `main` → `main-python`, `abc1234` → `abc1234-python`)
+  - Docker images are published from https://github.com/OpenHands/software-agent-sdk via the Agent Server workflow to `ghcr.io/openhands/agent-server`
 - Security: Both `scripts/dev-safe.mjs` and `scripts/dev-with-automation.mjs` auto-generate random API keys on each startup for better security isolation:
   - `SESSION_API_KEY` — 64-character hex (256-bit) for agent-server API authentication; auto-generated per session unless overridden via env var
   - `AUTOMATION_LOCAL_API_KEY` — 64-character hex for automation backend auth; auto-generated per session unless overridden

--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -68,8 +68,10 @@ const CONTAINER_LOCAL_SDK_DIR = "/agent-server-src";
 
 // Docker image for the agent-server.
 const AGENT_SERVER_REPO = "ghcr.io/openhands/agent-server";
-// Default tag used when OH_AGENT_SERVER_GIT_REF is not set. Update to upgrade.
-const DEFAULT_AGENT_SERVER_TAG = "0924962-python";
+// Default tag used when OH_AGENT_SERVER_GIT_REF is not set.
+// Should match DEFAULT_AGENT_SERVER_VERSION in dev-safe.mjs for consistency.
+// Format: v{version}-python (e.g., v1.22.0-python) for released versions.
+const DEFAULT_AGENT_SERVER_TAG = "v1.22.0-python";
 const CONTAINER_NAME = "agent-canvas-dev-agent-server";
 
 // Default secret key matches dev-safe.mjs so persisted settings stay


### PR DESCRIPTION
## Summary

Update `DEFAULT_AGENT_SERVER_TAG` in `dev-docker.mjs` from commit-based tag (`0924962-python`) to versioned release tag (`v1.22.0-python`) for better reproducibility and consistency with the PyPI version used in `dev-safe.mjs`.

## Changes

- **`scripts/dev-docker.mjs`**: Update `DEFAULT_AGENT_SERVER_TAG` to `v1.22.0-python`
- **`AGENTS.md`**: Add documentation explaining the versioning approach for Docker dev mode

## Why

The `software-agent-sdk` repository builds Docker images with versioned tags in the format `v{version}-python` when release tags are pushed (via the Agent Server workflow). Using these versioned tags instead of commit-based tags provides:

1. **Reproducibility**: Pinned to a specific release version
2. **Consistency**: Docker mode (`npm run dev:docker`) and non-Docker mode (`npm run dev`) now use matching versions (1.22.0)
3. **Maintainability**: Easier to understand which SDK version is being used

## Verification

- Confirmed that `v1.22.0` release exists in software-agent-sdk (released 2026-05-11T18:23:49Z)
- Confirmed that the Agent Server workflow ran successfully for the `v1.22.0` tag (SHA `025df53`)
- The workflow publishes multi-arch Docker images to `ghcr.io/openhands/agent-server` with versioned tags

Closes #323

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/671b265d-ca76-4893-8f4b-d849e88d700d)