### PR TITLE
fix: also tag prerelease versions as latest on npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -76,6 +76,8 @@ jobs:
         id: npm-tag
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          # Temporary until the first stable release; see cleanup issue:
+          # https://github.com/OpenHands/agent-canvas/issues/395
           if [[ "$TAG_VERSION" == *"alpha"* ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
             echo "also_latest=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -78,17 +78,28 @@ jobs:
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
           if [[ "$TAG_VERSION" == *"alpha"* ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
-            echo "Publishing with tag: alpha"
+            echo "also_latest=true" >> $GITHUB_OUTPUT
+            echo "Publishing with tag: alpha (also updating latest)"
           elif [[ "$TAG_VERSION" == *"beta"* ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
-            echo "Publishing with tag: beta"
+            echo "also_latest=true" >> $GITHUB_OUTPUT
+            echo "Publishing with tag: beta (also updating latest)"
           elif [[ "$TAG_VERSION" == *"rc"* ]]; then
             echo "tag=rc" >> $GITHUB_OUTPUT
-            echo "Publishing with tag: rc"
+            echo "also_latest=true" >> $GITHUB_OUTPUT
+            echo "Publishing with tag: rc (also updating latest)"
           else
             echo "tag=latest" >> $GITHUB_OUTPUT
+            echo "also_latest=false" >> $GITHUB_OUTPUT
             echo "Publishing with tag: latest"
           fi
 
       - name: Publish to npm with provenance
         run: npm publish --access public --provenance --tag ${{ steps.npm-tag.outputs.tag }}
+
+      - name: Also tag as latest for prerelease versions
+        if: steps.npm-tag.outputs.also_latest == 'true'
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          echo "Adding 'latest' tag to @openhands/agent-canvas@$PACKAGE_VERSION"
+          npm dist-tag add @openhands/agent-canvas@$PACKAGE_VERSION latest

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ The Agent Server is often paired with an [Automation Server](https://github.com/
 
 Agent Canvas is also available as an npm package for embedding in your own applications:
 
+> [!WARNING]
+> Agent Canvas has not published a stable release yet. Until the first stable version is available, the npm `latest` dist-tag may point to alpha, beta, or release-candidate builds, so `npm install @openhands/agent-canvas` can install a prerelease. Pin an exact version if you need predictable behavior.
+> This temporary behavior is tracked in [#395](https://github.com/OpenHands/agent-canvas/issues/395); retag `latest` to the first stable release when it ships.
+
 ```bash
 npm install @openhands/agent-canvas
 ```


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

When publishing prerelease versions (alpha, beta, rc), npm by default only tags them with their prerelease identifier (e.g., `alpha`), not `latest`. This meant users running `npm install @openhands/agent-canvas` wouldn't get the most recent version and required manual intervention after each release:

```bash
npm dist-tag add @openhands/agent-canvas@1.0.0-alpha.3 latest
```

Since we don't have stable releases yet, prerelease versions should also be tagged as `latest` so users get the most recent version without needing to specify `@alpha` explicitly.

## Summary

- Updated npm-publish workflow to also add the `latest` tag when publishing prerelease versions (alpha, beta, rc)
- The prerelease-specific tag (e.g., `alpha`) is still applied first, then `latest` is added as a secondary tag
- Added a README warning that `latest` may currently install prerelease builds
- Created tracking issue #395 to restore standard npm `latest` behavior for the first stable release

## Issue Number

N/A — follow-up cleanup tracked in #395

## How to Test

1. Push a new release tag (e.g., `v1.0.0-alpha.4`) after merging
2. Verify the GitHub Actions workflow completes successfully
3. Check npm tags: `npm view @openhands/agent-canvas dist-tags`
4. Both `alpha` and `latest` should point to the new version

## Video/Screenshots

N/A - CI workflow change

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This behavior can be reverted once we have stable (non-prerelease) versions and want to follow standard semver practices where `latest` only points to stable releases. Cleanup is tracked in #395.

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b044aa2a-5267-4b7c-9030-9a95546bb784)
