### PR TITLE
docs(readme): point users at the OpenAPI docs alongside the UI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm install
 node --env-file-if-exists=.env .\scripts\dev-docker.mjs
 ```
 
-Access the UI at [http://localhost:8000](http://localhost:8000)
+Access the UI at [http://localhost:8000](http://localhost:8000). The OpenAPI docs for the agent server and the automation backend are also served through the ingress proxy at [http://localhost:8000/docs](http://localhost:8000/docs) and [http://localhost:8000/api/automation/docs](http://localhost:8000/api/automation/docs).
 
 ### Without Docker
 
@@ -80,7 +80,7 @@ npm install
 npm run dev:dangerously-dockerless
 ```
 
-Access the UI at [http://localhost:8000](http://localhost:8000)
+Access the UI at [http://localhost:8000](http://localhost:8000). The OpenAPI docs for the agent server and the automation backend are also served through the ingress proxy at [http://localhost:8000/docs](http://localhost:8000/docs) and [http://localhost:8000/api/automation/docs](http://localhost:8000/api/automation/docs).
 
 This also serves a static production build for stability. If you are developing the Agent Canvas frontend itself and want live reload, use the dynamic dockerless command instead:
 


### PR DESCRIPTION
## Summary

The README's quickstart sections tell users to open the UI at <http://localhost:8000> but don't mention that the ingress proxy also serves two useful OpenAPI doc pages on the same port:

- **Agent server** FastAPI docs at [`/docs`](http://localhost:8000/docs) (proxied through ingress as of #501)
- **Automation backend** FastAPI docs at [`/api/automation/docs`](http://localhost:8000/api/automation/docs)

This PR adds a single sentence next to each existing `Access the UI at …` line (one in the Docker quickstart, one in the Without-Docker quickstart) so users discover these without having to spelunk through `SELF_HOSTING.md` or the dev scripts.

## Changes

- `README.md`: append an OpenAPI-docs note to both `Access the UI at …` lines.

## Verification

Against a local `npm run dev:docker` stack:

| URL | Result |
|---|---|
| `http://localhost:8000/docs` | 200 OK (agent-server Swagger UI) |
| `http://localhost:8000/api/automation/docs` | 200 OK (automation Swagger UI) |

No code changes; docs only.

---

_This pull request was created by an AI agent (OpenHands) on behalf of the requesting user._