### PR TITLE
Revert "fix: show folder name for local-only repos in git control bar"

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -197,7 +197,7 @@ describe("buildStartConversationRequest", () => {
     expect(payload.workspace.working_dir).toBe(workingDir);
   });
 
-  it("requests a git worktree by default for new conversations", () => {
+  it("always requests a git worktree for new conversations", () => {
     const payload = buildStartConversationRequest({
       settings: {
         ...DEFAULT_SETTINGS,
@@ -209,21 +209,6 @@ describe("buildStartConversationRequest", () => {
     }) as { worktree: boolean };
 
     expect(payload.worktree).toBe(true);
-  });
-
-  it("skips the worktree when the caller opts out (non-git workspace)", () => {
-    const payload = buildStartConversationRequest({
-      settings: {
-        ...DEFAULT_SETTINGS,
-        agent_settings: {
-          ...DEFAULT_SETTINGS.agent_settings,
-          llm: { model: "nested-model" },
-        },
-      },
-      worktree: false,
-    }) as { worktree: boolean };
-
-    expect(payload.worktree).toBe(false);
   });
 
   it("forwards supported conversation runtime fields from nested settings", () => {

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -377,13 +377,6 @@ export interface StartConversationOptions {
    * The actual values are fetched at runtime via LookupSecret.
    */
   customSecrets?: Array<{ name: string; description?: string }>;
-  /**
-   * Whether to request a dedicated git worktree for the conversation.
-   * Defaults to true. Set to false for local-only workspaces that aren't
-   * git repos (or have no commits), where `git worktree add HEAD` would
-   * fail and prevent the conversation from starting.
-   */
-  worktree?: boolean;
 }
 
 export function buildStartConversationRequest(
@@ -423,7 +416,7 @@ export function buildStartConversationRequest(
         : 500,
     stuck_detection: true,
     autotitle: true,
-    worktree: options.worktree ?? true,
+    worktree: true,
   };
 
   // Add secrets_encrypted flag if secrets are encrypted
@@ -505,7 +498,6 @@ export async function buildStartConversationRequestWithEncryptedSettings(options
   plugins?: PluginSpec[];
   conversationId?: string;
   workingDir?: string;
-  worktree?: boolean;
 }): Promise<Record<string, unknown>> {
   // Import SecretsService dynamically to avoid circular dependencies
   const { SecretsService } = await import("./secrets-service");

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -119,12 +119,6 @@ class AgentServerConversationService {
       plugins,
       conversationId,
       workingDir,
-      // Only request a per-conversation git worktree when the user has
-      // attached a real repository. Local-only workspaces (no
-      // `selected_repository`) may not be git checkouts, in which case
-      // `git worktree add HEAD` on the server fails and the conversation
-      // never starts.
-      worktree: !!metadata?.selected_repository,
     });
 
     const response = await createHttpClient().post<DirectConversationInfo>(

--- a/src/hooks/query/use-local-git-info.ts
+++ b/src/hooks/query/use-local-git-info.ts
@@ -13,12 +13,21 @@ export interface LocalGitInfo {
   remoteUrl: string | null;
 }
 
+const EMPTY_LOCAL_GIT_INFO: LocalGitInfo = {
+  repository: null,
+  branch: null,
+  provider: null,
+  remoteUrl: null,
+};
+
 /**
  * For local-workspace conversations (no `selected_repository` recorded on the
  * conversation), shell out via the agent server's bash-execute endpoint to
  * read `git remote get-url origin` and the current branch from the
- * conversation's working directory. Falls back to the working-dir basename
- * when the dir is not a git checkout.
+ * conversation's working directory.
+ *
+ * Returns `null` fields when the working dir is not a git checkout — callers
+ * should treat that the same as "no repo detected".
  */
 export const useLocalGitInfo = () => {
   const { data: conversation } = useActiveConversation();
@@ -59,12 +68,11 @@ export const useLocalGitInfo = () => {
         branchResult.exit_code === 0 ? branchResult.stdout.trim() : "";
       const branch = rawBranch && rawBranch !== "HEAD" ? rawBranch : null;
 
+      if (!remoteUrl && !branch) return EMPTY_LOCAL_GIT_INFO;
+
       const parsedRemote = parseGitRemoteUrl(remoteUrl);
-      // Fall back to the working-dir basename so the repo button shows a
-      // name even when there's no `origin` remote or no git at all.
-      const folderName = workingDir?.split("/").filter(Boolean).pop() ?? null;
       return {
-        repository: parsedRemote?.repository ?? folderName,
+        repository: parsedRemote?.repository ?? null,
         provider: parsedRemote?.provider ?? null,
         remoteUrl: remoteUrl || null,
         branch,


### PR DESCRIPTION
Reverts OpenHands/agent-canvas#322

@VascoSch92 I think this broke worktrees. The frontend is always sending `worktree: false` for me

I believe `selected_repository` is only set when working with remote conversations--i.e. when the user chose a repo from the remote picker