### PR TITLE
fix(frontend): prevent add custom server button from being shrunk by flex header

### DIFF
--- a/__tests__/routes/mcp-page.test.tsx
+++ b/__tests__/routes/mcp-page.test.tsx
@@ -265,4 +265,17 @@ describe("MCPPage", () => {
       slack_1: { env: { SLACK_BOT_TOKEN: "xoxb-new", SLACK_TEAM_ID: "T02" } },
     });
   });
+
+  it("opens the custom server editor when the header 'Add custom server' button is clicked", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(buildSettings());
+
+    renderPage();
+
+    const addCustomBtn = await screen.findByTestId("mcp-add-custom-server");
+    fireEvent.click(addCustomBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mcp-custom-editor")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/routes/mcp.tsx
+++ b/src/routes/mcp.tsx
@@ -152,6 +152,7 @@ export default function MCPPage() {
                 type="button"
                 variant="secondary"
                 testId="mcp-add-custom-server"
+                className="flex-shrink-0 whitespace-nowrap"
                 onClick={() => setEditingServer({ id: "", type: "sse" })}
               >
                 {t(I18nKey.MCP$ADD_CUSTOM)}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

<img width="1440" height="786" alt="Image" src="https://github.com/user-attachments/assets/fcd4ace0-99c0-4a67-9d75-4b8b988370bf" />

On `http://localhost:3001/mcp`, the "Add custom server" button in the page header renders extremely narrow. Its label wraps across three lines instead of sitting on a single line, so the page's primary CTA looks broken and is hard to read.

### Steps to reproduce

1. Clone `agent-canvas` and start the dev server:

   ```bash
   export PROJECT_PATH=~/Documents/openhands && npm run dev
   ```

2. Open `http://localhost:3001/mcp`.
3. Look at the top-right of the page header, next to the "Model Context Protocol (MCP)" heading.

### Current behavior

The "Add custom server" button is shrunk to roughly the width of its longest word ("custom"), causing the label to wrap into three stacked lines.

### Expected behavior

The button should render on a single line, sized to fit its label, top-right of the page header — matching the visual treatment of other header CTAs in the app.

### Root cause

`src/routes/mcp.tsx` lays out the header as a `flex justify-between` row containing the heading/description on the left and the `BrandButton` on the right. `BrandButton` sets `w-fit` but no `flex-shrink-0` / `whitespace-nowrap`. Flex items default to `flex-shrink: 1` with `min-width: auto`, which for wrappable text content resolves toward the **min-content** width (the longest word) rather than max-content. The long heading + `max-w-2xl` description on the left claims most of the row's width, so the button gets compressed and its label wraps.

### Fix

Add `flex-shrink-0 whitespace-nowrap` to the `BrandButton` instance in `src/routes/mcp.tsx`. Localized to this instance — `BrandButton` is a shared primitive used in many other places that don't have this layout issue.

### Acceptance criteria

- [ ] On `/mcp`, the "Add custom server" button label renders on a single line.
- [ ] At narrower viewport widths, the heading/description column wraps; the button still stays on one line.
- [ ] Clicking the button still opens the custom server editor.
- [ ] An automated test covers the click-to-open behavior so the header CTA cannot silently break in the future.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The "Add custom server" button in the `/mcp` page header was being shrunk by its flex parent and its label wrapped onto three lines.
- Add `flex-shrink-0 whitespace-nowrap` to the `BrandButton` instance in `src/routes/mcp.tsx` so it keeps its `w-fit` width regardless of how the heading/description column claims space.
- Add a regression test that clicks the header CTA and asserts the custom server editor opens.

### Root cause

`src/routes/mcp.tsx` renders the page header as:

```tsx
<div className="flex items-start justify-between gap-4">
  <div className="space-y-1"> ...heading + max-w-2xl description... </div>
  <BrandButton ...>{t(I18nKey.MCP$ADD_CUSTOM)}</BrandButton>
</div>
```

`BrandButton` applies `w-fit` but does not set `flex-shrink-0` or `whitespace-nowrap`. Flex items default to `flex-shrink: 1` with `min-width: auto`, and for wrappable text content `min-width: auto` resolves toward min-content (the longest word) rather than max-content. The left column's long heading + description dominate the row's available width, so the flex layout shrinks the button to ~"custom" wide and the label wraps to three lines. `w-fit` is honored only up to what `flex-shrink` permits.

### Fix

Localized to the call site:

```diff
 <BrandButton
   type="button"
   variant="secondary"
   testId="mcp-add-custom-server"
+  className="flex-shrink-0 whitespace-nowrap"
   onClick={() => setEditingServer({ id: "", type: "sse" })}
 >
```

- `flex-shrink-0` prevents the flex row from compressing the button below its intrinsic `w-fit` width.
- `whitespace-nowrap` is defensive: it pins the button's intrinsic width to max-content so the label stays on one line even under future layout changes.

Localized rather than modified on the shared `BrandButton` because no other call sites are exhibiting this bug; changing the shared primitive risks unintended regressions elsewhere.

### Files changed

- `src/routes/mcp.tsx` — add `flex-shrink-0 whitespace-nowrap` to the header BrandButton.
- `__tests__/routes/mcp-page.test.tsx` — extend suite with a click-to-open regression test for the header CTA.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #428 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-canvas` and start the dev server:

   ```bash
   export PROJECT_PATH=~/Documents/openhands && npm run dev
   ```

2. Open `http://localhost:3001/mcp`.
3. Look at the top-right of the page header, next to the "Model Context Protocol (MCP)" heading.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="786" alt="output" src="https://github.com/user-attachments/assets/daffc2c9-32e1-492d-9626-0f0420978a65" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
