### PR TITLE
[codex] Fix automation agent-server auth

### DIFF
--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -478,6 +478,7 @@ function startAutomationBackend(config) {
       cwd: config.stateDir,
       env: {
         AUTOMATION_AGENT_SERVER_URL: `http://localhost:${config.agentServerPort}`,
+        AUTOMATION_AGENT_SERVER_API_KEY: config.sessionApiKey,
         AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(config.stateDir, "automations.db")}`,
         AUTOMATION_BASE_URL: `http://localhost:${config.ingressPort}`,
         AUTOMATION_WORKSPACE_BASE: join(config.stateDir, "workspaces"),


### PR DESCRIPTION
## Summary
- Pass the dev stack session API key to the local automation backend as `AUTOMATION_AGENT_SERVER_API_KEY`.
- Allows local automation runs to authenticate to the agent-server file API when uploading generated tarballs.

## Root Cause
The local automation backend was launched with `AUTOMATION_AGENT_SERVER_URL` but without the corresponding agent-server session key, so dispatch failed with `401 Unauthorized` on `/api/file/upload` before a conversation could be created.

## Validation
- Restarted locally with `npm run dev:dangerously-dockerless` and confirmed the automation backend process had `AUTOMATION_AGENT_SERVER_API_KEY` set.
- Observed the 5-minute automation get past tarball upload and create conversation `b11c595e-8d93-4fff-b3fb-084ee2ce18d9`.
- `npm test -- --run __tests__/scripts/dev-with-automation.test.ts` could not complete in the Codex sandbox because binding `127.0.0.1` is not permitted there; this appears unrelated to the change.

## Follow-up
The latest automation run progressed past the original auth failure, but the conversation later failed inside the agent run after a large `git log --stat` command hung and the model request returned `LLMBadRequestError`. That is separate from the `401 Unauthorized` startup issue fixed here.
