### PR TITLE
Use ws for HTTP websocket targets

### DIFF
--- a/__tests__/build-websocket-url.test.ts
+++ b/__tests__/build-websocket-url.test.ts
@@ -35,7 +35,7 @@ describe("buildWebSocketUrl", () => {
       expect(result).toBe("wss://example.com:8080/sockets/events/conv-123");
     });
 
-    it("should use wss:// for external hosts even when page is HTTP (Safari compatibility)", () => {
+    it("should use ws:// for external HTTP hosts when page is HTTP", () => {
       vi.stubGlobal("location", {
         protocol: "http:",
         host: "localhost:3000",
@@ -46,7 +46,23 @@ describe("buildWebSocketUrl", () => {
         "http://agent-server.com:9000/api/conversations/conv-456",
       );
 
-      expect(result).toBe("wss://agent-server.com:9000/sockets/events/conv-456");
+      expect(result).toBe("ws://agent-server.com:9000/sockets/events/conv-456");
+    });
+
+    it("should use wss:// for external HTTPS hosts when page is HTTP", () => {
+      vi.stubGlobal("location", {
+        protocol: "http:",
+        host: "localhost:3000",
+      });
+
+      const result = buildWebSocketUrl(
+        "conv-456",
+        "https://agent-server.com:9000/api/conversations/conv-456",
+      );
+
+      expect(result).toBe(
+        "wss://agent-server.com:9000/sockets/events/conv-456",
+      );
     });
 
     it("should use ws:// for localhost when page is HTTP", () => {
@@ -93,7 +109,7 @@ describe("buildWebSocketUrl", () => {
 
       const result = buildWebSocketUrl("conv-123", null);
 
-      expect(result).toBe("wss://fallback-host:4000/sockets/events/conv-123");
+      expect(result).toBe("ws://fallback-host:4000/sockets/events/conv-123");
     });
 
     it("should use window.location.host when conversation URL is undefined", () => {
@@ -104,7 +120,7 @@ describe("buildWebSocketUrl", () => {
 
       const result = buildWebSocketUrl("conv-123", undefined);
 
-      expect(result).toBe("wss://fallback-host:4000/sockets/events/conv-123");
+      expect(result).toBe("ws://fallback-host:4000/sockets/events/conv-123");
     });
 
     it("should use window.location.host when conversation URL is relative path", () => {
@@ -118,7 +134,7 @@ describe("buildWebSocketUrl", () => {
         "/api/conversations/conv-123",
       );
 
-      expect(result).toBe("wss://fallback-host:4000/sockets/events/conv-123");
+      expect(result).toBe("ws://fallback-host:4000/sockets/events/conv-123");
     });
 
     it("should use window.location.host when conversation URL is invalid", () => {
@@ -129,7 +145,7 @@ describe("buildWebSocketUrl", () => {
 
       const result = buildWebSocketUrl("conv-123", "not-a-valid-url");
 
-      expect(result).toBe("wss://fallback-host:4000/sockets/events/conv-123");
+      expect(result).toBe("ws://fallback-host:4000/sockets/events/conv-123");
     });
   });
 
@@ -165,7 +181,7 @@ describe("buildWebSocketUrl", () => {
         "http://example.com:12345/api/conversations/conv-123",
       );
 
-      expect(result).toBe("wss://example.com:12345/sockets/events/conv-123");
+      expect(result).toBe("ws://example.com:12345/sockets/events/conv-123");
     });
 
     it("should handle conversation URLs without port (default port) on external hosts", () => {
@@ -174,7 +190,7 @@ describe("buildWebSocketUrl", () => {
         "http://example.com/api/conversations/conv-123",
       );
 
-      expect(result).toBe("wss://example.com/sockets/events/conv-123");
+      expect(result).toBe("ws://example.com/sockets/events/conv-123");
     });
 
     it("should handle conversation IDs with special characters", () => {
@@ -199,8 +215,8 @@ describe("buildWebSocketUrl", () => {
     });
   });
 
-  describe("Safari compatibility - external host detection", () => {
-    it("should use wss:// for prod-runtime.all-hands.dev domains", () => {
+  describe("protocol selection for external hosts", () => {
+    it("should use wss:// for HTTPS prod-runtime.all-hands.dev domains", () => {
       vi.stubGlobal("location", {
         protocol: "http:",
         host: "localhost:8000",
@@ -212,7 +228,7 @@ describe("buildWebSocketUrl", () => {
 
       const result = buildWebSocketUrl(
         fakeConversationId,
-        `http://${fakeRuntimeHost}/api/conversations/${fakeConversationId}`,
+        `https://${fakeRuntimeHost}/api/conversations/${fakeConversationId}`,
       );
 
       expect(result).toBe(

--- a/__tests__/utils/websocket-url.test.ts
+++ b/__tests__/utils/websocket-url.test.ts
@@ -167,6 +167,22 @@ describe("websocket-url utilities", () => {
       expect(result).toBe("ws://localhost:3000/sockets/events/conv-123");
     });
 
+    it("should use ws for a remote HTTP page served by the local ingress", () => {
+      vi.stubGlobal("location", {
+        host: "spark-1874.tailae62af.ts.net:8000",
+        hostname: "spark-1874.tailae62af.ts.net",
+        protocol: "http:",
+      });
+
+      const result = buildWebSocketUrl(
+        "conv-123",
+        "http://localhost:8000/api/conversations/conv-123",
+      );
+      expect(result).toBe(
+        "ws://spark-1874.tailae62af.ts.net:8000/sockets/events/conv-123",
+      );
+    });
+
     it("should fallback to window.location.host for null URL", () => {
       const result = buildWebSocketUrl("conv-123", null);
       expect(result).toBe("wss://localhost:3001/sockets/events/conv-123");

--- a/src/utils/websocket-url.ts
+++ b/src/utils/websocket-url.ts
@@ -65,18 +65,18 @@ export function buildHttpBaseUrl(
   return `${protocol}//${baseHost}${pathPrefix}`;
 }
 
-/**
- * Determines if a hostname is a local/loopback address
- */
-function isLocalHost(hostname: string): boolean {
-  // Strip brackets from IPv6 addresses (e.g., "[::1]" -> "::1")
-  const normalizedHostname = hostname.replace(/^\[|\]$/g, "");
-  return (
-    normalizedHostname === "localhost" ||
-    normalizedHostname === "127.0.0.1" ||
-    normalizedHostname === "::1" ||
-    normalizedHostname.endsWith(".localhost")
-  );
+function getConversationUrlProtocol(
+  conversationUrl: string | null | undefined,
+): string | null {
+  if (!conversationUrl || conversationUrl.startsWith("/")) {
+    return null;
+  }
+
+  try {
+    return new URL(conversationUrl).protocol;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -100,19 +100,15 @@ export function buildWebSocketUrl(
   // The path prefix (e.g., /runtime/55313) is needed for proxy deployments
   // Note: Query params should be passed via the useWebSocket hook options
   //
-  // Protocol selection:
-  // - Use wss:// when the page is served over HTTPS
-  // - Use wss:// for external (non-localhost) hosts even when page is HTTP,
-  //   because Safari blocks insecure ws:// connections to external domains
-  // - Use ws:// only for localhost connections when page is HTTP
-  //
-  // Extract hostname, handling IPv6 addresses like [::1]:8080
-  const wsHostname = baseHost.startsWith("[")
-    ? baseHost.slice(0, baseHost.indexOf("]") + 1) // IPv6: "[::1]"
-    : baseHost.split(":")[0]; // IPv4/hostname: "localhost" or "example.com"
-  const isExternalHost = !isLocalHost(wsHostname);
+  // Protocol selection follows the actual HTTP access path. A page served
+  // over HTTPS must use WSS, but an HTTP page that reaches a remote dev ingress
+  // over plain HTTP (for example a Tailscale hostname) must use WS; forcing WSS
+  // sends a TLS handshake to the HTTP-only ingress and Node reports it as a
+  // malformed HTTP method.
   const pageIsSecure = window.location.protocol === "https:";
-  const protocol = pageIsSecure || isExternalHost ? "wss:" : "ws:";
+  const targetIsSecure =
+    getConversationUrlProtocol(conversationUrl) === "https:";
+  const protocol = pageIsSecure || targetIsSecure ? "wss:" : "ws:";
 
   return `${protocol}//${baseHost}${pathPrefix}/sockets/events/${conversationId}`;
 }


### PR DESCRIPTION
## Summary
- select `ws://` for websocket URLs when the page is HTTP and the conversation target is HTTP
- keep `wss://` for HTTPS pages or HTTPS conversation targets
- add a regression test for HTTP access through a Tailscale-style remote hostname that proxies to the local ingress
- update websocket URL expectations for HTTP external targets

## Root Cause
`buildWebSocketUrl` forced `wss://` for any non-localhost host, even when the page and dev ingress were served over plain HTTP. When a browser opened `http://<tailscale-host>:8000`, the frontend tried `wss://<tailscale-host>:8000/...`; that sends a TLS handshake to the HTTP-only ingress, which Node logs as `Parse Error: Invalid method encountered`.

## Validation
- `npx vitest run __tests__/build-websocket-url.test.ts __tests__/utils/websocket-url.test.ts`
- `npm exec prettier -- --check src/utils/websocket-url.ts __tests__/build-websocket-url.test.ts __tests__/utils/websocket-url.test.ts`
- `npm run typecheck && npm run build`