### PR TITLE
fix(frontend): suppress Chrome DevTools .well-known probe 404 logs

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,6 +60,19 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [
+      {
+        name: "suppress-chrome-devtools-well-known",
+        apply: "serve",
+        configureServer(server) {
+          server.middlewares.use(
+            "/.well-known/appspecific/com.chrome.devtools.json",
+            (_req, res) => {
+              res.statusCode = 204;
+              res.end();
+            },
+          );
+        },
+      },
       !process.env.VITEST && !isLibraryBuild && reactRouter(),
       svgr(),
       tailwindcss(),


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description:**

Running `npm run dev:docker:dynamic` floods the terminal with React Router 404 stack traces whenever Chrome DevTools is open in the browser. Chrome auto-probes `/.well-known/appspecific/com.chrome.devtools.json` (the Automatic Workspace Folders discovery endpoint), and because the app runs in SPA mode (`ssr: false`) with no upstream middleware for `.well-known/*`, the request falls through to `@react-router/dev`'s catch-all and logs a full `ErrorResponseImpl { status: 404 }` for every probe.

### Steps to Reproduce

1. Clone `agent-canvas`.
2. Run `npm run dev:docker:dynamic`.
3. Open Chrome DevTools against the running app.
4. Observe the terminal output.

### Current Behavior

Repeated logs of the form:

```
[vite] Error: No route matches URL "/.well-known/appspecific/com.chrome.devtools.json"
[vite] at getInternalRouterError (...)
[vite] at Object.query (...)
[vite] at handleDocumentRequest (...)
[vite] No routes matched location "/.well-known/appspecific/com.chrome.devtools.json"
[vite] ErrorResponseImpl { status: 404, statusText: 'Not Found', internal: true, ... }
```

### Expected Behavior

- Request is handled gracefully without polluting the log.
- Dev server output stays focused on actionable issues.
- Production builds are unaffected.

### Root Cause

`vite.config.ts` registers `reactRouter()` first in the plugins array, and React Router's `configureServer` installs a catch-all node handler. There is no upstream middleware to short-circuit `.well-known/*`, so Chrome's probe is treated as an unmatched SPA route.

### Proposed Fix

Add a dev-only inline Vite plugin (`apply: "serve"`) to `vite.config.ts`, positioned **before** `reactRouter()` in the plugins array, that mounts a path-scoped middleware at the exact probe URL and responds with `204 No Content`. Chrome DevTools interprets 204 as "no workspace integration configured" and stops probing without further UI prompts.

### Acceptance Criteria

- [ ] `curl -i http://localhost:3001/.well-known/appspecific/com.chrome.devtools.json` returns `HTTP/1.1 204 No Content` with an empty body.
- [ ] No React Router 404 stack traces appear for this URL during `npm run dev:docker:dynamic`.
- [ ] Opening Chrome DevTools against the running app no longer produces recurring `[vite]` 404 logs.
- [ ] `npm run build` succeeds; production output is unchanged (`apply: "serve"`).

## Summary

<!-- 1-3 bullets describing what changed. -->
- Chrome DevTools auto-probes `/.well-known/appspecific/com.chrome.devtools.json` whenever the panel is open, and the request was falling through to `@react-router/dev`'s catch-all handler, producing a noisy `ErrorResponseImpl { status: 404 }` stack trace for every probe during `npm run dev:docker:dynamic`.
- Added a dev-only inline Vite plugin in `vite.config.ts`, positioned before `reactRouter()`, that mounts a path-scoped middleware at the exact probe URL and responds with `204 No Content`. Chrome treats 204 as "no workspace integration configured" and stops probing.
- `apply: "serve"` ensures the plugin is excluded from production builds.

### Why this shape

- **Plugin order matters** — Vite invokes `configureServer` hooks in plugin-array order. Mounting our middleware _before_ `reactRouter()` registers its catch-all guarantees the probe is intercepted upstream.
- **Path-scoped `server.middlewares.use(path, handler)`** — fires only for the exact probe URL; nothing else in the dev server is affected.
- **204 over `{}`** — returning an empty JSON body with 200 would invite DevTools to attempt workspace-folder integration UI. 204 cleanly opts out and emits no body.
- **Inline plugin, no helper module** — keeps the change surgical (~12 lines in one file) and matches the project's existing minimal-Vite-config style.

### Files Changed

- `vite.config.ts` — prepend a `suppress-chrome-devtools-well-known` plugin to the `plugins` array.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #545 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository.

2. Start the development server using the following command:

   ```bash
   npm run dev:docker:dynamic
   ```

3. Observe the terminal output after the server starts.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

