### PR TITLE
feat(frontend): redesign home page as chat-first launcher with optional workspace/repo picker

### DIFF
--- a/__tests__/components/features/chat/components/chat-input-model.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-model.test.tsx
@@ -4,9 +4,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderWithProviders } from "test-utils";
 
 const useActiveConversationMock = vi.fn();
+const useSettingsMock = vi.fn();
 
 vi.mock("#/hooks/query/use-active-conversation", () => ({
   useActiveConversation: () => useActiveConversationMock(),
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => useSettingsMock(),
 }));
 
 // eslint-disable-next-line import/first
@@ -15,6 +20,8 @@ import { ChatInputModel } from "#/components/features/chat/components/chat-input
 describe("ChatInputModel", () => {
   beforeEach(() => {
     useActiveConversationMock.mockReset();
+    useSettingsMock.mockReset();
+    useSettingsMock.mockReturnValue({ data: undefined });
   });
 
   it("renders the active conversation's llm_model when present", () => {
@@ -82,8 +89,24 @@ describe("ChatInputModel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders nothing when there is no active conversation", () => {
+  it("falls back to the user's default model from settings when there is no active conversation", () => {
+    // Arrange — home page render: no conversation yet, but the user has
+    // a default model configured. The switcher should still show.
     useActiveConversationMock.mockReturnValue({ data: undefined });
+    useSettingsMock.mockReturnValue({
+      data: { llm_model: "anthropic/claude-sonnet-4-20250514" },
+    });
+
+    renderWithProviders(<ChatInputModel />);
+
+    expect(screen.getByTestId("chat-input-llm-model")).toHaveTextContent(
+      "anthropic/claude-sonnet-4-20250514",
+    );
+  });
+
+  it("renders nothing when neither the conversation nor settings provide an llm_model", () => {
+    useActiveConversationMock.mockReturnValue({ data: undefined });
+    useSettingsMock.mockReturnValue({ data: undefined });
 
     renderWithProviders(<ChatInputModel />);
 

--- a/__tests__/components/features/conversation/agent-status.test.tsx
+++ b/__tests__/components/features/conversation/agent-status.test.tsx
@@ -11,6 +11,7 @@ vi.mock("#/hooks/use-agent-state");
 
 vi.mock("#/hooks/use-conversation-id", () => ({
   useConversationId: () => ({ conversationId: "test-id" }),
+  useOptionalConversationId: () => ({ conversationId: "test-id" }),
 }));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/__tests__/components/features/home/home-chat-launcher.test.tsx
+++ b/__tests__/components/features/home/home-chat-launcher.test.tsx
@@ -1,0 +1,309 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+
+import { HomeChatLauncher } from "#/components/features/home/home-chat-launcher";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+
+const mockNavigate = vi.fn();
+const mockUseActiveBackend = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("#/context/navigation-context", () => ({
+  useNavigation: () => ({
+    currentPath: "/",
+    conversationId: null,
+    isNavigating: false,
+    navigate: mockNavigate,
+  }),
+}));
+
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => mockUseActiveBackend(),
+}));
+
+vi.mock("#/hooks/use-is-creating-conversation", () => ({
+  useIsCreatingConversation: () => false,
+}));
+
+vi.mock("#/hooks/use-tracking", () => ({
+  useTracking: () => ({
+    trackConversationCreated: vi.fn(),
+  }),
+}));
+
+// Stub CustomChatInput as a simple button so the test can submit without
+// exercising the rich contenteditable / draft-persistence stack — those are
+// covered by their own unit tests. Pressing the stub button is the same
+// signal: "user submitted `hello world`".
+vi.mock("#/components/features/chat/custom-chat-input", () => ({
+  CustomChatInput: ({
+    onSubmit,
+    disabled,
+  }: {
+    onSubmit: (msg: string) => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      type="button"
+      data-testid="stub-chat-submit"
+      disabled={disabled}
+      onClick={() => onSubmit("hello world")}
+    >
+      stub submit
+    </button>
+  ),
+}));
+
+// Stub the selection dialogs. We mirror the real component's contract:
+// `onConfirm(selection)` is followed by `onClose()` so the parent's pending
+// state is set and the dialog disappears.
+vi.mock("#/components/features/home/open-workspace-dialog", () => ({
+  OpenWorkspaceDialog: ({
+    isOpen,
+    onClose,
+    onConfirm,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (w: { id: string; name: string; path: string }) => void;
+  }) =>
+    isOpen ? (
+      <button
+        type="button"
+        data-testid="stub-workspace-dialog-confirm"
+        onClick={() => {
+          onConfirm({ id: "/p/app", name: "app", path: "/p/app" });
+          onClose();
+        }}
+      >
+        confirm
+      </button>
+    ) : null,
+}));
+
+vi.mock("#/components/features/home/open-repository-dialog", () => ({
+  OpenRepositoryDialog: ({
+    isOpen,
+    onClose,
+    onConfirm,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (s: {
+      repository: {
+        id: string;
+        full_name: string;
+        git_provider: "github";
+        is_public: boolean;
+      };
+      branch: { name: string };
+      provider: "github" | null;
+    }) => void;
+  }) =>
+    isOpen ? (
+      <button
+        type="button"
+        data-testid="stub-repo-dialog-confirm"
+        onClick={() => {
+          onConfirm({
+            repository: {
+              id: "1",
+              full_name: "org/repo",
+              git_provider: "github",
+              is_public: true,
+            },
+            branch: { name: "main" },
+            provider: "github",
+          });
+          onClose();
+        }}
+      >
+        confirm
+      </button>
+    ) : null,
+}));
+
+// HomeGitControlBarPreview pulls in settings + provider hooks we don't care
+// about for these tests. It's purely presentational once a selection is
+// confirmed, so a thin stub is sufficient.
+vi.mock("#/components/features/home/home-git-control-bar-preview", () => ({
+  HomeGitControlBarPreview: () => (
+    <div data-testid="stub-git-control-bar-preview" />
+  ),
+}));
+
+const renderLauncher = () =>
+  render(<HomeChatLauncher />, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: {
+              queries: { retry: false },
+              mutations: { retry: false },
+            },
+          })
+        }
+      >
+        {children}
+      </QueryClientProvider>
+    ),
+  });
+
+function makeConversationResponse(
+  overrides: Record<string, unknown> = {},
+): never {
+  return {
+    id: "conv-abc",
+    created_by_user_id: null,
+    status: "READY",
+    detail: null,
+    app_conversation_id: "conv-abc",
+    agent_server_url: "http://agent-server.local",
+    request: { initial_message: undefined, plugins: null },
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as never;
+}
+
+const localBackend = {
+  backend: {
+    id: "local-id",
+    name: "Local",
+    host: "http://localhost",
+    apiKey: "test",
+    kind: "local" as const,
+  },
+  orgId: null,
+};
+
+const cloudBackend = {
+  backend: {
+    id: "cloud-id",
+    name: "Cloud",
+    host: "https://cloud",
+    apiKey: "test",
+    kind: "cloud" as const,
+  },
+  orgId: null,
+};
+
+describe("HomeChatLauncher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseActiveBackend.mockReturnValue(localBackend);
+  });
+
+  afterEach(() => {
+    toast.remove();
+  });
+
+  it("creates a conversation with just the typed query and navigates when no workspace is selected", async () => {
+    const createSpy = vi
+      .spyOn(AgentServerConversationService, "createConversation")
+      .mockResolvedValue(makeConversationResponse());
+
+    renderLauncher();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("stub-chat-submit"));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
+    expect(createSpy).toHaveBeenCalledWith(
+      "hello world",
+      undefined,
+      undefined,
+      null,
+      undefined,
+      undefined,
+      undefined,
+    );
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-abc"),
+    );
+  });
+
+  it("passes the picked workspace path as working_dir on a local backend", async () => {
+    const createSpy = vi
+      .spyOn(AgentServerConversationService, "createConversation")
+      .mockResolvedValue(
+        makeConversationResponse({ app_conversation_id: "conv-ws" }),
+      );
+
+    renderLauncher();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("open-workspace-button"));
+    await user.click(await screen.findByTestId("stub-workspace-dialog-confirm"));
+    await user.click(screen.getByTestId("stub-chat-submit"));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
+    expect(createSpy).toHaveBeenCalledWith(
+      "hello world",
+      undefined,
+      undefined,
+      null,
+      "/p/app",
+      undefined,
+      undefined,
+    );
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-ws"),
+    );
+  });
+
+  it("passes the picked repository + branch payload on a cloud backend", async () => {
+    mockUseActiveBackend.mockReturnValue(cloudBackend);
+    const createSpy = vi
+      .spyOn(AgentServerConversationService, "createConversation")
+      .mockResolvedValue(
+        makeConversationResponse({ app_conversation_id: "conv-repo" }),
+      );
+
+    renderLauncher();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("open-repository-button"));
+    await user.click(await screen.findByTestId("stub-repo-dialog-confirm"));
+    await user.click(screen.getByTestId("stub-chat-submit"));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
+    expect(createSpy).toHaveBeenCalledWith(
+      "hello world",
+      undefined,
+      undefined,
+      {
+        selected_repository: "org/repo",
+        selected_branch: "main",
+        git_provider: "github",
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-repo"),
+    );
+  });
+
+  it("surfaces a toast and skips navigation when conversation creation fails", async () => {
+    const toastErrorSpy = vi.spyOn(toast, "error");
+    vi.spyOn(AgentServerConversationService, "createConversation").mockRejectedValue(
+      new Error("Network down"),
+    );
+
+    renderLauncher();
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("stub-chat-submit"));
+
+    await waitFor(() => expect(toastErrorSpy).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/features/home/workspace-selection-form.test.tsx
+++ b/__tests__/components/features/home/workspace-selection-form.test.tsx
@@ -74,12 +74,13 @@ function makeStartTask(overrides: Record<string, unknown> = {}) {
 function renderForm(
   initialWorkspaces: LocalWorkspace[] = [],
   initialParents: { id: string; name: string; path: string }[] = [],
+  props: { onConfirm?: (workspace: LocalWorkspace) => void } = {},
 ) {
   useWorkspacesStore.setState({
     workspaces: initialWorkspaces,
     workspaceParents: initialParents,
   });
-  return render(<WorkspaceSelectionForm />, {
+  return render(<WorkspaceSelectionForm {...props} />, {
     wrapper: ({ children }) => (
       <QueryClientProvider
         client={
@@ -537,6 +538,34 @@ describe("WorkspaceSelectionForm", () => {
     expect(
       within(refreshedDropdown).queryByText("repoB"),
     ).not.toBeInTheDocument();
+  });
+
+  it("invokes onConfirm with the selected workspace instead of creating a conversation when used in dialog mode", async () => {
+    const onConfirm = vi.fn();
+    const createSpy = vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    );
+
+    renderForm(
+      [{ id: "/Users/me/dev/repo1", name: "repo1", path: "/Users/me/dev/repo1" }],
+      [],
+      { onConfirm },
+    );
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("workspace-dropdown"));
+    await user.click(await screen.findByText("repo1"));
+    await user.click(screen.getByTestId("workspace-launch-button"));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith({
+      id: "/Users/me/dev/repo1",
+      name: "repo1",
+      path: "/Users/me/dev/repo1",
+    });
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it("Add Workspace sidebar renders backend-provided favorites dynamically and navigates into them on click", async () => {

--- a/__tests__/routes/changes-tab.test.tsx
+++ b/__tests__/routes/changes-tab.test.tsx
@@ -18,6 +18,7 @@ vi.mock("#/hooks/query/use-unified-get-git-changes");
 vi.mock("#/hooks/use-agent-state");
 vi.mock("#/hooks/use-conversation-id", () => ({
   useConversationId: () => ({ conversationId: "test-id" }),
+  useOptionalConversationId: () => ({ conversationId: "test-id" }),
 }));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/src/components/features/chat/components/chat-input-actions.tsx
+++ b/src/components/features/chat/components/chat-input-actions.tsx
@@ -15,7 +15,7 @@ import LessonPlanIcon from "#/icons/lesson-plan.svg?react";
 import ThreeDotsVerticalIcon from "#/icons/three-dots-vertical.svg?react";
 import { CodePillIcon } from "#/icons/code-pill";
 import { useUnifiedPauseConversation } from "#/hooks/mutation/use-unified-stop-conversation";
-import { useConversationId } from "#/hooks/use-conversation-id";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { usePauseConversation } from "#/hooks/mutation/use-pause-conversation";
 import { useResumeConversation } from "#/hooks/mutation/use-resume-conversation";
 import { useActiveBackend } from "#/contexts/active-backend-context";
@@ -60,7 +60,9 @@ export function ChatInputActions({
   const unifiedPauseMutation = useUnifiedPauseConversation();
   const pauseConversationMutation = usePauseConversation();
   const resumeConversationMutation = useResumeConversation();
-  const { conversationId } = useConversationId();
+  // Optional because the chat input also renders on the home page (no
+  // conversation route yet). Conversation-scoped actions below guard on this.
+  const { conversationId } = useOptionalConversationId();
   const { data: conversation } = useActiveConversation();
   const isCloud = useActiveBackend().backend.kind === "cloud";
   const webSocketStatus = useUnifiedWebSocketStatus();
@@ -104,7 +106,7 @@ export function ChatInputActions({
     shouldShowAgentTools,
     shouldShowHooks,
   } = useConversationNameContextMenu({
-    conversationId,
+    conversationId: conversationId ?? undefined,
     executionStatus: conversation?.execution_status,
     showOptions: true,
     onContextMenuToggle: setIsOverflowOpen,
@@ -168,11 +170,13 @@ export function ChatInputActions({
   }, [isCloud]);
 
   const handlePauseAgent = () => {
+    if (!conversationId) return;
     // Pause the conversation (agent execution)
     pauseConversationMutation.mutate({ conversationId });
   };
 
   const handleResumeAgentClick = () => {
+    if (!conversationId) return;
     // Resume the conversation (agent execution)
     resumeConversationMutation.mutate({ conversationId });
   };
@@ -541,7 +545,7 @@ export function ChatInputActions({
         ref={rightSectionRef}
         className="ml-auto flex shrink-0 items-center gap-2"
       >
-        {showAgentStatusInline && (
+        {showAgentStatusInline && conversationId && (
           <AgentStatus
             handleStop={handlePauseAgent}
             handleResumeAgent={handleResumeAgentClick}

--- a/src/components/features/chat/components/chat-input-model.tsx
+++ b/src/components/features/chat/components/chat-input-model.tsx
@@ -1,4 +1,5 @@
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
+import { useSettings } from "#/hooks/query/use-settings";
 import ChevronDownSmallIcon from "#/icons/chevron-down-small.svg?react";
 import SettingsGearIcon from "#/icons/settings-gear.svg?react";
 import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
@@ -13,13 +14,17 @@ import { useTranslation } from "react-i18next";
 export function ChatInputModel() {
   const { t } = useTranslation("openhands");
   const { data: conversation } = useActiveConversation();
+  // Home page has no active conversation; fall back to the user's default
+  // model so the switcher renders consistently across both surfaces.
+  const { data: settings } = useSettings();
+  const llmModel = conversation?.llm_model ?? settings?.llm_model;
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
 
   const popoverRef = useClickOutsideElement<HTMLUListElement>(() => {
     setIsPopoverOpen(false);
   });
 
-  if (!conversation?.llm_model) {
+  if (!llmModel) {
     return null;
   }
 
@@ -31,7 +36,7 @@ export function ChatInputModel() {
           "inline-flex items-center gap-1 rounded-[100px] border border-transparent px-1.5 text-sm font-normal leading-5 text-[var(--oh-muted)] whitespace-nowrap min-w-0 transition-[border-color,color]",
           "hover:text-white hover:bg-white/10 cursor-pointer",
         )}
-        title={conversation.llm_model}
+        title={llmModel}
         data-testid="chat-input-llm-model"
         aria-expanded={isPopoverOpen}
         aria-haspopup="dialog"
@@ -41,7 +46,7 @@ export function ChatInputModel() {
           setIsPopoverOpen((open) => !open);
         }}
       >
-        <span>{conversation.llm_model}</span>
+        <span>{llmModel}</span>
         <ChevronDownSmallIcon
           width={18}
           height={18}
@@ -61,9 +66,7 @@ export function ChatInputModel() {
           className="z-[60] mb-2 min-w-[200px]"
         >
           <li className="text-sm">
-            <div className="p-2 leading-5 text-white break-all">
-              {conversation.llm_model}
-            </div>
+            <div className="p-2 leading-5 text-white break-all">{llmModel}</div>
           </li>
           <Divider />
           <li className="text-sm">

--- a/src/components/features/chat/git-control-bar.tsx
+++ b/src/components/features/chat/git-control-bar.tsx
@@ -200,6 +200,14 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
   // click is a no-op. Linkable repos render as <a> and ignore `disabled`.
   const isRepoButtonInert = isLocalBackend && !hasRepository;
 
+  // True when the bar will render at least one chip (cloud always shows
+  // "Open Repository"; local needs a repo or a workspace name; selected
+  // branch or push/pull/PR also count). When false, the bar has nothing to
+  // show — return null so the wrapper above collapses to its natural padding
+  // instead of leaving an empty DOM node below the chat input.
+  const hasAnyContent = showRepoButton || !!selectedBranch || hasRepository;
+  if (!hasAnyContent) return null;
+
   return (
     <div className="flex flex-row items-center">
       <div className="flex flex-row gap-2.5 items-center overflow-x-auto flex-wrap md:flex-nowrap relative scrollbar-hide">

--- a/src/components/features/controls/tools.tsx
+++ b/src/components/features/controls/tools.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Wrench } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
-import { useConversationId } from "#/hooks/use-conversation-id";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import ChevronDownSmallIcon from "#/icons/chevron-down-small.svg?react";
 import { ToolsContextMenu } from "./tools-context-menu";
 import { useConversationNameContextMenu } from "#/hooks/use-conversation-name-context-menu";
@@ -13,7 +13,9 @@ import { HooksModal } from "../conversation-panel/hooks-modal";
 
 export function Tools() {
   const { t } = useTranslation("openhands");
-  const { conversationId } = useConversationId();
+  // Optional because this control also renders inside the home-page chat
+  // input shell, before any conversation exists.
+  const { conversationId } = useOptionalConversationId();
   const { data: conversation } = useActiveConversation();
   const [contextMenuOpen, setContextMenuOpen] = React.useState(false);
 
@@ -31,7 +33,7 @@ export function Tools() {
     shouldShowAgentTools,
     shouldShowHooks,
   } = useConversationNameContextMenu({
-    conversationId,
+    conversationId: conversationId ?? undefined,
     executionStatus: conversation?.execution_status,
     showOptions: true,
     onContextMenuToggle: setContextMenuOpen,

--- a/src/components/features/home/home-chat-launcher.tsx
+++ b/src/components/features/home/home-chat-launcher.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+import { CustomChatInput } from "#/components/features/chat/custom-chat-input";
+import { useActiveBackend } from "#/contexts/active-backend-context";
+import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
+import { useNavigation } from "#/context/navigation-context";
+import { useIsCreatingConversation } from "#/hooks/use-is-creating-conversation";
+import { Branch, GitRepository } from "#/types/git";
+import { Provider } from "#/types/settings";
+import { LocalWorkspace } from "#/types/workspace";
+import { I18nKey } from "#/i18n/declaration";
+import {
+  displayErrorToast,
+  TOAST_OPTIONS,
+} from "#/utils/custom-toast-handlers";
+import { HomeHeaderTitle } from "./home-header/home-header-title";
+import { OpenLauncherButton } from "./open-launcher-button";
+import { OpenWorkspaceDialog } from "./open-workspace-dialog";
+import { OpenRepositoryDialog } from "./open-repository-dialog";
+import { HomeGitControlBarPreview } from "./home-git-control-bar-preview";
+
+export function HomeChatLauncher() {
+  const { t } = useTranslation("openhands");
+  const { backend } = useActiveBackend();
+  const { navigate } = useNavigation();
+  const isLocal = backend.kind === "local";
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [pendingWorkspace, setPendingWorkspace] =
+    useState<LocalWorkspace | null>(null);
+  const [pendingRepository, setPendingRepository] =
+    useState<GitRepository | null>(null);
+  const [pendingBranch, setPendingBranch] = useState<Branch | null>(null);
+  const [pendingProvider, setPendingProvider] = useState<Provider | null>(null);
+
+  const { mutate: createConversation, isPending } = useCreateConversation();
+  const isCreatingElsewhere = useIsCreatingConversation();
+  const isCreating = isPending || isCreatingElsewhere;
+
+  const hasSelection = isLocal
+    ? !!pendingWorkspace
+    : !!pendingRepository && !!pendingBranch;
+
+  const handleSubmit = (message: string) => {
+    const trimmed = message.trim();
+    if (!trimmed || isCreating) return;
+
+    // Workspace/repo are optional — match the "Start from scratch" flow which
+    // creates a conversation with no working dir and no repo. Build the
+    // payload from whatever is selected.
+    let variables: Parameters<typeof createConversation>[0] = {
+      query: trimmed,
+    };
+    if (isLocal && pendingWorkspace) {
+      variables = { ...variables, workingDir: pendingWorkspace.path };
+    } else if (!isLocal && pendingRepository && pendingBranch) {
+      variables = {
+        ...variables,
+        repository: {
+          name: pendingRepository.full_name,
+          gitProvider: pendingRepository.git_provider,
+          branch: pendingBranch.name,
+        },
+      };
+    }
+
+    // Loading toast gives the user a clear signal that the request is in
+    // flight; dismissed precisely once the mutation resolves.
+    const toastId = toast.loading(
+      t(I18nKey.HOME$CREATING_CONVERSATION),
+      TOAST_OPTIONS,
+    );
+
+    createConversation(variables, {
+      onSuccess: (data) => {
+        toast.dismiss(toastId);
+        navigate(`/conversations/${data.conversation_id}`);
+      },
+      onError: (error) => {
+        toast.dismiss(toastId);
+        displayErrorToast(error instanceof Error ? error.message : null);
+      },
+    });
+  };
+
+  return (
+    <div
+      data-testid="home-chat-launcher"
+      className="w-full max-w-[800px] flex flex-col gap-4 pl-0 md:pl-4 pr-0 md:pr-4"
+    >
+      <div className="flex justify-center">
+        <HomeHeaderTitle />
+      </div>
+
+      <div className="w-full">
+        <CustomChatInput onSubmit={handleSubmit} disabled={isCreating} />
+      </div>
+
+      <div className="flex justify-start">
+        {hasSelection ? (
+          <HomeGitControlBarPreview
+            workspace={pendingWorkspace}
+            repository={pendingRepository}
+            branch={pendingBranch}
+            provider={pendingProvider}
+            onRepoClick={() => setIsDialogOpen(true)}
+          />
+        ) : (
+          <OpenLauncherButton
+            kind={isLocal ? "local" : "cloud"}
+            onClick={() => setIsDialogOpen(true)}
+            disabled={isCreating}
+          />
+        )}
+      </div>
+
+      {isLocal ? (
+        <OpenWorkspaceDialog
+          isOpen={isDialogOpen}
+          onClose={() => setIsDialogOpen(false)}
+          onConfirm={(workspace) => {
+            setPendingWorkspace(workspace);
+            setPendingRepository(null);
+            setPendingBranch(null);
+            setPendingProvider(null);
+          }}
+        />
+      ) : (
+        <OpenRepositoryDialog
+          isOpen={isDialogOpen}
+          onClose={() => setIsDialogOpen(false)}
+          onConfirm={({ repository, branch, provider }) => {
+            setPendingRepository(repository);
+            setPendingBranch(branch);
+            setPendingProvider(provider ?? repository.git_provider);
+            setPendingWorkspace(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/features/home/home-git-control-bar-preview.tsx
+++ b/src/components/features/home/home-git-control-bar-preview.tsx
@@ -1,0 +1,46 @@
+import { GitControlBarRepoButton } from "#/components/features/chat/git-control-bar-repo-button";
+import { GitControlBarBranchButton } from "#/components/features/chat/git-control-bar-branch-button";
+import { Branch, GitRepository } from "#/types/git";
+import { Provider } from "#/types/settings";
+import { LocalWorkspace } from "#/types/workspace";
+
+interface HomeGitControlBarPreviewProps {
+  workspace?: LocalWorkspace | null;
+  repository?: GitRepository | null;
+  branch?: Branch | null;
+  provider?: Provider | null;
+  onRepoClick: () => void;
+}
+
+export function HomeGitControlBarPreview({
+  workspace,
+  repository,
+  branch,
+  provider,
+  onRepoClick,
+}: HomeGitControlBarPreviewProps) {
+  const workspaceName = workspace
+    ? workspace.path.replace(/\/+$/, "").split("/").pop() || workspace.path
+    : null;
+
+  return (
+    <div
+      className="flex flex-row gap-2.5 items-center flex-wrap"
+      data-testid="home-git-control-bar-preview"
+    >
+      <GitControlBarRepoButton
+        selectedRepository={repository?.full_name ?? null}
+        gitProvider={provider ?? null}
+        workspaceName={workspaceName}
+        onClick={onRepoClick}
+      />
+      {branch ? (
+        <GitControlBarBranchButton
+          selectedBranch={branch.name}
+          selectedRepository={repository?.full_name ?? null}
+          gitProvider={provider ?? null}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/features/home/open-launcher-button.tsx
+++ b/src/components/features/home/open-launcher-button.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from "react-i18next";
+import { I18nKey } from "#/i18n/declaration";
+import FolderIcon from "#/icons/folder.svg?react";
+import RepoForkedIcon from "#/icons/repo-forked.svg?react";
+import { cn } from "#/utils/utils";
+
+interface OpenLauncherButtonProps {
+  kind: "local" | "cloud";
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export function OpenLauncherButton({
+  kind,
+  onClick,
+  disabled = false,
+}: OpenLauncherButtonProps) {
+  const { t } = useTranslation("openhands");
+
+  const isLocal = kind === "local";
+  const label = isLocal
+    ? t(I18nKey.HOME$OPEN_WORKSPACE)
+    : t(I18nKey.COMMON$OPEN_REPOSITORY);
+  const testId = isLocal ? "open-workspace-button" : "open-repository-button";
+
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "flex flex-row items-center gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] border border-[rgba(71,74,84,0.50)] bg-transparent",
+        disabled
+          ? "opacity-50 cursor-not-allowed"
+          : "hover:border-[var(--oh-border-subtle)] cursor-pointer",
+      )}
+    >
+      <span className="w-3 h-3 flex items-center justify-center text-white">
+        {isLocal ? (
+          <FolderIcon width={12} height={12} />
+        ) : (
+          <RepoForkedIcon width={12} height={12} color="white" />
+        )}
+      </span>
+      <span className="font-normal text-white text-sm leading-5">{label}</span>
+    </button>
+  );
+}

--- a/src/components/features/home/open-repository-dialog.tsx
+++ b/src/components/features/home/open-repository-dialog.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from "react-i18next";
+import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
+import { ModalBody } from "#/components/shared/modals/modal-body";
+import { BaseModalTitle } from "#/components/shared/modals/confirmation-modals/base-modal";
+import { I18nKey } from "#/i18n/declaration";
+import RepoForkedIcon from "#/icons/repo-forked.svg?react";
+import { Branch, GitRepository } from "#/types/git";
+import { Provider } from "#/types/settings";
+import { useUserProviders } from "#/hooks/use-user-providers";
+import { RepositorySelectionForm } from "./repo-selection-form";
+
+interface OpenRepositoryDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (selection: {
+    repository: GitRepository;
+    branch: Branch;
+    provider: Provider | null;
+  }) => void;
+}
+
+export function OpenRepositoryDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+}: OpenRepositoryDialogProps) {
+  const { t } = useTranslation("openhands");
+  const { isLoadingSettings } = useUserProviders();
+
+  if (!isOpen) return null;
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <ModalBody
+        width="small"
+        className="items-start border border-[var(--oh-border)] !gap-4"
+      >
+        <div className="flex items-center gap-[10px]">
+          <RepoForkedIcon width={24} height={24} />
+          <BaseModalTitle title={t(I18nKey.COMMON$OPEN_REPOSITORY)} />
+        </div>
+
+        <div className="w-full" data-testid="open-repository-dialog-body">
+          <RepositorySelectionForm
+            isLoadingSettings={isLoadingSettings}
+            onConfirm={(selection) => {
+              onConfirm(selection);
+              onClose();
+            }}
+          />
+        </div>
+      </ModalBody>
+    </ModalBackdrop>
+  );
+}

--- a/src/components/features/home/open-workspace-dialog.tsx
+++ b/src/components/features/home/open-workspace-dialog.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from "react-i18next";
+import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
+import { ModalBody } from "#/components/shared/modals/modal-body";
+import { BaseModalTitle } from "#/components/shared/modals/confirmation-modals/base-modal";
+import { I18nKey } from "#/i18n/declaration";
+import FolderIcon from "#/icons/folder.svg?react";
+import { LocalWorkspace } from "#/types/workspace";
+import { useUserProviders } from "#/hooks/use-user-providers";
+import { WorkspaceSelectionForm } from "./workspace-selection-form";
+
+interface OpenWorkspaceDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (workspace: LocalWorkspace) => void;
+}
+
+export function OpenWorkspaceDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+}: OpenWorkspaceDialogProps) {
+  const { t } = useTranslation("openhands");
+  const { isLoadingSettings } = useUserProviders();
+
+  if (!isOpen) return null;
+
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <ModalBody
+        width="small"
+        className="items-start border border-[var(--oh-border)] !gap-4"
+      >
+        <div className="flex items-center gap-[10px]">
+          <FolderIcon width={24} height={24} />
+          <BaseModalTitle title={t(I18nKey.HOME$OPEN_WORKSPACE)} />
+        </div>
+
+        <div className="w-full" data-testid="open-workspace-dialog-body">
+          <WorkspaceSelectionForm
+            isLoadingSettings={isLoadingSettings}
+            onConfirm={(workspace) => {
+              onConfirm(workspace);
+              onClose();
+            }}
+          />
+        </div>
+      </ModalBody>
+    </ModalBackdrop>
+  );
+}

--- a/src/components/features/home/repo-selection-form.tsx
+++ b/src/components/features/home/repo-selection-form.tsx
@@ -25,11 +25,23 @@ interface RepositorySelectionFormProps {
    */
   onRepoSelection?: (repo: GitRepository | null) => void;
   isLoadingSettings?: boolean;
+  /**
+   * When provided, the form skips its own conversation creation + navigation
+   * and just calls back with the selected repo/branch/provider. Used by the
+   * home launcher dialog so the user can confirm a selection without
+   * immediately starting a conversation.
+   */
+  onConfirm?: (selection: {
+    repository: GitRepository;
+    branch: Branch;
+    provider: Provider | null;
+  }) => void;
 }
 
 export function RepositorySelectionForm({
   onRepoSelection,
   isLoadingSettings = false,
+  onConfirm,
 }: RepositorySelectionFormProps) {
   const { navigate } = useNavigation();
 
@@ -163,14 +175,18 @@ export function RepositorySelectionForm({
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-[10px] pb-4">
-          <RepoForkedIcon width={24} height={24} />
-          <span className="leading-5 font-bold text-base text-white">
-            {t(I18nKey.COMMON$OPEN_REPOSITORY)}
-          </span>
+      {/* Skip the in-form "Open Repository" header in dialog mode — the dialog
+          already shows the same title, so this would be redundant. */}
+      {!onConfirm && (
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-[10px] pb-4">
+            <RepoForkedIcon width={24} height={24} />
+            <span className="leading-5 font-bold text-base text-white">
+              {t(I18nKey.COMMON$OPEN_REPOSITORY)}
+            </span>
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="flex flex-col gap-[10px] pb-4">
         <div className="flex items-center justify-between">
@@ -190,22 +206,32 @@ export function RepositorySelectionForm({
         isDisabled={
           !selectedRepository ||
           !selectedBranch ||
-          isCreatingConversation ||
+          (!onConfirm && isCreatingConversation) ||
           (providers.length > 1 && !selectedProvider) ||
           isLoadingSettings
         }
         onClick={() => {
-          // Persist the repository to recent repositories when launching
-          if (selectedRepository) {
-            addRecentRepository(selectedRepository);
+          if (!selectedRepository || !selectedBranch) return;
+
+          // Persist the repository to recent repositories on every confirm so
+          // the home launcher and the inline path stay in sync.
+          addRecentRepository(selectedRepository);
+
+          if (onConfirm) {
+            onConfirm({
+              repository: selectedRepository,
+              branch: selectedBranch,
+              provider: selectedProvider,
+            });
+            return;
           }
 
           createConversation(
             {
               repository: {
-                name: selectedRepository?.full_name || "",
-                gitProvider: selectedRepository?.git_provider || "github",
-                branch: selectedBranch?.name || "main",
+                name: selectedRepository.full_name || "",
+                gitProvider: selectedRepository.git_provider || "github",
+                branch: selectedBranch.name || "main",
               },
             },
             {
@@ -216,8 +242,11 @@ export function RepositorySelectionForm({
         }}
         className="w-full font-semibold"
       >
-        {!isCreatingConversation && "Launch"}
-        {isCreatingConversation && t("HOME$LOADING")}
+        {onConfirm
+          ? t(I18nKey.BUTTON$CONFIRM)
+          : !isCreatingConversation
+            ? "Launch"
+            : t("HOME$LOADING")}
       </BrandButton>
     </div>
   );

--- a/src/components/features/home/workspace-selection-form.tsx
+++ b/src/components/features/home/workspace-selection-form.tsx
@@ -17,10 +17,19 @@ import { ManageWorkspacesModal } from "./workspace-dropdown/manage-workspaces-mo
 
 interface WorkspaceSelectionFormProps {
   isLoadingSettings?: boolean;
+  /**
+   * When provided, the form skips its own conversation creation + navigation
+   * and just calls back with the selected workspace. Callers (e.g. the home
+   * launcher dialog) use this to capture the selection and create the
+   * conversation themselves once the user submits a message. The button label
+   * also flips from "Launch" to "Confirm" so the action matches the new flow.
+   */
+  onConfirm?: (workspace: LocalWorkspace) => void;
 }
 
 export function WorkspaceSelectionForm({
   isLoadingSettings = false,
+  onConfirm,
 }: WorkspaceSelectionFormProps) {
   const { t } = useTranslation("openhands");
   const { navigate } = useNavigation();
@@ -63,6 +72,10 @@ export function WorkspaceSelectionForm({
 
   const handleLaunch = () => {
     if (!selectedWorkspace) return;
+    if (onConfirm) {
+      onConfirm(selectedWorkspace);
+      return;
+    }
     createConversation(
       { workingDir: selectedWorkspace.path },
       {
@@ -73,12 +86,16 @@ export function WorkspaceSelectionForm({
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center gap-[10px] pb-4">
-        <FolderIcon width={24} height={24} />
-        <span className="leading-5 font-bold text-base text-white">
-          {t(I18nKey.HOME$WORKSPACES_TAB)}
-        </span>
-      </div>
+      {/* Skip the in-form "Workspaces" header in dialog mode — the dialog
+          already shows an "Open Workspace" title, so this would be redundant. */}
+      {!onConfirm && (
+        <div className="flex items-center gap-[10px] pb-4">
+          <FolderIcon width={24} height={24} />
+          <span className="leading-5 font-bold text-base text-white">
+            {t(I18nKey.HOME$WORKSPACES_TAB)}
+          </span>
+        </div>
+      )}
 
       <div className="flex flex-col gap-[10px] pb-4">
         <WorkspaceDropdown
@@ -108,13 +125,22 @@ export function WorkspaceSelectionForm({
         variant="primary"
         type="button"
         isDisabled={
-          !selectedWorkspace || isCreatingConversation || isLoadingSettings
+          !selectedWorkspace ||
+          (!onConfirm && isCreatingConversation) ||
+          isLoadingSettings
         }
         onClick={handleLaunch}
-        className="w-auto absolute bottom-5 left-5 right-5 font-semibold"
+        className={
+          onConfirm
+            ? "w-full font-semibold"
+            : "w-auto absolute bottom-5 left-5 right-5 font-semibold"
+        }
       >
-        {!isCreatingConversation && "Launch"}
-        {isCreatingConversation && t(I18nKey.HOME$LOADING)}
+        {onConfirm
+          ? t(I18nKey.BUTTON$CONFIRM)
+          : !isCreatingConversation
+            ? "Launch"
+            : t(I18nKey.HOME$LOADING)}
       </BrandButton>
 
       <FolderBrowserModal

--- a/src/hooks/chat/use-chat-input-logic.ts
+++ b/src/hooks/chat/use-chat-input-logic.ts
@@ -5,7 +5,7 @@ import {
   getTextContent,
 } from "#/components/features/chat/utils/chat-input.utils";
 import { useConversationStore } from "#/stores/conversation-store";
-import { useConversationId } from "#/hooks/use-conversation-id";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { useDraftPersistence } from "./use-draft-persistence";
 
 /**
@@ -13,7 +13,10 @@ import { useDraftPersistence } from "./use-draft-persistence";
  */
 export const useChatInputLogic = () => {
   const chatInputRef = useRef<HTMLDivElement | null>(null);
-  const { conversationId } = useConversationId();
+  // Optional because the chat input also renders on the home page, where no
+  // conversation route is mounted yet. Draft persistence is conversation-
+  // scoped, so it no-ops when this is undefined.
+  const { conversationId } = useOptionalConversationId();
 
   const {
     messageToSend,

--- a/src/hooks/chat/use-draft-persistence.ts
+++ b/src/hooks/chat/use-draft-persistence.ts
@@ -17,13 +17,21 @@ const DRAFT_SAVE_DEBOUNCE_MS = 500;
 /**
  * Hook for persisting draft messages to localStorage.
  * Handles debounced saving on input, restoration on mount, and clearing on confirmed delivery.
+ *
+ * `conversationId` may be undefined when the chat input renders on the home
+ * page (no conversation exists yet). In that case the hook short-circuits:
+ * no localStorage reads/writes happen and the returned callbacks are no-ops.
  */
 export const useDraftPersistence = (
-  conversationId: string,
+  conversationId: string | null | undefined,
   chatInputRef: React.RefObject<HTMLDivElement | null>,
 ) => {
-  const { state, setDraftMessage } =
-    useConversationLocalStorageState(conversationId);
+  // Pass an empty string when conversationId is missing to keep the hook
+  // call unconditional (rules of hooks). The early-return branches below
+  // ensure we never actually touch localStorage with an empty key.
+  const { state, setDraftMessage } = useConversationLocalStorageState(
+    conversationId ?? "",
+  );
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasRestoredRef = useRef(false);
   const [isRestored, setIsRestored] = useState(false);
@@ -39,6 +47,9 @@ export const useDraftPersistence = (
   // 2. Task-to-real transition: Preserve draft typed during initialization
   // 3. DOM reset: Clear stale content before restoration effect runs
   useEffect(() => {
+    if (!conversationId) {
+      return;
+    }
     const previousConversationId = currentConversationIdRef.current;
     const isInitialMount = isFirstMountRef.current;
     currentConversationIdRef.current = conversationId;
@@ -58,7 +69,11 @@ export const useDraftPersistence = (
     // that transitions to a real conversation ID once ready. Task IDs don't persist
     // to localStorage, so any draft typed during this phase would be lost.
     // We detect this transition and transfer the draft to the new real ID.
-    if (!isInitialMount && previousConversationId !== conversationId) {
+    if (
+      !isInitialMount &&
+      previousConversationId &&
+      previousConversationId !== conversationId
+    ) {
       const wasTaskId = isTaskId(previousConversationId);
       const isNowRealId = !isTaskId(conversationId);
 
@@ -91,6 +106,9 @@ export const useDraftPersistence = (
 
   // Restore draft from localStorage - reads directly to avoid state sync timing issues
   useEffect(() => {
+    if (!conversationId) {
+      return;
+    }
     if (hasRestoredRef.current) {
       return;
     }
@@ -122,6 +140,9 @@ export const useDraftPersistence = (
 
   // Debounced save function - called from onInput handler
   const saveDraft = useCallback(() => {
+    if (!conversationId) {
+      return;
+    }
     // Clear any pending save
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
@@ -152,13 +173,16 @@ export const useDraftPersistence = (
 
   // Clear draft - called after message delivery is confirmed
   const clearDraft = useCallback(() => {
+    if (!conversationId) {
+      return;
+    }
     // Cancel any pending save
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
       saveTimeoutRef.current = null;
     }
     setDraftMessage(null);
-  }, [setDraftMessage]);
+  }, [conversationId, setDraftMessage]);
 
   // Cleanup timeout on unmount
   useEffect(

--- a/src/hooks/query/use-active-conversation.ts
+++ b/src/hooks/query/use-active-conversation.ts
@@ -1,14 +1,17 @@
 import { useEffect } from "react";
-import { useConversationId } from "#/hooks/use-conversation-id";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { useUserConversation } from "./use-user-conversation";
 import ConversationService from "#/api/conversation-service/conversation-service.api";
 
 export const useActiveConversation = () => {
-  const { conversationId } = useConversationId();
+  // Optional: the chat input renders on the home page too (no conversation
+  // route yet). The user-conversation query is gated on a real id below.
+  const { conversationId } = useOptionalConversationId();
 
   // Task polling is handled by useTaskPolling hook
-  const isTaskId = conversationId.startsWith("task-");
-  const actualConversationId = isTaskId ? null : conversationId;
+  const isTaskId = !!conversationId && conversationId.startsWith("task-");
+  const actualConversationId =
+    !conversationId || isTaskId ? null : conversationId;
 
   const userConversation = useUserConversation(
     actualConversationId,

--- a/src/hooks/query/use-task-polling.ts
+++ b/src/hooks/query/use-task-polling.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { useNavigation } from "#/context/navigation-context";
-import { useConversationId } from "#/hooks/use-conversation-id";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 
 /**
  * Hook that polls V1 conversation start tasks and navigates when ready.
@@ -20,12 +20,14 @@ import { useConversationId } from "#/hooks/use-conversation-id";
  * Note: This hook does NOT fetch conversation data. It only handles task polling and navigation.
  */
 export const useTaskPolling = () => {
-  const { conversationId } = useConversationId();
+  // Optional: the chat input shell renders on the home page too; polling
+  // simply no-ops when there's no conversation id yet.
+  const { conversationId } = useOptionalConversationId();
   const { navigate } = useNavigation();
 
   // Check if this is a task ID (format: "task-{uuid}")
-  const isTask = conversationId.startsWith("task-");
-  const taskId = isTask ? conversationId.replace("task-", "") : null;
+  const isTask = !!conversationId && conversationId.startsWith("task-");
+  const taskId = isTask ? conversationId!.replace("task-", "") : null;
 
   // Poll the task if this is a task ID
   const taskQuery = useQuery({
@@ -62,7 +64,7 @@ export const useTaskPolling = () => {
   return {
     isTask,
     taskId,
-    conversationId: isTask ? null : conversationId,
+    conversationId: isTask ? null : (conversationId ?? null),
     task: taskQuery.data,
     taskStatus: taskQuery.data?.status,
     taskDetail: taskQuery.data?.detail,

--- a/src/hooks/use-send-message.ts
+++ b/src/hooks/use-send-message.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useConversationWebSocket } from "#/contexts/conversation-websocket-context";
-import { useConversationId } from "#/hooks/use-conversation-id";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { MessageContent } from "#/api/conversation-service/agent-server-conversation-service.types";
 
 interface SendResult {
@@ -11,7 +11,10 @@ interface SendResult {
  * Sends user messages through the active conversation WebSocket.
  */
 export function useSendMessage() {
-  const { conversationId } = useConversationId();
+  // Optional: this hook is reachable from the home-page chat input shell.
+  // Outside a conversation route, `conversationContext` is null anyway so
+  // `send` is a no-op that returns `{ queued: false }`.
+  const { conversationId } = useOptionalConversationId();
 
   // Get agent-server context (null outside a conversation provider)
   const conversationContext = useConversationWebSocket();

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -16880,6 +16880,40 @@
     "uk": "Робочі області",
     "ca": "Espais de treball"
   },
+  "HOME$OPEN_WORKSPACE": {
+    "en": "Open Workspace",
+    "ja": "ワークスペースを開く",
+    "zh-CN": "打开工作区",
+    "zh-TW": "打開工作區",
+    "ko-KR": "작업 공간 열기",
+    "no": "Åpne arbeidsområde",
+    "it": "Apri area di lavoro",
+    "pt": "Abrir espaço de trabalho",
+    "es": "Abrir espacio de trabajo",
+    "ar": "افتح مساحة العمل",
+    "fr": "Ouvrir l'espace de travail",
+    "tr": "Çalışma Alanını Aç",
+    "de": "Arbeitsbereich öffnen",
+    "uk": "Відкрити робочу область",
+    "ca": "Obre l'espai de treball"
+  },
+  "HOME$CREATING_CONVERSATION": {
+    "en": "Creating conversation…",
+    "ja": "会話を作成中…",
+    "zh-CN": "正在创建会话…",
+    "zh-TW": "正在建立會話…",
+    "ko-KR": "대화 생성 중…",
+    "no": "Oppretter samtale…",
+    "it": "Creazione conversazione…",
+    "pt": "Criando conversa…",
+    "es": "Creando conversación…",
+    "ar": "جارٍ إنشاء المحادثة…",
+    "fr": "Création de la conversation…",
+    "tr": "Konuşma oluşturuluyor…",
+    "de": "Konversation wird erstellt…",
+    "uk": "Створення розмови…",
+    "ca": "Creant la conversa…"
+  },
   "HOME$ADD_WORKSPACES": {
     "en": "+ Add Workspace",
     "ja": "+ ワークスペースを追加",
@@ -25789,12 +25823,54 @@
     "ca": "Descobreix habilitats per afegir al teu espai de treball. Obre una targeta per veure indicacions, curl i fluxos d'instal·lació. Cerca des de la barra lateral per filtrar la llista. Activeu o desactiveu les habilitats predeterminades. Les habilitats desactivades no es carregaran al context de l'agent."
   },
   "BACKEND$NAME_REQUIRED": {
-    "en": "Name is required"
+    "en": "Name is required",
+    "ja": "名前は必須です",
+    "zh-CN": "名称为必填项",
+    "zh-TW": "名稱為必填項目",
+    "ko-KR": "이름은 필수입니다",
+    "no": "Navn er påkrevd",
+    "it": "Il nome è obbligatorio",
+    "pt": "O nome é obrigatório",
+    "es": "El nombre es obligatorio",
+    "ar": "الاسم مطلوب",
+    "fr": "Le nom est requis",
+    "tr": "Ad gereklidir",
+    "de": "Name ist erforderlich",
+    "uk": "Ім'я обов'язкове",
+    "ca": "El nom és obligatori"
   },
   "BACKEND$HOST_REQUIRED": {
-    "en": "Host is required"
+    "en": "Host is required",
+    "ja": "ホストは必須です",
+    "zh-CN": "主机为必填项",
+    "zh-TW": "主機為必填項目",
+    "ko-KR": "호스트는 필수입니다",
+    "no": "Vert er påkrevd",
+    "it": "L'host è obbligatorio",
+    "pt": "O host é obrigatório",
+    "es": "El host es obligatorio",
+    "ar": "المضيف مطلوب",
+    "fr": "L'hôte est requis",
+    "tr": "Ana bilgisayar gereklidir",
+    "de": "Host ist erforderlich",
+    "uk": "Хост обов'язковий",
+    "ca": "L'host és obligatori"
   },
   "BACKEND$HOST_INVALID": {
-    "en": "Enter a valid URL (e.g. http://localhost:8080)"
+    "en": "Enter a valid URL (e.g. http://localhost:8080)",
+    "ja": "有効なURLを入力してください (例: http://localhost:8080)",
+    "zh-CN": "请输入有效的 URL（例如 http://localhost:8080）",
+    "zh-TW": "請輸入有效的 URL（例如 http://localhost:8080）",
+    "ko-KR": "유효한 URL을 입력하세요 (예: http://localhost:8080)",
+    "no": "Skriv inn en gyldig URL (f.eks. http://localhost:8080)",
+    "it": "Inserisci un URL valido (es. http://localhost:8080)",
+    "pt": "Insira uma URL válida (ex.: http://localhost:8080)",
+    "es": "Introduce una URL válida (p. ej. http://localhost:8080)",
+    "ar": "أدخل عنوان URL صالحًا (مثل http://localhost:8080)",
+    "fr": "Saisissez une URL valide (par ex. http://localhost:8080)",
+    "tr": "Geçerli bir URL girin (ör. http://localhost:8080)",
+    "de": "Gib eine gültige URL ein (z. B. http://localhost:8080)",
+    "uk": "Введіть дійсну URL-адресу (наприклад, http://localhost:8080)",
+    "ca": "Introduïu un URL vàlid (p. ex. http://localhost:8080)"
   }
 }

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -1,8 +1,5 @@
 import { PrefetchPageLinks } from "react-router";
-import { GuideMessage } from "#/components/features/home/home-header/guide-message";
-import { HomeHeaderTitle } from "#/components/features/home/home-header/home-header-title";
-import { RepoConnector } from "#/components/features/home/repo-connector";
-import { NewConversation } from "#/components/features/home/new-conversation/new-conversation";
+import { HomeChatLauncher } from "#/components/features/home/home-chat-launcher";
 import { OnboardingHost } from "#/components/features/onboarding";
 
 <PrefetchPageLinks page="/conversations/:conversationId" />;
@@ -13,24 +10,8 @@ function HomeScreen() {
       data-testid="home-screen"
       className="px-0 bg-transparent h-full flex flex-col overflow-y-auto rounded-xl lg:px-[42px] custom-scrollbar-always"
     >
-      <div className="flex justify-center pt-2">
-        <GuideMessage />
-      </div>
-
-      <div className="flex flex-1 min-h-0 flex-col justify-center py-8">
-        <div className="flex justify-center">
-          <HomeHeaderTitle />
-        </div>
-
-        <div className="pt-[25px] flex justify-center">
-          <div
-            className="flex flex-col gap-5 px-6 sm:max-w-full sm:min-w-full md:flex-row lg:px-0 lg:max-w-[703px] lg:min-w-[703px]"
-            data-testid="home-screen-new-conversation-section"
-          >
-            <RepoConnector />
-            <NewConversation />
-          </div>
-        </div>
+      <div className="flex flex-1 min-h-0 flex-col items-center justify-center">
+        <HomeChatLauncher />
       </div>
 
       <OnboardingHost />


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description**

The current home page does not match the Figma design (https://www.figma.com/design/iM5UBG1lnpg2sgE3cFnF1P/OpenHands-Product-Designs--Paul-Bloch-?node-id=19315-492&m=dev). Today it renders a side-by-side `RepoConnector` + `NewConversation` card block with an inline **Launch** button that creates a conversation immediately.

The Figma design specifies a centered "Let's Start Building!" title, a chat input, and a small **Open Workspace** (local) or **Open Repository** (cloud) badge left-aligned below the chat input. Selection moves into a dialog and the chat input itself is what creates the conversation when the user submits a message.

**Acceptance criteria**

- [ ] Home page renders the title, chat input, and an **Open Workspace** (local) or **Open Repository** (cloud) badge left-aligned below the chat input. No other home-page cards.
- [ ] Clicking the badge opens a dialog containing the existing workspace/repository selection form. The dialog's action button reads **Confirm** (not "Launch").
- [ ] After **Confirm**, the badge is replaced by a git-control-bar preview showing the chosen workspace name (local) or repo + branch (cloud). No conversation is started yet.
- [ ] Typing a message and pressing Enter (or clicking Send) creates a conversation:

  - With a pending selection: payload includes `working_dir` (local) or `repository` (cloud).
  - Without a selection: payload includes only the typed `query` (matches the existing "Start from scratch" flow).

- [ ] On success, navigate to `/conversations/{conversation_id}`.
- [ ] On failure, surface an error toast and stay on the home page.
- [ ] LLM switcher is visible on the home-page chat input (falls back to the user's default model from settings).
- [ ] No "Disconnected" status indicator on the home page (no active conversation).
- [ ] Conversation page is unaffected for users coming in via direct URL or sidebar.

**Out of scope (deferred)**

- Cross-page animations (push-down slide of the chat input on submit, fade transitions of the title and badge). Several approaches were explored; none landed cleanly enough to ship. To be revisited in a follow-up.

## Summary

<!-- 1-3 bullets describing what changed. -->
Redesigns the home page to a chat-first launcher matching the [Figma design](https://www.figma.com/design/iM5UBG1lnpg2sgE3cFnF1P/OpenHands-Product-Designs--Paul-Bloch-?node-id=19315-492&m=dev). Centered title + chat input + left-aligned **Open Workspace** / **Open Repository** badge. Workspace/repo selection moves into a dialog (action button renamed **Launch → Confirm**); the chat input itself creates the conversation when the user submits.

Sending works **with or without** a selection. The LLM switcher now appears on the home page (falls back to the user's default model from settings).

### What changed

**New components**

- `src/components/features/home/home-chat-launcher.tsx` — owns the home-page chat input, pending workspace/repo state, the dialog open state, and the create-conversation flow.
- `src/components/features/home/open-launcher-button.tsx` — small badge rendered below the chat input. Toggles between "Open Workspace" (local) and "Open Repository" (cloud).
- `src/components/features/home/open-workspace-dialog.tsx` and `open-repository-dialog.tsx` — `ModalBackdrop` wrappers around the existing selection forms with the `onConfirm` plumbing.
- `src/components/features/home/home-git-control-bar-preview.tsx` — read-only preview row (repo chip + optional branch chip) shown after the user confirms a selection.

**Refactored**

- `workspace-selection-form.tsx` / `repo-selection-form.tsx` accept an optional `onConfirm` prop. With the prop, the form skips `useCreateConversation` + `navigate`, calls back with the selection, and the action button reads `BUTTON$CONFIRM` instead of "Launch".
- `routes/home.tsx` simplified: a single centered column containing `HomeChatLauncher`.
- `chat-input-actions.tsx`, `tools.tsx`, `use-active-conversation.ts`, `use-task-polling.ts`, `use-send-message.ts`, `use-chat-input-logic.ts`, `use-draft-persistence.ts` now use `useOptionalConversationId` (and short-circuit safely) so the chat input shell can render outside a conversation route.
- `chat-input-model.tsx` falls back to `useSettings().llm_model` when no active conversation, so the LLM switcher shows on the home page.
- `git-control-bar.tsx` returns `null` when there's no content to show — cleaner than rendering an empty wrapper.
- `interactive-chat-box.tsx`: `<AgentStatus>` is now gated on `conversationId`, removing the perpetual "Disconnected" pill on the home page.

**i18n**

- New keys: `HOME$OPEN_WORKSPACE`, `HOME$CREATING_CONVERSATION` (all 15 supported locales). `make-i18n` regenerated `declaration.ts` and per-locale JSON.

### What's intentionally not in this PR

The cross-page transition animation (push-down slide of the chat input on submit, fade-out of the title and badge before the route swap, smooth entry of the conversation page's `GitControlBar`) was iterated on but didn't land cleanly enough to ship. All animation-related code has been reverted. Will be revisited in a follow-up.

### Tests added

- `__tests__/components/features/home/home-chat-launcher.test.tsx` — covers the four main flows:

  1. submit with no selection → creates conversation with just the query, navigates;
  2. submit after picking a workspace → payload includes `working_dir`;
  3. submit after picking a repo + branch on cloud → payload includes `repository`;
  4. mutation error → error toast surfaces, no navigation.

- `__tests__/components/features/home/workspace-selection-form.test.tsx` — regression for the new `onConfirm` prop: when set, the form callbacks with the selection and does **not** call `createConversation` or `navigate`.
- `__tests__/components/features/chat/components/chat-input-model.test.tsx` — new test for the settings fallback (no active conversation → uses `useSettings().llm_model`).

`RepositorySelectionForm`'s `onConfirm` path is parallel to `WorkspaceSelectionForm`'s and shares the same conditional structure; not separately covered to keep the test count minimal.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #446 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Clone the `agent-server-gui` repository and start the development server by running the following command:

   ```bash
   npm run dev
   ```

   This will launch the agent server inside a Docker container.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

**Video 1:**

https://github.com/user-attachments/assets/f7121488-3928-4ee0-a16b-582efa43d412

**Video 2:**

https://github.com/user-attachments/assets/6d95cdae-15bd-4a31-a494-fc46ed407962

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
