### PR TITLE
fix: gate public skills in conversations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
   - `VITE_WORKING_DIR` for the default workspace path sent when starting conversations.
   - `VITE_WORKER_URLS` as a comma-separated list of browser worker URLs if you want the Browser tab to probe exposed app hosts.
   - `VITE_ENABLE_BROWSER_TOOLS=false` to omit `BrowserToolSet` from new conversation payloads.
-  - `VITE_LOAD_PUBLIC_SKILLS=false` to disable loading public skills from the OpenHands extensions marketplace (https://github.com/OpenHands/extensions). Defaults to true.
+  - `VITE_LOAD_PUBLIC_SKILLS=true` to opt conversations into loading public skills from the OpenHands extensions marketplace (https://github.com/OpenHands/extensions). Defaults to false; the global Skills page still forces `load_public=true` so users can browse the public catalog even when conversations keep it disabled.
 - Default working-dir fallback is now the relative path `workspace/project` (exported as `DEFAULT_WORKING_DIR` from `src/api/agent-server-config.ts`); git-path heuristics and the default PLAN preview path should reuse that constant instead of hardcoding `/workspace/project`.
 - The UI keeps most OpenHands routes/layout intact, but hosted-only behavior (org, account management, integrations) has been removed via the fabricated OSS config because there is no separate app backend.
 - Verification command: `npm run typecheck && npm run build`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
   - `VITE_WORKING_DIR` for the default workspace path sent when starting conversations.
   - `VITE_WORKER_URLS` as a comma-separated list of browser worker URLs if you want the Browser tab to probe exposed app hosts.
   - `VITE_ENABLE_BROWSER_TOOLS=false` to omit `BrowserToolSet` from new conversation payloads.
-  - `VITE_LOAD_PUBLIC_SKILLS=true` to opt conversations into loading public skills from the OpenHands extensions marketplace (https://github.com/OpenHands/extensions). Defaults to false; the global Skills page still forces `load_public=true` so users can browse the public catalog even when conversations keep it disabled.
+  - `VITE_LOAD_PUBLIC_SKILLS=false` to disable loading public skills from the OpenHands extensions marketplace (https://github.com/OpenHands/extensions). Defaults to true; the global Skills page still forces `load_public=true` so users can browse the public catalog even when conversations are opted out.
 - Default working-dir fallback is now the relative path `workspace/project` (exported as `DEFAULT_WORKING_DIR` from `src/api/agent-server-config.ts`); git-path heuristics and the default PLAN preview path should reuse that constant instead of hardcoding `/workspace/project`.
 - The UI keeps most OpenHands routes/layout intact, but hosted-only behavior (org, account management, integrations) has been removed via the fabricated OSS config because there is no separate app backend.
 - Verification command: `npm run typecheck && npm run build`.

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -24,7 +24,7 @@ const {
     apiKey: "session-key",
     kind: "local" as const,
   })),
-  mockShouldLoadPublicSkills: vi.fn(() => false),
+  mockShouldLoadPublicSkills: vi.fn(() => true),
 }));
 
 vi.mock("#/api/agent-server-config", () => ({
@@ -45,7 +45,7 @@ vi.mock("#/api/backend-registry/active-store", () => ({
 
 beforeEach(() => {
   mockIsAgentServerToolAvailable.mockReturnValue(true);
-  mockShouldLoadPublicSkills.mockReturnValue(false);
+  mockShouldLoadPublicSkills.mockReturnValue(true);
   mockGetEffectiveLocalBackend.mockReturnValue({
     id: "default-local",
     name: "Local backend",
@@ -119,7 +119,7 @@ describe("buildStartConversationRequest", () => {
       "ThinkTool",
     ]);
     expect(payload.agent.agent_context).toEqual({
-      load_public_skills: false,
+      load_public_skills: true,
       load_user_skills: true,
     });
     expect(payload.agent.agent).toBeUndefined();
@@ -585,13 +585,13 @@ describe("createAgentFromSettings runtime services suffix", () => {
       agent: { agent_context: Record<string, unknown> };
     };
     expect(payload.agent.agent_context).toEqual({
-      load_public_skills: false,
+      load_public_skills: true,
       load_user_skills: true,
     });
   });
 
-  it("opts conversations into public skills only when explicitly enabled", () => {
-    mockShouldLoadPublicSkills.mockReturnValue(true);
+  it("opts conversations out of public skills only when explicitly disabled", () => {
+    mockShouldLoadPublicSkills.mockReturnValue(false);
 
     const payload = buildStartConversationRequest({
       settings: DEFAULT_SETTINGS,
@@ -601,7 +601,7 @@ describe("createAgentFromSettings runtime services suffix", () => {
     };
 
     expect(payload.agent.agent_context).toEqual({
-      load_public_skills: true,
+      load_public_skills: false,
       load_user_skills: true,
     });
   });
@@ -626,7 +626,7 @@ describe("createAgentFromSettings runtime services suffix", () => {
       agent: { agent_context: Record<string, unknown> };
     };
     expect(payload.agent.agent_context).toMatchObject({
-      load_public_skills: false,
+      load_public_skills: true,
       load_user_skills: true,
     });
     expect(

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -13,6 +13,7 @@ const {
   mockGetAgentServerWorkingDir,
   mockIsAgentServerToolAvailable,
   mockGetEffectiveLocalBackend,
+  mockShouldLoadPublicSkills,
 } = vi.hoisted(() => ({
   mockGetAgentServerWorkingDir: vi.fn(() => "/workspace/project/agent-canvas"),
   mockIsAgentServerToolAvailable: vi.fn((_toolName: string) => true),
@@ -23,6 +24,7 @@ const {
     apiKey: "session-key",
     kind: "local" as const,
   })),
+  mockShouldLoadPublicSkills: vi.fn(() => false),
 }));
 
 vi.mock("#/api/agent-server-config", () => ({
@@ -30,7 +32,7 @@ vi.mock("#/api/agent-server-config", () => ({
   getAgentServerSessionApiKey: vi.fn(() => null),
   getAgentServerWorkingDir: mockGetAgentServerWorkingDir,
   getConfiguredWorkerUrls: vi.fn(() => []),
-  shouldLoadPublicSkills: vi.fn(() => true),
+  shouldLoadPublicSkills: mockShouldLoadPublicSkills,
 }));
 
 vi.mock("#/api/agent-server-compatibility", () => ({
@@ -43,6 +45,7 @@ vi.mock("#/api/backend-registry/active-store", () => ({
 
 beforeEach(() => {
   mockIsAgentServerToolAvailable.mockReturnValue(true);
+  mockShouldLoadPublicSkills.mockReturnValue(false);
   mockGetEffectiveLocalBackend.mockReturnValue({
     id: "default-local",
     name: "Local backend",
@@ -116,7 +119,7 @@ describe("buildStartConversationRequest", () => {
       "ThinkTool",
     ]);
     expect(payload.agent.agent_context).toEqual({
-      load_public_skills: true,
+      load_public_skills: false,
       load_user_skills: true,
     });
     expect(payload.agent.agent).toBeUndefined();
@@ -582,6 +585,22 @@ describe("createAgentFromSettings runtime services suffix", () => {
       agent: { agent_context: Record<string, unknown> };
     };
     expect(payload.agent.agent_context).toEqual({
+      load_public_skills: false,
+      load_user_skills: true,
+    });
+  });
+
+  it("opts conversations into public skills only when explicitly enabled", () => {
+    mockShouldLoadPublicSkills.mockReturnValue(true);
+
+    const payload = buildStartConversationRequest({
+      settings: DEFAULT_SETTINGS,
+      query: "hello",
+    }) as {
+      agent: { agent_context: Record<string, unknown> };
+    };
+
+    expect(payload.agent.agent_context).toEqual({
       load_public_skills: true,
       load_user_skills: true,
     });
@@ -607,7 +626,7 @@ describe("createAgentFromSettings runtime services suffix", () => {
       agent: { agent_context: Record<string, unknown> };
     };
     expect(payload.agent.agent_context).toMatchObject({
-      load_public_skills: true,
+      load_public_skills: false,
       load_user_skills: true,
     });
     expect(

--- a/__tests__/api/agent-server-config.test.ts
+++ b/__tests__/api/agent-server-config.test.ts
@@ -90,19 +90,19 @@ describe("agent server config", () => {
     expect(getAgentServerSessionApiKey()).toBe("saved-session-key");
   });
 
-  it("does not load public skills by default when VITE_LOAD_PUBLIC_SKILLS is unset", () => {
+  it("loads public skills by default when VITE_LOAD_PUBLIC_SKILLS is unset", () => {
     vi.stubEnv("VITE_LOAD_PUBLIC_SKILLS", "");
 
-    expect(shouldLoadPublicSkills()).toBe(false);
+    expect(shouldLoadPublicSkills()).toBe(true);
   });
 
-  it("loads public skills only when VITE_LOAD_PUBLIC_SKILLS is explicitly 'true'", () => {
+  it("loads public skills when VITE_LOAD_PUBLIC_SKILLS is explicitly 'true'", () => {
     vi.stubEnv("VITE_LOAD_PUBLIC_SKILLS", "true");
 
     expect(shouldLoadPublicSkills()).toBe(true);
   });
 
-  it("does not load public skills for any non-'true' value of VITE_LOAD_PUBLIC_SKILLS", () => {
+  it("disables public skills only when VITE_LOAD_PUBLIC_SKILLS is explicitly 'false'", () => {
     vi.stubEnv("VITE_LOAD_PUBLIC_SKILLS", "false");
 
     expect(shouldLoadPublicSkills()).toBe(false);

--- a/__tests__/api/skills-service.test.ts
+++ b/__tests__/api/skills-service.test.ts
@@ -41,11 +41,10 @@ afterEach(() => {
 });
 
 describe("SkillsService.getSkills against the agent-server backend", () => {
-  it("requests load_public:true for the global Skills page even when VITE_LOAD_PUBLIC_SKILLS is unset, so a fresh dev env still shows the public catalog", async () => {
-    // Arrange: the dev-default scenario that shipped the empty Skills page —
-    // VITE_LOAD_PUBLIC_SKILLS is not set, so shouldLoadPublicSkills() would
-    // return false. The agent-server has one public skill it can return.
-    vi.stubEnv("VITE_LOAD_PUBLIC_SKILLS", "");
+  it("requests load_public:true for the global Skills page even when VITE_LOAD_PUBLIC_SKILLS is explicitly false", async () => {
+    // Arrange: the conversation-level opt-out scenario. The Skills page
+    // should still show the public catalog even when conversations disable it.
+    vi.stubEnv("VITE_LOAD_PUBLIC_SKILLS", "false");
     mockGetSkills.mockResolvedValue({
       skills: [
         {

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -2,7 +2,10 @@ import { DEFAULT_SETTINGS } from "#/services/settings";
 import { ExecutionStatus } from "#/types/agent-server/core";
 import { Settings, SettingsValue } from "#/types/settings";
 import { isAgentServerToolAvailable } from "./agent-server-compatibility";
-import { getAgentServerWorkingDir } from "./agent-server-config";
+import {
+  getAgentServerWorkingDir,
+  shouldLoadPublicSkills,
+} from "./agent-server-config";
 import { getEffectiveLocalBackend } from "./backend-registry/active-store";
 import { buildAuthHeaders } from "./backend-registry/auth";
 import {
@@ -474,7 +477,7 @@ function createAgentFromSettings(agentSettings: SettingsRecord) {
     kind: "Agent",
     ...agentSettings,
     agent_context: {
-      load_public_skills: true,
+      load_public_skills: shouldLoadPublicSkills(),
       load_user_skills: true,
       // When the dev launcher provided `VITE_RUNTIME_SERVICES_INFO`, append
       // a <RUNTIME_SERVICES> block to the system prompt so the agent knows

--- a/src/api/agent-server-config.ts
+++ b/src/api/agent-server-config.ts
@@ -182,8 +182,8 @@ export function getAgentServerHeaders(): Record<string, string> {
  * Returns whether public skills from the OpenHands extensions marketplace
  * (https://github.com/OpenHands/extensions) should be loaded.
  *
- * Defaults to false. Set VITE_LOAD_PUBLIC_SKILLS=true to enable.
+ * Defaults to true. Set VITE_LOAD_PUBLIC_SKILLS=false to disable.
  */
 export function shouldLoadPublicSkills(): boolean {
-  return import.meta.env.VITE_LOAD_PUBLIC_SKILLS === "true";
+  return import.meta.env.VITE_LOAD_PUBLIC_SKILLS !== "false";
 }


### PR DESCRIPTION
## Summary
- gate `agent_context.load_public_skills` behind `shouldLoadPublicSkills()` when starting conversations
- keep public skills enabled by default so existing conversations retain current behavior
- let deployers opt out with `VITE_LOAD_PUBLIC_SKILLS=false`, while the global Skills page still loads the public catalog
- add regression coverage for the default-on and explicit-opt-out cases

Important: there is no eval risk because default behavior does not change, this only allows users to opt out of public skills if they want to.

## Testing
- npm run make-i18n
- npx --yes vitest run __tests__/api/agent-server-config.test.ts __tests__/api/agent-server-adapter.test.ts __tests__/api/skills-service.test.ts
- npm run typecheck

Refs #211

_This PR was updated by an AI agent (OpenHands) on behalf of the user._