### PR TITLE
fix: correct Docker image tag format (remove v prefix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
   - Default: released PyPI version `1.22.0` for agent-server SDK libraries
 - `scripts/dev-docker.mjs` runs the agent-server inside a Docker container instead of via `uvx`. The default image uses versioned release tags:
-  - `DEFAULT_AGENT_SERVER_TAG` — uses format `v{version}-python` (e.g., `v1.22.0-python`) for reproducibility
+  - `DEFAULT_AGENT_SERVER_TAG` — uses format `{version}-python` (e.g., `1.22.0-python`) for reproducibility. Note: the SDK build script strips the "v" prefix from semver release tags.
   - Should stay in sync with `DEFAULT_AGENT_SERVER_VERSION` in `dev-safe.mjs` for consistency between Docker and non-Docker dev modes
   - `OH_AGENT_SERVER_GIT_REF` — override to use a git ref-based tag (e.g., `main` → `main-python`, `abc1234` → `abc1234-python`)
   - Docker images are published from https://github.com/OpenHands/software-agent-sdk via the Agent Server workflow to `ghcr.io/openhands/agent-server`

--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -70,8 +70,9 @@ const CONTAINER_LOCAL_SDK_DIR = "/agent-server-src";
 const AGENT_SERVER_REPO = "ghcr.io/openhands/agent-server";
 // Default tag used when OH_AGENT_SERVER_GIT_REF is not set.
 // Should match DEFAULT_AGENT_SERVER_VERSION in dev-safe.mjs for consistency.
-// Format: v{version}-python (e.g., v1.22.0-python) for released versions.
-const DEFAULT_AGENT_SERVER_TAG = "v1.22.0-python";
+// Format: {version}-python (e.g., 1.22.0-python) for released versions.
+// Note: The SDK build script strips the "v" prefix from semver release tags.
+const DEFAULT_AGENT_SERVER_TAG = "1.22.0-python";
 const CONTAINER_NAME = "agent-canvas-dev-agent-server";
 
 // Default secret key matches dev-safe.mjs so persisted settings stay


### PR DESCRIPTION
## Summary

Fixes the "Unable to find image" error when running `npm run dev:docker` by correcting the Docker image tag format.

## Problem

The previous PR (#338) used `v1.22.0-python` as the tag format, but the SDK build script (`build.py`) strips the "v" prefix from semver release tags when publishing Docker images. The actual published tag is `1.22.0-python`.

From `build.py`:
```python
@property
def release_tag_source(self) -> str | None:
    if self.git_ref.startswith("refs/tags/"):
        tag = self.git_ref.removeprefix("refs/tags/")
        # For semver release tags (v1.2.3), use the SDK package version
        # which follows PEP 440 (bare semver, no "v" prefix).
        if _SEMVER_RELEASE_RE.fullmatch(tag):
            if self.sdk_version != "unknown":
                return self.sdk_version  # Returns "1.22.0", not "v1.22.0"
```

## Changes

- **`scripts/dev-docker.mjs`**: Update `DEFAULT_AGENT_SERVER_TAG` from `v1.22.0-python` to `1.22.0-python`
- **`AGENTS.md`**: Update documentation to reflect correct tag format

## Verification

The correct tag `1.22.0-python` should exist on GHCR as published by the Agent Server workflow for the v1.22.0 release.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/671b265d-ca76-4893-8f4b-d849e88d700d)