### PR TITLE
fix(frontend): allow chat column to shrink below content min-content

### DIFF
--- a/__tests__/components/features/conversation/chat-interface-wrapper.test.tsx
+++ b/__tests__/components/features/conversation/chat-interface-wrapper.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ChatInterfaceWrapper } from "#/components/features/conversation/conversation-main/chat-interface-wrapper";
+
+vi.mock("#/components/features/chat/chat-interface", () => ({
+  ChatInterface: () => <div data-testid="chat-interface" />,
+}));
+
+describe("ChatInterfaceWrapper", () => {
+  it("renders the chat interface when the right panel is hidden", () => {
+    render(<ChatInterfaceWrapper isRightPanelShown={false} />);
+
+    expect(screen.getByTestId("chat-interface")).toBeInTheDocument();
+  });
+
+  it("renders the chat interface when the right panel is shown", () => {
+    render(<ChatInterfaceWrapper isRightPanelShown />);
+
+    expect(screen.getByTestId("chat-interface")).toBeInTheDocument();
+  });
+});

--- a/src/components/features/conversation/conversation-main/chat-interface-wrapper.tsx
+++ b/src/components/features/conversation/conversation-main/chat-interface-wrapper.tsx
@@ -12,7 +12,7 @@ export function ChatInterfaceWrapper({
     <div className="flex justify-center w-full h-full">
       <div
         className={cn(
-          "w-full transition-all duration-300 ease-in-out",
+          "w-full min-w-0 transition-all duration-300 ease-in-out",
           isRightPanelShown ? "max-w-4xl" : "max-w-6xl",
         )}
       >

--- a/src/routes/root-layout.tsx
+++ b/src/routes/root-layout.tsx
@@ -107,7 +107,7 @@ export default function MainApp() {
         <title>{appTitle}</title>
         <Sidebar />
 
-        <div className="flex flex-col w-full h-[calc(100%-50px)] md:h-full gap-3">
+        <div className="flex flex-col w-full min-w-0 h-[calc(100%-50px)] md:h-full gap-3">
           {config.data &&
             (config.data.maintenance_start_time ||
               (config.data.faulty_models &&


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description:**

When viewing a conversation that contains a task tracker observation (e.g. a `TaskTrackerObservation` produced by the `task_tracker` tool), the rounded task-list card extends past the right edge of the browser as soon as the viewport is narrower than the chat content's natural width. The effect is reproducible at any viewport ≤ ~840 px and is visible whenever an event note holds an unbreakable string such as a long URL or file path.

The truncation is a UI-layout regression, not a text-wrapping issue. The task card itself fails to shrink with the browser — every descendant inside the chat column inherits an inflated width and the chat panel's `overflow-hidden` then clips the right edge.

**Steps to reproduce**

1. Clone the `agent-server-gui` repo and run `export PROJECT_PATH=~/Documents/openhands && npm run dev`.
2. Open the home page and create a new conversation.
3. Send a message that causes the agent to call the `task_tracker` tool (for example: *"Write a hello world script in bash. Use task_tracker tool before doing the task."*).
4. Resize the browser window so it is ≤ 840 px wide.

**Current behavior**

The task list card extends past the right edge of the chat column and is hard-clipped. Content on the right side is no longer visible and there is no horizontal scroll to recover it.

**Expected behavior**

The conversation column — including the task list card and every chat block — must shrink with the browser. The card stays inside the visible chat area regardless of viewport width.

**Root cause**

CSS flex `min-width: auto` propagation:

- The right-hand column in `src/routes/root-layout.tsx` is a flex item inside the row-direction root layout. Its default `min-width: auto` resolves to its content's min-content.
- Deep inside the chat tree, `TaskItem` uses `text-nowrap whitespace-pre`. With unbreakable text in a task's `notes`, the min-content of the chat subtree exceeds the available column width.
- Because `min-width` always wins over `max-width`, the right column inflates to fit the unbreakable line. Every descendant (chat panel, `ChatInterfaceWrapper`'s constrained inner div, `TaskListSection`) inherits the inflated width, and the chat panel's `overflow-hidden` clips the overflow on the right.

`min-w-0` has to be set at **two** levels — each independent flex item along the chain defaults to `min-width: auto` and one fix at the lower level is not enough.

**Fix**

1. `src/routes/root-layout.tsx` — add `min-w-0` to the right-column flex item so it can shrink below its content's min-content.
2. `src/components/features/conversation/conversation-main/chat-interface-wrapper.tsx` — add `min-w-0` to the inner constrained div so `max-w-6xl` / `max-w-4xl` are actually respected when the chat tree wants to be wider.

**Acceptance criteria**

- At any viewport ≥ the project's mobile breakpoint, the task list card stays fully inside the chat column when the browser is resized.
- Existing chat layout (centered content, `max-w-6xl` / `max-w-4xl` when the right panel toggles) is preserved.
- No regression in conversation-main or root-layout tests.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add `min-w-0` to the right-column flex item in `root-layout.tsx` and to the constrained inner div in `chat-interface-wrapper.tsx` so the chat column shrinks with the browser instead of being inflated by `text-nowrap` content deep inside the chat tree.
- The task-list card (and every other chat block) now stays inside the visible chat area at narrow viewports.

### Why

In CSS flexbox, a flex item's `min-width: auto` resolves to its content's min-content along the main axis. When a conversation contains a `TaskTrackerObservation` whose notes hold long unbreakable strings (URLs, file paths), the min-content of the chat subtree exceeds the available column width. `min-width` always wins over `max-width`, so the right column inflated past the viewport, the chat panel's `overflow-hidden` clipped it, and the task-list card visibly fell off the right edge below ~840 px. Two `min-w-0` additions are required — one on each independent flex item in the chain.

### Changes

- `src/routes/root-layout.tsx` — add `min-w-0` on the right-column flex item.
- `src/components/features/conversation/conversation-main/chat-interface-wrapper.tsx` — add `min-w-0` on the constrained inner div.
- `__tests__/components/features/conversation/chat-interface-wrapper.test.tsx` — new file. Per the project's testing rules (no CSS / styling assertions), the test exercises the component's functional contract for both `isRightPanelShown` states. The layout fix itself is verified manually using the reproduction steps below.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #433 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repo and run `export PROJECT_PATH=~/Documents/openhands && npm run dev`.
2. Open the home page and create a new conversation.
3. Send a message that causes the agent to call the `task_tracker` tool (for example: *"Write a hello world script in bash. Use task_tracker tool before doing the task."*).
4. Resize the browser window so it is ≤ 840 px wide.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/9e6fc38d-cd33-44b8-9b9e-f8a09b217e6c

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
