### PR TITLE
fix(frontend): hide repo button on local backend in GitControlBar

### DIFF
--- a/__tests__/components/features/chat/git-control-bar-repo-button.test.tsx
+++ b/__tests__/components/features/chat/git-control-bar-repo-button.test.tsx
@@ -120,21 +120,6 @@ describe("GitControlBarRepoButton", () => {
       expect(screen.getByText("COMMON$CONNECT_REPO")).toBeInTheDocument();
     });
 
-    it("should render a custom empty-state label when provided", () => {
-      render(
-        <GitControlBarRepoButton
-          selectedRepository={null}
-          gitProvider={null}
-          emptyStateLabel="Open Workspace"
-        />,
-      );
-
-      expect(screen.getByText("Open Workspace")).toBeInTheDocument();
-      expect(
-        screen.queryByText("COMMON$CONNECT_REPO"),
-      ).not.toBeInTheDocument();
-    });
-
     it("should show folder-open icon for connect-repo CTA", () => {
       render(
         <GitControlBarRepoButton

--- a/__tests__/components/features/chat/git-control-bar.test.tsx
+++ b/__tests__/components/features/chat/git-control-bar.test.tsx
@@ -29,8 +29,12 @@ vi.mock("#/stores/optimistic-user-message-store");
 vi.mock("#/api/conversation-metadata-store");
 
 vi.mock("#/components/features/chat/git-control-bar-repo-button", () => ({
-  GitControlBarRepoButton: () => (
-    <button data-testid="git-control-bar-repo-button" type="button" />
+  GitControlBarRepoButton: ({ disabled }: { disabled?: boolean }) => (
+    <button
+      data-testid="git-control-bar-repo-button"
+      type="button"
+      data-disabled={String(!!disabled)}
+    />
   ),
 }));
 vi.mock("#/components/features/chat/git-control-bar-branch-button", () => ({
@@ -161,7 +165,7 @@ describe("GitControlBar repo button visibility", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the repo button on a local backend when a workspace name is available", () => {
+  it("renders the repo button as disabled on a local backend when only a workspace name is available", () => {
     vi.mocked(useActiveBackend).mockReturnValue(makeBackend("local"));
     vi.mocked(getStoredConversationMetadata).mockReturnValue({
       selected_workspace: "/projects/my-app",
@@ -169,8 +173,7 @@ describe("GitControlBar repo button visibility", () => {
 
     renderWithProviders(<GitControlBar onSuggestionsClick={vi.fn()} />);
 
-    expect(
-      screen.getByTestId("git-control-bar-repo-button"),
-    ).toBeInTheDocument();
+    const button = screen.getByTestId("git-control-bar-repo-button");
+    expect(button).toHaveAttribute("data-disabled", "true");
   });
 });

--- a/__tests__/components/features/chat/git-control-bar.test.tsx
+++ b/__tests__/components/features/chat/git-control-bar.test.tsx
@@ -1,4 +1,68 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "test-utils";
+
+import { useActiveBackend } from "#/contexts/active-backend-context";
+import { useActiveConversation } from "#/hooks/query/use-active-conversation";
+import { useTaskPolling } from "#/hooks/query/use-task-polling";
+import { useLocalGitInfo } from "#/hooks/query/use-local-git-info";
+import { useUnifiedWebSocketStatus } from "#/hooks/use-unified-websocket-status";
+import { useSendMessage } from "#/hooks/use-send-message";
+import { useUpdateConversationRepository } from "#/hooks/mutation/use-update-conversation-repository";
+import { useHomeStore } from "#/stores/home-store";
+import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
+import { getStoredConversationMetadata } from "#/api/conversation-metadata-store";
+import { GitControlBar } from "#/components/features/chat/git-control-bar";
+
+vi.mock("#/hooks/use-conversation-id", () => ({
+  useConversationId: () => ({ conversationId: "test-conversation-id" }),
+}));
+vi.mock("#/contexts/active-backend-context");
+vi.mock("#/hooks/query/use-active-conversation");
+vi.mock("#/hooks/query/use-task-polling");
+vi.mock("#/hooks/query/use-local-git-info");
+vi.mock("#/hooks/use-unified-websocket-status");
+vi.mock("#/hooks/use-send-message");
+vi.mock("#/hooks/mutation/use-update-conversation-repository");
+vi.mock("#/stores/home-store");
+vi.mock("#/stores/optimistic-user-message-store");
+vi.mock("#/api/conversation-metadata-store");
+
+vi.mock("#/components/features/chat/git-control-bar-repo-button", () => ({
+  GitControlBarRepoButton: () => (
+    <button data-testid="git-control-bar-repo-button" type="button" />
+  ),
+}));
+vi.mock("#/components/features/chat/git-control-bar-branch-button", () => ({
+  GitControlBarBranchButton: () => null,
+}));
+vi.mock("#/components/features/chat/git-control-bar-pull-button", () => ({
+  GitControlBarPullButton: () => null,
+}));
+vi.mock("#/components/features/chat/git-control-bar-push-button", () => ({
+  GitControlBarPushButton: () => null,
+}));
+vi.mock("#/components/features/chat/git-control-bar-pr-button", () => ({
+  GitControlBarPrButton: () => null,
+}));
+vi.mock("#/components/features/chat/git-control-bar-tooltip-wrapper", () => ({
+  GitControlBarTooltipWrapper: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+vi.mock("#/components/features/chat/open-repository-modal", () => ({
+  OpenRepositoryModal: () => null,
+}));
+
+const makeBackend = (kind: "local" | "cloud") => ({
+  backend: {
+    id: "backend-id",
+    name: kind === "local" ? "Local" : "Cloud",
+    host: "http://example.test",
+    apiKey: "test-key",
+    kind,
+  },
+  orgId: null,
+});
 
 describe("GitControlBar clone prompt format", () => {
   // Helper function that mirrors the logic in git-control-bar.tsx
@@ -14,7 +78,9 @@ describe("GitControlBar clone prompt format", () => {
 
   it("should include GitHub in clone prompt for github provider", () => {
     const prompt = generateClonePrompt("user/repo", "github", "main");
-    expect(prompt).toBe("Clone user/repo from Github and checkout branch main.");
+    expect(prompt).toBe(
+      "Clone user/repo from Github and checkout branch main.",
+    );
   });
 
   it("should include GitLab in clone prompt for gitlab provider", () => {
@@ -41,5 +107,70 @@ describe("GitControlBar clone prompt format", () => {
 
     expect(githubPrompt).toContain("from Github");
     expect(gitlabPrompt).toContain("from Gitlab");
+  });
+});
+
+describe("GitControlBar repo button visibility", () => {
+  beforeEach(() => {
+    vi.mocked(useActiveConversation).mockReturnValue({
+      data: { id: "test-conversation-id" },
+    } as ReturnType<typeof useActiveConversation>);
+    vi.mocked(useTaskPolling).mockReturnValue({
+      repositoryInfo: null,
+    } as unknown as ReturnType<typeof useTaskPolling>);
+    vi.mocked(useLocalGitInfo).mockReturnValue({
+      data: null,
+    } as unknown as ReturnType<typeof useLocalGitInfo>);
+    vi.mocked(useUnifiedWebSocketStatus).mockReturnValue("OPEN");
+    vi.mocked(useSendMessage).mockReturnValue({
+      send: vi.fn(),
+    } as unknown as ReturnType<typeof useSendMessage>);
+    vi.mocked(useUpdateConversationRepository).mockReturnValue({
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useUpdateConversationRepository>);
+    vi.mocked(useHomeStore).mockReturnValue({
+      addRecentRepository: vi.fn(),
+    } as unknown as ReturnType<typeof useHomeStore>);
+    vi.mocked(useOptimisticUserMessageStore).mockImplementation(((
+      selector: (s: unknown) => unknown,
+    ) =>
+      selector({
+        enqueuePendingMessage: vi.fn(),
+        markPendingMessageError: vi.fn(),
+      })) as unknown as typeof useOptimisticUserMessageStore);
+    vi.mocked(getStoredConversationMetadata).mockReturnValue(null);
+  });
+
+  it("hides the repo button on a local backend with no repository or workspace name", () => {
+    vi.mocked(useActiveBackend).mockReturnValue(makeBackend("local"));
+
+    renderWithProviders(<GitControlBar onSuggestionsClick={vi.fn()} />);
+
+    expect(
+      screen.queryByTestId("git-control-bar-repo-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the repo button on a cloud backend with no repository connected", () => {
+    vi.mocked(useActiveBackend).mockReturnValue(makeBackend("cloud"));
+
+    renderWithProviders(<GitControlBar onSuggestionsClick={vi.fn()} />);
+
+    expect(
+      screen.getByTestId("git-control-bar-repo-button"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the repo button on a local backend when a workspace name is available", () => {
+    vi.mocked(useActiveBackend).mockReturnValue(makeBackend("local"));
+    vi.mocked(getStoredConversationMetadata).mockReturnValue({
+      selected_workspace: "/projects/my-app",
+    } as ReturnType<typeof getStoredConversationMetadata>);
+
+    renderWithProviders(<GitControlBar onSuggestionsClick={vi.fn()} />);
+
+    expect(
+      screen.getByTestId("git-control-bar-repo-button"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/features/chat/git-control-bar-repo-button.tsx
+++ b/src/components/features/chat/git-control-bar-repo-button.tsx
@@ -12,7 +12,6 @@ interface GitControlBarRepoButtonProps {
   selectedRepository: string | null | undefined;
   gitProvider: Provider | null | undefined;
   workspaceName?: string | null;
-  emptyStateLabel?: string;
   onClick?: () => void;
   disabled?: boolean;
 }
@@ -21,7 +20,6 @@ export function GitControlBarRepoButton({
   selectedRepository,
   gitProvider,
   workspaceName,
-  emptyStateLabel,
   onClick,
   disabled,
 }: GitControlBarRepoButtonProps) {
@@ -45,10 +43,7 @@ export function GitControlBarRepoButton({
 
   const showConnectRepoCta = !selectedRepository && !workspaceName;
   const buttonText =
-    selectedRepository ||
-    workspaceName ||
-    emptyStateLabel ||
-    t(I18nKey.COMMON$CONNECT_REPO);
+    selectedRepository || workspaceName || t(I18nKey.COMMON$CONNECT_REPO);
 
   if (hasLinkableRepo) {
     return (

--- a/src/components/features/chat/git-control-bar.tsx
+++ b/src/components/features/chat/git-control-bar.tsx
@@ -163,6 +163,11 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
   // metadata is still informational and stays visible.
   const showRepoButton =
     !isLocalBackend || !!selectedRepository || !!workspaceName;
+  // On a local backend the informational pill (e.g. workspace name, or a repo
+  // detected without a recognized provider) should not open the remote-repo
+  // modal — that flow is cloud-only. Disable the button in that case so the
+  // click is a no-op. Linkable repos render as <a> and ignore `disabled`.
+  const isRepoButtonInert = isLocalBackend && !hasRepository;
 
   return (
     <div className="flex flex-row items-center">
@@ -173,7 +178,7 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
             gitProvider={gitProvider}
             workspaceName={workspaceName}
             onClick={() => setIsOpenRepoModalOpen(true)}
-            disabled={!isConversationReady}
+            disabled={!isConversationReady || isRepoButtonInert}
           />
         ) : null}
 

--- a/src/components/features/chat/git-control-bar.tsx
+++ b/src/components/features/chat/git-control-bar.tsx
@@ -11,7 +11,6 @@ import { useTaskPolling } from "#/hooks/query/use-task-polling";
 import { useUnifiedWebSocketStatus } from "#/hooks/use-unified-websocket-status";
 import { useSendMessage } from "#/hooks/use-send-message";
 import { useUpdateConversationRepository } from "#/hooks/mutation/use-update-conversation-repository";
-import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
 import { Provider } from "#/types/settings";
 import { Branch, GitRepository } from "#/types/git";
 import { I18nKey } from "#/i18n/declaration";
@@ -23,11 +22,6 @@ import { useHomeStore } from "#/stores/home-store";
 import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
 import { getStoredConversationMetadata } from "#/api/conversation-metadata-store";
 import { useActiveBackend } from "#/contexts/active-backend-context";
-import { useResolvedWorkspaces } from "#/hooks/query/use-resolved-workspaces";
-import { useWorkspacesStore } from "#/stores/workspaces-store";
-import { useNavigation } from "#/context/navigation-context";
-import { FolderBrowserModal } from "#/components/features/home/workspace-dropdown/folder-browser-modal";
-import RepoIcon from "#/icons/repo.svg?react";
 
 interface GitControlBarProps {
   onSuggestionsClick: (value: string) => void;
@@ -37,11 +31,7 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
   const { t } = useTranslation("openhands");
   const { conversationId } = useConversationId();
   const [isOpenRepoModalOpen, setIsOpenRepoModalOpen] = useState(false);
-  const [isWorkspaceMenuOpen, setIsWorkspaceMenuOpen] = useState(false);
-  const [isFolderBrowserOpen, setIsFolderBrowserOpen] = useState(false);
-  const workspaceMenuContainerRef = useRef<HTMLDivElement>(null);
   const { addRecentRepository } = useHomeStore();
-  const { navigate } = useNavigation();
   const enqueuePendingMessage = useOptimisticUserMessageStore(
     (state) => state.enqueuePendingMessage,
   );
@@ -50,8 +40,6 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
   );
   const { backend } = useActiveBackend();
   const isLocalBackend = backend.kind === "local";
-  const { addWorkspaces, addWorkspaceParents } = useWorkspacesStore();
-  const { workspaces } = useResolvedWorkspaces();
 
   const { data: conversation } = useActiveConversation();
   const { repositoryInfo } = useTaskPolling();
@@ -67,8 +55,6 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
     sendRef.current = send;
   }, [send]);
   const { mutate: updateRepository } = useUpdateConversationRepository();
-  const { mutate: createConversation, isPending: isCreatingConversation } =
-    useCreateConversation();
 
   // Priority: conversation data > task data > locally-detected git info.
   // The local fallback runs `git remote get-url origin` / `git rev-parse --abbrev-ref HEAD`
@@ -107,31 +93,6 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
 
   // Enable buttons only when conversation exists and WS is connected
   const isConversationReady = !!conversation && webSocketStatus === "OPEN";
-
-  useEffect(() => {
-    if (!isWorkspaceMenuOpen || isFolderBrowserOpen) return undefined;
-    const onMouseDown = (event: MouseEvent) => {
-      if (
-        workspaceMenuContainerRef.current &&
-        !workspaceMenuContainerRef.current.contains(event.target as Node)
-      ) {
-        setIsWorkspaceMenuOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    return () => document.removeEventListener("mousedown", onMouseDown);
-  }, [isWorkspaceMenuOpen, isFolderBrowserOpen]);
-
-  useEffect(() => {
-    if (!isWorkspaceMenuOpen || isFolderBrowserOpen) return undefined;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setIsWorkspaceMenuOpen(false);
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [isWorkspaceMenuOpen, isFolderBrowserOpen]);
 
   const handleLaunchRepository = (
     repository: GitRepository,
@@ -197,106 +158,24 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
     );
   };
 
-  const handleOpenWorkspaceClick = () => {
-    if (!isConversationReady || isCreatingConversation) return;
-
-    if (workspaces.length === 0) {
-      setIsFolderBrowserOpen(true);
-      setIsWorkspaceMenuOpen(false);
-      return;
-    }
-
-    setIsWorkspaceMenuOpen((open) => !open);
-  };
-
-  const handleLaunchWorkspaceConversation = (workingDir?: string) => {
-    if (isCreatingConversation) return;
-    createConversation(
-      { workingDir },
-      {
-        onSuccess: (data) => {
-          setIsWorkspaceMenuOpen(false);
-          navigate(`/conversations/${data.conversation_id}`);
-        },
-      },
-    );
-  };
+  // Local backends never use the remote-repo "Connect Repo" CTA, so suppress the
+  // empty-state button there. A repo or workspace label inferred from local git
+  // metadata is still informational and stays visible.
+  const showRepoButton =
+    !isLocalBackend || !!selectedRepository || !!workspaceName;
 
   return (
     <div className="flex flex-row items-center">
       <div className="flex flex-row gap-2.5 items-center overflow-x-auto flex-wrap md:flex-nowrap relative scrollbar-hide">
-        <div className="relative" ref={workspaceMenuContainerRef}>
+        {showRepoButton ? (
           <GitControlBarRepoButton
             selectedRepository={selectedRepository}
             gitProvider={gitProvider}
             workspaceName={workspaceName}
-            emptyStateLabel={isLocalBackend ? "Open Workspace" : undefined}
-            onClick={
-              isLocalBackend
-                ? handleOpenWorkspaceClick
-                : () => setIsOpenRepoModalOpen(true)
-            }
+            onClick={() => setIsOpenRepoModalOpen(true)}
             disabled={!isConversationReady}
           />
-          {isLocalBackend && isWorkspaceMenuOpen && (
-            <div
-              data-testid="git-control-bar-workspace-menu"
-              className="absolute z-50 left-0 bottom-full mb-2 min-w-[220px] rounded-[6px] bg-tertiary context-menu-box-shadow py-[6px] px-1"
-            >
-              <ul className="max-h-64 overflow-y-auto">
-                <li>
-                  <button
-                    type="button"
-                    disabled={isCreatingConversation}
-                    data-testid="git-control-bar-open-no-workspace"
-                    onClick={() => handleLaunchWorkspaceConversation()}
-                    className="flex items-center w-full px-2 py-2 text-sm text-white text-left hover:bg-[#5C5D62] rounded font-normal cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
-                  >
-                    <span className="italic text-[#A3A3A3]">
-                      {t(I18nKey.HOME$NO_WORKSPACE_OPTION)}
-                    </span>
-                  </button>
-                </li>
-                {workspaces.map((workspace) => (
-                  <li key={workspace.id}>
-                    <button
-                      type="button"
-                      disabled={isCreatingConversation}
-                      data-testid="git-control-bar-open-workspace"
-                      data-workspace-path={workspace.path}
-                      onClick={() =>
-                        handleLaunchWorkspaceConversation(workspace.path)
-                      }
-                      className="flex items-center gap-2 w-full px-2 py-2 text-sm text-white text-left hover:bg-[#5C5D62] rounded font-normal cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
-                    >
-                      <RepoIcon width={14} height={14} className="shrink-0" />
-                      <span className="truncate">{workspace.name}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-              <div className="border-t border-[#5C5D62] mt-1 pt-1">
-                <button
-                  type="button"
-                  data-testid="git-control-bar-add-workspace"
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                  }}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    setIsFolderBrowserOpen(true);
-                    setIsWorkspaceMenuOpen(false);
-                  }}
-                  className="flex items-center w-full px-2 py-2 text-sm text-white hover:bg-[#5C5D62] rounded font-normal cursor-pointer"
-                >
-                  {t(I18nKey.HOME$ADD_WORKSPACES)}
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
+        ) : null}
 
         {selectedBranch ? (
           <GitControlBarBranchButton
@@ -353,12 +232,6 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
         onClose={() => setIsOpenRepoModalOpen(false)}
         onLaunch={handleLaunchRepository}
         defaultProvider={gitProvider}
-      />
-      <FolderBrowserModal
-        isOpen={isFolderBrowserOpen}
-        onClose={() => setIsFolderBrowserOpen(false)}
-        onAdd={(items) => addWorkspaces(items)}
-        onAddParent={(items) => addWorkspaceParents(items)}
       />
     </div>
   );


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description:**

When the active backend is `local`, the `<GitControlBar />` on the conversation page renders the repo-button as **"Open Workspace"** with a workspace dropdown (browse existing local workspaces + "Add Workspaces" entry that opens `FolderBrowserModal`). This entire local-workspace launch flow is **not functional** today — clicking it leads to a dead-end.

The repo-button only makes sense for cloud backends (where it correctly opens the remote-repo picker). On local backends it should be hidden from the empty state.

### Steps to reproduce

1. Clone `agent-canvas` and run `npm run dev` (launches the agent-server in Docker).
2. From the home page, create a new conversation against the **Local** backend.
3. On the conversation page, look at the row below the chat input.

### Current behavior

- A button labeled "Open Workspace" (with a folder icon) is rendered.
- Clicking it opens a non-functional workspace dropdown / Add Workspace dialog.

### Expected behavior

- The repo-button is **not displayed** on a local backend when no repository or workspace name is known.
- If a local conversation has an inferred repository (from `git remote get-url origin`) or a `selected_workspace` from stored metadata, the informational pill (repo link / workspace name) may still appear, since it conveys real state.
- Cloud backends are unaffected — the empty-state button still reads "Connect Repo" and opens `OpenRepositoryModal`.

### Acceptance criteria

- [ ] No repo-button is rendered for a fresh local-backend conversation.
- [ ] Cloud-backend conversations continue to show the "Connect Repo" CTA.
- [ ] Vitest suite remains green; new test guards the regression.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Remove the non-functional "Open Workspace" / workspace-menu branch from `<GitControlBar />` and its `FolderBrowserModal` wiring.
- Hide the empty-state repo button entirely on local backends; cloud backends still see the "Connect Repo" CTA opening `OpenRepositoryModal`.
- Local conversations that have an inferred repository (via `useLocalGitInfo`) or a stored `selected_workspace` still render the informational pill.
- Drop the dead `emptyStateLabel` prop from `GitControlBarRepoButton`.

## Why

The Open Workspace flow on local backends was a dead-end: clicking it surfaced a workspace dropdown / Add Workspace dialog that is not wired up. The fallback "Connect Repo" CTA is a remote-repo concept that doesn't apply to local backends either, so the entire empty-state button should be suppressed there.

## Files changed

- `src/components/features/chat/git-control-bar.tsx` — Removed `isLocalBackend` workspace branch, the workspace menu, the `FolderBrowserModal` render, and all related state / refs / effects / handlers / imports. Added a `showRepoButton` guard that keeps the empty-state CTA off local backends but still shows informational repo / workspace data when present.
- `src/components/features/chat/git-control-bar-repo-button.tsx` — Removed the now-unused `emptyStateLabel` prop and its fallback in `buttonText`.
- `__tests__/components/features/chat/git-control-bar.test.tsx` — Added three rendering-level tests guarding the new visibility behavior.
- `__tests__/components/features/chat/git-control-bar-repo-button.test.tsx` — Removed the orphaned test for the deleted `emptyStateLabel` prop.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #463 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-canvas` and run `npm run dev` (launches the agent-server in Docker).
2. From the home page, create a new conversation against the **Local** backend.
3. On the conversation page, look at the row below the chat input.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="829" alt="image" src="https://github.com/user-attachments/assets/1ad1ffc8-53a0-4983-942c-f1ae3ed8e166" />

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
