### PR TITLE
fix(frontend): remove stale MCP item from Settings sidebar

### DIFF
--- a/__tests__/hooks/use-settings-nav-items.test.tsx
+++ b/__tests__/hooks/use-settings-nav-items.test.tsx
@@ -68,5 +68,6 @@ describe("useSettingsNavItems", () => {
     expect(paths).not.toContain("/settings/agent-server");
     expect(paths).not.toContain("/settings/integrations");
     expect(paths).not.toContain("/settings/skills");
+    expect(paths).not.toContain("/settings/mcp");
   });
 });

--- a/src/constants/settings-nav.tsx
+++ b/src/constants/settings-nav.tsx
@@ -1,7 +1,6 @@
 import KeyIcon from "#/icons/key.svg?react";
 import LockIcon from "#/icons/lock.svg?react";
 import MemoryIcon from "#/icons/memory_icon.svg?react";
-import ServerProcessIcon from "#/icons/server-process.svg?react";
 import SettingsGearIcon from "#/icons/settings-gear.svg?react";
 import CircuitIcon from "#/icons/u-circuit.svg?react";
 
@@ -26,11 +25,6 @@ export const OSS_NAV_ITEMS: SettingsNavItem[] = [
     icon: <LockIcon width={16} height={16} />,
     to: "/settings/verification",
     text: "SETTINGS$NAV_VERIFICATION",
-  },
-  {
-    icon: <ServerProcessIcon width={16} height={16} />,
-    to: "/settings/mcp",
-    text: "SETTINGS$NAV_MCP",
   },
   {
     icon: <SettingsGearIcon width={16} height={16} />,

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -1053,23 +1053,6 @@
     "uk": "Налаштуйте сервери MCP для розширених можливостей моделі",
     "ca": "Configura els servidors MCP per a capacitats de model millorades"
   },
-  "SETTINGS$NAV_MCP": {
-    "en": "MCP",
-    "ja": "MCP",
-    "zh-CN": "MCP",
-    "zh-TW": "MCP",
-    "ko-KR": "MCP",
-    "no": "MCP",
-    "it": "MCP",
-    "pt": "MCP",
-    "es": "MCP",
-    "ar": "MCP",
-    "fr": "MCP",
-    "tr": "MCP",
-    "de": "MCP",
-    "uk": "MCP",
-    "ca": "MCP"
-  },
   "SETTINGS$MCP_CONFIGURATION": {
     "en": "MCP Configuration",
     "ja": "MCP設定",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

After the MCP page was migrated from `/settings/mcp` to a top-level `/mcp` route under the **Extensions** navigation, the legacy entry in the **Settings** sidebar (`OSS_NAV_ITEMS` in `src/constants/settings-nav.tsx`) was not removed. Clicking it silently redirects users out of the Settings section to `/mcp`, exposing a defunct path and breaking the mental model of the navigation areas.

The intended layout is:

- **Extensions** nav: "MCP Servers" → `/mcp` (correct, kept as-is).
- **Settings** nav: no MCP entry (current bug: it still appears).

### Steps to Reproduce

1. Clone `agent-canvas` and start the dev server:
   ```bash
   export PROJECT_PATH=~/Documents/openhands && npm run dev
   ```
2. Open the **Settings** screen.
3. Inspect the sidebar.

### Current Behavior

- "MCP Servers" appears under Extensions.
- "MCP" *also* appears under Settings. Clicking it redirects to `/mcp`.

### Expected Behavior

- "MCP Servers" remains under Extensions.
- "MCP" is **removed** from the Settings sidebar.
- The legacy `/settings/mcp` URL still redirects to `/mcp` (preserves old bookmarks).

### Acceptance Criteria

- [ ] The "MCP" entry no longer appears in the Settings sidebar (desktop and mobile).
- [ ] The "MCP Servers" entry remains in the Extensions sidebar and loads `/mcp` correctly.
- [ ] Manually navigating to `/settings/mcp` still redirects to `/mcp`.
- [ ] Automated test in `__tests__/hooks/use-settings-nav-items.test.tsx` asserts that `/settings/mcp` is **not** in the Settings nav items.
- [ ] Typecheck and full test suite pass.

### Technical Notes

- Root cause is a single stale entry in `OSS_NAV_ITEMS` (`src/constants/settings-nav.tsx`).
- The redirect route (`src/routes/mcp-settings-redirect.tsx`) and the `MCPSettings` library re-export (`src/routes/mcp-settings.tsx` → `src/components/settings/index.ts`) must be preserved per `AGENTS.md:224`.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Removes the stale "MCP" menu item from the **Settings** sidebar. It still appears under **Extensions** as "MCP Servers" — that entry is unchanged.
- Cleans up the now-orphan `SETTINGS$NAV_MCP` i18n key from `translation.json` (the generated `declaration.ts` is regenerated by `npm run make-i18n`).
- Adds a TDD assertion to `use-settings-nav-items.test.tsx` so this entry cannot be re-introduced silently.

### Why

The MCP page was previously migrated from `/settings/mcp` to a top-level `/mcp` route under Extensions (see `AGENTS.md:224`). The legacy URL was kept as a redirect for old bookmarks, but the corresponding Settings-sidebar entry was never removed. Clicking it silently bounced users out of the Settings area, exposing a defunct path and confusing the navigation model.

### Changes

| File | Change |
| --- | --- |
| `src/constants/settings-nav.tsx` | Removed the MCP entry from `OSS_NAV_ITEMS` and the now-unused `ServerProcessIcon` import. |
| `src/i18n/translation.json` | Removed the orphan `SETTINGS$NAV_MCP` block. |
| `src/i18n/declaration.ts` | Regenerated by `npm run make-i18n` (derived from `translation.json`). |
| `__tests__/hooks/use-settings-nav-items.test.tsx` | Extended the existing "never lists removed settings sub-pages" assertion to also exclude `/settings/mcp`. |

### Intentionally NOT changed

- `src/routes.ts` and `src/routes/mcp-settings-redirect.tsx` — the `/settings/mcp` → `/mcp` redirect stays for backward compatibility.
- `src/routes/mcp-settings.tsx` — re-exports the new MCP page so the published `MCPSettings` library symbol (`src/components/settings/index.ts`) keeps its shape (per `AGENTS.md:224`).
- `src/components/features/skills/extensions-navigation.tsx` — the "MCP Servers" Extensions entry is untouched.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #426 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-canvas` and start the dev server:
   ```bash
   export PROJECT_PATH=~/Documents/openhands && npm run dev
   ```
2. Open the **Settings** screen.
3. Inspect the sidebar.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/961f964e-6ecd-45f8-9702-3bfde4f6e8bb

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

### Risk

Low. Single stale list entry removal, plus an orphan i18n key cleanup. No behavioral change to the MCP page itself or to any kept route.