### PR TITLE
Check Docker dev home permissions before launch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,12 +149,13 @@
   - Should stay in sync with `DEFAULT_AGENT_SERVER_VERSION` in `dev-safe.mjs` for consistency between Docker and non-Docker dev modes
   - `OH_AGENT_SERVER_GIT_REF` — override to use a git ref-based tag (e.g., `main` → `main-python`, `abc1234` → `abc1234-python`)
   - Docker images are published from https://github.com/OpenHands/software-agent-sdk via the Agent Server workflow to `ghcr.io/openhands/agent-server`
+  - Startup runs a short Docker permission probe against the mounted `~/.openhands` path before starting services. Keep this fail-fast check when changing Docker mounts or persistence paths so settings writes do not fail later with opaque 500s.
 - Security: Both `scripts/dev-safe.mjs` and `scripts/dev-with-automation.mjs` auto-generate random API keys on each startup for better security isolation:
   - `SESSION_API_KEY` — 64-character hex (256-bit) for agent-server API authentication; auto-generated per session unless overridden via env var
   - `AUTOMATION_LOCAL_API_KEY` — 64-character hex for automation backend auth; auto-generated per session unless overridden
   - `OH_SECRET_KEY` — kept as a static default because it's used for encrypting/decrypting persisted settings values and needs consistency across restarts
 - `scripts/dev-safe.mjs` should fail fast if `uvx` cannot be spawned (for example missing PATH entries).
-- `npm run dev` now runs the full stack with automation by default (via `dev:automation`). Use `npm run dev:minimal` for agent-server + Vite only.
+- `npm run dev` now runs the full stack with automation by default (via `dev:docker`). Use `npm run dev:minimal` for agent-server + Vite only.
 - `scripts/dev-with-automation.mjs` runs the full stack: agent-server, automation backend (both via uvx), Vite dev server, and ingress proxy. Uses a standalone ingress proxy (`scripts/ingress.mjs`) to route traffic:
   - `/api/automation/*` → automation backend (:18001)
   - `/api/*`, `/sockets`, etc. → agent server (:18000)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Set `$PROJECT_PATH` to the directory on your machine where your projects live (e
 
 By default the container is kept isolated from your host home — only `~/.openhands`, `~/.claude`, `~/.codex`, and `~/.ssh` are mounted individually (and only if they exist). If you want the **Add Workspace** dialog to browse your real host filesystem, set `OH_MOUNT_HOST_HOME=1` before `npm run dev:docker` to bind-mount your entire host home onto `/home/openhands` in the container. The Add Workspace modal also shows this hint inline when it detects the mount is off. Watch the video on how to run this on [Mac](https://www.youtube.com/watch?v=BenkkQmmFCg) or [Windows](https://www.youtube.com/watch?v=WAxf_RRIrB8).
 
+On startup, Docker mode checks that the mounted `~/.openhands` directory can be used by the agent-server container. If the directory has incompatible ownership or permissions, `npm run dev:docker` fails before starting services and prints the host-side fix commands.
+
 ```sh
 export PROJECT_PATH=/path/to/your/projects
 git clone https://github.com/OpenHands/agent-canvas.git

--- a/__tests__/scripts/dev-docker.test.ts
+++ b/__tests__/scripts/dev-docker.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   CONTAINER_WORKSPACES_DIR,
+  buildDockerHomePermissionCheckArgs,
   isDockerPermissionDenied,
+  parseContainerUser,
 } from "../../scripts/dev-docker.mjs";
 
 describe("CONTAINER_WORKSPACES_DIR", () => {
@@ -28,5 +30,45 @@ describe("isDockerPermissionDenied", () => {
         "failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running",
       ),
     ).toBe(false);
+  });
+});
+
+describe("buildDockerHomePermissionCheckArgs", () => {
+  it("checks the individually mounted ~/.openhands directory by default", () => {
+    const args = buildDockerHomePermissionCheckArgs({
+      image: "ghcr.io/openhands/agent-server:1.22.0-python",
+      home: "/home/test",
+    });
+
+    expect(args).toContain("-v");
+    expect(args).toContain("/home/test/.openhands:/home/openhands/.openhands");
+    expect(args).toContain("--entrypoint");
+    expect(args).toContain("/bin/sh");
+    expect(args).toContain("ghcr.io/openhands/agent-server:1.22.0-python");
+    expect(args.at(-1)).toContain('chmod "$mode" "$target"');
+    expect(args.at(-1)).toContain(".agent-canvas-permission-check");
+  });
+
+  it("checks the same in-container path when the full host home is mounted", () => {
+    const args = buildDockerHomePermissionCheckArgs({
+      image: "agent-server:test",
+      home: "/Users/test",
+      mountHostHome: true,
+    });
+
+    expect(args).toContain("/Users/test:/home/openhands");
+    expect(args.at(-1)).toContain('target="/home/openhands/.openhands"');
+  });
+});
+
+describe("parseContainerUser", () => {
+  it("extracts the image user from permission probe output", () => {
+    expect(parseContainerUser("container_user=10001:10001\n")).toBe(
+      "10001:10001",
+    );
+  });
+
+  it("returns null when the probe did not print a user", () => {
+    expect(parseContainerUser("permission denied")).toBeNull();
   });
 });

--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -48,7 +48,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import process from "node:process";
 
@@ -74,6 +74,9 @@ const AGENT_SERVER_REPO = "ghcr.io/openhands/agent-server";
 // Note: The SDK build script strips the "v" prefix from semver release tags.
 const DEFAULT_AGENT_SERVER_TAG = "1.22.0-python";
 const CONTAINER_NAME = "agent-canvas-dev-agent-server";
+const CONTAINER_HOME_DIR = "/home/openhands";
+const CONTAINER_OPENHANDS_DIR = `${CONTAINER_HOME_DIR}/.openhands`;
+const HOME_PERMISSION_CHECK_FILE = ".agent-canvas-permission-check";
 
 // Default secret key matches dev-safe.mjs so persisted settings stay
 // decryptable across docker / non-docker runs.
@@ -85,8 +88,20 @@ const DEFAULT_SECRET_KEY = "openhands-dev-secret-key-change-in-prod";
 // dir (which is `~/.openhands` on the host, mounted in below). The frontend
 // receives this via VITE_WORKING_DIR so the working_dir it sends to the
 // agent-server is one the container can actually mkdir.
-const CONTAINER_WORKSPACES_DIR =
-  "/home/openhands/.openhands/agent-canvas/workspaces";
+const CONTAINER_WORKSPACES_DIR = `${CONTAINER_OPENHANDS_DIR}/agent-canvas/workspaces`;
+
+const HOME_PERMISSION_CHECK_SCRIPT = [
+  "set -eu",
+  `target=${JSON.stringify(CONTAINER_OPENHANDS_DIR)}`,
+  'echo "container_user=$(id -u):$(id -g)"',
+  'test -d "$target" || { echo "$target does not exist" >&2; exit 1; }',
+  'test -w "$target" || { echo "$target is not writable by the container user" >&2; exit 1; }',
+  'mode=$(stat -c %a "$target")',
+  'chmod "$mode" "$target" || { echo "$target permissions cannot be adjusted by the container user" >&2; exit 1; }',
+  `tmp="$target/${HOME_PERMISSION_CHECK_FILE}.$$"`,
+  `printf '%s\\n' ok > "$tmp"`,
+  'rm -f "$tmp"',
+].join("\n");
 
 /**
  * Resolve the docker image to use based on environment.
@@ -144,6 +159,122 @@ function logDockerInfoFailure(stderr) {
   logError("Start Docker (e.g. open Docker Desktop) and try again.");
 }
 
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function parseContainerUser(stdout) {
+  const match = stdout.match(/^container_user=(\d+:\d+)$/m);
+  return match ? match[1] : null;
+}
+
+function buildDockerHomePermissionCheckArgs({
+  image = resolveAgentServerImage(),
+  home = homedir(),
+  openhandsDir = join(home, ".openhands"),
+  mountHostHome = process.env.OH_MOUNT_HOST_HOME === "1",
+} = {}) {
+  const source = mountHostHome ? home : openhandsDir;
+  const target = mountHostHome ? CONTAINER_HOME_DIR : CONTAINER_OPENHANDS_DIR;
+
+  return [
+    "run",
+    "--rm",
+    "--entrypoint",
+    "/bin/sh",
+    "-v",
+    `${source}:${target}`,
+    image,
+    "-c",
+    HOME_PERMISSION_CHECK_SCRIPT,
+  ];
+}
+
+function logDockerHomePermissionFailure({
+  hostPath,
+  image,
+  stdout = "",
+  stderr = "",
+  error,
+}) {
+  const containerUser = parseContainerUser(stdout);
+  const firstDiagnosticLine = stderr.split("\n").find(Boolean);
+
+  logError("");
+  logError(
+    `Docker agent-server cannot use ${hostPath} as its persisted OpenHands state directory.`,
+  );
+  logError(
+    "The directory is bind-mounted into the container at /home/openhands/.openhands,",
+  );
+  logError(
+    "and the container must be able to adjust its permissions and write settings there.",
+  );
+  logError(`Image checked: ${image}`);
+  if (containerUser) {
+    logError(`Container user: ${containerUser}`);
+  }
+  if (firstDiagnosticLine) {
+    logError(`Docker check failed: ${firstDiagnosticLine}`);
+  }
+  if (error) {
+    logError(`Docker check failed: ${error.message}`);
+  }
+  logError("");
+  logError("Fix the host directory permissions, then rerun npm run dev.");
+  logError("On Linux, the usual fix is:");
+  if (containerUser) {
+    logError(`  sudo chown -R ${containerUser} ${shellQuote(hostPath)}`);
+  } else {
+    logError(
+      `  sudo chown -R <container-uid>:<container-gid> ${shellQuote(hostPath)}`,
+    );
+  }
+  logError(`  sudo chmod -R u+rwX ${shellQuote(hostPath)}`);
+  logError("");
+  logError(
+    "If you want to keep that directory owned only by your host user, use:",
+  );
+  logError("  npm run dev:dangerously-dockerless");
+}
+
+function checkDockerHomePermissions(config, env = process.env) {
+  const image = resolveAgentServerImage(env);
+  const openhandsDir = dirname(config.stateDir);
+  const mountHostHome = env.OH_MOUNT_HOST_HOME === "1";
+  const dockerArgs = buildDockerHomePermissionCheckArgs({
+    image,
+    openhandsDir,
+    mountHostHome,
+  });
+
+  logService(
+    "docker",
+    `Checking ${openhandsDir} permissions with ${image}...`,
+    c.dim,
+  );
+
+  const check = spawnSync("docker", dockerArgs, {
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 30_000,
+  });
+  const stdout = check.stdout ? check.stdout.toString().trim() : "";
+  const stderr = check.stderr ? check.stderr.toString().trim() : "";
+
+  if (check.error || check.status !== 0) {
+    logDockerHomePermissionFailure({
+      hostPath: openhandsDir,
+      image,
+      stdout,
+      stderr,
+      error: check.error,
+    });
+    process.exit(1);
+  }
+
+  logSuccess(`${openhandsDir} is writable by the Docker agent-server`);
+}
+
 /**
  * Check that the docker CLI is on PATH AND that the docker daemon is
  * actually responding. `commandExists("docker")` only verifies the binary is
@@ -180,6 +311,8 @@ function checkDockerPrereqs(config) {
     process.exit(1);
   }
   logSuccess(`PROJECT_PATH=${process.env.PROJECT_PATH}`);
+
+  checkDockerHomePermissions(config);
 }
 
 function startAgentServerDocker(config) {
@@ -320,12 +453,16 @@ if (isMainModule) {
 
 export {
   AGENT_SERVER_REPO,
+  buildDockerHomePermissionCheckArgs,
   CONTAINER_LOCAL_SDK_DIR,
   CONTAINER_NAME,
+  CONTAINER_OPENHANDS_DIR,
   CONTAINER_WORKSPACES_DIR,
   DEFAULT_AGENT_SERVER_TAG,
   checkDockerPrereqs,
+  checkDockerHomePermissions,
   isDockerPermissionDenied,
+  parseContainerUser,
   resolveAgentServerImage,
   startAgentServerDocker,
 };


### PR DESCRIPTION
## Summary

- Add a Docker preflight probe for the mounted `~/.openhands` persistence directory before `npm run dev` starts services.
- The probe uses the same agent-server image and mount target as the real dev container, then verifies the container user can write there and adjust permissions.
- Fail fast with the image user, the failing probe detail, and host-side permission fix commands instead of surfacing a later `PATCH /api/settings` 500.
- Add regression tests for the generated probe command and document the startup check.

## Validation

- `npx vitest run __tests__/scripts/dev-docker.test.ts`
- `PROJECT_PATH=/home/xingyaow/Projects timeout 60s node --env-file-if-exists=.env scripts/dev-docker.mjs` (verified fail-fast permission message before services start)
- `npm exec prettier -- --check scripts/dev-docker.mjs __tests__/scripts/dev-docker.test.ts`
- `npm run typecheck && npm run build`