### PR TITLE
fix(frontend): use HTTPS instead of SSH for typescript-client git dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3438,7 +3438,7 @@
     },
     "node_modules/@openhands/typescript-client": {
       "version": "0.1.1",
-      "resolved": "git+ssh://git@github.com/OpenHands/typescript-client.git#ef62e82fc3dfb03991a1c8025429caf354427263",
+      "resolved": "git+https://github.com/OpenHands/typescript-client.git#ef62e82fc3dfb03991a1c8025429caf354427263",
       "integrity": "sha512-Xf/qAgdXAhOLvEg6kxpYrXj2UWUhqQwWDLGOmUqMK8pY5MJCCLthArPYu5TGxJAmf5YWa3oFLadn67NE4RSFQg==",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

Vercel cannot authenticate to GitHub via SSH, so `npm ci` could not resolve commit `ef62e82` and ended up serving a stale cache of the package — one that doesn't include the newer client exports added in that commit. Switching to HTTPS lets Vercel fetch the exact pinned commit. The package contents themselves are fine (verified locally against the same SHA).

## Summary

<!-- 1-3 bullets describing what changed. -->
- Switch `@openhands/typescript-client`'s `resolved` URL in `package-lock.json` from `git+ssh://...` to `git+https://...`.
- Unblocks Vercel preview deployments, which have been failing on `main` since PR #278 with `MISSING_EXPORT` errors for `SharedClient`, `ConversationClient`, and `FileClient`.

### Changes

- `package-lock.json` — one-line change to `node_modules/@openhands/typescript-client` `resolved` URL. Integrity hash and commit SHA are unchanged.

```diff
-      "resolved": "git+ssh://git@github.com/OpenHands/typescript-client.git#ef62e82fc3dfb03991a1c8025429caf354427263",
+      "resolved": "git+https://github.com/OpenHands/typescript-client.git#ef62e82fc3dfb03991a1c8025429caf354427263",
```

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #384 

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
