### PR TITLE
Auto-refresh stale static frontend

### DIFF
--- a/__tests__/utils/static-build-refresh.test.ts
+++ b/__tests__/utils/static-build-refresh.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  STATIC_BUILD_REFRESH_QUERY_PARAM,
+  refreshIfStaticAssetsChanged,
+} from "#/utils/static-build-refresh";
+
+function htmlResponse(html: string): Pick<Response, "ok" | "text"> {
+  return {
+    ok: true,
+    text: () => Promise.resolve(html),
+  };
+}
+
+describe("static build refresh", () => {
+  it("reloads when the current HTML no longer references a loaded asset", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      htmlResponse(`
+        <script type="module" src="/assets/entry.client-new.js"></script>
+        <link rel="stylesheet" href="/assets/root-new.css" />
+      `),
+    );
+    const reload = vi.fn();
+
+    await expect(
+      refreshIfStaticAssetsChanged({
+        currentAssets: ["/assets/entry.client-old.js", "/assets/root-old.css"],
+        htmlUrl: "/conversations",
+        fetcher,
+        reload,
+      }),
+    ).resolves.toBe(true);
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "/conversations",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: { Accept: "text/html" },
+      }),
+    );
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("does not reload when the current HTML still references the loaded assets", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      htmlResponse(`
+        <script type="module" src="/assets/entry.client-current.js"></script>
+        <link rel="stylesheet" href="/assets/root-current.css" />
+      `),
+    );
+    const reload = vi.fn();
+
+    await expect(
+      refreshIfStaticAssetsChanged({
+        currentAssets: [
+          "/assets/entry.client-current.js",
+          "/assets/root-current.css",
+        ],
+        htmlUrl: "/conversations",
+        fetcher,
+        reload,
+      }),
+    ).resolves.toBe(false);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the loaded page has no static assets", async () => {
+    const fetcher = vi.fn();
+    const reload = vi.fn();
+
+    await expect(
+      refreshIfStaticAssetsChanged({
+        currentAssets: [],
+        fetcher,
+        reload,
+      }),
+    ).resolves.toBe(false);
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("cache-busts the current HTML URL when one is not provided", async () => {
+    window.history.pushState({}, "", "/conversations");
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse('<script src="/assets/app.js"></script>'),
+      );
+
+    await refreshIfStaticAssetsChanged({
+      currentAssets: ["/assets/app.js"],
+      fetcher,
+      reload: vi.fn(),
+    });
+
+    const requestedUrl = new URL(fetcher.mock.calls[0][0] as string);
+    expect(requestedUrl.pathname).toBe("/conversations");
+    expect(
+      requestedUrl.searchParams.has(STATIC_BUILD_REFRESH_QUERY_PARAM),
+    ).toBe(true);
+  });
+});

--- a/src/entry.client.tsx
+++ b/src/entry.client.tsx
@@ -13,6 +13,7 @@ import {
 } from "./components/providers";
 import { waitForI18n } from "./i18n";
 import { shouldStartMockWorker } from "./mocks/should-start-mock-worker";
+import { startStaticBuildRefreshWatcher } from "./utils/static-build-refresh";
 
 async function prepareApp() {
   await waitForI18n();
@@ -41,6 +42,7 @@ async function prepareApp() {
 
 prepareApp().then(() =>
   startTransition(() => {
+    startStaticBuildRefreshWatcher();
     hydrateRoot(
       document,
       <StrictMode>

--- a/src/utils/static-build-refresh.ts
+++ b/src/utils/static-build-refresh.ts
@@ -1,0 +1,106 @@
+export const STATIC_BUILD_REFRESH_INTERVAL_MS = 10_000;
+export const STATIC_BUILD_REFRESH_QUERY_PARAM = "__agent_canvas_static_refresh";
+
+type HtmlResponse = Pick<Response, "ok" | "text">;
+
+interface StaticBuildRefreshOptions {
+  currentAssets?: string[];
+  htmlUrl?: string;
+  fetcher?: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<HtmlResponse>;
+  reload?: () => void;
+}
+
+interface StaticBuildRefreshWatcherOptions extends StaticBuildRefreshOptions {
+  intervalMs?: number;
+}
+
+function getAssetPathsFromHtml(html: string): string[] {
+  return Array.from(
+    html.matchAll(/["'](\/assets\/[^"']+)["']/g),
+    (match) => match[1],
+  );
+}
+
+function getCurrentDocumentAssets(): string[] {
+  if (typeof document === "undefined") return [];
+  return [
+    ...new Set(getAssetPathsFromHtml(document.documentElement.outerHTML)),
+  ];
+}
+
+function getCurrentHtmlUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  const url = new URL(window.location.href);
+  url.searchParams.set(STATIC_BUILD_REFRESH_QUERY_PARAM, String(Date.now()));
+  return url.toString();
+}
+
+export async function refreshIfStaticAssetsChanged(
+  options: StaticBuildRefreshOptions = {},
+): Promise<boolean> {
+  const currentAssets = options.currentAssets ?? getCurrentDocumentAssets();
+  if (currentAssets.length === 0) return false;
+
+  const fetcher = options.fetcher ?? globalThis.fetch?.bind(globalThis);
+  if (!fetcher) return false;
+
+  const htmlUrl = options.htmlUrl ?? getCurrentHtmlUrl();
+  if (!htmlUrl) return false;
+
+  try {
+    const response = await fetcher(htmlUrl, {
+      cache: "no-store",
+      headers: { Accept: "text/html" },
+    });
+    if (!response.ok) return false;
+
+    const nextHtml = await response.text();
+    if (currentAssets.every((asset) => nextHtml.includes(asset))) {
+      return false;
+    }
+
+    const reload = options.reload ?? (() => globalThis.location?.reload?.());
+    reload();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function startStaticBuildRefreshWatcher(
+  options: StaticBuildRefreshWatcherOptions = {},
+): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const currentAssets = options.currentAssets ?? getCurrentDocumentAssets();
+  if (currentAssets.length === 0) return () => {};
+
+  let pending = false;
+
+  const check = () => {
+    if (document.visibilityState === "hidden" || pending) return;
+    pending = true;
+    void refreshIfStaticAssetsChanged({ ...options, currentAssets }).finally(
+      () => {
+        pending = false;
+      },
+    );
+  };
+
+  const interval = window.setInterval(
+    check,
+    options.intervalMs ?? STATIC_BUILD_REFRESH_INTERVAL_MS,
+  );
+  window.addEventListener("focus", check);
+  document.addEventListener("visibilitychange", check);
+  check();
+
+  return () => {
+    window.clearInterval(interval);
+    window.removeEventListener("focus", check);
+    document.removeEventListener("visibilitychange", check);
+  };
+}


### PR DESCRIPTION
## Summary
- detect when an already-open static frontend is still running an older set of `/assets/...` files
- fetch the current page HTML with `cache: no-store` and reload when the served asset fingerprints have changed
- run the check on startup, on focus/visibility changes, and at a small interval
- add focused unit coverage for reload/no-reload behavior and cache-busted HTML checks

## Root Cause
In static dev mode, rebuilding the frontend changes the content-hashed asset URLs served by `build/`, but an already-open browser tab can keep executing the old JavaScript until the user manually refreshes. That can leave the UI using stale baked frontend configuration after `npm run dev` is relaunched.

## Validation
- `npx vitest run __tests__/utils/static-build-refresh.test.ts`
- `npm exec prettier -- --check src/entry.client.tsx src/utils/static-build-refresh.ts __tests__/utils/static-build-refresh.test.ts`
- `npm run typecheck && npm run build`