### PR TITLE
fix(frontend): use SPA navigation for Start a conversation CTA

### DIFF
--- a/__tests__/components/automations/create-instructions.test.tsx
+++ b/__tests__/components/automations/create-instructions.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import {
+  NavigationProvider,
+  type NavigationContextValue,
+} from "#/context/navigation-context";
+import { CreateInstructions } from "#/components/features/automations/create-instructions";
+import { I18nKey } from "#/i18n/declaration";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        [I18nKey.AUTOMATIONS$EMPTY_START_CONVERSATION]: "Start a conversation",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+function renderCreateInstructions() {
+  const value: NavigationContextValue = {
+    currentPath: "/automations",
+    conversationId: null,
+    isNavigating: false,
+    navigate: vi.fn(),
+  };
+
+  const result = render(
+    <NavigationProvider value={value}>
+      <CreateInstructions />
+    </NavigationProvider>,
+  );
+
+  return { ...result, navigate: value.navigate };
+}
+
+describe("CreateInstructions", () => {
+  it("navigates to the home route via SPA routing when 'Start a conversation' is clicked", () => {
+    const { navigate } = renderCreateInstructions();
+
+    const link = screen.getByRole("link", { name: /start a conversation/i });
+    const clickEvent = fireEvent.click(link);
+
+    expect(navigate).toHaveBeenCalledWith("/", { replace: false });
+    expect(clickEvent).toBe(false);
+  });
+});

--- a/src/components/features/automations/create-instructions.tsx
+++ b/src/components/features/automations/create-instructions.tsx
@@ -4,6 +4,7 @@ import { I18nKey } from "#/i18n/declaration";
 import TerminalIcon from "#/icons/terminal.svg?react";
 import SparkleIcon from "#/icons/sparkle.svg?react";
 import ChevronDownIcon from "#/icons/chevron-down.svg?react";
+import { NavigationLink } from "#/components/shared/navigation-link";
 
 const DOCS_URL =
   "https://docs.openhands.dev/openhands/usage/automations/overview";
@@ -61,13 +62,13 @@ export function CreateInstructions({
           <p className="mt-2 text-sm text-muted">
             {t(I18nKey.AUTOMATIONS$EMPTY_OPTION_CONVERSATION_DESC)}
           </p>
-          <a
-            href={NEW_CONVERSATION_URL}
+          <NavigationLink
+            to={NEW_CONVERSATION_URL}
             className="mt-2 inline-flex items-center gap-1 rounded-md bg-surface-raised px-3 py-2 text-xs font-medium text-content hover:bg-surface-raised transition-colors"
           >
             {t(I18nKey.AUTOMATIONS$EMPTY_START_CONVERSATION)}
             <span aria-hidden="true">→</span>
-          </a>
+          </NavigationLink>
         </div>
       </div>
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary
On the `/automations` page, the **Start a conversation** button inside the "How to create" instructions card performs a browser-level navigation. The page does a full reload, all client state (theme, query cache, websocket connections, scroll position) is rebuilt, and the SPA experience breaks for a flow we expect to be entirely client-side.

### Steps to reproduce
1. `npm run dev` (launches the agent server in Docker).
2. Open `http://localhost:3001/automations`.
3. In the empty state — or the collapsible "How to create" panel above the list — click **Start a conversation**.

### Actual behavior
Full document request to `localhost`. The page flashes white and the React tree remounts before landing on `/conversations`.

### Expected behavior
Same destination (`/` → redirects to `/conversations`), but reached through SPA routing: no document fetch, no remount, history pushed via the in-app navigation context.

### Root cause
`src/components/features/automations/create-instructions.tsx` rendered the CTA as a plain `<a href="/">`. The anchor never went through the app's `NavigationContext`, so the browser performed its default navigation. Every other in-app link in the repo routes through `NavigationLink` (`src/components/shared/navigation-link.tsx`) or `useNavigate()`, which `preventDefault()` and push history via the router.

### Fix
Swap the plain anchor for `NavigationLink to="/"`. The two external links in the same file (`PLUGIN_INSTALL_URL`, `DOCS_URL`) intentionally stay as `<a target="_blank">` — they leave the SPA.

### Acceptance criteria
- [ ] Clicking **Start a conversation** on `/automations` updates the URL to `/conversations` with no document request in the Network tab.
- [ ] React state (theme, sidebar collapsed state, react-query cache) is preserved through the navigation.
- [ ] Cmd/Ctrl-click still opens in a new tab; right-click "Copy link address" still returns the absolute URL of `/`.
- [ ] Unit test in `__tests__/components/automations/create-instructions.test.tsx` asserts the CTA invokes `NavigationContext.navigate("/")` and cancels the default browser navigation.

## Summary

<!-- 1-3 bullets describing what changed. -->
#### Summary
- Replace the plain `<a href="/">` in `src/components/features/automations/create-instructions.tsx` with `NavigationLink to="/"` so the **Start a conversation** CTA on `/automations` uses the in-app router instead of a full page reload.
- Leave the two external links in the same component (`PLUGIN_INSTALL_URL`, `DOCS_URL`) as plain anchors with `target="_blank"` — they intentionally leave the SPA.
- Add a focused unit test verifying the CTA dispatches through `NavigationContext.navigate("/")` and cancels the default anchor behavior.

#### Why
`NavigationLink` is the established in-app navigation primitive in this repo (see `src/components/shared/navigation-link.tsx` and its consumers in `src/components/features/sidebar/`). Using a raw anchor bypassed `preventDefault()` + `navigate()`, causing the browser to perform a top-level document load. That remounted the React tree, dropped the react-query cache, and reset transient UI state every time the CTA was used — none of which happened with any other in-app link.

#### Changes
- `src/components/features/automations/create-instructions.tsx`
  - Import `NavigationLink` from `#/components/shared/navigation-link`.
  - Replace the `<a href={NEW_CONVERSATION_URL}>…</a>` block with `<NavigationLink to={NEW_CONVERSATION_URL}>…</NavigationLink>`. Same `href` is still emitted on the rendered `<a>`, so middle-click / right-click / "open in new tab" behavior is preserved.
- `__tests__/components/automations/create-instructions.test.tsx` (new)
  - Renders `<CreateInstructions />` inside a `NavigationProvider` whose `navigate` is a `vi.fn()`.
  - Clicks **Start a conversation** and asserts `navigate` was called with `("/", { replace: false })`, and that `fireEvent.click` returned `false` (i.e., `preventDefault()` ran — proving no full reload).

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #539 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev` (launches the agent server in Docker).
2. Open `http://localhost:3001/automations`.
3. In the empty state — or the collapsible "How to create" panel above the list — click **Start a conversation**.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/e7733fc7-758d-4579-a71d-700f99e852a5

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

#### Out of scope
- The two external `<a target="_blank">` links in the same component (plugin install, docs).
- The behavior of the `/` index redirect itself (already redirects to `/conversations` via `src/routes/index-redirect.tsx`).