### PR TITLE
fix(frontend): stop tripping SaaS 500 on cloud conversation history

### DIFF
--- a/__tests__/api/event-service.test.ts
+++ b/__tests__/api/event-service.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import EventService from "#/api/event-service/event-service.api";
+import { callCloudProxy } from "#/api/cloud/proxy";
+import type { Backend } from "#/api/backend-registry/types";
+
+vi.mock("#/api/cloud/proxy", () => ({
+  callCloudProxy: vi.fn(),
+}));
+
+const cloudBackend: Backend = {
+  id: "cloud-1",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "cloud-key",
+  kind: "cloud",
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  setRegisteredBackends([cloudBackend]);
+  setActiveSelection({ backendId: cloudBackend.id, orgId: "org-1" });
+  vi.mocked(callCloudProxy).mockReset();
+  vi.mocked(callCloudProxy).mockResolvedValue({ items: [], next_page_id: null });
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  vi.mocked(callCloudProxy).mockReset();
+});
+
+describe("EventService.searchEvents — cloud branch", () => {
+  it("strips timestamp/sort/page params and clamps limit to <=100", async () => {
+    // Arrange: the caller (e.g. `useLoadOlderEvents`) may pass pagination
+    // filters the OpenHands SaaS App API can't handle without 500-ing.
+    // The cloud branch must mirror the cloud frontend's shape: limit only.
+    const options = {
+      limit: 500,
+      sortOrder: "TIMESTAMP_DESC" as const,
+      pageId: "p1",
+      timestampGte: "2026-05-01T00:00:00.000000",
+      timestampLt: "2026-05-12T07:20:29.087853",
+    };
+
+    // Act
+    await EventService.searchEvents("conv-1", null, null, options);
+
+    // Assert: forwarded path contains only limit=100 (caller's 500 clamped).
+    const proxyCall = vi.mocked(callCloudProxy).mock.calls[0][0];
+    expect(proxyCall.path).toBe(
+      "/api/v1/conversation/conv-1/events/search?limit=100",
+    );
+  });
+});

--- a/__tests__/hooks/use-load-older-events.test.tsx
+++ b/__tests__/hooks/use-load-older-events.test.tsx
@@ -15,6 +15,11 @@ import type { EventSearchPage } from "#/api/event-service/event-service.types";
 vi.mock("#/api/event-service/event-service.api");
 vi.mock("#/hooks/query/use-user-conversation");
 
+const mockUseActiveBackend = vi.fn();
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => mockUseActiveBackend(),
+}));
+
 function makeConversation(): Conversation {
   // Cast: `useUserConversation` actually returns an `AppConversation` whose
   // event-host URL lives on `conversation_url` (not the `Conversation.url`
@@ -70,6 +75,13 @@ describe("useLoadOlderEvents", () => {
     // Reset event store between tests so prior tests don't leak state.
     act(() => {
       useEventStore.getState().clearEvents();
+    });
+
+    // Default to a local backend so existing tests exercise the
+    // pagination path. Individual tests can override to cloud.
+    mockUseActiveBackend.mockReturnValue({
+      backend: { kind: "local" },
+      orgId: null,
     });
 
     vi.mocked(useUserConversation).mockReturnValue({
@@ -286,6 +298,35 @@ describe("useLoadOlderEvents", () => {
 
 
 
+
+  it("disables REST older-event pagination for cloud backends", async () => {
+    // Arrange: cloud backend active, plus an anchor event in the store
+    // that would otherwise let `loadOlder` issue a `timestamp__lt` request.
+    mockUseActiveBackend.mockReturnValue({
+      backend: { kind: "cloud" },
+      orgId: "org-1",
+    });
+    act(() => {
+      useEventStore
+        .getState()
+        .addEvent(makeEvent("evt-recent", "2024-06-01T00:00:00Z"));
+    });
+    const spy = vi.spyOn(EventService, "searchEvents");
+
+    const { result } = renderHook(() => useLoadOlderEvents("conv-1"), {
+      wrapper,
+    });
+
+    // Act
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    // Assert: cloud short-circuits — no request fires and hasMore is false
+    // from first render so the chat scroll handler never triggers.
+    expect(spy).not.toHaveBeenCalled();
+    expect(result.current.hasMore).toBe(false);
+  });
 
   it("stops paginating and throws when the oldest loaded event is missing a timestamp", async () => {
     act(() => {

--- a/src/api/event-service/event-service.api.ts
+++ b/src/api/event-service/event-service.api.ts
@@ -104,13 +104,21 @@ class EventService {
     if (active.kind === "cloud") {
       // Event *history* lives on the SaaS App API, not the runtime
       // sandbox. Path is singular `conversation` and v1-prefixed.
+      //
+      // Mirror the OpenHands SaaS frontend's request shape and send ONLY
+      // `limit`. The SaaS app-server's `search_events` has a server-side
+      // TypeError when filtering by `timestamp__lt` / `timestamp__gte`
+      // (it compares the stored `event.timestamp` str against the parsed
+      // datetime, which raises in Python 3 and surfaces as HTTP 500). The
+      // cloud frontend has never sent timestamp/sort/page filters here,
+      // so the broken path is untested; the safe contract is "limit
+      // only" until the server is fixed. `sort_order` and `page_id` are
+      // also dropped — neither is part of the proven-working shape, and
+      // older-event pagination is gated off in `useLoadOlderEvents` for
+      // cloud, so they have no caller to satisfy.
+      const cloudLimit = Math.min(limit, 100);
       const params = new URLSearchParams();
-      params.set("limit", String(limit));
-      if (options.pageId) params.set("page_id", options.pageId);
-      if (options.sortOrder) params.set("sort_order", options.sortOrder);
-      if (options.timestampGte)
-        params.set("timestamp__gte", options.timestampGte);
-      if (options.timestampLt) params.set("timestamp__lt", options.timestampLt);
+      params.set("limit", String(cloudLimit));
 
       const data = await callCloudProxy<EventSearchPage<OpenHandsEvent>>({
         backend: active,

--- a/src/hooks/use-load-older-events.ts
+++ b/src/hooks/use-load-older-events.ts
@@ -3,6 +3,7 @@ import EventService from "#/api/event-service/event-service.api";
 import { useUserConversation } from "#/hooks/query/use-user-conversation";
 import { useEventStore } from "#/stores/use-event-store";
 import { INITIAL_HISTORY_PAGE_SIZE } from "#/hooks/query/use-conversation-history";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import type { OpenHandsEvent } from "#/types/agent-server/core";
 
 const getEventTimestamp = (event: OpenHandsEvent): string | undefined =>
@@ -25,27 +26,40 @@ interface UseLoadOlderEventsResult {
  * REST-side companion to `useConversationHistory`: paginates older events
  * (`timestamp < oldest known`) into the event store on demand. Used by the
  * chat scroll handler to lazily backfill history when the user scrolls up.
+ *
+ * Cloud-mode caveat: REST-side older-event pagination is **disabled** for
+ * cloud backends. The SaaS app-server's `search_events` 500s when called
+ * with `timestamp__lt` / `timestamp__gte` (compares stored event.timestamp
+ * `str` against the parsed `datetime` and raises `TypeError`). Until the
+ * server-side bug at `openhands/app_server/event/event_service_base.py`
+ * (lines ~101–103) is fixed, the hook reports `hasMore: false` from first
+ * render and `loadOlder` is a no-op for cloud — matching the OpenHands
+ * cloud frontend, which never paginates older events either.
  */
 export const useLoadOlderEvents = (
   conversationId?: string | null,
 ): UseLoadOlderEventsResult => {
   const { data: conversation } = useUserConversation(conversationId ?? null);
   const addEvents = useEventStore((state) => state.addEvents);
+  const isCloud = useActiveBackend().backend.kind === "cloud";
 
   const [isLoading, setIsLoading] = React.useState(false);
-  const [hasMore, setHasMore] = React.useState(true);
+  const [hasMore, setHasMore] = React.useState(!isCloud);
   const isLoadingRef = React.useRef(false);
-  const hasMoreRef = React.useRef(true);
+  const hasMoreRef = React.useRef(!isCloud);
 
-  // Reset the pagination cursor whenever we switch conversations.
+  // Reset the pagination cursor whenever we switch conversations or
+  // backends. Cloud backends never have more older events to fetch via
+  // REST (see top-of-file comment), so `hasMore` settles to `false`.
   React.useEffect(() => {
-    hasMoreRef.current = true;
+    hasMoreRef.current = !isCloud;
     isLoadingRef.current = false;
-    setHasMore(true);
+    setHasMore(!isCloud);
     setIsLoading(false);
-  }, [conversationId]);
+  }, [conversationId, isCloud]);
 
   const loadOlder = React.useCallback(async () => {
+    if (isCloud) return;
     if (!conversationId || isLoadingRef.current || !hasMoreRef.current) {
       return;
     }
@@ -108,6 +122,7 @@ export const useLoadOlderEvents = (
     conversation?.conversation_url,
     conversation?.session_api_key,
     addEvents,
+    isCloud,
   ]);
 
   return { isLoading, hasMore, loadOlder };


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description**

When a user adds a cloud backend (e.g. `https://app.all-hands.dev`), selects it, and opens an existing cloud conversation, the conversation page surfaces an error toast — `Request failed with status code 500` — and event history fails to load cleanly. The same SaaS endpoint succeeds when called directly without timestamp filters.

**Steps to reproduce**

1. Run the GUI: `npm run dev` from the `agent-canvas` repo.
2. In the **Backend Selector** dropdown, click **Add Backend**.
3. Fill the form to point at the OpenHands Cloud production env:
   - Host Name: `Production`
   - Host: `https://app.all-hands.dev`
   - Type: `Cloud`
   - API Key: a Personal Workspace key for that env.
4. Verify the backend is added.
5. Select **Production – Personal Workspace** in the dropdown.
6. Open an existing cloud conversation.

**Actual behavior**

Conversation page shows `Request failed with status code 500`. The failing call is:

```
POST http://127.0.0.1:8000/api/cloud-proxy   →   500

{
  "host": "https://staging.all-hands.dev",
  "method": "GET",
  "path": "/api/v1/conversation/<id>/events/search?limit=50&sort_order=TIMESTAMP_DESC&timestamp__lt=2026-05-12T07:20:29.087853",
  "headers": { "Authorization": "Bearer …", "X-Org-Id": "…" },
  "body": null
}
```

The same endpoint with just `?limit=100` returns `200 OK`.

**Expected behavior**

Cloud conversations open cleanly and render event history; no 500 toast.

**Root cause**

The OpenHands SaaS App Server's `openhands/app_server/event/event_service_base.py:101-103` compares `event.timestamp` (a `str` per `openhands/sdk/event/base.py:28`) with `timestamp__lt` / `timestamp__gte` (a `datetime` from the route signature). In Python 3, `str < datetime` raises `TypeError` → 500. The OpenHands cloud frontend (`frontend/src/api/event-service/event-service.api.ts:68`) sidesteps this — `searchEventsV1` only sends `?limit=N`, no timestamp filters and no older-event pagination. Our `agent-canvas`'s `useLoadOlderEvents` sends `timestamp__lt` and trips the bug.

**Scope (client-side only)**

Fix the `agent-canvas` client to match the OpenHands cloud frontend's request shape for cloud backends. The server-side bug should be tracked separately and patched in `OpenHands` so older-event REST pagination can be re-enabled for cloud later.

**Acceptance criteria**

- [ ] Opening a cloud conversation no longer surfaces the 500 toast on initial load or on scroll.
- [ ] The forwarded `/api/v1/conversation/{id}/events/search` call sends **only** `?limit=N` (no `sort_order`, no `timestamp__lt`, no `timestamp__gte`, no `page_id`).
- [ ] `limit` is clamped to `≤ 100` on the cloud branch (server-enforced cap).
- [ ] Older-event REST pagination is intentionally disabled for cloud (`useLoadOlderEvents` reports `hasMore: false` and `loadOlder` is a no-op).
- [ ] Local backends keep their existing scroll-up pagination behavior (regression check).
- [ ] Switching between cloud ↔ local recomputes `hasMore` correctly without a page reload.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Cloud conversations 500'd on the conversation page because `useLoadOlderEvents` sent `?...&timestamp__lt=…` to the SaaS `/api/v1/conversation/{id}/events/search` endpoint, which raises `TypeError` server-side when comparing the stored event.timestamp (`str`) against the parsed datetime filter.
- Match the OpenHands cloud frontend's request shape on the cloud branch of `EventService.searchEvents` — `?limit=N` only — and short-circuit `useLoadOlderEvents` for cloud backends so the scroll-up handler never issues the broken request.
- Local backends are untouched; their bundled agent-server normalizes datetimes correctly, so `timestamp__lt` pagination keeps working.

## Root cause

`OpenHands` repo, `openhands/app_server/event/event_service_base.py:101-103`:

```python
# TODO: Are these comparison operators valid?
if timestamp__gte and event.timestamp < timestamp__gte:   # type: ignore[operator]
    continue
if timestamp__lt and event.timestamp >= timestamp__lt:    # type: ignore[operator]
    continue
````

`event.timestamp` is a `str`; `timestamp__lt` is parsed as `datetime` by FastAPI/Pydantic. `str < datetime` raises `TypeError` in Python 3 → 500. The OpenHands cloud frontend never triggers it because `searchEventsV1` only sends `?limit=N`.

Server-side fix is tracked separately. This PR is a defensive client-side fix that matches the proven-working request shape until the server is patched.

## Changes

* **`src/api/event-service/event-service.api.ts`** — cloud branch of `searchEvents`:

  * Build query with only `limit=min(options.limit ?? 100, 100)`.
  * Unconditionally drop `sort_order`, `page_id`, `timestamp__gte`, `timestamp__lt` (mirrors the OpenHands cloud frontend's `searchEventsV1`).
  * JSDoc explains the SaaS bug and the deferred re-enablement path.
* **`src/hooks/use-load-older-events.ts`** — short-circuit for cloud:

  * Read `useActiveBackend().backend.kind` to detect cloud (reactive form, so a local→cloud→local swap recomputes).
  * Initialize `hasMore` (and its ref) to `!isCloud`.
  * Reset effect now treats `isCloud` as a dependency.
  * `loadOlder` returns early when cloud is active.
  * JSDoc documents the cloud-mode degraded behavior and references the upstream server bug.

## Trade-offs

* **Cloud conversations with > 100 events**: the user sees only the most recent (or first, per SaaS default sort) 100 events. Matches the OpenHands cloud frontend behavior exactly. Re-enable older-event pagination after the server bug is fixed.
* No behavior change for local backends.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #319 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Run the GUI: `npm run dev` from the `agent-canvas` repo.
2. In the **Backend Selector** dropdown, click **Add Backend**.
3. Fill the form to point at the OpenHands Cloud production env:

   * Host Name: `Production`
   * Host: `https://app.all-hands.dev`
   * Type: `Cloud`
   * API Key: a Personal Workspace key for that env.
4. Verify the backend is added.
5. Select **Production – Personal Workspace** in the dropdown.
6. Open an existing cloud conversation.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="829" alt="app-1682" src="https://github.com/user-attachments/assets/791579e2-6c7d-48f6-8b01-63543edfbd21" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

* File a server-side fix in `OpenHands` at `openhands/app_server/event/event_service_base.py:101-103`: parse `event.timestamp` (str) into a datetime before comparison; normalize tz the same way `agent_server/event_router.py` already does locally.
* Once shipped, re-enable cloud older-event REST pagination here by reverting both gates.