### PR TITLE
fix(frontend): show folder name in repo button for non-git workspaces

### DIFF
--- a/__tests__/components/features/chat/git-control-bar-repo-button.test.tsx
+++ b/__tests__/components/features/chat/git-control-bar-repo-button.test.tsx
@@ -92,6 +92,20 @@ describe("GitControlBarRepoButton", () => {
     });
   });
 
+  describe("when only a workspace name is provided", () => {
+    it("should display the workspace name as the button text", () => {
+      render(
+        <GitControlBarRepoButton
+          selectedRepository={null}
+          gitProvider={null}
+          workspaceName="test"
+        />,
+      );
+
+      expect(screen.getByText("test")).toBeInTheDocument();
+    });
+  });
+
   describe("when no repository is connected", () => {
     it("should render as a button with 'No Repo Connected' text", () => {
       render(

--- a/src/components/features/chat/git-control-bar-repo-button.tsx
+++ b/src/components/features/chat/git-control-bar-repo-button.tsx
@@ -10,6 +10,7 @@ import { useSettings } from "#/hooks/query/use-settings";
 interface GitControlBarRepoButtonProps {
   selectedRepository: string | null | undefined;
   gitProvider: Provider | null | undefined;
+  workspaceName?: string | null;
   onClick?: () => void;
   disabled?: boolean;
 }
@@ -17,6 +18,7 @@ interface GitControlBarRepoButtonProps {
 export function GitControlBarRepoButton({
   selectedRepository,
   gitProvider,
+  workspaceName,
   onClick,
   disabled,
 }: GitControlBarRepoButtonProps) {
@@ -38,7 +40,8 @@ export function GitControlBarRepoButton({
     ? constructRepositoryUrl(gitProvider, selectedRepository, providerHost)
     : undefined;
 
-  const buttonText = selectedRepository || t(I18nKey.COMMON$NO_REPO_CONNECTED);
+  const buttonText =
+    selectedRepository || workspaceName || t(I18nKey.COMMON$NO_REPO_CONNECTED);
 
   if (hasLinkableRepo) {
     return (
@@ -74,7 +77,7 @@ export function GitControlBarRepoButton({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] flex-1 truncate relative min-w-[170px]",
+        "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] truncate relative",
         "border border-[rgba(71,74,84,0.50)] bg-transparent",
         disabled
           ? "cursor-not-allowed opacity-50"

--- a/src/components/features/chat/git-control-bar.tsx
+++ b/src/components/features/chat/git-control-bar.tsx
@@ -20,6 +20,7 @@ import { useConversationId } from "#/hooks/use-conversation-id";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { useHomeStore } from "#/stores/home-store";
 import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
+import { getStoredConversationMetadata } from "#/api/conversation-metadata-store";
 
 interface GitControlBarProps {
   onSuggestionsClick: (value: string) => void;
@@ -69,6 +70,19 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
     localGitInfo?.provider) as Provider;
   const selectedBranch =
     conversationBranch || localGitInfo?.branch || undefined;
+
+  // For folder-only conversations (no remote repo), surface the basename of
+  // the originally attached workspace path so the button reads e.g. "test"
+  // rather than "No Repo Connected". `selected_workspace` is recorded at
+  // conversation creation; we prefer it over `workspace.working_dir` because
+  // the latter may point at a worktree subdir.
+  const storedMetadata = conversation?.id
+    ? getStoredConversationMetadata(conversation.id)
+    : null;
+  const workspacePath = storedMetadata?.selected_workspace ?? null;
+  const workspaceName = workspacePath
+    ? workspacePath.replace(/\/+$/, "").split("/").pop() || null
+    : null;
 
   // Keep git actions (pull/push/PR) gated on the conversation actually being
   // associated with a known git provider — local-only repos shouldn't enable
@@ -148,6 +162,7 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
         <GitControlBarRepoButton
           selectedRepository={selectedRepository}
           gitProvider={gitProvider}
+          workspaceName={workspaceName}
           onClick={() => setIsOpenRepoModalOpen(true)}
           disabled={!isConversationReady}
         />


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Problem
When a conversation is started against a local folder that has no `.git` directory (e.g. a workspace named `test` containing only a `README.md`), the `<GitControlBarRepoButton />` in the chat control bar shows the i18n string "No Repo Connected" instead of the folder name. The user *did* attach a workspace — the conversation runs inside that folder and the agent-server git-inits it for change tracking — so the empty label misrepresents the state and makes the control bar useless as a workspace indicator.

### Steps to reproduce
1. Clone `agent-server-gui` and start the dev server:
   ```
   export PROJECT_PATH=~/Documents/openhands && npm run dev
   ```
2. In `~/Documents/openhands`, ensure there is a workspace `test` consisting of a plain folder with a `README.md` only (no `.git` directory).
3. Open `http://localhost:3001`, click the `<NewConversationButton />`, and pick the `test` workspace.
4. Wait for the conversation page to load and observe the leftmost button in the git control bar.

### Current behavior
- `<GitControlBarRepoButton />` shows the text "No Repo Connected".
- Button width is artificially padded by a 170px minimum.

### Expected behavior
- `<GitControlBarRepoButton />` shows the folder name (`test`).
- Button width sizes to its content.
- Git worktree support remains enabled (already the case — `worktree: true` is sent from `agent-server-adapter.ts:419` unconditionally).

### Acceptance criteria
- Non-git workspace conversations: button text is the folder basename.
- Real git repos (`selected_repository` + `git_provider`): button still renders as an external `<a>` link with the repo name.
- Unattached conversations ("No workspace" launch): button still reads "No Repo Connected".
- Trailing slash in the stored workspace path does not produce an empty label.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Surface the folder basename (e.g. `test`) in `<GitControlBarRepoButton />` when a conversation is attached to a local folder that has no remote git repo.
- `<GitControlBar />` reads `selected_workspace` from the existing conversation-metadata store, derives the basename (trailing-slash safe, empty-string guarded), and forwards it as a new optional `workspaceName` prop.
- `<GitControlBarRepoButton />` consumes `workspaceName` as a middle-tier fallback in `buttonText`: `selectedRepository || workspaceName || t(COMMON$NO_REPO_CONNECTED)`. The link/non-link branching is unchanged, so folder-only conversations still render as a plain `<button>` (no external arrow icon) while real repos keep their external-link rendering.
- Removed `flex-1` and `min-w-[170px]` from the non-link button's classes so it sizes to its content instead of stretching to a forced minimum.

### Files changed
- `src/components/features/chat/git-control-bar-repo-button.tsx` — new `workspaceName` prop, fallback chain, content-sized non-link styling.
- `src/components/features/chat/git-control-bar.tsx` — read `selected_workspace` from metadata, derive basename, forward to the button.
- `__tests__/components/features/chat/git-control-bar-repo-button.test.tsx` — new test for the `workspaceName` fallback.

### Out of scope
- `software-agent-sdk` backend stays unchanged. `worktree: true` is already sent unconditionally from `agent-server-adapter.ts:419`; `_create_conversation_worktree` still returns `None` for non-git folders and `event_service._ensure_workspace_is_git_repo` runs `git init` afterward as before.
- Pull / Push / PR buttons remain gated on `conversationRepository` only, so folder-only conversations correctly do not get git-remote actions.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #320 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-server-gui` and start the dev server:
   ```
   export PROJECT_PATH=~/Documents/openhands && npm run dev
   ```
2. In `~/Documents/openhands`, ensure there is a workspace `test` consisting of a plain folder with a `README.md` only (no `.git` directory).
3. Open `http://localhost:3001`, click the `<NewConversationButton />`, and pick the `test` workspace.
4. Wait for the conversation page to load and observe the leftmost button in the git control bar.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="786" alt="image" src="https://github.com/user-attachments/assets/a261122d-cd96-4d0b-b0ab-68bf8b77d385" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore