### PR TITLE
refactor(frontend): replace inline style props with Tailwind classes and design tokens

### DIFF
--- a/__tests__/agent-server-ui-providers.test.tsx
+++ b/__tests__/agent-server-ui-providers.test.tsx
@@ -215,7 +215,6 @@ describe("AgentServerUIProviders", () => {
       scopeRoot?.firstElementChild as HTMLDivElement | null;
     expect(themedContainer).toHaveAttribute("data-theme", "dark");
     expect(themedContainer).toHaveClass("dark", "min-h-screen");
-    expect(themedContainer).toHaveStyle({ color: "var(--foreground)" });
     expect(themedContainer).toContainElement(
       screen.getByTestId("styled-child"),
     );

--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -580,8 +580,7 @@ export function BackendFormModal({
       >
         <div
           data-testid="add-backend-modal"
-          className="bg-base-secondary rounded-xl border border-tertiary"
-          style={{ width: "720px" }}
+          className="bg-base-secondary rounded-xl border border-tertiary w-[720px]"
         >
           {/* Header */}
           <div className="flex items-center justify-between px-6 pt-6 pb-2">
@@ -635,8 +634,7 @@ export function BackendFormModal({
     >
       <div
         data-testid={`${testIdRoot}-modal`}
-        className="bg-base-secondary p-6 rounded-xl flex flex-col gap-4 border border-[var(--oh-border)]"
-        style={{ width: "480px" }}
+        className="bg-base-secondary p-6 rounded-xl flex flex-col gap-4 border border-[var(--oh-border)] w-[480px]"
       >
         <h3 className="text-xl font-bold">{t(I18nKey.BACKEND$EDIT_TITLE)}</h3>
         <BackendForm

--- a/src/components/features/browser/browser-snapshot.tsx
+++ b/src/components/features/browser/browser-snapshot.tsx
@@ -11,8 +11,7 @@ export function BrowserSnapshot({ src }: BrowserSnaphsotProps) {
   return (
     <img
       src={src}
-      style={{ objectFit: "contain", width: "100%", height: "auto" }}
-      className="rounded-xl"
+      className="rounded-xl object-contain w-full h-auto"
       alt={t(I18nKey.BROWSER$SCREENSHOT_ALT)}
     />
   );

--- a/src/components/features/chat/chat-message.tsx
+++ b/src/components/features/chat/chat-message.tsx
@@ -112,13 +112,7 @@ export function ChatMessage({
         />
       </div>
 
-      <div
-        className="text-sm"
-        style={{
-          whiteSpace: "normal",
-          wordBreak: "break-word",
-        }}
-      >
+      <div className="text-sm whitespace-normal [word-break:break-word]">
         <MarkdownRenderer includeStandard includeHeadings>
           {message}
         </MarkdownRenderer>

--- a/src/components/features/chat/components/chat-input-actions.tsx
+++ b/src/components/features/chat/components/chat-input-actions.tsx
@@ -538,6 +538,7 @@ export function ChatInputActions({
                 typeof document !== "undefined" &&
                 overflowPortalStyle &&
                 ReactDOM.createPortal(
+                  // portal position computed from DOM bounding rect at runtime
                   <div style={overflowPortalStyle}>{overflowMenu}</div>,
                   document.body,
                 )}

--- a/src/components/features/chat/components/chat-input-grip.tsx
+++ b/src/components/features/chat/components/chat-input-grip.tsx
@@ -26,10 +26,9 @@ export function ChatInputGrip({
     >
       {/* Tall hit target; 1px line is drawn at top-0 (flush with chat input box) */}
       <div
-        className="absolute inset-0 z-[1] cursor-ns-resize"
+        className="absolute inset-0 z-[1] cursor-ns-resize select-none"
         onMouseDown={handleGripMouseDown}
         onTouchStart={handleGripTouchStart}
-        style={{ userSelect: "none" }}
         aria-hidden
       />
       <div

--- a/src/components/features/chat/components/hidden-file-input.tsx
+++ b/src/components/features/chat/components/hidden-file-input.tsx
@@ -15,7 +15,7 @@ export function HiddenFileInput({
       ref={fileInputRef}
       multiple
       accept="*/*"
-      style={{ display: "none" }}
+      className="hidden"
       onChange={onChange}
       data-testid="upload-image-input"
     />

--- a/src/components/features/chat/typing-indicator.tsx
+++ b/src/components/features/chat/typing-indicator.tsx
@@ -1,18 +1,9 @@
 export function TypingIndicator() {
   return (
     <div className="flex items-center space-x-1.5 rounded-full bg-[var(--oh-surface)] px-3 py-1.5">
-      <span
-        className="h-1.5 w-1.5 rounded-full bg-[var(--oh-muted)] animate-[bounce_0.5s_infinite] translate-y-[1px]"
-        style={{ animationDelay: "0ms" }}
-      />
-      <span
-        className="h-1.5 w-1.5 rounded-full bg-[var(--oh-muted)] animate-[bounce_0.5s_infinite] translate-y-[1px]"
-        style={{ animationDelay: "75ms" }}
-      />
-      <span
-        className="h-1.5 w-1.5 rounded-full bg-[var(--oh-muted)] animate-[bounce_0.5s_infinite] translate-y-[1px]"
-        style={{ animationDelay: "150ms" }}
-      />
+      <span className="h-1.5 w-1.5 rounded-full bg-[var(--oh-muted)] animate-[bounce_0.5s_infinite] translate-y-[1px] [animation-delay:0ms]" />
+      <span className="h-1.5 w-1.5 rounded-full bg-[var(--oh-muted)] animate-[bounce_0.5s_infinite] translate-y-[1px] [animation-delay:75ms]" />
+      <span className="h-1.5 w-1.5 rounded-full bg-[var(--oh-muted)] animate-[bounce_0.5s_infinite] translate-y-[1px] [animation-delay:150ms]" />
     </div>
   );
 }

--- a/src/components/features/conversation-panel/budget-progress-bar.tsx
+++ b/src/components/features/conversation-panel/budget-progress-bar.tsx
@@ -18,6 +18,7 @@ export function BudgetProgressBar({
         className={`h-full transition-all duration-300 ${
           isNearLimit ? "bg-red-500" : "bg-blue-500"
         }`}
+        // runtime usage-percentage width
         style={{
           width: `${Math.min(100, usagePercentage)}%`,
         }}

--- a/src/components/features/conversation-panel/conversation-card/conversation-status-badges.tsx
+++ b/src/components/features/conversation-panel/conversation-card/conversation-status-badges.tsx
@@ -24,7 +24,7 @@ export function ConversationStatusBadges({
 
   if (conversationStatus === "ERROR") {
     return (
-      <span className="flex items-center gap-1 px-1.5 py-0.5 bg-[#FF684E] text-white text-xs font-medium rounded-full">
+      <span className="flex items-center gap-1 px-1.5 py-0.5 bg-[var(--oh-status-error)] text-white text-xs font-medium rounded-full">
         <CircleErrorIcon className="text-white w-3 h-3" />
         <span>{t(I18nKey.COMMON$ERROR)}</span>
       </span>

--- a/src/components/features/conversation-panel/conversation-status-dot.tsx
+++ b/src/components/features/conversation-panel/conversation-status-dot.tsx
@@ -15,11 +15,6 @@ interface ConversationStatusDotProps {
 
 type Visual = "check" | "working" | "active" | "paused" | "error" | "unknown";
 
-const SUCCESS_GREEN = "#1FBD53";
-const PAUSED_GRAY = "var(--oh-muted)";
-const ERROR_RED = "#FF684E";
-const UNKNOWN_GRAY = "var(--oh-color-tertiary)";
-
 const visualFor = (status: ExecutionStatus | null | undefined): Visual => {
   switch (status) {
     case ExecutionStatus.FINISHED:
@@ -62,9 +57,8 @@ function renderIndicator(visual: Visual) {
         <svg
           data-testid="conversation-status-check"
           viewBox="0 0 12 12"
-          className="w-2.5 h-2.5"
+          className="w-2.5 h-2.5 stroke-[var(--oh-status-success)]"
           fill="none"
-          stroke={SUCCESS_GREEN}
           strokeWidth={2.25}
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -77,40 +71,35 @@ function renderIndicator(visual: Visual) {
       return (
         <span
           data-testid="conversation-status-working"
-          className="w-1.5 h-1.5 rounded-full animate-pulse"
-          style={{ backgroundColor: SUCCESS_GREEN }}
+          className="w-1.5 h-1.5 rounded-full animate-pulse bg-[var(--oh-status-success)]"
         />
       );
     case "active":
       return (
         <span
           data-testid="conversation-status-active"
-          className="w-1.5 h-1.5 rounded-full"
-          style={{ backgroundColor: SUCCESS_GREEN }}
+          className="w-1.5 h-1.5 rounded-full bg-[var(--oh-status-success)]"
         />
       );
     case "paused":
       return (
         <span
           data-testid="conversation-status-paused"
-          className="w-1.5 h-1.5 rounded-full"
-          style={{ backgroundColor: PAUSED_GRAY }}
+          className="w-1.5 h-1.5 rounded-full bg-[var(--oh-muted)]"
         />
       );
     case "error":
       return (
         <span
           data-testid="conversation-status-error"
-          className="w-1.5 h-1.5 rounded-full"
-          style={{ backgroundColor: ERROR_RED }}
+          className="w-1.5 h-1.5 rounded-full bg-[var(--oh-status-error)]"
         />
       );
     default:
       return (
         <span
           data-testid="conversation-status-unknown"
-          className="w-1.5 h-1.5 rounded-full"
-          style={{ backgroundColor: UNKNOWN_GRAY }}
+          className="w-1.5 h-1.5 rounded-full bg-[var(--oh-color-tertiary)]"
         />
       );
   }

--- a/src/components/features/conversation/conversation-loading.tsx
+++ b/src/components/features/conversation/conversation-loading.tsx
@@ -21,13 +21,7 @@ export function ConversationLoading({ className }: ConversationLoadingProps) {
         className="h-8 w-8 shrink-0 animate-spin text-[var(--oh-text-secondary)]"
         aria-hidden
       />
-      <span
-        className="text-base font-normal leading-5"
-        style={{
-          color: "var(--oh-focus, #ffffff)",
-          opacity: 0.8,
-        }}
-      >
+      <span className="text-base font-normal leading-5 text-[var(--oh-focus)] opacity-80">
         {t(I18nKey.HOME$LOADING)}
       </span>
     </div>

--- a/src/components/features/conversation/conversation-main/conversation-main.tsx
+++ b/src/components/features/conversation/conversation-main/conversation-main.tsx
@@ -44,6 +44,7 @@ export function ConversationMain() {
           "flex flex-1 overflow-hidden",
           isMobile ? "flex-col" : "transition-all duration-300 ease-in-out",
         )}
+        // transition toggled at runtime based on drag state
         style={
           !isMobile
             ? { transitionProperty: isDragging ? "none" : "all" }
@@ -60,6 +61,7 @@ export function ConversationMain() {
               ? getMobileChatPanelClass(isRightPanelShown)
               : "transition-all duration-300 ease-in-out",
           )}
+          // panel width computed at runtime by resize hook; transition toggled by drag state
           style={
             !isMobile
               ? {
@@ -102,6 +104,7 @@ export function ConversationMain() {
                 )
               : getDesktopTabPanelClass(isRightPanelShown),
           )}
+          // panel width computed at runtime by resize hook; transition toggled by drag state
           style={
             !isMobile
               ? {

--- a/src/components/features/conversation/conversation-name-context-menu.tsx
+++ b/src/components/features/conversation/conversation-name-context-menu.tsx
@@ -304,6 +304,7 @@ export function ConversationNameContextMenu({
       return null;
     }
     return ReactDOM.createPortal(
+      // portal position computed from DOM bounding rect at runtime
       <div style={portalStyle}>{menu}</div>,
       document.body,
     );

--- a/src/components/features/conversation/metrics-modal/context-window-section.tsx
+++ b/src/components/features/conversation/metrics-modal/context-window-section.tsx
@@ -26,6 +26,7 @@ export function ContextWindowSection({
       <div className="w-full h-1.5 bg-tertiary rounded-full overflow-hidden">
         <div
           className="h-full bg-blue-500 transition-all duration-300"
+          // runtime usage-percentage width
           style={{ width: `${progressWidth}%` }}
         />
       </div>

--- a/src/components/features/diff-viewer/editor-container.tsx
+++ b/src/components/features/diff-viewer/editor-container.tsx
@@ -10,6 +10,7 @@ export function EditorContainer({ height, children }: EditorContainerProps) {
     <div
       data-testid="editor-container"
       className="w-full border-b border-[var(--oh-border)] overflow-hidden h-[var(--editor-height)]"
+      // CSS custom property plumbed through for h-[var(--editor-height)] above
       style={{ "--editor-height": `${height}px` } as React.CSSProperties}
     >
       {children}

--- a/src/components/features/files-tab/file-tree-view.tsx
+++ b/src/components/features/files-tab/file-tree-view.tsx
@@ -36,6 +36,7 @@ function TreeNode({ node, depth, selectedPath, onSelectFile }: TreeNodeProps) {
             "flex w-full items-center gap-1.5 py-1 pr-2 text-left text-sm text-white",
             "hover:bg-tertiary cursor-pointer",
           )}
+          // per-row indentation computed from tree depth at runtime
           style={{ paddingLeft: `${indentPx}px` }}
         >
           <span
@@ -81,6 +82,7 @@ function TreeNode({ node, depth, selectedPath, onSelectFile }: TreeNodeProps) {
             ? "bg-[var(--oh-interactive-hover)] text-white"
             : "text-[var(--oh-text-tertiary)]",
         )}
+        // per-row indentation computed from tree depth at runtime
         style={{ paddingLeft: `${indentPx + 16}px` }}
       >
         <FileIcon className="w-3.5 h-3.5 shrink-0" />

--- a/src/components/features/markdown/code.tsx
+++ b/src/components/features/markdown/code.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ExtraProps } from "react-markdown";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { CopyableContentWrapper } from "#/components/shared/buttons/copyable-content-wrapper";
+import { cn } from "#/utils/utils";
 import { SyntaxHighlighter } from "./syntax-highlighter";
 
 // See https://github.com/remarkjs/react-markdown?tab=readme-ov-file#use-custom-components-syntax-highlight
@@ -24,14 +25,10 @@ export function code({
     if (!isMultiline) {
       return (
         <code
-          className={className}
-          style={{
-            backgroundColor: "var(--oh-surface-raised)",
-            padding: "0.2em 0.4em",
-            borderRadius: "4px",
-            color: "var(--oh-foreground)",
-            border: "1px solid var(--oh-surface-raised)",
-          }}
+          className={cn(
+            className,
+            "bg-surface-raised text-foreground border border-surface-raised rounded px-[0.4em] py-[0.2em]",
+          )}
         >
           {children}
         </code>
@@ -40,16 +37,7 @@ export function code({
 
     return (
       <CopyableContentWrapper text={codeString}>
-        <pre
-          style={{
-            backgroundColor: "var(--oh-surface-raised)",
-            padding: "1em",
-            borderRadius: "4px",
-            color: "var(--oh-foreground)",
-            border: "1px solid var(--oh-surface-raised)",
-            overflow: "auto",
-          }}
-        >
+        <pre className="bg-surface-raised text-foreground border border-surface-raised rounded p-[1em] overflow-auto">
           <code className={className}>{codeString}</code>
         </pre>
       </CopyableContentWrapper>

--- a/src/components/features/mcp-page/install-server-modal.tsx
+++ b/src/components/features/mcp-page/install-server-modal.tsx
@@ -270,6 +270,7 @@ export function InstallServerModal({
           <span
             aria-hidden="true"
             className="shrink-0 inline-flex items-center justify-center h-10 w-10 rounded-lg"
+            // data-driven icon colors from marketplace entry
             style={{
               backgroundColor: entry.iconBg,
               color: entry.iconColor ?? "#FFFFFF",

--- a/src/components/features/mcp-page/installed-server-card.tsx
+++ b/src/components/features/mcp-page/installed-server-card.tsx
@@ -67,6 +67,7 @@ export function InstalledServerCard({
       <span
         aria-hidden="true"
         className="shrink-0 inline-flex items-center justify-center h-10 w-10 rounded-lg"
+        // data-driven icon colors from catalog entry
         style={{
           backgroundColor: catalog?.iconBg ?? "var(--oh-color-tertiary)",
           color: catalog?.iconColor ?? "#FFFFFF",

--- a/src/components/features/mcp-page/marketplace-card.tsx
+++ b/src/components/features/mcp-page/marketplace-card.tsx
@@ -49,6 +49,7 @@ export function MarketplaceCard({
             "shrink-0 inline-flex items-center justify-center",
             "h-10 w-10 rounded-lg",
           )}
+          // data-driven icon colors from marketplace entry
           style={{
             backgroundColor: entry.iconBg,
             color: entry.iconColor ?? "#FFFFFF",

--- a/src/components/features/onboarding/onboarding-modal.tsx
+++ b/src/components/features/onboarding/onboarding-modal.tsx
@@ -43,6 +43,7 @@ function Slide({ index, currentStep, children }: SlideProps) {
       data-testid={`onboarding-slide-${index}`}
       data-active={isActive}
       aria-hidden={!isActive}
+      // slide offset computed from step index at runtime
       style={{ transform: `translateX(${offsetPct}%)` }}
       className={cn(
         "w-full transition-transform duration-300 ease-out",

--- a/src/components/features/settings/api-key-modal-base.tsx
+++ b/src/components/features/settings/api-key-modal-base.tsx
@@ -80,6 +80,7 @@ export function ApiKeyModalBase({
         aria-modal="true"
         aria-labelledby="modal-title"
         className="bg-base-secondary p-6 rounded-xl flex flex-col gap-4 border border-[var(--oh-border)]"
+        // runtime prop-driven width; cannot move to className
         style={{ width }}
       >
         <h3 id="modal-title" className="text-xl font-bold">

--- a/src/components/features/settings/llm-profiles/profile-actions-menu.tsx
+++ b/src/components/features/settings/llm-profiles/profile-actions-menu.tsx
@@ -227,6 +227,7 @@ export function ProfileActionsMenu({
       return null;
     }
     return ReactDOM.createPortal(
+      // portal position computed from DOM bounding rect at runtime
       <div style={portalStyle}>{menu}</div>,
       document.body,
     );

--- a/src/components/providers/agent-server-ui-root.tsx
+++ b/src/components/providers/agent-server-ui-root.tsx
@@ -42,12 +42,12 @@ export function AgentServerUIRoot({
       data-agent-server-ui=""
       {...divProps}
       className={className}
+      // CSS custom properties injected onto the scope root so descendants can resolve var(--oh-*)
       style={scopedStyle}
     >
       <div
-        className={cn(theme, contentClassName)}
+        className={cn(theme, contentClassName, "text-foreground")}
         data-theme={theme}
-        style={{ color: "var(--foreground)" }}
       >
         {children}
       </div>

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -45,7 +45,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body data-agent-server-ui="" style={{ margin: 0 }}>
+      <body data-agent-server-ui="" className="m-0">
         <AgentServerUIRoot contentClassName="min-h-screen">
           <ColorThemeApplier />
           {children}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -111,6 +111,8 @@
   --oh-border-subtle: var(--cool-grey-800);  /* within-panel separators, list dividers */
   --oh-separator: rgba(113, 120, 136, 0.5);
   --oh-focus: #ffffff;
+  --oh-status-success: #1FBD53;
+  --oh-status-error: #FF684E;
   --oh-link: var(--cool-grey-100);
   --oh-radius: 5px;
   --oh-field-radius: 5px;

--- a/src/utils/custom-toast-handlers.tsx
+++ b/src/utils/custom-toast-handlers.tsx
@@ -3,6 +3,7 @@ import toast, { ToastOptions } from "react-hot-toast";
 import { calculateToastDuration } from "./toast-duration";
 import i18n from "#/i18n";
 
+// react-hot-toast accepts only CSSProperties via the style option — cannot use className
 const TOAST_STYLE: CSSProperties = {
   background: "var(--oh-color-tertiary)",
   border: "1px solid var(--oh-border-input)",
@@ -23,7 +24,7 @@ export const displayErrorToast = (error: string | null | undefined) => {
   const errorMessage = error || i18n.t("STATUS$ERROR");
   const duration = calculateToastDuration(errorMessage, 4000);
   toast.error(
-    <span style={{ wordBreak: "break-word", overflowWrap: "anywhere" }}>
+    <span className="[word-break:break-word] [overflow-wrap:anywhere]">
       {errorMessage}
     </span>,
     { ...TOAST_OPTIONS, duration },
@@ -33,7 +34,7 @@ export const displayErrorToast = (error: string | null | undefined) => {
 export const displaySuccessToast = (message: string) => {
   const duration = calculateToastDuration(message, 5000);
   toast.success(
-    <span style={{ wordBreak: "break-word", overflowWrap: "anywhere" }}>
+    <span className="[word-break:break-word] [overflow-wrap:anywhere]">
       {message}
     </span>,
     { ...TOAST_OPTIONS, duration },


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Problem

A grep for `style={{` across `src/` returns ~28 hits. Many are static styles that bypass Tailwind, `tailwind-merge`, and the project's `cn()` helper, which makes the codebase inconsistent with the rest of the styling layer (Tailwind v4 + `--oh-*` CSS variables + HeroUI). A subset also embed hardcoded hex literals (`#1FBD53`, `#FF684E`) that drift from the design token system.

### Expected behavior

- Every static inline style is expressed as a Tailwind class (using `cn()` where the element already has a `className`).
- No new hardcoded hex literals are introduced. Existing hex literals tied to the status-dot palette are promoted to CSS variables in `src/tailwind.css`.
- Any remaining inline style is **only** for genuinely runtime-driven values (portal positions computed from DOM rects, drag-resized panel widths, data-driven icon colors from MCP payloads, percentage-width progress bars, prop-driven modal widths, third-party theme objects, or public-API `style` pass-throughs). Each such case carries a one-line `//` comment explaining why it cannot move to `className`.

### Acceptance criteria

- [ ] `rg "style=\{" src/` returns only annotated or pre-justified call sites.
- [ ] `rg "1FBD53|FF684E" src/` returns hits only in `src/tailwind.css` (the new variables) and `src/utils/utils.ts` (the `getStatusColor()` helper, out of scope here).
- [ ] `npx tsc --noEmit` passes.
- [ ] No visual regression in: chat message wrapping, typing-indicator stagger, all five `ConversationStatusDot` variants, `add-backend` / `edit-backend` modals, markdown inline `<code>` and fenced `<pre><code>`, toasts with long unbroken text, hidden file input, API-key modal at default and custom width.

### Out of scope

- `src/utils/utils.ts` `getStatusColor()` still returns `#FF684E`/`#FFD600`/`#BCFF8C` as raw hex; migrating those return values requires touching every caller and is a separate ticket.
- `src/components/features/markdown/code.tsx:51` and `src/components/features/files-tab/highlighted-source-view.tsx:52` keep `style={vscDarkPlus}` because that prop is a third-party `react-syntax-highlighter` theme object, not a CSS rule.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Replace static `style={{}}` props with Tailwind classes across 13 components (`root.tsx`, `hidden-file-input.tsx`, `chat-input-grip.tsx`, `browser-snapshot.tsx`, `custom-toast-handlers.tsx`, `chat-message.tsx`, `backend-form-modal.tsx`, `agent-server-ui-root.tsx`, `conversation-loading.tsx`, `markdown/code.tsx`, `typing-indicator.tsx`, `conversation-status-dot.tsx`, `conversation-status-badges.tsx`).
- Promote two previously-hardcoded hex literals (`#1FBD53`, `#FF684E`) to `--oh-status-success` / `--oh-status-error` in `src/tailwind.css` so the status-dot palette is consumable as `bg-[var(--oh-status-*)]` and stops duplicating between `conversation-status-dot.tsx` and `conversation-status-badges.tsx`.
- Annotate 15 remaining inline styles with a one-line `//` comment explaining why each one is necessarily inline (runtime portal positioning, drag-state widths, depth-driven indentation, data-driven icon colors, runtime percentages, CSS-variable plumbing, slide transforms, `react-hot-toast` API constraint, theming-scope foundation).

### Why

The codebase consistently uses Tailwind v4 + `--oh-*` CSS variables + the `cn()` helper, but a handful of components still reach for `style={{}}`. That makes class audits (and `tailwind-merge`) miss them, and embeds hex literals that drift from the design token system. This PR pulls every static case into the Tailwind layer and labels the rest so the next reader knows the inline style is deliberate.

### Notable choices

- Used `[word-break:break-word]` (arbitrary property) instead of Tailwind's stock `break-words`. The stock utility maps to `overflow-wrap: break-word` only; the existing inline rule asked for `word-break: break-word`, which is stronger. Preserving exact behavior.
- Used `p-[1em]` (em-based) instead of `p-4` (rem-based) for the `<pre>` block in `markdown/code.tsx`. The original was `padding: "1em"` — em-relative to `<pre>`'s own font-size. The two coincide at default root font-size, but `p-[1em]` is the exact equivalent.
- Did **not** reuse the existing `--oh-color-success` (`#a5e75e`) / `--oh-color-danger` (`#e76a5e`) tokens for the status dots — those are visually different colors (lime/coral vs forest-green/bright-red) and the goal here is hex removal without visual regression. Added dedicated `--oh-status-success` / `--oh-status-error` variables instead.
- For `typing-indicator.tsx` and `backend-form-modal.tsx`, used Tailwind arbitrary classes (`[animation-delay:75ms]`, `w-[720px]`). They are magic-number-shaped but local to one file each; extracting them to theme tokens would be over-abstraction for two/three call sites.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #541 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Clone the `agent-canvas` repository.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- `src/utils/utils.ts` `getStatusColor()` still returns raw hex strings — migrating those means touching every caller and is best tracked as a follow-up.
- `style={vscDarkPlus}` on `SyntaxHighlighter` stays (it's a third-party theme object, not CSS).
- `style={style}` prop pass-through on `AgentServerUIRoot` / `AgentServerUIProviders` is intentionally a public API.