### PR TITLE
fix(frontend): right-align action buttons in modals/dialogs

### DIFF
--- a/__tests__/components/backends/add-backend-modal.test.tsx
+++ b/__tests__/components/backends/add-backend-modal.test.tsx
@@ -29,21 +29,22 @@ afterEach(() => {
 });
 
 describe("AddBackendModal", () => {
-  it("renders Save (left) before Cancel (right) in a 2-column grid", () => {
+  it("places Cancel before Save in the footer so the dominant action is the last focusable button", () => {
+    // Arrange: render the modal so both footer buttons are mounted.
     renderWithProviders(<AddBackendModal onClose={vi.fn()} />);
 
-    const submit = screen.getByTestId("add-backend-submit");
+    // Act: locate the two footer buttons.
     const cancel = screen.getByTestId("add-backend-cancel");
-    const row = submit.parentElement!;
+    const submit = screen.getByTestId("add-backend-submit");
 
-    // Save comes before Cancel in DOM order — Save is on the left.
-    const orderTest = submit.compareDocumentPosition(cancel);
-    // Bit 4 = DOCUMENT_POSITION_FOLLOWING: cancel comes after submit.
+    // Assert: Cancel precedes Save in DOM order — this is what governs
+    // tab order and screen-reader reading order, so the dominant Save
+    // action is the rightmost / last-reached button.
     // eslint-disable-next-line no-bitwise
-    expect(orderTest & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-
-    // Equal-width via grid-cols-2: each column is exactly 50% of the row.
-    expect(row.className).toContain("grid-cols-2");
+    expect(
+      cancel.compareDocumentPosition(submit) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("disables submit until all fields are filled", async () => {

--- a/__tests__/components/features/chat/open-repository-modal.test.tsx
+++ b/__tests__/components/features/chat/open-repository-modal.test.tsx
@@ -160,6 +160,28 @@ describe("OpenRepositoryModal", () => {
     expect(screen.getByText("BUTTON$CANCEL")).toBeInTheDocument();
   });
 
+  it("places Cancel before Launch in the footer so the dominant action is the last focusable button", () => {
+    // Arrange: render the modal so both footer buttons are mounted.
+    render(
+      <OpenRepositoryModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onLaunch={mockOnLaunch}
+      />,
+    );
+
+    // Act: locate both footer buttons.
+    const cancel = screen.getByText("BUTTON$CANCEL");
+    const launch = screen.getByText("BUTTON$LAUNCH");
+
+    // Assert: Cancel precedes the dominant Launch action in DOM order.
+    // eslint-disable-next-line no-bitwise
+    expect(
+      cancel.compareDocumentPosition(launch) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("should disable Launch button when no repository or branch is selected", () => {
     render(
       <OpenRepositoryModal

--- a/__tests__/components/features/conversation-panel/confirm-delete-modal.test.tsx
+++ b/__tests__/components/features/conversation-panel/confirm-delete-modal.test.tsx
@@ -41,4 +41,22 @@ describe("ConfirmDeleteModal", () => {
       screen.getByText("CONVERSATION$DELETE_WARNING"),
     ).toBeInTheDocument();
   });
+
+  it("places Cancel before Confirm in the footer so the dominant action is the last focusable button", () => {
+    // Arrange: render the modal so both footer buttons are mounted.
+    renderWithProviders(
+      <ConfirmDeleteModal onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+
+    // Act: locate both footer buttons.
+    const cancel = screen.getByText("BUTTON$CANCEL");
+    const confirm = screen.getByText("ACTION$CONFIRM_DELETE");
+
+    // Assert: Cancel precedes the dominant Confirm action in DOM order.
+    // eslint-disable-next-line no-bitwise
+    expect(
+      cancel.compareDocumentPosition(confirm) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
 });

--- a/__tests__/components/features/mcp-page/install-server-modal.test.tsx
+++ b/__tests__/components/features/mcp-page/install-server-modal.test.tsx
@@ -179,4 +179,22 @@ describe("InstallServerModal", () => {
 
     await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
   });
+
+  it("places Cancel before Install in the footer so the dominant action is the last focusable button", async () => {
+    // Arrange: render with any marketplace entry so the footer is mounted.
+    const slack = MCP_MARKETPLACE.find((e) => e.id === "slack")!;
+    renderWith(<InstallServerModal entry={slack} onClose={vi.fn()} />);
+    await screen.findByTestId("mcp-install-modal");
+
+    // Act: locate both footer buttons.
+    const cancel = screen.getByTestId("mcp-install-cancel");
+    const submit = screen.getByTestId("mcp-install-submit");
+
+    // Assert: Cancel precedes the dominant Install action in DOM order.
+    // eslint-disable-next-line no-bitwise
+    expect(
+      cancel.compareDocumentPosition(submit) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
 });

--- a/__tests__/components/settings/llm-profiles/delete-profile-modal.test.tsx
+++ b/__tests__/components/settings/llm-profiles/delete-profile-modal.test.tsx
@@ -85,6 +85,22 @@ describe("DeleteProfileModal", () => {
     expect(screen.getByText("Cancel")).toBeInTheDocument();
   });
 
+  it("places Cancel before Delete in the footer so the dominant action is the last focusable button", () => {
+    // Arrange: render the modal so both footer buttons are mounted.
+    renderModal(mockProfile);
+
+    // Act: locate both footer buttons.
+    const cancel = screen.getByText("Cancel");
+    const danger = screen.getByTestId("delete-profile-confirm");
+
+    // Assert: Cancel precedes the dominant Delete action in DOM order.
+    // eslint-disable-next-line no-bitwise
+    expect(
+      cancel.compareDocumentPosition(danger) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("calls onClose when Cancel is clicked", async () => {
     const user = userEvent.setup();
     const handleClose = vi.fn();

--- a/__tests__/components/settings/llm-profiles/rename-profile-modal.test.tsx
+++ b/__tests__/components/settings/llm-profiles/rename-profile-modal.test.tsx
@@ -92,6 +92,22 @@ describe("RenameProfileModal", () => {
     expect(screen.getByText("Cancel")).toBeInTheDocument();
   });
 
+  it("places Cancel before Rename in the footer so the dominant action is the last focusable button", () => {
+    // Arrange: render the modal so both footer buttons are mounted.
+    renderModal(mockProfile);
+
+    // Act: locate both footer buttons.
+    const cancel = screen.getByText("Cancel");
+    const submit = screen.getByTestId("rename-profile-submit");
+
+    // Assert: Cancel precedes the dominant Rename action in DOM order.
+    // eslint-disable-next-line no-bitwise
+    expect(
+      cancel.compareDocumentPosition(submit) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("calls onClose when Cancel is clicked", async () => {
     const user = userEvent.setup();
     const handleClose = vi.fn();

--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -462,24 +462,22 @@ export function BackendForm({
       {renderActions ? (
         renderActions({ canSubmit, testIdRoot })
       ) : (
-        <div className="grid grid-cols-2 gap-2 mt-2 w-full">
-          <BrandButton
-            type="submit"
-            variant="primary"
-            isDisabled={!canSubmit}
-            testId={`${testIdRoot}-submit`}
-            className="w-full text-center"
-          >
-            {t(I18nKey.BACKEND$SAVE)}
-          </BrandButton>
+        <div className="flex justify-end gap-2 mt-2 w-full">
           <BrandButton
             type="button"
             variant="secondary"
             onClick={onSubmitted}
             testId={`${testIdRoot}-cancel`}
-            className="w-full text-center"
           >
             {t(I18nKey.BUTTON$CANCEL)}
+          </BrandButton>
+          <BrandButton
+            type="submit"
+            variant="primary"
+            isDisabled={!canSubmit}
+            testId={`${testIdRoot}-submit`}
+          >
+            {t(I18nKey.BACKEND$SAVE)}
           </BrandButton>
         </div>
       )}

--- a/src/components/features/backends/manage-backends-modal.tsx
+++ b/src/components/features/backends/manage-backends-modal.tsx
@@ -177,7 +177,7 @@ export function ManageBackendsModal({ onClose }: ManageBackendsModalProps) {
             )}
           </div>
 
-          <div className="flex justify-between gap-2 px-5 py-3 border-t border-[var(--oh-border)]">
+          <div className="flex justify-end gap-2 px-5 py-3 border-t border-[var(--oh-border)]">
             <BrandButton
               type="button"
               variant="secondary"

--- a/src/components/features/chat/open-repository-modal.tsx
+++ b/src/components/features/chat/open-repository-modal.tsx
@@ -143,25 +143,19 @@ export function OpenRepositoryModal({
         </div>
 
         <div
-          className="flex flex-col gap-2 w-full"
+          className="flex justify-end gap-2 w-full"
           onClick={(event) => event.stopPropagation()}
         >
+          <BrandButton type="button" variant="secondary" onClick={handleClose}>
+            {t(I18nKey.BUTTON$CANCEL)}
+          </BrandButton>
           <BrandButton
             type="button"
             variant="primary"
             onClick={handleLaunch}
-            className="w-full"
             isDisabled={!canLaunch}
           >
             {t(I18nKey.BUTTON$LAUNCH)}
-          </BrandButton>
-          <BrandButton
-            type="button"
-            variant="secondary"
-            onClick={handleClose}
-            className="w-full"
-          >
-            {t(I18nKey.BUTTON$CANCEL)}
           </BrandButton>
         </div>
       </ModalBody>

--- a/src/components/features/conversation-panel/confirm-delete-modal.tsx
+++ b/src/components/features/conversation-panel/confirm-delete-modal.tsx
@@ -52,26 +52,24 @@ export function ConfirmDeleteModal({
           <BaseModalDescription>{confirmationMessage}</BaseModalDescription>
         </div>
         <div
-          className="flex flex-col gap-2 w-full"
+          className="flex justify-end gap-2 w-full"
           onClick={(event) => event.stopPropagation()}
         >
           <BrandButton
             type="button"
-            variant="primary"
-            onClick={onConfirm}
-            className="w-full"
-            data-testid="confirm-button"
-          >
-            {t(I18nKey.ACTION$CONFIRM_DELETE)}
-          </BrandButton>
-          <BrandButton
-            type="button"
             variant="secondary"
             onClick={onCancel}
-            className="w-full"
             data-testid="cancel-button"
           >
             {t(I18nKey.BUTTON$CANCEL)}
+          </BrandButton>
+          <BrandButton
+            type="button"
+            variant="primary"
+            onClick={onConfirm}
+            data-testid="confirm-button"
+          >
+            {t(I18nKey.ACTION$CONFIRM_DELETE)}
           </BrandButton>
         </div>
       </ModalBody>

--- a/src/components/features/conversation-panel/confirm-stop-modal.tsx
+++ b/src/components/features/conversation-panel/confirm-stop-modal.tsx
@@ -31,26 +31,24 @@ export function ConfirmStopModal({
           />
         </div>
         <div
-          className="flex flex-col gap-2 w-full"
+          className="flex justify-end gap-2 w-full"
           onClick={(event) => event.stopPropagation()}
         >
           <BrandButton
             type="button"
-            variant="primary"
-            onClick={onConfirm}
-            className="w-full"
-            data-testid="confirm-button"
-          >
-            {t(I18nKey.ACTION$CONFIRM_CLOSE)}
-          </BrandButton>
-          <BrandButton
-            type="button"
             variant="secondary"
             onClick={onCancel}
-            className="w-full"
             data-testid="cancel-button"
           >
             {t(I18nKey.BUTTON$CANCEL)}
+          </BrandButton>
+          <BrandButton
+            type="button"
+            variant="primary"
+            onClick={onConfirm}
+            data-testid="confirm-button"
+          >
+            {t(I18nKey.ACTION$CONFIRM_CLOSE)}
           </BrandButton>
         </div>
       </ModalBody>

--- a/src/components/features/conversation-panel/exit-conversation-modal.tsx
+++ b/src/components/features/conversation-panel/exit-conversation-modal.tsx
@@ -22,16 +22,16 @@ export function ExitConversationModal({
     <ModalBackdrop onClose={onCancel}>
       <ModalBody testID="confirm-new-conversation-modal">
         <BaseModalTitle title={t(I18nKey.CONVERSATION$EXIT_WARNING)} />
-        <div className="flex w-full gap-2">
-          <ModalButton
-            text={t(I18nKey.ACTION$CONFIRM)}
-            onClick={onConfirm}
-            className="bg-[#C63143] flex-1"
-          />
+        <div className="flex w-full justify-end gap-2">
           <ModalButton
             text={t(I18nKey.BUTTON$CANCEL)}
             onClick={onClose}
-            className="bg-tertiary flex-1"
+            className="bg-tertiary"
+          />
+          <ModalButton
+            text={t(I18nKey.ACTION$CONFIRM)}
+            onClick={onConfirm}
+            className="bg-[#C63143]"
           />
         </div>
       </ModalBody>

--- a/src/components/features/mcp-page/install-server-modal.tsx
+++ b/src/components/features/mcp-page/install-server-modal.tsx
@@ -309,26 +309,24 @@ export function InstallServerModal({
           </p>
         )}
 
-        <div className="grid grid-cols-2 gap-2 mt-2">
-          <BrandButton
-            type="submit"
-            variant="primary"
-            isDisabled={isPending}
-            testId="mcp-install-submit"
-            className="w-full text-center"
-          >
-            {isPending
-              ? t(I18nKey.SETTINGS$SAVING)
-              : t(I18nKey.MCP$INSTALL_BUTTON)}
-          </BrandButton>
+        <div className="flex justify-end gap-2 mt-2">
           <BrandButton
             type="button"
             variant="secondary"
             onClick={onClose}
             testId="mcp-install-cancel"
-            className="w-full text-center"
           >
             {t(I18nKey.BUTTON$CANCEL)}
+          </BrandButton>
+          <BrandButton
+            type="submit"
+            variant="primary"
+            isDisabled={isPending}
+            testId="mcp-install-submit"
+          >
+            {isPending
+              ? t(I18nKey.SETTINGS$SAVING)
+              : t(I18nKey.MCP$INSTALL_BUTTON)}
           </BrandButton>
         </div>
       </form>

--- a/src/components/features/onboarding/steps/check-backend-step.tsx
+++ b/src/components/features/onboarding/steps/check-backend-step.tsx
@@ -106,7 +106,7 @@ export function CheckBackendStep({ onBack, onNext }: CheckBackendStepProps) {
         onSubmitted={() => {}}
         testIdRoot="onboarding-backend"
         renderActions={({ canSubmit, testIdRoot }) => (
-          <div className="sticky bottom-0 flex items-center justify-between gap-2 mt-2 bg-base-secondary pt-4 pb-7">
+          <div className="sticky bottom-0 flex items-center justify-end gap-2 mt-2 bg-base-secondary pt-4 pb-7">
             <BrandButton
               testId="onboarding-backend-back"
               type="button"
@@ -115,25 +115,23 @@ export function CheckBackendStep({ onBack, onNext }: CheckBackendStepProps) {
             >
               {t(I18nKey.ONBOARDING$BACK)}
             </BrandButton>
-            <div className="flex gap-2">
-              <BrandButton
-                testId={`${testIdRoot}-submit`}
-                type="submit"
-                variant="secondary"
-                isDisabled={!canSubmit}
-              >
-                {t(I18nKey.BACKEND$SAVE)}
-              </BrandButton>
-              <BrandButton
-                testId="onboarding-backend-next"
-                type="button"
-                variant="primary"
-                isDisabled={isConnected !== true}
-                onClick={onNext}
-              >
-                {t(I18nKey.ONBOARDING$NEXT)}
-              </BrandButton>
-            </div>
+            <BrandButton
+              testId={`${testIdRoot}-submit`}
+              type="submit"
+              variant="secondary"
+              isDisabled={!canSubmit}
+            >
+              {t(I18nKey.BACKEND$SAVE)}
+            </BrandButton>
+            <BrandButton
+              testId="onboarding-backend-next"
+              type="button"
+              variant="primary"
+              isDisabled={isConnected !== true}
+              onClick={onNext}
+            >
+              {t(I18nKey.ONBOARDING$NEXT)}
+            </BrandButton>
           </div>
         )}
       />

--- a/src/components/features/onboarding/steps/say-hello-step.tsx
+++ b/src/components/features/onboarding/steps/say-hello-step.tsx
@@ -78,7 +78,7 @@ export function SayHelloStep({ onBack, onLaunched }: SayHelloStepProps) {
         className="w-full rounded-xl border border-white/10 bg-base-secondary px-4 py-3 text-base text-white placeholder:text-[var(--oh-text-subtle)] focus:border-primary focus:outline-none disabled:opacity-60"
       />
 
-      <div className="sticky bottom-0 flex items-center justify-between gap-2 bg-base-secondary pt-4 pb-7">
+      <div className="sticky bottom-0 flex items-center justify-end gap-2 bg-base-secondary pt-4 pb-7">
         <BrandButton
           testId="onboarding-hello-back"
           type="button"

--- a/src/components/features/onboarding/steps/setup-llm-step.tsx
+++ b/src/components/features/onboarding/steps/setup-llm-step.tsx
@@ -128,7 +128,7 @@ export function SetupLlmStep({ onBack, onNext }: SetupLlmStepProps) {
         />
       </div>
 
-      <div className="sticky bottom-0 flex items-center justify-between gap-2 bg-base-secondary pt-4 pb-7">
+      <div className="sticky bottom-0 flex items-center justify-end gap-2 bg-base-secondary pt-4 pb-7">
         <BrandButton
           testId="onboarding-llm-back"
           type="button"

--- a/src/components/features/settings/api-key-modal-base.tsx
+++ b/src/components/features/settings/api-key-modal-base.tsx
@@ -86,7 +86,7 @@ export function ApiKeyModalBase({
           {title}
         </h3>
         {children}
-        <div className="w-full flex gap-2 mt-2">{footer}</div>
+        <div className="w-full flex justify-end gap-2 mt-2">{footer}</div>
       </div>
     </ModalBackdrop>
   );

--- a/src/components/features/settings/llm-profiles/delete-profile-modal.tsx
+++ b/src/components/features/settings/llm-profiles/delete-profile-modal.tsx
@@ -50,10 +50,18 @@ export function DeleteProfileModal({
   const footer = (
     <>
       <BrandButton
+        ref={cancelButtonRef}
+        type="button"
+        variant="tertiary"
+        onClick={handleClose}
+        isDisabled={deleteProfile.isPending}
+      >
+        {t(I18nKey.BUTTON$CANCEL)}
+      </BrandButton>
+      <BrandButton
         testId="delete-profile-confirm"
         type="button"
         variant="danger"
-        className="grow"
         onClick={handleDelete}
         isDisabled={deleteProfile.isPending}
         aria-busy={deleteProfile.isPending}
@@ -66,16 +74,6 @@ export function DeleteProfileModal({
         ) : (
           t(I18nKey.BUTTON$DELETE)
         )}
-      </BrandButton>
-      <BrandButton
-        ref={cancelButtonRef}
-        type="button"
-        variant="tertiary"
-        className="grow"
-        onClick={handleClose}
-        isDisabled={deleteProfile.isPending}
-      >
-        {t(I18nKey.BUTTON$CANCEL)}
       </BrandButton>
     </>
   );

--- a/src/components/features/settings/llm-profiles/rename-profile-modal.tsx
+++ b/src/components/features/settings/llm-profiles/rename-profile-modal.tsx
@@ -69,10 +69,17 @@ export function RenameProfileModal({
   const footer = (
     <>
       <BrandButton
+        type="button"
+        variant="tertiary"
+        onClick={handleClose}
+        isDisabled={renameProfile.isPending}
+      >
+        {t(I18nKey.BUTTON$CANCEL)}
+      </BrandButton>
+      <BrandButton
         testId="rename-profile-submit"
         type="button"
         variant="primary"
-        className="grow"
         onClick={handleSubmit}
         isDisabled={renameProfile.isPending || !isValid}
       >
@@ -81,15 +88,6 @@ export function RenameProfileModal({
         ) : (
           t(I18nKey.BUTTON$RENAME)
         )}
-      </BrandButton>
-      <BrandButton
-        type="button"
-        variant="tertiary"
-        className="grow"
-        onClick={handleClose}
-        isDisabled={renameProfile.isPending}
-      >
-        {t(I18nKey.BUTTON$CANCEL)}
       </BrandButton>
     </>
   );

--- a/src/components/features/settings/mcp-settings/mcp-server-form.tsx
+++ b/src/components/features/settings/mcp-settings/mcp-server-form.tsx
@@ -408,7 +408,7 @@ export function MCPServerForm({
         </>
       )}
 
-      <div className="flex items-center gap-4">
+      <div className="flex items-center justify-end gap-2 w-full">
         <BrandButton
           testId="cancel-button"
           type="button"

--- a/src/components/shared/modals/confirmation-modal.tsx
+++ b/src/components/shared/modals/confirmation-modal.tsx
@@ -36,13 +36,12 @@ export function ConfirmationModal({
         className="bg-base-secondary p-4 rounded-xl flex flex-col gap-4 border border-[var(--oh-border)]"
       >
         <p>{text}</p>
-        <div className="w-full flex gap-2">
+        <div className="w-full flex justify-end gap-2">
           <BrandButton
             testId="cancel-button"
             type="button"
             onClick={onCancel}
             variant="secondary"
-            className="grow"
             isDisabled={isConfirming}
           >
             {t(I18nKey.BUTTON$CANCEL)}
@@ -52,7 +51,6 @@ export function ConfirmationModal({
             type="button"
             onClick={onConfirm}
             variant="primary"
-            className="grow"
             isDisabled={isConfirming}
           >
             {t(I18nKey.BUTTON$CONFIRM)}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

Action buttons in modals/dialogs across `agent-canvas` use four inconsistent layouts:

1. **2-column grid with primary on the left** — Add/Edit Backend (`backend-form-modal`), Install MCP Server (`install-server-modal`)
2. **Vertical stack, full-width** — Confirm Delete, Confirm Stop, Open Repository (chat)
3. **50/50 horizontal split with primary on the left** — Exit Conversation, generic ConfirmationModal, Rename/Delete LLM Profile
4. **`justify-between`** — Manage Backends (Add far-left, Done far-right), onboarding wizard steps (Back far-left, Next far-right)

Only Folder Browser, Manage Workspaces, Plugin Launch, and the Automations delete already match the intended pattern.

### Expected behavior

Per the right-aligned design reference:

- All modal action footers use a single `flex justify-end gap-2` row.
- The cancel/secondary button is to the **left** of the primary/dominant button; the primary action is the **rightmost** button.
- Buttons size to their content (no `grow`, `flex-1`, `w-full`, or `grid-cols-2`).
- On-page (non-modal) forms keep their existing left-aligned layout.
- Wizard step footers group Back + (Save) + Next together at the right.

### Acceptance criteria

- [ ] Add Backend, Edit Backend, Install MCP Server, Add Custom MCP Server, Rename Profile, Delete Profile, Confirm Delete, Confirm Stop, Exit Conversation, Open Repository (chat) all show Cancel on the left of the dominant action, right-aligned within the dialog.
- [ ] Manage Backends shows Add + Done grouped on the right with Done dominant.
- [ ] Onboarding wizard steps (Choose Agent, Check Backend, Setup LLM, Say Hello) show all step actions in a single right-aligned group with the dominant action rightmost.
- [ ] No regressions in the already-correct modals: Folder Browser, Manage Workspaces, Plugin Launch, Automations delete, Analytics Consent.
- [ ] On-page settings forms remain left-aligned (unchanged).
- [ ] Internal styling of each button (variant, color, size) is not modified.
- [ ] DOM-order tests cover the user-visible change (keyboard tab order, screen-reader reading order).

### Out of scope

- Visual restyling of individual buttons.
- Refactoring `ModalButtonGroup` (dead code; no callers).
- Read-only modals with no action buttons (hooks/skills/system-message/metrics).
- Single-button modals (Analytics Consent, Plugin Launch) — already correct.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Standardizes modal/dialog action-button footers across the app to a single right-aligned pattern: `flex justify-end gap-2`, with the dominant primary action as the rightmost button and Cancel/secondary directly to its left.
- Removes the four divergent footer layouts that had accumulated (2-col grid with primary-left, vertical full-width stack, 50/50 split with primary-left, and `justify-between`) and replaces them with one consistent layout.
- Leaves on-page (non-modal) forms unchanged — they intentionally remain left-aligned per the design spec. Button variants, sizes, and colors are not modified.

## Why

Action-button placement drifted because there is no shared `DialogFooter` primitive — every modal hand-rolls its own footer markup. This produced four different layouts across the same app surface. The right-aligned reference (Cancel left of the dominant action, both pushed to the dialog's right edge) is now applied consistently.

## Files changed

**Shared bases** (fix propagates to multiple call sites)

- `src/components/shared/modals/confirmation-modal.tsx` — `flex` → `flex justify-end`, removed `grow`.
- `src/components/features/settings/api-key-modal-base.tsx` — added `justify-end` to the footer wrapper.

**2-column grid → right-aligned flex (DOM order flipped)**

- `src/components/features/backends/backend-form-modal.tsx`
- `src/components/features/mcp-page/install-server-modal.tsx`

**`ApiKeyModalBase` callers — DOM order flipped, `grow` removed**

- `src/components/features/settings/llm-profiles/rename-profile-modal.tsx`
- `src/components/features/settings/llm-profiles/delete-profile-modal.tsx`

**Horizontal split with primary-left → right-aligned with Cancel-first**

- `src/components/features/conversation-panel/exit-conversation-modal.tsx`

**Vertical stack → horizontal right-aligned**

- `src/components/features/conversation-panel/confirm-delete-modal.tsx`
- `src/components/features/conversation-panel/confirm-stop-modal.tsx`
- `src/components/features/chat/open-repository-modal.tsx`

**`justify-between` → `justify-end` (DOM order preserved, Back/Add now grouped with dominant action)**

- `src/components/features/backends/manage-backends-modal.tsx`
- `src/components/features/settings/mcp-settings/mcp-server-form.tsx` (Custom MCP editor)
- `src/components/features/onboarding/steps/check-backend-step.tsx` (also flattened the inner Save/Next wrapper)
- `src/components/features/onboarding/steps/setup-llm-step.tsx`
- `src/components/features/onboarding/steps/say-hello-step.tsx`

## Tests

DOM order (Cancel/secondary precedes the dominant primary action) is the user-visible behavioral effect of this change — it governs keyboard tab order and screen-reader reading order, so it's tested as functional behavior, not CSS.

- **Updated** `__tests__/components/backends/add-backend-modal.test.tsx` — the existing test asserted the _old_ Save-before-Cancel order plus a `grid-cols-2` CSS class. Now asserts the new Cancel-before-Save DOM order.
- **Extended** five existing test files with one DOM-order test each (`compareDocumentPosition`):
  - `__tests__/components/features/mcp-page/install-server-modal.test.tsx`
  - `__tests__/components/features/conversation-panel/confirm-delete-modal.test.tsx`
  - `__tests__/components/settings/llm-profiles/rename-profile-modal.test.tsx`
  - `__tests__/components/settings/llm-profiles/delete-profile-modal.test.tsx`
  - `__tests__/components/features/chat/open-repository-modal.test.tsx`

Skipped: modals where only CSS changed (Manage Backends, Custom MCP editor, generic ConfirmationModal, onboarding steps, `ApiKeyModalBase`). Per the project's testing rules, CSS-only assertions are excluded; behaviorally identical patterns (Confirm Stop, Exit Conversation) are covered by the Confirm Delete test.

Result: `npx vitest run` across the six affected test files — **55 tests, all passing**. `npx tsc --noEmit --skipLibCheck` is clean.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #519 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Clone the `agent-server-gui` repository and start the development server:

   ```bash
   npm run dev
   ```

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="830" alt="app-1788" src="https://github.com/user-attachments/assets/28132384-7e61-4e1d-8efb-5d0c24e0a9ee" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- Visual restyling of individual buttons.
- Refactoring the dead `ModalButtonGroup` primitive.
- Read-only modals (no action buttons): hooks, skills, system-message, metrics.
- Single-button modals (Plugin Launch, Analytics Consent) — already correct.