### PR TITLE
fix: guard SdkSectionPage against schema responses missing `sections`

### DIFF
--- a/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
+++ b/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
@@ -613,6 +613,35 @@ describe("SdkSectionPage", () => {
     });
   });
 
+  it("renders the schema-unavailable fallback instead of crashing when the schema is malformed", async () => {
+    // Simulates the production failure mode we hit on Vercel previews:
+    // the frontend points at a host that does not serve
+    // `/api/settings/agent-schema`, so the schema query resolves with a
+    // truthy object that nevertheless has no `sections` array. The page
+    // must surface this as the existing "schema unavailable" message
+    // instead of throwing
+    // `Cannot read properties of undefined (reading 'filter')` and
+    // letting React Router escalate to a full-screen error.
+    const malformedSchema = {
+      model_name: "AgentSettings",
+      // `sections` deliberately omitted to mimic an SPA shell that
+      // happened to parse into a non-schema object.
+    } as unknown as NonNullable<Settings["agent_settings_schema"]>;
+
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({ agent_settings_schema: malformedSchema }),
+    );
+
+    renderSdkSectionPage({ sectionKeys: ["llm"] });
+
+    expect(
+      await screen.findByText("SETTINGS$SDK_SCHEMA_UNAVAILABLE"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("sdk-section-settings-screen"),
+    ).not.toBeInTheDocument();
+  });
+
   it("allows saving custom payloads when only external state is dirty", async () => {
     vi.spyOn(SettingsService, "getSettings").mockResolvedValue(buildSettings());
     const saveSettingsSpy = vi

--- a/__tests__/utils/sdk-settings-schema.test.ts
+++ b/__tests__/utils/sdk-settings-schema.test.ts
@@ -7,10 +7,11 @@ import {
   getVisibleSettingsSections,
   hasAdvancedSettingsOverrides,
   inferInitialView,
+  isValidSettingsSchema,
   SPECIALLY_RENDERED_KEYS,
 } from "#/utils/sdk-settings-schema";
 import { DEFAULT_SETTINGS } from "#/services/settings";
-import { Settings } from "#/types/settings";
+import { Settings, SettingsSchema } from "#/types/settings";
 
 const BASE_SETTINGS: Settings = {
   ...DEFAULT_SETTINGS,
@@ -336,6 +337,42 @@ describe("sdk settings schema helpers", () => {
         litellm_extra_body: { metadata: { tier: "sample" } },
       },
       critic: { enabled: true, mode: "all_actions" },
+    });
+  });
+
+  describe("isValidSettingsSchema", () => {
+    it("accepts a schema with an array sections field", () => {
+      expect(
+        isValidSettingsSchema({
+          model_name: "AgentSettings",
+          sections: [],
+        }),
+      ).toBe(true);
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["object without sections", { model_name: "AgentSettings" }],
+      [
+        "object with non-array sections",
+        { model_name: "AgentSettings", sections: "oops" },
+      ],
+    ])("rejects %s", (_label, value) => {
+      expect(isValidSettingsSchema(value as unknown as SettingsSchema)).toBe(
+        false,
+      );
+    });
+
+    it("makes getVisibleSettingsSections tolerate malformed schemas", () => {
+      // Regression test for the Vercel preview crash where the schema
+      // endpoint resolved with a truthy object that had no `sections`
+      // array, causing `.filter` to throw on undefined.
+      const malformed = {
+        model_name: "AgentSettings",
+      } as unknown as SettingsSchema;
+
+      expect(getVisibleSettingsSections(malformed, {}, "basic")).toEqual([]);
     });
   });
 });

--- a/src/components/features/settings/sdk-settings/sdk-section-page.tsx
+++ b/src/components/features/settings/sdk-settings/sdk-section-page.tsx
@@ -24,6 +24,7 @@ import {
   hasAdvancedSettings,
   hasMinorSettings,
   inferInitialView,
+  isValidSettingsSchema,
   SettingsDirtyState,
   SettingsFormValues,
   type SettingsValueSource,
@@ -226,9 +227,15 @@ export function SdkSectionPage({
     [sectionKeysSignature],
   );
 
-  // Build a filtered schema containing only the requested sections
+  // Build a filtered schema containing only the requested sections.
+  // `isValidSettingsSchema` guards against truthy-but-malformed schema
+  // responses (e.g. when the deployment is pointed at a host that does
+  // not serve `/api/settings/agent-schema` and returns an SPA shell
+  // that parses into an object without a `sections` array). Without
+  // the guard, `schema.sections.filter(...)` would throw and React
+  // Router would escalate the crash to a full-screen error.
   const filteredSchema = React.useMemo(() => {
-    if (!schema) return null;
+    if (!isValidSettingsSchema(schema)) return null;
     const sectionSet = new Set(stableSectionKeys);
     return {
       ...schema,

--- a/src/utils/sdk-settings-schema.ts
+++ b/src/utils/sdk-settings-schema.ts
@@ -30,7 +30,26 @@ const VIEW_PROMINENCES: Record<SettingsView, Set<SettingProminence>> = {
   all: new Set<SettingProminence>(["critical", "major", "minor"]),
 };
 
+/**
+ * True when `schema` looks like a usable `SettingsSchema` — i.e. an
+ * object with an array `sections` field. Guards every helper in this
+ * module against malformed/empty schema responses (e.g. when the
+ * frontend ends up pointing at a host that does not actually serve
+ * `/api/settings/agent-schema`, such as an unconfigured Vercel preview
+ * origin that returns the React Router SPA shell for arbitrary
+ * `/api/*` paths). Without this check, `schema.sections.filter(...)`
+ * inside `SdkSectionPage` blows up with
+ * `Cannot read properties of undefined (reading 'filter')` and React
+ * Router escalates to a full-screen error page.
+ */
+export function isValidSettingsSchema(
+  schema: SettingsSchema | null | undefined,
+): schema is SettingsSchema {
+  return !!schema && Array.isArray((schema as SettingsSchema).sections);
+}
+
 function getSchemaFields(schema: SettingsSchema): SettingsFieldSchema[] {
+  if (!isValidSettingsSchema(schema)) return [];
   return schema.sections.flatMap((section) => section.fields);
 }
 
@@ -434,6 +453,7 @@ export function getVisibleSettingsSections(
   view: SettingsView,
   excludeKeys: Set<string> = SPECIALLY_RENDERED_KEYS,
 ): SettingsSectionSchema[] {
+  if (!isValidSettingsSchema(schema)) return [];
   return schema.sections
     .map((section) => ({
       ...section,


### PR DESCRIPTION
## Why

Production Vercel deployments crash with a full-screen error boundary as soon as the user lands on any settings route that mounts `SdkSectionPage`:

```
TypeError: Cannot read properties of undefined (reading 'filter')
    at sdk-section-page-CqYnyhKB.js:1:6715
    ...
React Router caught the following error during render TypeError: Cannot read properties of undefined (reading 'filter')
```

### Root cause

`src/api/agent-server-config.ts::getAgentServerBaseUrl()` falls back to `window.location.origin` whenever no backend URL is configured. On Vercel, that means the seeded "Local" backend ends up pointing at the Vercel host itself, and `/api/settings/agent-schema` is served by the React Router runtime instead of an agent-server. The response sometimes resolves to a truthy non-schema object, which the unchecked cast in `SettingsService.getSettingsSchema()` happily passes through to the page. The page then does:

```ts
const filteredSchema = React.useMemo(() => {
  if (!schema) return null;
  return {
    ...schema,
    sections: schema.sections.filter((s) => sectionSet.has(s.key)),  // 💥 sections is undefined
  };
}, [schema, stableSectionKeys]);
```

…which throws, and React Router escalates to its error boundary.

`AGENTS.md` already acknowledges this hazard:

> Static mock verification … the client must start MSW whenever that flag is enabled, even in production/static builds, otherwise routes like `/settings` and the conversations pane fall through to the static server and crash on undefined `.filter`/`.map` assumptions.

The companion concern — preventing the frontend from auto-seeding the Vercel preview origin as a default agent-server URL in the first place — is being handled by #278. This PR adds the minimal defense-in-depth so production stops crashing while #278 finishes review.

## Summary

- New `isValidSettingsSchema` type guard in `src/utils/sdk-settings-schema.ts` that requires `Array.isArray(schema.sections)`.
- Apply the guard inside `getSchemaFields` and `getVisibleSettingsSections` so every helper in the module tolerates a malformed schema.
- Use the same guard in `SdkSectionPage`'s `filteredSchema` `useMemo`, which converts the crash into the existing `SETTINGS$SDK_SCHEMA_UNAVAILABLE` message path (the same render branch we already use when the schema query is in error).

## Tests

- `__tests__/utils/sdk-settings-schema.test.ts`: unit tests for `isValidSettingsSchema` (accepts a real schema, rejects `null`/`undefined`/`{model_name}`/non-array `sections`) plus a `getVisibleSettingsSections` regression that exercises the malformed-schema path.
- `__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx`: a new integration test that resolves the settings query with a schema that has no `sections` field and asserts the page renders the existing "schema unavailable" message instead of crashing.

I verified the integration test reproduces the production stack trace exactly when the guard is removed:

```
TypeError: Cannot read properties of undefined (reading 'filter')
 ❯ src/components/features/settings/sdk-settings/sdk-section-page.tsx:235:33
```

## Validation

- `npm run lint` — clean (0 errors, pre-existing warnings unchanged).
- `npm run typecheck` — pass.
- `npm run build` — pass.
- `npx vitest run __tests__/utils/sdk-settings-schema.test.ts __tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx` — 24 tests pass.

## Risk

Low. The only behavioral change for a well-formed schema is one extra `Array.isArray` check; malformed responses are now rendered as the existing "schema unavailable" fallback instead of crashing the route.

_This PR was created by an AI agent (OpenHands) on behalf of the user._