### PR TITLE
ci: increase Playwright CI workers from 1 to 2

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,8 +20,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Use 2 workers on CI (matches ubuntu-24.04's 2 vCPUs). Tests are isolated
+   * per browser context so parallel execution is safe. */
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
 


### PR DESCRIPTION
## What

Increases `workers` in `playwright.config.ts` from `1` to `2` on CI.

## Why it's safe

Each Playwright worker runs in a completely isolated browser context, so there's no shared state between workers:

- **MSW handler state** is page-level JS (compiled into the client bundle, re-initialized per page load) — one worker's mutations to `automations`, `secrets`, `conversations`, etc. are invisible to another worker's page
- **localStorage** and **React Query cache** (`window.__OH_QUERY_CLIENT__`) are browser-context-scoped
- **The dev server** is stateless (read-only Vite/static file server)
- **Snapshot files** are written one-per-test; Playwright guarantees each test runs on exactly one worker

The existing `test.describe.configure({ mode: "serial" })` in `onboarding` and `collapsible-thinking` handles within-file concurrency for heavier WebSocket-backed tests — those files still run serially within themselves, but can freely parallelize against other files.

## Why 2

`ubuntu-24.04` runners (used by `snapshot-tests.yml`) have **2 vCPUs**. Running one browser process per CPU core is the standard Playwright recommendation. Since snapshot tests are largely I/O-bound (waiting for renders, DOM mutations, animations to settle), 2 workers should roughly halve wall-clock CI time with minimal resource pressure.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/74d90f6c-087f-497c-888a-cfaefbc81445)