### PR TITLE
fix: normalize path separators in no-direct-agent-server-calls test (Windows CI fix)

### DIFF
--- a/src/api/no-direct-agent-server-calls.test.ts
+++ b/src/api/no-direct-agent-server-calls.test.ts
@@ -12,7 +12,9 @@ const ALLOWED_AD_HOC_HTTP_FILES = new Set([
 function collectSourceFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const fullPath = join(dir, entry.name);
-    const relPath = relative(SRC_ROOT, fullPath);
+    // Normalize to forward slashes so the path matches ALLOWED_AD_HOC_HTTP_FILES
+    // entries on Windows where path.relative() returns backslash-separated paths.
+    const relPath = relative(SRC_ROOT, fullPath).replace(/\\/g, "/");
 
     if (entry.isDirectory()) {
       if (EXCLUDED_SEGMENTS.has(entry.name)) return [];


### PR DESCRIPTION
## Summary

Fixes two related CI failures on `main`:

### 1. Windows CI test failure (`no-direct-agent-server-calls.test.ts`)

`path.relative()` returns backslash-separated paths on Windows (e.g. `api\\automation-service\\automation-service.api.ts`), but `ALLOWED_AD_HOC_HTTP_FILES` is a `Set` with forward-slash entries. The `Set.has()` check therefore never matches on Windows, producing a false-positive violation:

```
AssertionError: expected [ Array(1) ] to deeply equal []
  + [ "api\\automation-service\\automation-service.api.ts: uses axios directly for HTTP calls" ]
```

**Fix:** add `.replace(/\\/g, "/")` to normalize `relPath` to forward slashes before the set membership check. This is a no-op on POSIX platforms.

### 2. Snapshot test baseline regeneration

The snapshot tests on `main` were failing (98% pixel difference) because the cool-grey palette redesign (`ac0741e`) changed the UI significantly and left the old git-committed baselines stale. `9f945b6` then removed those PNG files from git and switched to artifact-based baseline storage.

No new baselines had been established in the new artifact system yet, so I've manually triggered a `workflow_dispatch` on `main` with `force_update=true` ([run #25934319820](https://github.com/OpenHands/agent-canvas/actions/runs/25934319820)) to regenerate and upload the baselines from the current UI. When this PR merges, the main-branch push run will also regenerate them.

---

> This PR was created by an AI agent (OpenHands) on behalf of the repo maintainer.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f41d453f-31df-4987-8c06-0fb96a3fa1ca)