### PR TITLE
Add session_start hook to run setup.sh automatically

### DIFF
--- a/.openhands/hooks.json
+++ b/.openhands/hooks.json
@@ -1,4 +1,16 @@
 {
+  "session_start": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".openhands/setup.sh",
+          "timeout": 300
+        }
+      ]
+    }
+  ],
   "stop": [
     {
       "matcher": "*",

--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -22,9 +22,10 @@ if ! command -v uvx &> /dev/null; then
   fi
 fi
 
-if [ ! -d node_modules ]; then
-  npm ci
-fi
+# Always run npm ci to ensure dependencies are installed and up-to-date.
+# This is idempotent and ensures hooks (like on_stop.sh) have access to
+# npm scripts like lint and test.
+npm ci
 
 if [ ! -f "$ENV_FILE" ]; then
   cp .env.sample "$ENV_FILE"


### PR DESCRIPTION
## Summary

This PR adds a `session_start` hook to `.openhands/hooks.json` to ensure `setup.sh` runs automatically when OpenHands begins working with this repository.

## Problem

The `hooks.json` was missing a `session_start` hook, which meant:
- `setup.sh` (which runs `npm ci` to install npm packages) was never executed automatically
- The `stop` hook (`on_stop.sh`) would fail because npm packages weren't installed
- Error message: `react-router: not found` when the stop hook tried to run `npm test`

## Root Cause

While OpenHands documentation states that `.openhands/setup.sh` runs automatically "every time OpenHands begins working with your repository," the hooks system requires explicit configuration via `hooks.json`. The `session_start` hook type exists but was not configured.

## Solution

Added a `session_start` hook that runs `.openhands/setup.sh` with a 5-minute timeout:

```json
"session_start": [
  {
    "matcher": "*",
    "hooks": [
      {
        "type": "command",
        "command": ".openhands/setup.sh",
        "timeout": 300
      }
    ]
  ]
]
```

## Testing

After this change, new OpenHands sessions should:
1. Automatically run `setup.sh` on session start
2. Install npm packages via `npm ci`
3. Generate i18n types via `npm run make-i18n`
4. Allow the stop hook to successfully run `npm test` and `npm run lint`

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d1392c12-f012-4361-b4a7-94496096c802)