### PR TITLE
fix: use wss:// for external hosts to fix Safari WebSocket connections

### DIFF
--- a/__tests__/build-websocket-url.test.ts
+++ b/__tests__/build-websocket-url.test.ts
@@ -35,7 +35,7 @@ describe("buildWebSocketUrl", () => {
       expect(result).toBe("wss://example.com:8080/sockets/events/conv-123");
     });
 
-    it("should extract host and port from conversation URL", () => {
+    it("should use wss:// for external hosts even when page is HTTP (Safari compatibility)", () => {
       vi.stubGlobal("location", {
         protocol: "http:",
         host: "localhost:3000",
@@ -46,7 +46,21 @@ describe("buildWebSocketUrl", () => {
         "http://agent-server.com:9000/api/conversations/conv-456",
       );
 
-      expect(result).toBe("ws://agent-server.com:9000/sockets/events/conv-456");
+      expect(result).toBe("wss://agent-server.com:9000/sockets/events/conv-456");
+    });
+
+    it("should use ws:// for localhost when page is HTTP", () => {
+      vi.stubGlobal("location", {
+        protocol: "http:",
+        host: "localhost:3000",
+      });
+
+      const result = buildWebSocketUrl(
+        "conv-456",
+        "http://127.0.0.1:9000/api/conversations/conv-456",
+      );
+
+      expect(result).toBe("ws://127.0.0.1:9000/sockets/events/conv-456");
     });
   });
 
@@ -79,7 +93,7 @@ describe("buildWebSocketUrl", () => {
 
       const result = buildWebSocketUrl("conv-123", null);
 
-      expect(result).toBe("ws://fallback-host:4000/sockets/events/conv-123");
+      expect(result).toBe("wss://fallback-host:4000/sockets/events/conv-123");
     });
 
     it("should use window.location.host when conversation URL is undefined", () => {
@@ -90,7 +104,7 @@ describe("buildWebSocketUrl", () => {
 
       const result = buildWebSocketUrl("conv-123", undefined);
 
-      expect(result).toBe("ws://fallback-host:4000/sockets/events/conv-123");
+      expect(result).toBe("wss://fallback-host:4000/sockets/events/conv-123");
     });
 
     it("should use window.location.host when conversation URL is relative path", () => {
@@ -104,7 +118,7 @@ describe("buildWebSocketUrl", () => {
         "/api/conversations/conv-123",
       );
 
-      expect(result).toBe("ws://fallback-host:4000/sockets/events/conv-123");
+      expect(result).toBe("wss://fallback-host:4000/sockets/events/conv-123");
     });
 
     it("should use window.location.host when conversation URL is invalid", () => {
@@ -115,7 +129,7 @@ describe("buildWebSocketUrl", () => {
 
       const result = buildWebSocketUrl("conv-123", "not-a-valid-url");
 
-      expect(result).toBe("ws://fallback-host:4000/sockets/events/conv-123");
+      expect(result).toBe("wss://fallback-host:4000/sockets/events/conv-123");
     });
   });
 
@@ -145,22 +159,22 @@ describe("buildWebSocketUrl", () => {
       expect(result).toBeNull();
     });
 
-    it("should handle conversation URLs with non-standard ports", () => {
+    it("should handle conversation URLs with non-standard ports on external hosts", () => {
       const result = buildWebSocketUrl(
         "conv-123",
         "http://example.com:12345/api/conversations/conv-123",
       );
 
-      expect(result).toBe("ws://example.com:12345/sockets/events/conv-123");
+      expect(result).toBe("wss://example.com:12345/sockets/events/conv-123");
     });
 
-    it("should handle conversation URLs without port (default port)", () => {
+    it("should handle conversation URLs without port (default port) on external hosts", () => {
       const result = buildWebSocketUrl(
         "conv-123",
         "http://example.com/api/conversations/conv-123",
       );
 
-      expect(result).toBe("ws://example.com/sockets/events/conv-123");
+      expect(result).toBe("wss://example.com/sockets/events/conv-123");
     });
 
     it("should handle conversation IDs with special characters", () => {
@@ -182,6 +196,58 @@ describe("buildWebSocketUrl", () => {
 
       expect(result).toBe("ws://localhost:8080/sockets/events/conv-123");
       expect(result).not.toContain("?");
+    });
+  });
+
+  describe("Safari compatibility - external host detection", () => {
+    it("should use wss:// for prod-runtime.all-hands.dev domains", () => {
+      vi.stubGlobal("location", {
+        protocol: "http:",
+        host: "localhost:8000",
+      });
+
+      // Use obviously fake IDs that follow the format pattern
+      const fakeConversationId = "00000000deadbeef0000000000000000";
+      const fakeRuntimeHost = "faketesthost.prod-runtime.all-hands.dev";
+
+      const result = buildWebSocketUrl(
+        fakeConversationId,
+        `http://${fakeRuntimeHost}/api/conversations/${fakeConversationId}`,
+      );
+
+      expect(result).toBe(
+        `wss://${fakeRuntimeHost}/sockets/events/${fakeConversationId}`,
+      );
+    });
+
+    it("should use ws:// for ::1 (IPv6 localhost)", () => {
+      vi.stubGlobal("location", {
+        protocol: "http:",
+        host: "[::1]:3000",
+      });
+
+      const result = buildWebSocketUrl(
+        "test-conv-ipv6",
+        "http://[::1]:8080/api/conversations/test-conv-ipv6",
+      );
+
+      expect(result).toBe("ws://[::1]:8080/sockets/events/test-conv-ipv6");
+    });
+
+    it("should use ws:// for .localhost subdomains", () => {
+      vi.stubGlobal("location", {
+        protocol: "http:",
+        host: "app.localhost:3000",
+      });
+
+      const result = buildWebSocketUrl(
+        "test-conv-localhost-subdomain",
+        "http://api.localhost:8080/api/conversations/test-conv-localhost-subdomain",
+      );
+
+      expect(result).toBe(
+        "ws://api.localhost:8080/sockets/events/test-conv-localhost-subdomain",
+      );
     });
   });
 });

--- a/src/utils/websocket-url.ts
+++ b/src/utils/websocket-url.ts
@@ -66,6 +66,20 @@ export function buildHttpBaseUrl(
 }
 
 /**
+ * Determines if a hostname is a local/loopback address
+ */
+function isLocalHost(hostname: string): boolean {
+  // Strip brackets from IPv6 addresses (e.g., "[::1]" -> "::1")
+  const normalizedHostname = hostname.replace(/^\[|\]$/g, "");
+  return (
+    normalizedHostname === "localhost" ||
+    normalizedHostname === "127.0.0.1" ||
+    normalizedHostname === "::1" ||
+    normalizedHostname.endsWith(".localhost")
+  );
+}
+
+/**
  * Builds the WebSocket URL for V1 conversations (without query params)
  * @param conversationId The conversation ID
  * @param conversationUrl The conversation URL containing host/port (e.g., "http://localhost:3000/api/conversations/123")
@@ -85,7 +99,20 @@ export function buildWebSocketUrl(
   // Build WebSocket URL: ws://host:port[/path-prefix]/sockets/events/{conversationId}
   // The path prefix (e.g., /runtime/55313) is needed for proxy deployments
   // Note: Query params should be passed via the useWebSocket hook options
-  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  //
+  // Protocol selection:
+  // - Use wss:// when the page is served over HTTPS
+  // - Use wss:// for external (non-localhost) hosts even when page is HTTP,
+  //   because Safari blocks insecure ws:// connections to external domains
+  // - Use ws:// only for localhost connections when page is HTTP
+  //
+  // Extract hostname, handling IPv6 addresses like [::1]:8080
+  const wsHostname = baseHost.startsWith("[")
+    ? baseHost.slice(0, baseHost.indexOf("]") + 1) // IPv6: "[::1]"
+    : baseHost.split(":")[0]; // IPv4/hostname: "localhost" or "example.com"
+  const isExternalHost = !isLocalHost(wsHostname);
+  const pageIsSecure = window.location.protocol === "https:";
+  const protocol = pageIsSecure || isExternalHost ? "wss:" : "ws:";
 
   return `${protocol}//${baseHost}${pathPrefix}/sockets/events/${conversationId}`;
 }


### PR DESCRIPTION
## Summary

Safari blocks insecure `ws://` WebSocket connections to external domains, even when the page itself is served over HTTP. Chrome is more lenient about this mixed content scenario.

This change updates `buildWebSocketUrl()` to use `wss://` for external (non-localhost) hosts regardless of the page protocol, fixing WebSocket failures in Safari.

## Steps to Reproduce

1. Open a longer pre-existing cloud conversation in agent-canvas using Safari
2. In Chrome, the entire conversation renders correctly
3. In Safari, only the initial part of the conversation renders
4. Safari's Developer Tools Network tab shows multiple WebSocket errors with "resource was requested insecurely" message

**Example failing URL:**
```
ws://ozuphbczrvvwviwx.prod-runtime.all-hands.dev/sockets/events/{conversation_id}?resend_mode=since&after_timestamp=...
```

## Solution

Update `buildWebSocketUrl()` to:
- Use `wss://` for external (non-localhost) hosts regardless of page protocol
- Use `ws://` only for localhost connections when page is HTTP  
- Properly handle IPv6 addresses like `[::1]:8080`

**After fix:**
```
wss://ozuphbczrvvwviwx.prod-runtime.all-hands.dev/sockets/events/{conversation_id}?resend_mode=since&after_timestamp=...
```

## Testing

- [x] All 18 `buildWebSocketUrl` tests pass
- [x] Manually verified fix works in Safari
- [x] Chrome continues to work as expected

---
_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._