### PR TITLE
refactor(frontend): use cn utility for className composition in 21 components

### DIFF
--- a/src/components/features/automations/create-instructions.tsx
+++ b/src/components/features/automations/create-instructions.tsx
@@ -4,6 +4,7 @@ import { I18nKey } from "#/i18n/declaration";
 import TerminalIcon from "#/icons/terminal.svg?react";
 import SparkleIcon from "#/icons/sparkle.svg?react";
 import ChevronDownIcon from "#/icons/chevron-down.svg?react";
+import { cn } from "#/utils/utils";
 
 const DOCS_URL =
   "https://docs.openhands.dev/openhands/usage/automations/overview";
@@ -98,9 +99,10 @@ export function CreateInstructions({
             {t(I18nKey.AUTOMATIONS$EMPTY_HOW_TO_CREATE_TITLE)}
           </span>
           <ChevronDownIcon
-            className={`size-5 text-muted transition-transform ${
-              isExpanded ? "rotate-180" : ""
-            }`}
+            className={cn(
+              "size-5 text-muted transition-transform",
+              isExpanded && "rotate-180",
+            )}
           />
         </button>
         {isExpanded && <div className="px-4 pb-4">{content}</div>}

--- a/src/components/features/automations/detail/active-status-badge.tsx
+++ b/src/components/features/automations/detail/active-status-badge.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
+import { cn } from "#/utils/utils";
 
 interface ActiveStatusBadgeProps {
   active: boolean;
@@ -13,11 +14,12 @@ export function ActiveStatusBadge({ active }: ActiveStatusBadgeProps) {
       data-testid={
         active ? "active-status-badge-active" : "active-status-badge-inactive"
       }
-      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${
+      className={cn(
+        "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium",
         active
           ? "bg-[var(--oh-success)]/15 text-[var(--oh-success)]"
-          : "bg-surface-raised text-muted"
-      }`}
+          : "bg-surface-raised text-muted",
+      )}
     >
       {active
         ? t(I18nKey.AUTOMATIONS$DETAIL$ACTIVE)

--- a/src/components/features/automations/detail/detail-skeleton.tsx
+++ b/src/components/features/automations/detail/detail-skeleton.tsx
@@ -1,6 +1,8 @@
+import { cn } from "#/utils/utils";
+
 function SkeletonBlock({ className }: { className: string }) {
   return (
-    <div className={`animate-pulse rounded bg-surface-raised ${className}`} />
+    <div className={cn("animate-pulse rounded bg-surface-raised", className)} />
   );
 }
 

--- a/src/components/features/automations/detail/run-status-badge.tsx
+++ b/src/components/features/automations/detail/run-status-badge.tsx
@@ -4,6 +4,7 @@ import CheckCircleIcon from "#/icons/check-circle.svg?react";
 import XCircleIcon from "#/icons/x-circle.svg?react";
 import ClockIcon from "#/icons/clock.svg?react";
 import { AutomationRunStatus } from "#/types/automation";
+import { cn } from "#/utils/utils";
 
 interface RunStatusBadgeProps {
   status: AutomationRunStatus;
@@ -61,7 +62,10 @@ export function RunStatusBadge({ status }: RunStatusBadgeProps) {
 
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium ${config.style}`}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium",
+        config.style,
+      )}
     >
       <StatusIcon status={status} />
       {t(config.label)}

--- a/src/components/features/automations/kebab-menu.tsx
+++ b/src/components/features/automations/kebab-menu.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import KebabVerticalIcon from "#/icons/kebab-vertical.svg?react";
+import { cn } from "#/utils/utils";
 
 export interface KebabMenuItem {
   label: string;
@@ -54,9 +55,10 @@ export function KebabMenu({ items }: KebabMenuProps) {
                 item.onClick();
                 setOpen(false);
               }}
-              className={`flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-sm hover:bg-surface-raised ${
-                item.variant === "danger" ? "text-danger" : "text-white"
-              }`}
+              className={cn(
+                "flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-sm hover:bg-surface-raised",
+                item.variant === "danger" ? "text-danger" : "text-white",
+              )}
             >
               {item.icon}
               {item.label}

--- a/src/components/features/automations/toggle-switch.tsx
+++ b/src/components/features/automations/toggle-switch.tsx
@@ -1,3 +1,5 @@
+import { cn } from "#/utils/utils";
+
 interface ToggleSwitchProps {
   enabled: boolean;
   label: string;
@@ -15,18 +17,20 @@ export function ToggleSwitch({ enabled, label, onToggle }: ToggleSwitchProps) {
         e.stopPropagation();
         onToggle();
       }}
-      className={`relative inline-flex h-[22px] w-[40px] shrink-0 cursor-pointer items-center rounded-full border transition-colors ${
+      className={cn(
+        "relative inline-flex h-[22px] w-[40px] shrink-0 cursor-pointer items-center rounded-full border transition-colors",
         enabled
           ? "border-[var(--oh-success)] bg-[var(--oh-success)]/15"
-          : "border-[var(--oh-border)] bg-surface-raised"
-      }`}
+          : "border-[var(--oh-border)] bg-surface-raised",
+      )}
     >
       <span
-        className={`inline-block size-4 rounded-full transition-transform ${
+        className={cn(
+          "inline-block size-4 rounded-full transition-transform",
           enabled
             ? "translate-x-[20px] bg-[var(--oh-success)]"
-            : "translate-x-[3px] bg-[var(--oh-muted)]"
-        }`}
+            : "translate-x-[3px] bg-[var(--oh-muted)]",
+        )}
       />
     </button>
   );

--- a/src/components/features/chat/chat-messages-skeleton.tsx
+++ b/src/components/features/chat/chat-messages-skeleton.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "#/utils/utils";
 
 const SKELETON_PATTERN = [
   { width: "w-[25%]", height: "h-4", align: "justify-end" },
@@ -15,7 +16,7 @@ const SKELETON_PATTERN = [
 function SkeletonBlock({ width, height }: { width: string; height: string }) {
   return (
     <div
-      className={`rounded-md bg-foreground/5 animate-pulse ${width} ${height}`}
+      className={cn("rounded-md bg-foreground/5 animate-pulse", width, height)}
     />
   );
 }
@@ -28,7 +29,7 @@ export function ChatMessagesSkeleton() {
       aria-label="Loading conversation"
     >
       {SKELETON_PATTERN.map((item, i) => (
-        <div key={i} className={`flex w-full ${item.align}`}>
+        <div key={i} className={cn("flex w-full", item.align)}>
           <SkeletonBlock width={item.width} height={item.height} />
         </div>
       ))}

--- a/src/components/features/chat/custom-chat-input.tsx
+++ b/src/components/features/chat/custom-chat-input.tsx
@@ -9,6 +9,7 @@ import { ChatInputGrip } from "./components/chat-input-grip";
 import { ChatInputContainer } from "./components/chat-input-container";
 import { HiddenFileInput } from "./components/hidden-file-input";
 import { useConversationStore } from "#/stores/conversation-store";
+import { cn } from "#/utils/utils";
 
 export interface CustomChatInputProps {
   disabled?: boolean;
@@ -154,7 +155,7 @@ export function CustomChatInput({
     syncCanSubmit();
   }, [syncCanSubmit]);
   return (
-    <div className={`w-full ${className}`}>
+    <div className={cn("w-full", className)}>
       {/* Hidden file input */}
       <HiddenFileInput
         fileInputRef={fileInputRef}

--- a/src/components/features/chat/generic-event-message.tsx
+++ b/src/components/features/chat/generic-event-message.tsx
@@ -4,6 +4,7 @@ import ArrowUp from "#/icons/angle-up-solid.svg?react";
 import { SuccessIndicator } from "./success-indicator";
 import { ObservationResultStatus } from "#/components/conversation-events/chat/event-content-helpers/get-observation-result";
 import { MarkdownRenderer } from "../markdown/markdown-renderer";
+import { cn } from "#/utils/utils";
 
 interface GenericEventMessageProps {
   title: React.ReactNode;
@@ -35,15 +36,17 @@ export function GenericEventMessage({
     >
       {showDetails ? (
         <ArrowUp
-          className={`h-4 w-4 inline fill-[var(--oh-muted)] ${
-            chevronPosition === "after" ? "ml-2" : "mr-2"
-          }`}
+          className={cn(
+            "h-4 w-4 inline fill-[var(--oh-muted)]",
+            chevronPosition === "after" ? "ml-2" : "mr-2",
+          )}
         />
       ) : (
         <ArrowDown
-          className={`h-4 w-4 inline fill-[var(--oh-muted)] ${
-            chevronPosition === "after" ? "ml-2" : "mr-2"
-          }`}
+          className={cn(
+            "h-4 w-4 inline fill-[var(--oh-muted)]",
+            chevronPosition === "after" ? "ml-2" : "mr-2",
+          )}
         />
       )}
     </button>

--- a/src/components/features/chat/task-tracking/status-badge.tsx
+++ b/src/components/features/chat/task-tracking/status-badge.tsx
@@ -1,4 +1,4 @@
-import { getStatusClassName } from "#/utils/utils";
+import { cn, getStatusClassName } from "#/utils/utils";
 
 interface StatusBadgeProps {
   status: string;
@@ -7,9 +7,10 @@ interface StatusBadgeProps {
 export function StatusBadge({ status }: StatusBadgeProps) {
   return (
     <span
-      className={`text-xs px-2 py-1 rounded uppercase font-semibold ${getStatusClassName(
-        status,
-      )}`}
+      className={cn(
+        "text-xs px-2 py-1 rounded uppercase font-semibold",
+        getStatusClassName(status),
+      )}
     >
       {status.replace("_", " ")}
     </span>

--- a/src/components/features/conversation-panel/budget-progress-bar.tsx
+++ b/src/components/features/conversation-panel/budget-progress-bar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "#/utils/utils";
 
 interface BudgetProgressBarProps {
   currentCost: number;
@@ -15,9 +16,10 @@ export function BudgetProgressBar({
   return (
     <div className="w-full h-1.5 bg-tertiary rounded-full overflow-hidden mt-1">
       <div
-        className={`h-full transition-all duration-300 ${
-          isNearLimit ? "bg-red-500" : "bg-blue-500"
-        }`}
+        className={cn(
+          "h-full transition-all duration-300",
+          isNearLimit ? "bg-red-500" : "bg-blue-500",
+        )}
         style={{
           width: `${Math.min(100, usagePercentage)}%`,
         }}

--- a/src/components/features/conversation-panel/hooks-modal-header.tsx
+++ b/src/components/features/conversation-panel/hooks-modal-header.tsx
@@ -3,6 +3,7 @@ import { RefreshCw } from "lucide-react";
 import { BaseModalTitle } from "#/components/shared/modals/confirmation-modals/base-modal";
 import { I18nKey } from "#/i18n/declaration";
 import { BrandButton } from "../settings/brand-button";
+import { cn } from "#/utils/utils";
 
 interface HooksModalHeaderProps {
   isAgentReady: boolean;
@@ -34,7 +35,7 @@ export function HooksModalHeader({
           >
             <RefreshCw
               size={16}
-              className={`${isRefetching ? "animate-spin" : ""}`}
+              className={cn(isRefetching && "animate-spin")}
             />
             {t(I18nKey.BUTTON$REFRESH)}
           </BrandButton>

--- a/src/components/features/conversation-panel/skills-modal-header.tsx
+++ b/src/components/features/conversation-panel/skills-modal-header.tsx
@@ -3,6 +3,7 @@ import { RefreshCw } from "lucide-react";
 import { BaseModalTitle } from "#/components/shared/modals/confirmation-modals/base-modal";
 import { I18nKey } from "#/i18n/declaration";
 import { BrandButton } from "../settings/brand-button";
+import { cn } from "#/utils/utils";
 
 interface SkillsModalHeaderProps {
   isAgentReady: boolean;
@@ -34,7 +35,7 @@ export function SkillsModalHeader({
           >
             <RefreshCw
               size={16}
-              className={`${isRefetching ? "animate-spin" : ""}`}
+              className={cn(isRefetching && "animate-spin")}
             />
             {t(I18nKey.BUTTON$REFRESH)}
           </BrandButton>

--- a/src/components/features/conversation-panel/system-message-modal/toggle-button.tsx
+++ b/src/components/features/conversation-panel/system-message-modal/toggle-button.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { Typography } from "#/ui/typography";
+import { cn } from "#/utils/utils";
 
 interface ToggleButtonProps {
   title: string;
@@ -19,7 +20,10 @@ export function ToggleButton({
       type="button"
       data-testid="toggle-button"
       onClick={onClick}
-      className={`w-full py-3 px-2 text-left flex items-center justify-between hover:bg-tertiary transition-colors ${className || ""}`}
+      className={cn(
+        "w-full py-3 px-2 text-left flex items-center justify-between hover:bg-tertiary transition-colors",
+        className,
+      )}
     >
       <div className="flex items-center">
         <Typography.Text className="font-bold text-content-2">

--- a/src/components/features/markdown/blockquote.tsx
+++ b/src/components/features/markdown/blockquote.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-icons/fa6";
 import type { IconType } from "react-icons";
 import type { AlertType } from "./remark-github-alerts";
+import { cn } from "#/utils/utils";
 
 interface AlertConfig {
   label: string;
@@ -89,12 +90,18 @@ export function blockquote({
     return (
       <div
         data-testid={`markdown-alert-${alertType}`}
-        className={`my-3 rounded-r-sm border-l-4 px-3 py-2 ${config.containerClass}`}
+        className={cn(
+          "my-3 rounded-r-sm border-l-4 px-3 py-2",
+          config.containerClass,
+        )}
       >
         <p
-          className={`flex items-center gap-2 font-semibold ${config.titleClass}`}
+          className={cn(
+            "flex items-center gap-2 font-semibold",
+            config.titleClass,
+          )}
         >
-          <Icon aria-hidden className={`shrink-0 ${config.iconClass}`} />
+          <Icon aria-hidden className={cn("shrink-0", config.iconClass)} />
           <span>{config.label}</span>
         </p>
         <div className="text-content">{children}</div>

--- a/src/components/features/settings/llm-profiles/profile-name-input.tsx
+++ b/src/components/features/settings/llm-profiles/profile-name-input.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { SettingsInput } from "#/components/features/settings/settings-input";
 import { isProfileNameValid } from "#/utils/derive-profile-name";
 import { I18nKey } from "#/i18n/declaration";
+import { cn } from "#/utils/utils";
 
 interface ProfileNameInputProps {
   testId?: string;
@@ -66,7 +67,10 @@ export const ProfileNameInput = forwardRef<
       <p
         id={describedById}
         data-testid={ruleTestId}
-        className={`text-xs ${isValid ? "text-[var(--oh-muted)]" : "text-red-400"}`}
+        className={cn(
+          "text-xs",
+          isValid ? "text-[var(--oh-muted)]" : "text-red-400",
+        )}
       >
         {t(I18nKey.SETTINGS$PROFILE_NAME_RULE)}
       </p>

--- a/src/components/shared/git-provider-icon.tsx
+++ b/src/components/shared/git-provider-icon.tsx
@@ -1,6 +1,7 @@
 import { FaBitbucket, FaGithub, FaGitlab } from "react-icons/fa6";
 import { Provider } from "#/types/settings";
 import AzureDevOpsLogo from "#/assets/branding/azure-devops-logo.svg?react";
+import { cn } from "#/utils/utils";
 
 interface GitProviderIconProps {
   gitProvider: Provider;
@@ -22,7 +23,7 @@ export function GitProviderIcon({
         <FaBitbucket size={14} className={className} />
       )}
       {gitProvider === "azure_devops" && (
-        <AzureDevOpsLogo className={`${className} w-[14px] h-[14px]`} />
+        <AzureDevOpsLogo className={cn(className, "w-[14px] h-[14px]")} />
       )}
     </>
   );

--- a/src/components/shared/hook-execution-event-message.tsx
+++ b/src/components/shared/hook-execution-event-message.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { isHookExecutionEvent } from "#/types/agent-server/type-guards";
 import { OpenHandsEvent } from "#/types/agent-server/core";
 import { GenericEventMessage } from "#/components/features/chat/generic-event-message";
+import { cn } from "#/utils/utils";
 
 interface HookExecutionEventMessageProps {
   event: OpenHandsEvent;
@@ -79,7 +80,7 @@ export function HookExecutionEventMessage({
       {event.tool_name && (
         <span className="text-[var(--oh-muted)] ml-2">({event.tool_name})</span>
       )}
-      <span className={`ml-2 px-1 py-0.5 rounded text-xs ${statusClassName}`}>
+      <span className={cn("ml-2 px-1 py-0.5 rounded text-xs", statusClassName)}>
         {statusText}
       </span>
     </span>

--- a/src/routes/device-verify.tsx
+++ b/src/routes/device-verify.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useIsAuthed } from "#/hooks/query/use-is-authed";
 import { I18nKey } from "#/i18n/declaration";
 import { H1 } from "#/ui/typography";
+import { cn } from "#/utils/utils";
 
 export default function DeviceVerify() {
   const { t } = useTranslation("openhands");
@@ -66,7 +67,10 @@ export default function DeviceVerify() {
         <div className="max-w-md w-full mx-auto p-6 bg-card rounded-lg shadow-lg">
           <div className="text-center">
             <div
-              className={`mb-4 ${verificationResult.success ? "text-green-600" : "text-red-600"}`}
+              className={cn(
+                "mb-4",
+                verificationResult.success ? "text-green-600" : "text-red-600",
+              )}
             >
               {verificationResult.success ? (
                 <svg


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

Several components in `agent-canvas` compose Tailwind CSS class names with JavaScript template literals (e.g. `` className={`base ${cond ? "a" : ""}`} ``) instead of the project's canonical `cn` utility from `src/utils/utils.ts` (`twMerge(clsx(...))`, already used in 170+ files).

This is inconsistent with project convention and has real downsides:

- Template literals leave stray spaces and dangling empty strings (`""`) when a conditional branch is empty.
- They do **not** deduplicate or resolve conflicting Tailwind utilities, so two classes targeting the same property both ship in the final string — the _first_ one wins, which is often not the intended override.
- They make `className` strings harder to read and harder to evolve.

A repo-wide grep confirmed **24 occurrences across 21 source files** in `src/`.

### Acceptance Criteria

- [ ] Every `className={\`...\`}`template literal in`src/`is replaced with`className={cn(...)}`.
- [ ] `grep -rn 'className={\`' src/` returns zero matches.
- [ ] No Tailwind class string content changes — only the composition mechanism.
- [ ] `npm run typecheck`, ESLint, and Prettier all pass.
- [ ] Existing tests for affected components continue to pass.
- [ ] TDD tests covering the conditional branches preserved by the refactor are added (deferred — separate sub-task).

### Files Touched (21)

`src/components/features/settings/llm-profiles/profile-name-input.tsx`,
`src/components/features/chat/{chat-messages-skeleton,custom-chat-input,generic-event-message}.tsx`,
`src/components/features/chat/task-tracking/status-badge.tsx`,
`src/components/features/markdown/blockquote.tsx`,
`src/components/features/conversation-panel/{hooks-modal-header,skills-modal-header,budget-progress-bar}.tsx`,
`src/components/features/conversation-panel/system-message-modal/toggle-button.tsx`,
`src/components/features/automations/{create-instructions,kebab-menu,toggle-switch}.tsx`,
`src/components/features/automations/detail/{active-status-badge,run-status-badge,detail-skeleton}.tsx`,
`src/components/shared/{git-provider-icon,hook-execution-event-message}.tsx`,
`src/routes/device-verify.tsx`.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Replace template-literal Tailwind class composition with the canonical `cn` helper (`twMerge(clsx(...))`) from `src/utils/utils.ts` across **24 sites in 21 components**.
- `cn` is already used in 170+ files; this PR removes the remaining drift so all conditional class composition flows through the same merge/dedupe path.
- No styling changes, no prop changes, no runtime-logic changes — only the composition mechanism.

### Why

`` className={`base ${cond ? "a" : ""}`} `` has three problems we keep hitting:

1. The falsy branch leaves an empty `""` token in the class string — harmless visually but noise in DOM and snapshots.
2. Conflicting Tailwind utilities (e.g. `ml-2` vs `mr-2`, `bg-red-500` vs `bg-blue-500`) both ship; without `twMerge`, the first declaration wins, which is the opposite of what authors usually intend.
3. It diverges from the convention already followed in 170+ files. Inconsistency makes onboarding and code-review noisier than it needs to be.

### What changed

For each of the 21 files:

1. Added `import { cn } from "#/utils/utils";` (or merged `cn` into the existing `#/utils/utils` import in `task-tracking/status-badge.tsx`).
2. Converted every template-literal `className={\`...\`}`to`className={cn(...)}`. Class strings are preserved verbatim.

Conversion rules applied consistently:

| Pattern in                       | Pattern out                    |
| -------------------------------- | ------------------------------ | ------- | ---------------------------------- |
| `` `base ${cond ? "a" : "b"}` `` | `cn("base", cond ? "a" : "b")` |
| `` `base ${cond ? "a" : ""}` ``  | `cn("base", cond && "a")`      |
| `` `base ${variable}` ``         | `cn("base", variable)`         |
| `` `${className                  |                                | ""}` `` | `cn(className)` (cn handles falsy) |

### Out of scope

- No changes to `cn`, `tailwind-merge`, `clsx`, or Tailwind config.
- No edits to existing class strings, color tokens, or component APIs.
- TDD tests for the conditional branches preserved by the refactor are intentionally deferred to a follow-up.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #543 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository.
2. Search the codebase for components that use template strings to compose Tailwind CSS class names.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- The diff is intentionally mechanical and surgical. Every changed line traces directly to the same refactor rule.
- The only "side change" is dropping `|| ""` in two places (`toggle-button.tsx`, formerly `${className || ""}`) — safe because `clsx`/`cn` already coerce `undefined`/`null`/`false` to no-ops.
- `task-tracking/status-badge.tsx` adds `cn` to an existing `#/utils/utils` import rather than adding a second import line.