### PR TITLE
fix(frontend): align sidebar conversation list loading skeleton with loaded card

### DIFF
--- a/src/components/features/conversation-panel/conversation-card/conversation-card-skeleton.test.tsx
+++ b/src/components/features/conversation-panel/conversation-card/conversation-card-skeleton.test.tsx
@@ -19,4 +19,18 @@ describe("ConversationCardSkeleton", () => {
       screen.queryByTestId("conversation-card-skeleton"),
     ).not.toBeInTheDocument();
   });
+
+  it("renders the same header slots a loaded conversation card shows: status dot, title, and timestamp", () => {
+    render(<ConversationCardSkeleton />);
+
+    expect(
+      screen.getByTestId("conversation-card-skeleton-status-dot"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("conversation-card-skeleton-title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("conversation-card-skeleton-timestamp"),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/features/conversation-panel/conversation-card/conversation-card-skeleton.tsx
+++ b/src/components/features/conversation-panel/conversation-card/conversation-card-skeleton.tsx
@@ -21,19 +21,24 @@ export function ConversationCardSkeleton({
   return (
     <div
       data-testid="conversation-card-skeleton"
-      className="relative h-auto w-full px-3 py-2 border-b border-[#1f2228]"
+      className="relative h-auto w-full rounded-md px-3 pt-1 pb-1"
     >
-      <div className="flex items-center justify-between w-full">
-        <div className="flex items-center gap-2 w-full">
-          <div className="skeleton-round h-1.5 w-1.5" />
-          <div className="skeleton h-3 w-2/3 rounded" />
+      <div className="flex items-center w-full min-w-0 h-6">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <div
+            data-testid="conversation-card-skeleton-status-dot"
+            className="skeleton-round h-2.5 w-2.5 shrink-0"
+          />
+          <div
+            data-testid="conversation-card-skeleton-title"
+            className="skeleton h-3 w-2/3 rounded"
+          />
         </div>
-      </div>
-      <div className="mt-2 flex flex-col gap-1">
-        <div className="skeleton h-2 w-1/2 rounded" />
-        <div className="flex justify-between">
-          <div className="skeleton h-2 w-1/4 rounded" />
-          <div className="skeleton h-2 w-8 rounded" />
+        <div className="ml-auto pl-2 shrink-0">
+          <div
+            data-testid="conversation-card-skeleton-timestamp"
+            className="skeleton h-2 w-8 rounded"
+          />
         </div>
       </div>
     </div>

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -388,9 +388,11 @@ export function ConversationPanel({
         className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain custom-scrollbar-always"
       >
         {showInitialSkeleton && (
-          <div className="space-y-2">
+          <div>
             {Array.from({ length: 5 }).map((_, index) => (
-              <ConversationCardSkeleton key={index} compact={compact} />
+              <div key={index} className={compact ? "" : "block px-2 py-0.5"}>
+                <ConversationCardSkeleton compact={compact} />
+              </div>
             ))}
           </div>
         )}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary

When the sidebar conversations panel is in its initial-load state, the skeleton placeholder UI does not visually match the actual conversation cards that replace it once data resolves. The list noticeably "jumps" as loading finishes — the skeleton is roughly twice the height of the real card, has a divider line that doesn't exist on the real card, and includes a second placeholder row for repo/branch metadata that the real card hides by default.

### Steps to reproduce

1. Clone `agent-canvas` and run `npm run dev`.
2. Open the app while the conversations query has no cached data (e.g. on first load or after clearing the React Query cache).
3. Observe the sidebar conversations list while it is loading, then watch it switch to the loaded state.

### Current behavior

- Each skeleton row uses `px-3 py-2` with a `border-b` divider and renders two stacked rows (header bar + two repo/branch bars).
- The placeholder status dot is `1.5×1.5` while the real status dot is `2.5×2.5`.
- The list visibly shifts vertically and the divider disappears when loaded data arrives.

### Expected behavior

- The skeleton row should mirror the real loaded card layout one-for-one: a single header row containing a status-dot placeholder, a title placeholder, and a timestamp placeholder.
- No divider line between skeleton rows.
- Outer padding, status-dot size, and row height should match the loaded card so the panel does not reflow when data resolves.

### Notes for the implementer

- Real card: `src/components/features/conversation-panel/conversation-card/conversation-card.tsx` (`px-3 pt-1 pb-1`, `rounded-md`, single header row; footer only shown when `showRepoBranchMetadata` is enabled — default `false`).
- Status dot: `ConversationStatusDot` is `w-2.5 h-2.5` (`src/components/features/home/recent-conversations/conversation-status-dot.tsx`).
- Title height: `text-xs leading-6` → 24 px tall (`conversation-card-title.tsx`).
- The home-page "recent conversations" skeleton is intentionally **out of scope**; that surface is being removed in a follow-up PR.

### Acceptance criteria

- Sidebar loading skeleton renders one row per item that matches the loaded card silhouette (status dot, title, timestamp).
- No divider line or extra repo/branch row in the skeleton.
- No vertical reflow when loading state transitions to loaded state on a list that defaults to `showRepoBranchMetadata=false`.
- Unit test asserting the skeleton exposes the same structural slots as the loaded card.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Rewrites `ConversationCardSkeleton` (non-compact branch) to mirror the real `ConversationCard`: single header row with status-dot, title, and right-aligned timestamp placeholders; same `rounded-md px-3 pt-1 pb-1` padding; `h-6` to match the title's `leading-6`.
- Removes the `border-b border-[#1f2228]` divider the skeleton was drawing between rows — the loaded card has no such divider, so the line disappears when data loads.
- Drops the obsolete two-row repo/branch placeholder block. The loaded card's footer is gated by `showRepoBranchMetadata`, which defaults to `false`, so the skeleton should not show it either.
- Aligns the skeleton list wrapper in `ConversationPanel` with the real list: each skeleton sits in a `block px-2 py-0.5` wrapper (mirroring the `NavigationLink` wrapping of real rows) instead of a `space-y-2` container.

## Why

On first load (or after a cache clear) the conversations panel visibly reflowed when the initial fetch resolved: the skeleton row was ~32 px taller than the loaded row, drew a divider that the loaded card doesn't have, and was indented differently. The fix makes the skeleton a true silhouette of the loaded card so the list stays still during the load-to-loaded transition.

## Out of scope

The home page's `RecentConversationsSkeleton` has similar drift, but the entire `RecentConversations` surface is being removed in a follow-up PR (it was unwired from `src/routes/home.tsx` in 4a9376a), so it is intentionally left untouched here.

## Files changed

- `src/components/features/conversation-panel/conversation-card/conversation-card-skeleton.tsx`
- `src/components/features/conversation-panel/conversation-panel.tsx`
- `src/components/features/conversation-panel/conversation-card/conversation-card-skeleton.test.tsx`

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #465 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-canvas` and run `npm run dev`.
2. Open the app while the conversations query has no cached data (e.g. on first load or after clearing the React Query cache).
3. Observe the sidebar conversations list while it is loading, then watch it switch to the loaded state.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="315" height="745" alt="app-1770" src="https://github.com/user-attachments/assets/3eb052ef-0865-42e2-b5e4-6908dfbb36e3" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
