### PR TITLE
feat(markdown): render GitHub-style alert blockquotes

### DIFF
--- a/__tests__/components/features/markdown/markdown-renderer.test.tsx
+++ b/__tests__/components/features/markdown/markdown-renderer.test.tsx
@@ -62,7 +62,7 @@ describe("MarkdownRenderer", () => {
   });
 
   it("strips <script> tags via rehype-sanitize", () => {
-    const md = 'Hello<script>window.__pwn = true;</script> world';
+    const md = "Hello<script>window.__pwn = true;</script> world";
     const { container } = render(<MarkdownRenderer>{md}</MarkdownRenderer>);
     expect(container.querySelector("script")).toBeNull();
     // The text content surrounding the script must still be there.
@@ -110,15 +110,13 @@ describe("MarkdownRenderer", () => {
     // schema deliberately omits `style` from the allowed attribute list
     // so the sanitizer drops it.
     const md =
-      '<div style="background:url(\'https://attacker.example/exfil\')">x</div>';
+      "<div style=\"background:url('https://attacker.example/exfil')\">x</div>";
     const { container } = render(<MarkdownRenderer>{md}</MarkdownRenderer>);
     const div = container.querySelector("div");
     expect(div).not.toBeNull();
     // The style attribute must be gone (or at minimum not contain the
     // attacker URL).
-    expect(div?.getAttribute("style") ?? "").not.toMatch(
-      /attacker\.example/i,
-    );
+    expect(div?.getAttribute("style") ?? "").not.toMatch(/attacker\.example/i);
     expect(div?.getAttribute("style")).toBeNull();
   });
 
@@ -177,6 +175,92 @@ describe("MarkdownRenderer", () => {
     // <mark> should not be parsed; the text should still appear.
     expect(container.querySelector("mark")).toBeNull();
     expect(container.textContent).toContain("world");
+  });
+
+  describe("GitHub-style alert blockquotes", () => {
+    const ALERT_CASES: Array<{ marker: string; label: string }> = [
+      { marker: "NOTE", label: "Note" },
+      { marker: "TIP", label: "Tip" },
+      { marker: "IMPORTANT", label: "Important" },
+      { marker: "WARNING", label: "Warning" },
+      { marker: "CAUTION", label: "Caution" },
+    ];
+
+    it.each(ALERT_CASES)(
+      "renders the $marker alert with title and body",
+      ({ marker, label }) => {
+        const md = [`> [!${marker}]`, "> Body content for the alert."].join(
+          "\n",
+        );
+        const { container } = render(<MarkdownRenderer>{md}</MarkdownRenderer>);
+
+        const alert = screen.getByTestId(
+          `markdown-alert-${marker.toLowerCase()}`,
+        );
+        expect(alert).not.toBeNull();
+        // Title label must appear and the original `[!TYPE]` marker must not.
+        expect(alert.textContent).toContain(label);
+        expect(alert.textContent).toContain("Body content for the alert.");
+        expect(alert.textContent).not.toContain(`[!${marker}]`);
+        // The styled alert is rendered as a <div>, not a <blockquote>.
+        expect(container.querySelector("blockquote")).toBeNull();
+      },
+    );
+
+    it("accepts the marker with lowercase casing", () => {
+      const md = ["> [!warning]", "> mixed-case body"].join("\n");
+      render(<MarkdownRenderer>{md}</MarkdownRenderer>);
+      const alert = screen.getByTestId("markdown-alert-warning");
+      expect(alert.textContent).toContain("Warning");
+      expect(alert.textContent).toContain("mixed-case body");
+    });
+
+    it("renders the linked-issue example end-to-end", () => {
+      // The exact snippet from the bug report.
+      const md = [
+        "> [!WARNING]",
+        "> This project is in sandbox phase. It may be vibecoded, untested, or out of date. OpenHands takes no responsibility for the code or its support. [Learn more](https://github.com/OpenHands/incubator-program).",
+      ].join("\n");
+
+      render(<MarkdownRenderer includeStandard>{md}</MarkdownRenderer>);
+
+      const alert = screen.getByTestId("markdown-alert-warning");
+      expect(alert.textContent).toContain("Warning");
+      expect(alert.textContent).toContain("This project is in sandbox phase.");
+      expect(alert.textContent).not.toContain("[!WARNING]");
+      // The inline link inside the alert body still renders as an anchor.
+      const link = alert.querySelector("a");
+      expect(link?.getAttribute("href")).toBe(
+        "https://github.com/OpenHands/incubator-program",
+      );
+    });
+
+    it("leaves regular blockquotes (no [!TYPE] marker) as <blockquote>", () => {
+      const md = ["> Just a normal quote.", "> Second line."].join("\n");
+      const { container } = render(<MarkdownRenderer>{md}</MarkdownRenderer>);
+      expect(container.querySelector("blockquote")).not.toBeNull();
+      expect(screen.queryByTestId(/^markdown-alert-/)).toBeNull();
+    });
+
+    it("does not treat unknown alert types as alerts", () => {
+      const md = ["> [!UNKNOWN]", "> body"].join("\n");
+      const { container } = render(<MarkdownRenderer>{md}</MarkdownRenderer>);
+      expect(screen.queryByTestId(/^markdown-alert-/)).toBeNull();
+      // Falls back to a regular blockquote that still contains the literal
+      // marker text so the user can see what they wrote.
+      const bq = container.querySelector("blockquote");
+      expect(bq).not.toBeNull();
+      expect(bq?.textContent).toContain("[!UNKNOWN]");
+    });
+
+    it("survives rehype-sanitize (className passes through unchanged)", () => {
+      // Regression guard: if a future schema change strips className from
+      // the blockquote, the renderer would fall back to a plain blockquote
+      // and the test-id would disappear.
+      const md = ["> [!WARNING]", "> sanitized body"].join("\n");
+      render(<MarkdownRenderer>{md}</MarkdownRenderer>);
+      expect(screen.getByTestId("markdown-alert-warning")).not.toBeNull();
+    });
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "socket.io-client": "4.8.3",
         "tailwind-merge": "3.5.0",
         "tailwind-scrollbar": "4.0.2",
+        "unist-util-visit": "5.1.0",
         "uuid": "^14.0.0",
         "vite": "8.0.10",
         "zustand": "5.0.12"
@@ -63,6 +64,7 @@
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",
+        "@types/mdast": "4.0.4",
         "@types/node": "25.6.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "socket.io-client": "4.8.3",
     "tailwind-merge": "3.5.0",
     "tailwind-scrollbar": "4.0.2",
+    "unist-util-visit": "5.1.0",
     "uuid": "^14.0.0",
     "vite": "8.0.10",
     "zustand": "5.0.12"
@@ -104,6 +105,7 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
+    "@types/mdast": "4.0.4",
     "@types/node": "25.6.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/src/components/features/markdown/blockquote.tsx
+++ b/src/components/features/markdown/blockquote.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { ExtraProps } from "react-markdown";
+import {
+  FaCircleInfo,
+  FaLightbulb,
+  FaCircleExclamation,
+  FaTriangleExclamation,
+  FaCircleStop,
+} from "react-icons/fa6";
+import type { IconType } from "react-icons";
+import type { AlertType } from "./remark-github-alerts";
+
+interface AlertConfig {
+  label: string;
+  icon: IconType;
+  // Per-alert color overrides. We stick to Tailwind palette utilities so
+  // the classes show up in the source for the v4 content scanner.
+  containerClass: string;
+  titleClass: string;
+  iconClass: string;
+}
+
+const ALERT_CONFIG: Record<AlertType, AlertConfig> = {
+  note: {
+    label: "Note",
+    icon: FaCircleInfo,
+    containerClass: "border-l-blue-500 bg-blue-500/10",
+    titleClass: "text-blue-300",
+    iconClass: "text-blue-400",
+  },
+  tip: {
+    label: "Tip",
+    icon: FaLightbulb,
+    containerClass: "border-l-emerald-500 bg-emerald-500/10",
+    titleClass: "text-emerald-300",
+    iconClass: "text-emerald-400",
+  },
+  important: {
+    label: "Important",
+    icon: FaCircleExclamation,
+    containerClass: "border-l-purple-500 bg-purple-500/10",
+    titleClass: "text-purple-300",
+    iconClass: "text-purple-400",
+  },
+  warning: {
+    label: "Warning",
+    icon: FaTriangleExclamation,
+    containerClass: "border-l-yellow-500 bg-yellow-500/10",
+    titleClass: "text-yellow-300",
+    iconClass: "text-yellow-400",
+  },
+  caution: {
+    label: "Caution",
+    icon: FaCircleStop,
+    containerClass: "border-l-rose-500 bg-rose-500/10",
+    titleClass: "text-rose-300",
+    iconClass: "text-rose-400",
+  },
+};
+
+// Match `markdown-alert-<type>` anywhere in the className string. The
+// remark plugin emits the classes as an array which React serialises to
+// a space-separated string before this component sees it.
+const ALERT_CLASS_REGEX =
+  /(?:^|\s)markdown-alert-(note|tip|important|warning|caution)(?:\s|$)/i;
+
+function detectAlertType(className: string | undefined): AlertType | null {
+  if (!className) return null;
+  const match = className.match(ALERT_CLASS_REGEX);
+  return match ? (match[1].toLowerCase() as AlertType) : null;
+}
+
+// Custom component to render <blockquote> in markdown. Standard
+// blockquotes get a muted left-border treatment; GitHub-style alert
+// blockquotes (tagged by the `remark-github-alerts` plugin via
+// `markdown-alert markdown-alert-<type>` classes on the node) get a
+// coloured panel with an icon + title row matching GitHub's rendering.
+export function blockquote({
+  children,
+  className,
+}: React.ClassAttributes<HTMLQuoteElement> &
+  React.BlockquoteHTMLAttributes<HTMLQuoteElement> &
+  ExtraProps) {
+  const alertType = detectAlertType(className);
+
+  if (alertType) {
+    const config = ALERT_CONFIG[alertType];
+    const Icon = config.icon;
+    return (
+      <div
+        data-testid={`markdown-alert-${alertType}`}
+        className={`my-3 rounded-r-sm border-l-4 px-3 py-2 ${config.containerClass}`}
+      >
+        <p
+          className={`flex items-center gap-2 font-semibold ${config.titleClass}`}
+        >
+          <Icon aria-hidden className={`shrink-0 ${config.iconClass}`} />
+          <span>{config.label}</span>
+        </p>
+        <div className="text-content">{children}</div>
+      </div>
+    );
+  }
+
+  return (
+    <blockquote className="my-2 border-l-4 border-border pl-3 italic text-content-muted">
+      {children}
+    </blockquote>
+  );
+}

--- a/src/components/features/markdown/markdown-renderer.tsx
+++ b/src/components/features/markdown/markdown-renderer.tsx
@@ -11,6 +11,8 @@ import { paragraph } from "./paragraph";
 import { anchor } from "./anchor";
 import { h1, h2, h3, h4, h5, h6 } from "./headings";
 import { table, th, td } from "./table";
+import { blockquote } from "./blockquote";
+import { remarkGithubAlerts } from "./remark-github-alerts";
 
 // Build a sanitize schema that extends rehype-sanitize's defaults with a
 // few markdown-friendly additions. The defaults strip `<script>`, event
@@ -144,6 +146,7 @@ export function MarkdownRenderer({
     table,
     th,
     td,
+    blockquote,
     ...(includeStandard && {
       a: anchor,
       p: paragraph,
@@ -173,7 +176,7 @@ export function MarkdownRenderer({
     <div data-testid="markdown-renderer">
       <Markdown
         components={components}
-        remarkPlugins={[remarkGfm, remarkBreaks]}
+        remarkPlugins={[remarkGithubAlerts, remarkGfm, remarkBreaks]}
         rehypePlugins={rehypePlugins}
       >
         {markdownContent}

--- a/src/components/features/markdown/remark-github-alerts.ts
+++ b/src/components/features/markdown/remark-github-alerts.ts
@@ -1,0 +1,87 @@
+import type { Plugin } from "unified";
+import type { Root } from "mdast";
+import { visit } from "unist-util-visit";
+
+export const ALERT_TYPES = [
+  "note",
+  "tip",
+  "important",
+  "warning",
+  "caution",
+] as const;
+export type AlertType = (typeof ALERT_TYPES)[number];
+
+// GitHub's alert marker has the form `[!TYPE]` on the first line of a
+// blockquote, optionally followed by a newline before the body. We match
+// case-insensitively because GitHub does, and we swallow the trailing
+// `\r?\n` so the body content can start on the next visual line without
+// inheriting a leading break.
+const ALERT_REGEX = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*\r?\n?/i;
+
+/**
+ * Remark plugin that recognises GitHub-style alert blockquotes:
+ *
+ *     > [!WARNING]
+ *     > Body content
+ *
+ * When the first text node of a blockquote matches `[!TYPE]`, the marker
+ * is stripped and `markdown-alert markdown-alert-<type>` classes are
+ * attached to the blockquote via `hProperties`. A downstream renderer
+ * (see `blockquote.tsx`) inspects those classes to render the styled
+ * alert layout. Blockquotes that don't match the marker are left alone.
+ *
+ * The plugin tolerates running before OR after `remark-breaks`:
+ *   - Before: the first text node is `"[!WARNING]\nBody"`, the regex
+ *     consumes the marker plus its newline, leaving `"Body"`.
+ *   - After:  the first text node is just `"[!WARNING]"`, followed by a
+ *     `break` node. We drop the now-empty text node and the leading
+ *     break so the body paragraph reads naturally.
+ */
+function toClassList(value: unknown): string[] {
+  if (Array.isArray(value)) return value as string[];
+  if (typeof value === "string") return value.split(/\s+/).filter(Boolean);
+  return [];
+}
+
+export const remarkGithubAlerts: Plugin<[], Root> = () => (tree) => {
+  // Remark plugins mutate the AST in place by design — that's the visitor
+  // pattern `unist-util-visit` is built around. Aliasing each node to a
+  // local variable keeps the mutations out of `no-param-reassign`'s view
+  // without changing semantics.
+  visit(tree, "blockquote", (node) => {
+    const block = node;
+    const firstChild = block.children[0];
+    if (!firstChild || firstChild.type !== "paragraph") return;
+    const paragraph = firstChild;
+    const firstText = paragraph.children[0];
+    if (!firstText || firstText.type !== "text") return;
+
+    const match = firstText.value.match(ALERT_REGEX);
+    if (!match) return;
+
+    const type = match[1].toLowerCase() as AlertType;
+    const text = firstText;
+    text.value = text.value.replace(ALERT_REGEX, "");
+
+    if (text.value === "") {
+      paragraph.children.shift();
+      if (paragraph.children[0]?.type === "break") {
+        paragraph.children.shift();
+      }
+      if (paragraph.children.length === 0) {
+        block.children.shift();
+      }
+    }
+
+    block.data = block.data ?? {};
+    const existingHProps = (block.data.hProperties ?? {}) as Record<
+      string,
+      unknown
+    >;
+    const baseClasses = toClassList(existingHProps.className);
+    block.data.hProperties = {
+      ...existingHProps,
+      className: [...baseClasses, "markdown-alert", `markdown-alert-${type}`],
+    };
+  });
+};


### PR DESCRIPTION
## Summary

Adds support for GitHub's alert blockquote extension in the shared `MarkdownRenderer`, so blocks like:

```markdown
> [!WARNING]
> This project is in sandbox phase. It may be vibecoded, untested, or out of date. OpenHands takes no responsibility for the code or its support. [Learn more](https://github.com/OpenHands/incubator-program).
```

now render as a styled panel (colored left border, icon, title row, body) instead of falling through as a plain blockquote with a literal `[!WARNING]` marker on the first line.

Since the files view (`FileContentViewer`) and chat surfaces (`chat-message`, `generic-event-message`, `error-message`, `plan-preview`, etc.) all share `MarkdownRenderer`, this fixes both at once.

## Implementation

- **`src/components/features/markdown/remark-github-alerts.ts`** — new remark plugin that strips the `[!NOTE|TIP|IMPORTANT|WARNING|CAUTION]` marker from a blockquote's first text node and attaches `markdown-alert markdown-alert-<type>` classes via `hProperties`. Tolerates running before or after `remark-breaks` (handles both the `"[!WARNING]\nBody"` single-text-node case and the post-`remark-breaks` `text + break + text` case).
- **`src/components/features/markdown/blockquote.tsx`** — new react-markdown `blockquote` component that detects the alert classes and renders the styled layout (icon + colored title row + body) using per-type Tailwind palette utilities. Non-alert blockquotes still render as a plain `<blockquote>`.
- **`src/components/features/markdown/markdown-renderer.tsx`** — registers `remarkGithubAlerts` (ahead of `remark-gfm`/`remark-breaks`) and adds `blockquote` to the default components map. No sanitize-schema change required: the existing schema already permits `className` on every element, so the alert classes pass through unmodified.
- **`package.json`** — promotes `unist-util-visit@5.1.0` (runtime) and `@types/mdast@4.0.4` (dev) from transitive to direct deps so the new plugin's imports stay reproducible.

## Tests

Added 9 cases to `__tests__/components/features/markdown/markdown-renderer.test.tsx` covering every alert type, lowercase markers, the exact linked-issue snippet (asserts the inline `[Learn more]` anchor still renders inside the alert), plain-blockquote fallback, unknown alert types falling back to a plain blockquote, and a sanitize-regression guard.

## Verification

- `npm test -- __tests__/components/features/markdown/markdown-renderer.test.tsx` — 26/26 ✓
- Broader pass on `__tests__/components/features/markdown/` + `__tests__/components/features/chat/` — 151/151 ✓
- `npm run typecheck` ✓
- `npm run build` ✓
- `eslint` clean on changed source files

---

_This PR was created by an AI agent (OpenHands) on behalf of @rbren._
