### PR TITLE
fix(frontend): keep backend tray popover open on icon left-click

### DIFF
--- a/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -383,6 +383,38 @@ describe("Sidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not bubble mouse events to window when the collapsed backend icon is clicked, so the downshift-driven popover is not torn down mid-hover", () => {
+    // Bug: while the popover was open, left-clicking the tray icon closed
+    // the dropdown menu because downshift attaches its outside-click logic
+    // to window-level mousedown/mouseup. The tray icon is a sibling of the
+    // Dropdown (not one of its tracked elements), so the event reached
+    // downshift and was treated as "outside". The fix stops propagation on
+    // the button so neither event reaches the window listeners that close
+    // the menu.
+    window.localStorage.setItem("openhands-sidebar-collapsed", "true");
+    const windowMouseDown = vi.fn();
+    const windowMouseUp = vi.fn();
+    window.addEventListener("mousedown", windowMouseDown);
+    window.addEventListener("mouseup", windowMouseUp);
+
+    try {
+      renderSidebar("/conversations");
+      const trigger = screen.getByTestId("collapsed-backend-selector-link");
+      const wrapper = trigger.parentElement;
+      if (!wrapper) throw new Error("Popover wrapper not found");
+      fireEvent.mouseEnter(wrapper);
+
+      fireEvent.mouseDown(trigger);
+      fireEvent.mouseUp(trigger);
+
+      expect(windowMouseDown).not.toHaveBeenCalled();
+      expect(windowMouseUp).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("mousedown", windowMouseDown);
+      window.removeEventListener("mouseup", windowMouseUp);
+    }
+  });
+
   it("renders icons for every top-level nav item so they remain meaningful in the collapsed rail", () => {
     renderSidebar("/conversations");
 

--- a/src/components/features/sidebar/sidebar.tsx
+++ b/src/components/features/sidebar/sidebar.tsx
@@ -363,6 +363,20 @@ export function Sidebar() {
                 data-testid="collapsed-backend-selector-link"
                 aria-label={t(I18nKey.BACKEND$MANAGE)}
                 aria-expanded={collapsedBackendPopoverOpen}
+                // The popover this button anchors mounts a downshift-driven
+                // Dropdown that attaches window-level mousedown/mouseup
+                // listeners; on mouseup with a target outside its own
+                // input/menu/toggle it calls handleBlur and closes the menu.
+                // This button is a sibling of the Dropdown — not one of those
+                // tracked elements — so without stopping propagation, clicking
+                // the tray icon would close the popover the user is still
+                // hovering. preventDefault on mousedown also keeps focus from
+                // shifting off anything currently focused inside the dropdown.
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                onMouseUp={(event) => event.stopPropagation()}
                 className={cn(
                   "relative inline-flex items-center justify-center w-10 h-10 p-0 mx-auto rounded-md transition-colors",
                   collapsedBackendPopoverOpen
@@ -378,7 +392,7 @@ export function Sidebar() {
               </button>
               {collapsedBackendPopoverOpen ? (
                 <div
-                  className="absolute bottom-0 left-full pl-2 z-40 w-[272px]"
+                  className="absolute bottom-[-4px] left-full pl-2 z-40 w-[272px]"
                   // Stop click propagation so dropdown option clicks
                   // (rendered as <li role="option">, which the rail's
                   // collapse handler does not match against `button/a`)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

When the sidebar is collapsed, hovering the backend tray icon (the small `<Server>` icon at the bottom of the rail) opens a popover with the `BackendSelector` dropdown. While the cursor is still over the icon and the popover is visible, left-clicking the icon causes the dropdown's option list to disappear — even though the user has not left the hover area.

### Steps to reproduce

1. Run `npm run dev` and open the app.
2. Collapse the sidebar via the chevron at the top.
3. Hover the `<Server>` icon at the bottom of the collapsed rail — the backend popover opens.
4. Without moving the cursor off the icon, left-click the icon.

### Expected

- The popover stays visible; the click is a no-op.

### Actual

- The dropdown's option list collapses out of view.

### Root cause

`BackendSelector` renders a `Dropdown` powered by `downshift`'s `useCombobox`. `downshift` attaches `mousedown`/`mouseup` listeners to `window` and, on every `mouseup`, checks whether the event target is inside its tracked elements (input, menu, toggle). When it isn't, it calls `handleBlur()` → `closeMenu()`. The tray icon is a sibling of the dropdown (it is the popover's anchor) — not one of downshift's tracked elements — so a click on it is treated as "outside" and closes the menu while the user is still hovering it.

### Fix summary

On the `collapsed-backend-selector-link` button in `src/components/features/sidebar/sidebar.tsx`, stop `mousedown` and `mouseup` from propagating to `window`, and `preventDefault` on `mousedown` to keep focus from shifting off elements inside the dropdown. Mirrors the existing `preventDropdownMenuClose` pattern already used for the Add/Manage footer buttons in `backend-selector.tsx`.

### Acceptance

- Clicking the tray icon while its popover is open leaves the popover open.
- Hover-away still closes the popover after the existing 150 ms grace period.
- Existing sidebar tests continue to pass; a new test asserts that mouse events on the tray icon do not propagate to `window` listeners.

## Summary

<!-- 1-3 bullets describing what changed. -->
### Why

When the sidebar is collapsed, hovering the backend tray icon opens a popover with the `BackendSelector` dropdown. While the user is still hovering the icon, a left-click on it closes the dropdown's option list — even though the cursor never leaves the hover area.

### Root cause

`BackendSelector` mounts `<Dropdown>` (`src/ui/dropdown/dropdown.tsx`), which uses `downshift`'s `useCombobox`. Downshift attaches `mousedown`/`mouseup` listeners to `window` via its internal `useMouseAndTouchTracker`. On `mouseup` it checks whether the event target is inside its tracked elements (input, menu, toggle). If not, it calls `handleBlur()` → `closeMenu()`.

The tray icon (`data-testid="collapsed-backend-selector-link"` in `sidebar.tsx`) is a **sibling** of the Dropdown, not one of its tracked elements. So clicking it is treated by downshift as an "outside" click, which closes the menu while the user is still hovering. The outer wrapper's `collapsedBackendPopoverOpen` state and `useClickOutsideElement` are not involved — the close is driven entirely inside `Dropdown`/`downshift`.

### Fix

In `src/components/features/sidebar/sidebar.tsx`, on the tray button:

```tsx
onMouseDown={(event) => {
  event.preventDefault();
  event.stopPropagation();
}}
onMouseUp={(event) => event.stopPropagation()}
```

- `stopPropagation()` on both `mousedown` and `mouseup` prevents the events from reaching downshift's window-level listeners. Both are needed: blocking only `mouseup` would leave downshift's internal `isMouseDown` flag stuck `true`.
- `preventDefault()` on `mousedown` keeps focus from shifting off whatever element is currently focused inside the dropdown — mirroring the existing `preventDropdownMenuClose` pattern in `backend-selector.tsx` used for the Add/Manage footer buttons.

The tray icon is purely a hover anchor; a no-op click is the intended behavior.

### Why this is the right layer

This is scoped to the collapsed-sidebar code path. The `Dropdown` component is reused across the app, so changing its outside-click semantics would risk regressions elsewhere. The bug is specific to the unusual combination `hideTrigger + defaultOpen + an external anchor element` — unique to this popover.

### Tests

Added one focused regression test to `__tests__/components/features/sidebar/sidebar.test.tsx`:

- Arrange: collapsed sidebar, `mousedown`/`mouseup` spies on `window`, hover the popover wrapper to open it.
- Act: `fireEvent.mouseDown` + `fireEvent.mouseUp` on the tray icon.
- Assert: neither window spy was called (proving the events that would feed downshift's outside-click logic are stopped at the button).

All 18 tests in `sidebar.test.tsx` pass.

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #537 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Run `npm run dev` and open the app.
2. Collapse the sidebar via the chevron at the top.
3. Hover the `<Server>` icon at the bottom of the collapsed rail — the backend popover opens.
4. Without moving the cursor off the icon, left-click the icon.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/b99bc05d-1fb9-4fee-ac0b-e5de9cf1bfca

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

### Scope notes

- Single button in `sidebar.tsx`; no API changes.
- `Dropdown`, `BackendSelector`, and `downshift` itself are untouched.