### PR TITLE
fix(conversation): re-enable worktrees for local workspace folders

### DIFF
--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -158,6 +158,65 @@ describe("AgentServerConversationService", () => {
         `/state/workspaces/${secondHex}`,
       );
     });
+
+    describe("worktree gating", () => {
+      beforeEach(() => {
+        mockGetSettings.mockResolvedValue({
+          agent_settings: { llm: { model: "gpt-4o" } },
+          conversation_settings: {},
+        });
+        mockGetSettingsForConversation.mockResolvedValue({
+          agentSettings: { llm: { model: "gpt-4o" } },
+          conversationSettings: {},
+          secretsEncrypted: true,
+        });
+        mockHttpPost.mockResolvedValue({
+          data: {
+            id: "ignored-server-id",
+            created_at: "2024-01-01",
+            updated_at: "2024-01-01",
+          },
+        });
+      });
+
+      const lastPayload = () => {
+        const calls = mockHttpPost.mock.calls;
+        return calls[calls.length - 1]![1] as { worktree: boolean };
+      };
+
+      it("requests a worktree when the user attached a git-provider repo", async () => {
+        await AgentServerConversationService.createConversation(
+          undefined,
+          undefined,
+          undefined,
+          {
+            selected_repository: "octo/repo",
+            selected_branch: "main",
+            git_provider: "github",
+          },
+        );
+
+        expect(lastPayload().worktree).toBe(true);
+      });
+
+      it("requests a worktree when the user picked a local workspace folder (workingDirOverride only)", async () => {
+        await AgentServerConversationService.createConversation(
+          undefined,
+          undefined,
+          undefined,
+          null,
+          "/some/local/workspace",
+        );
+
+        expect(lastPayload().worktree).toBe(true);
+      });
+
+      it("opts out of the worktree for the default ephemeral workspace (no repo, no override)", async () => {
+        await AgentServerConversationService.createConversation();
+
+        expect(lastPayload().worktree).toBe(false);
+      });
+    });
   });
 
   describe("downloadConversation local branch", () => {

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -119,12 +119,15 @@ class AgentServerConversationService {
       plugins,
       conversationId,
       workingDir,
-      // Only request a per-conversation git worktree when the user has
-      // attached a real repository. Local-only workspaces (no
-      // `selected_repository`) may not be git checkouts, in which case
-      // `git worktree add HEAD` on the server fails and the conversation
-      // never starts.
-      worktree: !!metadata?.selected_repository,
+      // Request a per-conversation git worktree for any real working
+      // tree the user attached — either a git-provider repo
+      // (`selected_repository`) or a locally-picked workspace folder
+      // (`workingDirOverride`). The only case that opts out is the
+      // default ephemeral workspace, where neither is set and
+      // `workingDir` falls back to `buildConversationWorkingDir(conversationId)`:
+      // that dir isn't a git repo, so `git worktree add HEAD` on the
+      // server would fail and the conversation would never start.
+      worktree: !!(metadata?.selected_repository || workingDirOverride),
     });
 
     const response = await createHttpClient().post<DirectConversationInfo>(


### PR DESCRIPTION
## Summary

Revert the `createConversation` worktree gating introduced in #322 so per-conversation git worktrees are requested for **any** real working tree the user attached — git-provider repos *and* locally-picked workspace folders — matching the pre-#322 behavior for those cases.

The only case that still opts out is the default ephemeral workspace, where neither `metadata.selected_repository` nor `workingDirOverride` is set and `workingDir` falls back to `buildConversationWorkingDir(conversationId)`. That directory isn't a git repo, so `git worktree add HEAD` on the server would fail and the conversation would never start — which is exactly the failure mode #322 was guarding against.

## Change

In `src/api/conversation-service/agent-server-conversation-service.api.ts`, inside `createConversation`:

```diff
-      // Only request a per-conversation git worktree when the user has
-      // attached a real repository. Local-only workspaces (no
-      // `selected_repository`) may not be git checkouts, in which case
-      // `git worktree add HEAD` on the server fails and the conversation
-      // never starts.
-      worktree: !!metadata?.selected_repository,
+      // Request a per-conversation git worktree for any real working
+      // tree the user attached — either a git-provider repo
+      // (`selected_repository`) or a locally-picked workspace folder
+      // (`workingDirOverride`). The only case that opts out is the
+      // default ephemeral workspace, where neither is set and
+      // `workingDir` falls back to `buildConversationWorkingDir(conversationId)`:
+      // that dir isn't a git repo, so `git worktree add HEAD` on the
+      // server would fail and the conversation would never start.
+      worktree: !!(metadata?.selected_repository || workingDirOverride),
```

## Explicitly **not** touched

- `src/api/agent-server-adapter.ts` — the `worktree?: boolean` plumbing and `?? true` default on the adapter side stay.
- `src/hooks/query/use-local-git-info.ts` — the folder-name fallback for the git control bar (the headline fix in #322) stays.
- `src/hooks/use-has-attached-source.ts` and anything else from #349 — the Files-tab Diff-vs-Files default stays.

## Tests

Added a `worktree gating` describe block in `__tests__/api/agent-server-conversation-service.test.ts` covering the three branches:

1. `selected_repository` set → `worktree: true`
2. `workingDirOverride` only (local workspace folder) → `worktree: true`
3. Neither set (default ephemeral workspace) → `worktree: false`

`__tests__/api/agent-server-conversation-service.test.ts` — 12 tests passing locally.

## Context

See PR #322 for the original gating and #349 for the Files-tab Diff default, both intentionally untouched here.

---

_This PR was opened by an AI agent (OpenHands) on behalf of the user._