### PR TITLE
fix(setup): always run npm ci to ensure hooks have dependencies

### DIFF
--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -22,9 +22,10 @@ if ! command -v uvx &> /dev/null; then
   fi
 fi
 
-if [ ! -d node_modules ]; then
-  npm ci
-fi
+# Always run npm ci to ensure dependencies are installed and up-to-date.
+# This is idempotent and ensures hooks (like on_stop.sh) have access to
+# npm scripts like lint and test.
+npm ci
 
 if [ ! -f "$ENV_FILE" ]; then
   cp .env.sample "$ENV_FILE"


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The `on_stop.sh` hook runs `npm run lint` and `npm test` as quality gates before the agent finishes. These commands require `node_modules` to be installed. Previously, `setup.sh` only ran `npm ci` conditionally (when `node_modules` didn't exist), which caused hook failures when:

1. `node_modules` existed but was incomplete or corrupt
2. `package-lock.json` was updated but `node_modules` was stale
3. The setup script hadn't fully completed before hooks ran

## Summary

- Changed `.openhands/setup.sh` to always run `npm ci` unconditionally instead of checking if `node_modules` exists
- This ensures dependencies are consistently installed when OpenHands begins working with the repository, preventing hook failures

## Issue Number

N/A - Identified through operational failures where hooks failed with "react-router: not found"

## How to Test

1. Clone this repo fresh (without `node_modules`)
2. Run `.openhands/setup.sh` - should install dependencies
3. Run `.openhands/hooks/on_stop.sh` - should pass lint and tests

Or test by starting a new OpenHands session on this repository - the stop hook should no longer fail with missing command errors.

## Video/Screenshots

N/A - This is a script change, no UI changes.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `npm ci` is idempotent and safe to run repeatedly - it clears and reinstalls from `package-lock.json`
- This aligns with OpenHands documentation which states setup.sh runs "every time OpenHands begins working with your repository"

_This PR was created by an AI agent (OpenHands) based on user request._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4a253d0b-5489-492d-bebd-629984103ce9)