### PR TITLE
Pin dependency versions exactly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "tailwind-merge": "3.5.0",
         "tailwind-scrollbar": "4.0.2",
         "unist-util-visit": "5.1.0",
-        "uuid": "^14.0.0",
+        "uuid": "14.0.0",
         "vite": "8.0.10",
         "zustand": "5.0.12"
       },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "tailwind-merge": "3.5.0",
     "tailwind-scrollbar": "4.0.2",
     "unist-util-visit": "5.1.0",
-    "uuid": "^14.0.0",
+    "uuid": "14.0.0",
     "vite": "8.0.10",
     "zustand": "5.0.12"
   },


### PR DESCRIPTION
## Summary
- Pin the remaining non-exact Node dependency spec (`uuid`) to the lockfile-resolved exact version
- Refresh package-lock root metadata to match `package.json`

## Validation
- `npm install --package-lock-only --ignore-scripts`
- `npm ci --ignore-scripts --dry-run`
- Custom exact-spec scan for Node direct dependencies

_This PR was created by an AI agent (OpenHands) on behalf of the user._
