### PR TITLE
[codex] Fix static automation agent-server auth

### DIFF
--- a/__tests__/scripts/dev-static.test.ts
+++ b/__tests__/scripts/dev-static.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAutomationBackendEnv } from "../../scripts/dev-static.mjs";
+
+describe("dev-static", () => {
+  it("passes the agent-server session key to the automation backend", () => {
+    const env = buildAutomationBackendEnv({
+      agentServerPort: 18000,
+      ingressPort: 8000,
+      localApiKey: "automation-local-key",
+      sessionApiKey: "agent-session-key",
+      stateDir: "/tmp/agent-canvas-state",
+    });
+
+    expect(env).toMatchObject({
+      AUTOMATION_AGENT_SERVER_URL: "http://localhost:18000",
+      AUTOMATION_AGENT_SERVER_API_KEY: "agent-session-key",
+      AUTOMATION_LOCAL_API_KEY: "automation-local-key",
+    });
+  });
+});

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -51,10 +51,7 @@ import {
   isPortBusy,
   releaseStaleConversationLeases,
 } from "./dev-safe.mjs";
-import {
-  buildAutomationCommand,
-  buildConfig,
-} from "./dev-with-automation.mjs";
+import { buildAutomationCommand, buildConfig } from "./dev-with-automation.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
@@ -310,6 +307,21 @@ function startAgentServer(config) {
   );
 }
 
+function buildAutomationBackendEnv(config) {
+  return {
+    AUTOMATION_AGENT_SERVER_URL: `http://localhost:${config.agentServerPort}`,
+    AUTOMATION_AGENT_SERVER_API_KEY: config.sessionApiKey,
+    AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(config.stateDir, "automations.db")}`,
+    AUTOMATION_BASE_URL: `http://localhost:${config.ingressPort}`,
+    AUTOMATION_WORKSPACE_BASE: join(config.stateDir, "workspaces"),
+    AUTOMATION_LOCAL_API_KEY: config.localApiKey,
+    AUTOMATION_CORS_ORIGINS: `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:3001,http://127.0.0.1:3001`,
+    FILE_STORE: "local",
+    LOCAL_STORAGE_PATH: join(config.stateDir, "storage"),
+    OPENHANDS_SUPPRESS_BANNER: "1",
+  };
+}
+
 function startAutomationBackend(config) {
   logService(
     "automation",
@@ -332,17 +344,7 @@ function startAutomationBackend(config) {
     ],
     {
       cwd: config.stateDir,
-      env: {
-        AUTOMATION_AGENT_SERVER_URL: `http://localhost:${config.agentServerPort}`,
-        AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(config.stateDir, "automations.db")}`,
-        AUTOMATION_BASE_URL: `http://localhost:${config.ingressPort}`,
-        AUTOMATION_WORKSPACE_BASE: join(config.stateDir, "workspaces"),
-        AUTOMATION_LOCAL_API_KEY: config.localApiKey,
-        AUTOMATION_CORS_ORIGINS: `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:3001,http://127.0.0.1:3001`,
-        FILE_STORE: "local",
-        LOCAL_STORAGE_PATH: join(config.stateDir, "storage"),
-        OPENHANDS_SUPPRESS_BANNER: "1",
-      },
+      env: buildAutomationBackendEnv(config),
       color: c.green,
     },
   );
@@ -584,7 +586,7 @@ async function main() {
 // Exports for testing
 // ═══════════════════════════════════════════════════════════════════════════
 
-export { buildFrontend, startStaticServer };
+export { buildAutomationBackendEnv, buildFrontend, startStaticServer };
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Main entry point (only when run directly, not when imported)


### PR DESCRIPTION
## Summary

- Pass the generated agent-server session key to the automation backend when using the static dockerless launcher.
- Reuse a tested env builder for the static automation backend startup environment.
- Add a regression test that verifies `AUTOMATION_AGENT_SERVER_API_KEY` is set from `config.sessionApiKey`.

## Root Cause

`npm run dev:dangerously-dockerless` starts the static launcher, whose automation backend env included `AUTOMATION_AGENT_SERVER_URL` but omitted `AUTOMATION_AGENT_SERVER_API_KEY`. Scheduled automation runs could reach the local agent server but failed authenticated calls such as `/api/file/upload` with `401 Unauthorized`, so no conversation was created.

## Validation

- `npm test -- __tests__/scripts/dev-static.test.ts`
- `npm run typecheck`
- `npm run build`
