### PR TITLE
fix(chat): extend pending message watchdog to 2.5 minutes

### DIFF
--- a/src/stores/optimistic-user-message-store.ts
+++ b/src/stores/optimistic-user-message-store.ts
@@ -11,7 +11,7 @@ export type PendingUserMessageStatus = "sending" | "error";
  * Exported so tests can override it via vi.fakeTimers without hard-coding the
  * value.
  */
-export const PENDING_MESSAGE_TIMEOUT_MS = 60_000;
+export const PENDING_MESSAGE_TIMEOUT_MS = 150_000;
 
 export interface PendingUserMessage {
   id: string;


### PR DESCRIPTION
## What

Bumps `PENDING_MESSAGE_TIMEOUT_MS` in `src/stores/optimistic-user-message-store.ts` from **60s → 150s (2.5 minutes)**.

## Why

When you send a message, the chat UI shows an optimistic "Sending…" bubble that's cleared when the server's `UserMessageEvent` echo arrives over the WebSocket. If the echo doesn't land within `PENDING_MESSAGE_TIMEOUT_MS`, a frontend watchdog flips the bubble to an "error" state with a Retry link.

The 60s threshold turned out to be too aggressive — slow agent turns / cold-start LLM calls regularly take longer than that, so users would hit Retry on messages that were *still in flight*. Because the watchdog is purely a UI state change (it doesn't cancel the original send), and the retry path has no idempotency key, both copies of the message would end up landing on the backend.

2.5 minutes gives a much larger envelope before we tell the user the send failed.

## Notes

- Purely a UI-side timeout; nothing on the backend changes.
- The duplicate-on-retry issue is still possible in principle (any time the echo is genuinely lost), but is now far less likely to be triggered by ordinary latency. A proper fix (idempotency key on send, or only enabling Retry on confirmed WS disconnect) is left for a follow-up.
- Existing tests reference the exported constant via `vi.advanceTimersByTime(PENDING_MESSAGE_TIMEOUT_MS)`, so they adapt automatically.

---

_This PR was opened by an AI agent (OpenHands) on behalf of the user._