### PR TITLE
chore: remove SaaS references from codebase

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -205,12 +205,12 @@ flag it -- the allowlist should not grow casually.
 ### Rule 2 -- All cloud backend calls must go through `callCloudProxy`
 
 **DO NOT APPROVE** a PR that issues a direct browser `fetch` or `axios` call to the
-cloud SaaS backend (`app.all-hands.dev`) or a cloud runtime sandbox
+cloud backend (`app.all-hands.dev`) or a cloud runtime sandbox
 (`*.prod-runtime.all-hands.dev`). Both origins block CORS from `localhost`. Cloud calls
 must go through `callCloudProxy()` in `src/api/cloud/proxy.ts`, which routes them
 server-side through `/api/cloud-proxy` on the local agent-server.
 
-Correct pattern -- cloud SaaS:
+Correct pattern -- cloud:
 ```ts
 callCloudProxy({ backend, method: "GET", path: "/api/v1/app-conversations/search?..." })
 ```
@@ -237,7 +237,7 @@ return new ConversationClient(getAgentServerClientOptions()).someMethod(...);
 ```
 
 Missing the `hostOverride` on a runtime-sandbox call is a silent bug: the proxy
-will target `backend.host` (the SaaS API) instead of the actual runtime URL.
+will target `backend.host` (the cloud API) instead of the actual runtime URL.
 Flag any `callCloudProxy` call that targets a runtime URL without `hostOverride`.
 
 ## SDK Architecture Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ const data = await fetch(`/api/conversations/${id}`);
 
 ### Rule 2 -- Cloud backend routes must go through `callCloudProxy`
 
-Any call from the browser to the cloud SaaS backend (`app.all-hands.dev`) or a cloud
+Any call from the browser to the cloud backend (`app.all-hands.dev`) or a cloud
 runtime sandbox (`*.prod-runtime.all-hands.dev`) **must** go through `callCloudProxy()`
 in `src/api/cloud/proxy.ts`. These origins do not permit CORS from `localhost`;
 `callCloudProxy` POSTs the request envelope to `/api/cloud-proxy` on the local
@@ -211,7 +211,7 @@ agent-server, which forwards it server-side.
 ```ts
 import { callCloudProxy } from "../cloud/proxy";
 
-// CORRECT -- cloud SaaS endpoint
+// CORRECT -- cloud endpoint
 const result = await callCloudProxy<ResponseType>({
   backend,
   method: "GET",
@@ -235,7 +235,7 @@ const result = await axios.get(`${backend.host}/api/v1/app-conversations`);
 `callCloudProxy` key options:
 - `backend` -- the cloud `Backend` object (provides host and bearer token)
 - `hostOverride` -- override for runtime-sandbox calls; replaces `backend.host`
-- `authMode` -- `"bearer"` (default, cloud SaaS) | `"session-api-key"` (runtime sandbox) | `"none"`
+- `authMode` -- `"bearer"` (default, cloud) | `"session-api-key"` (runtime sandbox) | `"none"`
 - `sessionApiKey` -- required when `authMode === "session-api-key"`
 
 Standard cloud/local branch pattern used throughout the service layer:
@@ -412,7 +412,7 @@ return new ConversationClient(getAgentServerClientOptions()).someMethod(...);
   - The terminal tab (`components/features/terminal/terminal.tsx`) is `React.lazy`'d in `conversation-tab-content.tsx` alongside the other tabs, so xterm + addon-fit + xterm.css don't enter the conversation route's eager graph (they ship as a separate `terminal-*.js` chunk now).
   - Avoid importing app code through `#/components/conversation-events/chat` or its `event-message-components/index.ts` barrel — they exist for `lib/index.ts` (npm subpath) consumers only. Internal callers use deep paths (`./messages`, `./event-message-components/<name>`, `./event-content-helpers/should-render-event`) so Vite dev doesn't fan out the barrel.
 
-- Backend dropdown connectivity indicator: `useBackendsHealth` (`src/hooks/query/use-backends-health.ts`) polls each registered backend every 10s. Local agent-server backends are probed via `ServerClient.getServerInfo()` (`/server_info`); cloud SaaS backends are probed via `getCurrentCloudApiKey()` (`/api/keys/current` through the bundled `/api/cloud-proxy`). Verdicts are surfaced as a colored dot rendered through `DropdownOption.prefix` (added to `src/ui/dropdown/types.ts`); the trigger reads its prefix from the live `options` array (not downshift's frozen `selectedItem`) so the indicator updates without remounting. The same dot is also rendered in each row of `ManageBackendsModal`, which now opts into a one-shot re-probe for previously disabled backends so opening the modal can clear stale persisted error state when a server has recovered. Tests live in `__tests__/hooks/query/use-backends-health.test.tsx`, the `connection indicator` block of `__tests__/components/backends/backend-selector.test.tsx`, and `__tests__/components/backends/manage-backends-modal.test.tsx`.
+- Backend dropdown connectivity indicator: `useBackendsHealth` (`src/hooks/query/use-backends-health.ts`) polls each registered backend every 10s. Local agent-server backends are probed via `ServerClient.getServerInfo()` (`/server_info`); cloud backends are probed via `getCurrentCloudApiKey()` (`/api/keys/current` through the bundled `/api/cloud-proxy`). Verdicts are surfaced as a colored dot rendered through `DropdownOption.prefix` (added to `src/ui/dropdown/types.ts`); the trigger reads its prefix from the live `options` array (not downshift's frozen `selectedItem`) so the indicator updates without remounting. The same dot is also rendered in each row of `ManageBackendsModal`, which now opts into a one-shot re-probe for previously disabled backends so opening the modal can clear stale persisted error state when a server has recovered. Tests live in `__tests__/hooks/query/use-backends-health.test.tsx`, the `connection indicator` block of `__tests__/components/backends/backend-selector.test.tsx`, and `__tests__/components/backends/manage-backends-modal.test.tsx`.
 
 - Manage Backends modal: `src/components/features/backends/manage-backends-modal.tsx` lets users edit (host/name/api-key/kind) and remove existing backends, plus add new ones inline via a "+ Add Backend" footer button that opens a `BackendFormModal`. Both the dropdown footer's "Add backend" and the manage modal's "+ Add Backend" reuse `BackendFormModal` (see `backend-form-modal.tsx`), with `mode="add"` or `mode="edit"`; `AddBackendModal` is now a thin compatibility wrapper for `BackendFormModal mode="add"`. The modal is also auto-rendered (with a no-op `onClose`) by `src/root.tsx` when the active backend is unreachable, replacing the old full-screen `MissingAgentServerNotice` onboarding screen.
 

--- a/__tests__/api/agent-server-compatibility-bundled-pin.test.ts
+++ b/__tests__/api/agent-server-compatibility-bundled-pin.test.ts
@@ -54,7 +54,7 @@ describe("loadAgentServerInfo", () => {
     ];
     const overrides = callArgs[0];
 
-    // Must NOT use the cloud host — that endpoint doesn't exist on SaaS
+    // Must NOT use the cloud host — that endpoint doesn't exist on cloud
     // and would fail with a CORS preflight error.
     expect(overrides.host).toBeDefined();
     expect(overrides.host).not.toBe(cloudBackend.host);

--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -519,7 +519,7 @@ describe("AgentServerConversationService", () => {
       });
     });
 
-    it("routes readConversationFile to the SaaS file endpoint with the file_path query param", async () => {
+    it("routes readConversationFile to the cloud file endpoint with the file_path query param", async () => {
       // Arrange
       vi.mocked(axios.post).mockResolvedValue({ data: "# PLAN content" });
 

--- a/__tests__/api/cloud/conversation-create.test.ts
+++ b/__tests__/api/cloud/conversation-create.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 });
 
 describe("AgentServerConversationService cloud branch", () => {
-  it("createConversation POSTs the SaaS payload through the proxy and returns a WORKING task", async () => {
+  it("createConversation POSTs the cloud payload through the proxy and returns a WORKING task", async () => {
     vi.mocked(axios.post).mockResolvedValue({
       data: {
         id: "task-123",
@@ -72,7 +72,7 @@ describe("AgentServerConversationService cloud branch", () => {
     });
     const proxiedBody = (body as { body: Record<string, unknown> }).body;
 
-    // SaaS payload shape — flat fields, NO encrypted-settings round-trip.
+    // cloud payload shape — flat fields, NO encrypted-settings round-trip.
     expect(proxiedBody.selected_repository).toBe("user/repo");
     expect(proxiedBody.selected_branch).toBe("main");
     expect(proxiedBody.git_provider).toBe("github");

--- a/__tests__/api/cloud/conversation-delete.test.ts
+++ b/__tests__/api/cloud/conversation-delete.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 });
 
 describe("AgentServerConversationService.deleteConversation cloud branch", () => {
-  it("routes through /api/cloud-proxy to the SaaS DELETE app-conversations endpoint", async () => {
+  it("routes through /api/cloud-proxy to the cloud DELETE app-conversations endpoint", async () => {
     vi.mocked(axios.post).mockResolvedValue({ data: { success: true } });
 
     await AgentServerConversationService.deleteConversation("conv-abc");

--- a/__tests__/api/cloud/conversation-download.test.ts
+++ b/__tests__/api/cloud/conversation-download.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 });
 
 describe("AgentServerConversationService.downloadConversation cloud branch", () => {
-  it("routes through /api/cloud-proxy to the SaaS download endpoint with responseType blob and returns the Blob", async () => {
+  it("routes through /api/cloud-proxy to the cloud download endpoint with responseType blob and returns the Blob", async () => {
     const zipBlob = new Blob(["zip-bytes"], { type: "application/zip" });
     vi.mocked(axios.post).mockResolvedValue({ data: zipBlob });
 

--- a/__tests__/api/cloud/conversation-pause.test.ts
+++ b/__tests__/api/cloud/conversation-pause.test.ts
@@ -59,7 +59,7 @@ afterEach(() => {
 });
 
 describe("pauseConversation cloud branch", () => {
-  it("routes through /api/cloud-proxy to POST the SaaS sandbox pause endpoint", async () => {
+  it("routes through /api/cloud-proxy to POST the cloud sandbox pause endpoint", async () => {
     vi.spyOn(
       AgentServerConversationService,
       "batchGetAppConversations",

--- a/__tests__/api/cloud/proxy.test.ts
+++ b/__tests__/api/cloud/proxy.test.ts
@@ -66,7 +66,7 @@ describe("callCloudProxy X-Org-Id injection", () => {
     });
 
     // Assert — the upstream envelope carries the X-Org-Id of the active
-    // selection so the SaaS can scope this request to the user's
+    // selection so the cloud backend can scope this request to the user's
     // locally-chosen org without depending on user.current_org_id.
     const [, body] = vi.mocked(axios.post).mock.calls[0]!;
     expect(
@@ -78,7 +78,7 @@ describe("callCloudProxy X-Org-Id injection", () => {
     // Arrange — the BackendSelector fan-out (e.g. useAllCloudOrganizations)
     // calls callCloudProxy(b) for every registered cloud backend. Sending
     // the active backend's orgId across an unrelated API key would cause
-    // the SaaS to 403 on api_key_org_id / X-Org-Id mismatch.
+    // the cloud backend to 403 on api_key_org_id / X-Org-Id mismatch.
     setRegisteredBackends([cloudPersonal, cloudAcme]);
     setActiveSelection({
       backendId: cloudPersonal.id,

--- a/__tests__/api/cloud/sandbox-service.test.ts
+++ b/__tests__/api/cloud/sandbox-service.test.ts
@@ -36,7 +36,7 @@ afterEach(() => {
 describe("batchGetCloudSandboxes", () => {
   it("targets /api/v1/sandboxes with one id query param per sandbox id", async () => {
     // Arrange — multiple ids exercises the URLSearchParams.append path,
-    // which is the SaaS contract for batch-fetching sandboxes (the GUI
+    // which is the cloud contract for batch-fetching sandboxes (the GUI
     // reads sandbox.exposed_urls from the response to find the VSCODE
     // URL instead of asking the runtime for a localhost address).
     const ids = ["sandbox-a", "sandbox-b"];
@@ -45,7 +45,7 @@ describe("batchGetCloudSandboxes", () => {
     await batchGetCloudSandboxes(ids);
 
     // Assert — the cloud-proxy envelope encodes a GET against
-    // /api/v1/sandboxes?id=sandbox-a&id=sandbox-b on the SaaS.
+    // /api/v1/sandboxes?id=sandbox-a&id=sandbox-b on the cloud backend.
     const [, body] = vi.mocked(axios.post).mock.calls[0]!;
     const upstream = body as { method: string; path: string };
     expect(upstream.method).toBe("GET");

--- a/__tests__/components/backends/backend-selector.test.tsx
+++ b/__tests__/components/backends/backend-selector.test.tsx
@@ -168,7 +168,7 @@ describe("BackendSelector", () => {
     expect(screen.getByText("Production")).toBeInTheDocument();
   });
 
-  it("expands a cloud backend into one row per org and records the org locally without calling SaaS /switch", async () => {
+  it("expands a cloud backend into one row per org and records the org locally without calling cloud /switch", async () => {
     vi.mocked(getCloudOrganizations).mockResolvedValue({
       items: [
         { id: "org-personal", name: "Personal" },
@@ -203,7 +203,7 @@ describe("BackendSelector", () => {
     await user.click(screen.getByText("Production – Acme Inc"));
 
     // Selecting an org row updates the active selection locally only —
-    // it must never trigger the SaaS-mutating /switch call that used to
+    // it must never trigger the cloud-mutating /switch call that used to
     // leak the local-UI choice into the cloud UI's `current_org_id`.
     await waitFor(() => {
       const stored = JSON.parse(
@@ -350,7 +350,7 @@ describe("BackendSelector", () => {
 
     // After orgs + /me resolve, the selector snaps the active selection
     // onto the personal-workspace org locally — without round-tripping
-    // /switch on the SaaS (which would have mutated the cloud UI's
+    // /switch on the cloud backend (which would have mutated the cloud UI's
     // user.current_org_id as a side effect).
     await waitFor(() => {
       const stored = JSON.parse(

--- a/__tests__/components/conversation-events/chat/event-message-acp-tool-call.test.tsx
+++ b/__tests__/components/conversation-events/chat/event-message-acp-tool-call.test.tsx
@@ -8,7 +8,7 @@ import { AgentState } from "#/types/agent-state";
 import { ACPToolCallEvent } from "#/types/agent-server/core/events/acp-tool-call-event";
 
 vi.mock("#/hooks/query/use-config", () => ({
-  useConfig: () => ({ data: { APP_MODE: "saas" } }),
+  useConfig: () => ({ data: { APP_MODE: "local" } }),
 }));
 vi.mock("#/hooks/use-agent-state");
 vi.mock("#/hooks/use-conversation-id", () => ({

--- a/__tests__/hooks/mutation/use-new-conversation-command.test.tsx
+++ b/__tests__/hooks/mutation/use-new-conversation-command.test.tsx
@@ -151,7 +151,7 @@ describe("useNewConversationCommand", () => {
     await result.current.mutateAsync();
 
     await waitFor(() => {
-      // Format matches OpenHands' SaaS pattern: useTaskPolling unwraps
+      // Format matches OpenHands' cloud pattern: useTaskPolling unwraps
       // `task-{uuid}` and polls until READY, then redirects.
       expect(mockNavigate).toHaveBeenCalledWith("/conversations/task-task-789");
     });

--- a/__tests__/hooks/use-unified-vscode-url.test.tsx
+++ b/__tests__/hooks/use-unified-vscode-url.test.tsx
@@ -129,9 +129,9 @@ afterEach(() => {
 });
 
 describe("useUnifiedVSCodeUrl", () => {
-  it("returns the SaaS-computed VSCode URL from sandbox.exposed_urls in cloud mode", async () => {
+  it("returns the cloud-computed VSCode URL from sandbox.exposed_urls in cloud mode", async () => {
     // Arrange — cloud backend, sandbox returned with a VSCODE entry.
-    // This is the steady-state happy path: the SaaS pre-builds the
+    // This is the steady-state happy path: the cloud backend pre-builds the
     // public vscode subdomain URL and the GUI must surface it directly
     // instead of asking the runtime for /api/vscode/url (which only
     // knows its own localhost:8001).

--- a/src/api/agent-server-compatibility.ts
+++ b/src/api/agent-server-compatibility.ts
@@ -55,7 +55,7 @@ export function isAgentServerToolAvailable(toolName: string) {
 export async function loadAgentServerInfo() {
   // The probe is a *local* agent-server concern — it verifies the runtime
   // hosting the GUI is reachable. It must NEVER run against the active
-  // backend when that backend is cloud, because cloud SaaS hosts don't
+  // backend when that backend is cloud, because cloud hosts don't
   // expose /api/server_info and would fail with a CORS error besides.
   const local = getEffectiveLocalBackend();
   let serverInfo: AgentServerInfo;

--- a/src/api/app-preferences-store.ts
+++ b/src/api/app-preferences-store.ts
@@ -7,7 +7,7 @@ import { Settings } from "#/types/settings";
  * identity) have no native home there, so we persist them in localStorage
  * — the same approach `secrets-service.ts` uses for git provider tokens.
  *
- * In cloud mode the SaaS backend accepts these fields as flat top-level
+ * In cloud mode the cloud backend accepts these fields as flat top-level
  * keys at POST /api/v1/settings, and the cloud fetch returns them. We
  * still write through to localStorage so the values survive momentary
  * fetch failures and so the merge logic in `syncDerivedSettings` has a

--- a/src/api/backend-registry/active-store.ts
+++ b/src/api/backend-registry/active-store.ts
@@ -78,7 +78,7 @@ export function getActiveBackend(): ResolvedActiveBackend {
  *
  * Most of the GUI's services (settings reads/writes, conversation CRUD,
  * skills/MCP/secrets, etc.) speak the local agent-server's protocol —
- * they would fail against a cloud SaaS host. When the user has chosen a
+ * they would fail against a cloud host. When the user has chosen a
  * cloud backend as active, those calls fall back to the first registered
  * local backend (or the env-derived default if none exists). Cloud-only
  * call sites import `getActiveBackend` directly.

--- a/src/api/backend-registry/auth.ts
+++ b/src/api/backend-registry/auth.ts
@@ -3,7 +3,7 @@ import type { Backend } from "./types";
 /**
  * Build the auth headers to send to a backend.
  *
- * Local agent-server uses `X-Session-API-Key`. Cloud SaaS expects a bearer
+ * Local agent-server uses `X-Session-API-Key`. Cloud expects a bearer
  * token in the `Authorization` header.
  */
 export function buildAuthHeaders(backend: Backend): Record<string, string> {

--- a/src/api/cloud/auth-service.api.ts
+++ b/src/api/cloud/auth-service.api.ts
@@ -3,7 +3,7 @@ import type { Backend } from "../backend-registry/types";
 import { callCloudProxy } from "./proxy";
 
 /**
- * Cloud (SaaS) authentication probe. Routed through the bundled local
+ * Cloud authentication probe. Routed through the bundled local
  * agent-server's `/api/cloud-proxy` to avoid cross-origin browser calls.
  *
  * Returns true if the API key is accepted by the cloud backend.

--- a/src/api/cloud/conversation-service.api.ts
+++ b/src/api/cloud/conversation-service.api.ts
@@ -10,7 +10,7 @@ import type {
 import { callCloudProxy } from "./proxy";
 
 /**
- * The cloud SaaS does not always echo `selected_repository` /
+ * The cloud backend does not always echo `selected_repository` /
  * `selected_branch` / `git_provider` back from
  * `GET /api/v1/app-conversations` until its own background hydration
  * completes. We persist the selection to local storage at connect time
@@ -49,9 +49,9 @@ function getActiveCloudBackend(): Backend {
 }
 
 /**
- * Search the cloud SaaS app-conversations list. Mirrors the local
+ * Search the cloud app-conversations list. Mirrors the local
  * `AgentServerConversationService.searchConversations` interface but routes
- * through the bundled agent-server's cloud proxy and hits the SaaS
+ * through the bundled agent-server's cloud proxy and hits the cloud
  * endpoint `/api/v1/app-conversations/search`.
  */
 export async function searchCloudConversations(
@@ -101,9 +101,9 @@ export async function batchGetCloudConversations(
 }
 
 /**
- * Create a v1 app-conversation on the cloud SaaS.
+ * Create a v1 app-conversation on the cloud backend.
  *
- * Mirrors OpenHands' SaaS flow: POST /api/v1/app-conversations with the
+ * Mirrors OpenHands' cloud flow: POST /api/v1/app-conversations with the
  * `AppConversationStartRequest` payload, returning a
  * `AppConversationStartTask`. The task is initially WORKING; the caller
  * polls `getCloudAppConversationStartTask` (3s cadence per OpenHands)
@@ -111,7 +111,7 @@ export async function batchGetCloudConversations(
  * and `session_api_key` are populated) or ERROR.
  *
  * This path does NOT use encrypted-settings round-tripping. Secrets stay
- * server-side on the SaaS — the only auth carried is the cloud bearer
+ * server-side on the cloud backend — the only auth carried is the cloud bearer
  * token (via the proxy's headers), and the conversation runtime is
  * provisioned with its own ephemeral session_api_key returned in the
  * task.
@@ -130,11 +130,11 @@ export async function createCloudAppConversation(
 }
 
 /**
- * Download a v1 app-conversation as a ZIP from the cloud SaaS. Mirrors
+ * Download a v1 app-conversation as a ZIP from the cloud backend. Mirrors
  * the local `AgentServerConversationService.downloadConversation` interface but
  * routes through the bundled agent-server's cloud proxy and hits
  * `GET /api/v1/app-conversations/{id}/download`, which returns
- * `application/zip` with `Content-Disposition` set by the SaaS.
+ * `application/zip` with `Content-Disposition` set by the cloud backend.
  */
 export async function downloadCloudConversation(
   conversationId: string,
@@ -149,7 +149,7 @@ export async function downloadCloudConversation(
 }
 
 /**
- * Delete a v1 app-conversation on the cloud SaaS. Mirrors the local
+ * Delete a v1 app-conversation on the cloud backend. Mirrors the local
  * `AgentServerConversationService.deleteConversation` interface but routes
  * through the bundled agent-server's cloud proxy and hits
  * `DELETE /api/v1/app-conversations/{id}`, which returns a JSON
@@ -192,7 +192,7 @@ export async function updateCloudConversationPublicFlag(
  * Pause the cloud sandbox backing a v1 app-conversation. Mirrors
  * OpenHands' `SandboxService.pauseSandbox` — routes through the
  * bundled agent-server's cloud proxy and hits
- * `POST /api/v1/sandboxes/{sandboxId}/pause` on the SaaS, which stops
+ * `POST /api/v1/sandboxes/{sandboxId}/pause` on the cloud backend, which stops
  * the runtime owning the conversation.
  */
 export async function pauseCloudSandbox(sandboxId: string): Promise<void> {
@@ -207,7 +207,7 @@ export async function pauseCloudSandbox(sandboxId: string): Promise<void> {
 /**
  * Read a file from a cloud conversation's sandbox workspace. Mirrors
  * OpenHands' `AgentServerConversationService.readConversationFile` — hits
- * `GET /api/v1/app-conversations/{id}/file?file_path=...` on the SaaS
+ * `GET /api/v1/app-conversations/{id}/file?file_path=...` on the cloud backend
  * and returns the file content as a string.
  */
 export async function readCloudConversationFile(

--- a/src/api/cloud/organization-service.api.ts
+++ b/src/api/cloud/organization-service.api.ts
@@ -56,7 +56,7 @@ export async function getCloudOrganizations(
 /**
  * Fetch metadata for the API key used to authenticate this cloud backend.
  * The returned `orgId` is the single org the key is authorized to act on
- * (the SaaS contract: one key → one org).
+ * (the cloud contract: one key → one org).
  *
  * Legacy keys minted before per-key org binding existed cause the upstream
  * to return HTTP 400 — we surface that as `isLegacyKey: true` with a null
@@ -86,7 +86,7 @@ export async function getCurrentCloudApiKey(
 /**
  * Fetch `GET /api/organizations/{orgId}/me`. Identifies the calling user as
  * a member of `orgId`. The GUI uses `me.org_id === me.user_id` to decide
- * whether `orgId` is the user's personal workspace — that's the SaaS
+ * whether `orgId` is the user's personal workspace — that's the cloud
  * contract (the auto-generated personal-workspace org has the same id as
  * the user).
  */

--- a/src/api/cloud/proxy.ts
+++ b/src/api/cloud/proxy.ts
@@ -28,7 +28,7 @@ interface CloudProxyRequest {
    * Override the upstream host. When set, the proxy targets this host
    * instead of `backend.host`. Used for runtime-sandbox calls where the
    * upstream lives at the conversation's runtime URL (e.g.
-   * `http://<id>.prod-runtime.all-hands.dev`) rather than the SaaS API.
+   * `http://<id>.prod-runtime.all-hands.dev`) rather than the cloud API.
    * The host must still pass the proxy's allowlist server-side.
    */
   hostOverride?: string;
@@ -64,7 +64,7 @@ function buildUpstreamAuthHeaders(
 /**
  * POST a cloud-proxy envelope to the local agent-server. The local server
  * forwards the request to the upstream host server-side, which sidesteps
- * the cross-origin restrictions that would block a direct browser → SaaS
+ * the cross-origin restrictions that would block a direct browser → cloud
  * or browser → runtime-sandbox call.
  *
  * Auth headers (bearer or session-api-key) are attached server-side; they
@@ -80,10 +80,10 @@ export async function callCloudProxy<TResponse = unknown>(
   };
   // Send `X-Org-Id` so the upstream scopes per-request to the org the user
   // selected locally, instead of the user's globally-shared
-  // `current_org_id` on the SaaS. Restricted to calls against the active
+  // `current_org_id` on the cloud backend. Restricted to calls against the active
   // backend: the selector also fans out per-backend bookkeeping calls
   // (e.g. `getCloudOrganizations(b)`) that would otherwise carry the
-  // active backend's orgId across an unrelated API key, which the SaaS
+  // active backend's orgId across an unrelated API key, which the cloud backend
   // rejects when api_key_org_id and X-Org-Id disagree.
   const active = getActiveBackend();
   const orgIdHeader =

--- a/src/api/cloud/sandbox-service.api.ts
+++ b/src/api/cloud/sandbox-service.api.ts
@@ -15,9 +15,9 @@ function getActiveCloudBackend(): Backend {
  * Batch-fetch cloud sandboxes by id. Mirrors OpenHands'
  * `SandboxService.batchGetSandboxes` — routes through the bundled
  * agent-server's cloud proxy and hits `GET /api/v1/sandboxes?id=...` on
- * the SaaS, returning each `SandboxInfo` (or null if not found).
+ * the cloud backend, returning each `SandboxInfo` (or null if not found).
  *
- * The returned `SandboxInfo.exposed_urls` carry the SaaS-computed,
+ * The returned `SandboxInfo.exposed_urls` carry the cloud-computed,
  * publicly-reachable URLs for the sandbox's services (VSCODE,
  * AGENT_SERVER, WORKER_*) — the GUI reads them directly instead of
  * asking the runtime for `/api/vscode/url`, which only knows its

--- a/src/api/cloud/secrets-service.api.ts
+++ b/src/api/cloud/secrets-service.api.ts
@@ -19,7 +19,7 @@ function getActiveCloudBackend(): Backend {
 }
 
 /**
- * Walk every page of the cloud SaaS `/api/v1/secrets/search` endpoint via the
+ * Walk every page of the cloud `/api/v1/secrets/search` endpoint via the
  * bundled `/api/cloud-proxy` and return the merged list. The cloud shape
  * (name + description) matches `CustomSecretWithoutValue`, so items pass
  * through unchanged.

--- a/src/api/cloud/settings-service.api.ts
+++ b/src/api/cloud/settings-service.api.ts
@@ -10,7 +10,7 @@ import type { Backend } from "../backend-registry/types";
 import { callCloudProxy } from "./proxy";
 
 /**
- * The cloud SaaS Settings response is mostly flat — top-level fields like
+ * The cloud Settings response is mostly flat — top-level fields like
  * `llm_model`, `provider_tokens_set`, etc., rather than the nested
  * `{ agent_settings, conversation_settings }` shape the local agent-server
  * uses. We deliberately do NOT remap cloud fields into the local shape:
@@ -120,7 +120,7 @@ function deriveConversationSettings(
 }
 
 /**
- * Fetch the cloud SaaS settings and return them as a `Partial<Settings>`.
+ * Fetch the cloud settings and return them as a `Partial<Settings>`.
  *
  * Top-level fields like `provider_tokens_set` are preserved unchanged so
  * the existing `useUserProviders` → `useAppInstallations` →

--- a/src/api/cloud/skills-service.api.ts
+++ b/src/api/cloud/skills-service.api.ts
@@ -19,7 +19,7 @@ function getActiveCloudBackend(): Backend {
 }
 
 /**
- * Fetch the full list of skills from the cloud SaaS via the bundled
+ * Fetch the full list of skills from the cloud backend via the bundled
  * /api/cloud-proxy. The cloud endpoint is paginated (page_id cursor); we
  * walk all pages so the settings UI gets a complete list in one call. The
  * cloud SkillInfo shape (name/type/source/triggers) matches the GUI's

--- a/src/api/cloud/types.ts
+++ b/src/api/cloud/types.ts
@@ -1,5 +1,5 @@
 /**
- * Minimal slice of the OpenHands SaaS organization shape that the GUI needs
+ * Minimal slice of the OpenHands cloud organization shape that the GUI needs
  * to render the backend selector. Full shape lives in the OpenHands repo;
  * we keep only the fields actually read by this codebase.
  */

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -271,11 +271,11 @@ class AgentServerConversationService {
     sandboxId?: string,
   ): Promise<AppConversationStartTask> {
     if (getActiveBackend().backend.kind === "cloud") {
-      // Cloud SaaS path mirrors OpenHands' frontend: build a flat
+      // Cloud path mirrors OpenHands' frontend: build a flat
       // AppConversationStartRequest, POST /api/v1/app-conversations
       // (returns a WORKING task), and let the conversation route's
       // useTaskPolling drive it to READY. NO encrypted-settings
-      // round-trip — the SaaS holds secrets server-side.
+      // round-trip — the cloud backend holds secrets server-side.
       const request: AppConversationStartRequest = {
         initial_message: initialUserMsg
           ? {
@@ -365,7 +365,7 @@ class AgentServerConversationService {
     sessionApiKey?: string | null,
   ): Promise<GetVSCodeUrlResponse> {
     // Local-only path. Cloud conversations read the VSCode URL straight
-    // from the SaaS-computed `sandbox.exposed_urls` (see
+    // from the cloud-computed `sandbox.exposed_urls` (see
     // `useUnifiedVSCodeUrl` + `useCloudSandbox`); the runtime's own
     // `/api/vscode/url` only knows its internal `localhost:8001`, which
     // the user's browser can't reach.
@@ -452,7 +452,7 @@ class AgentServerConversationService {
     filePath?: string,
   ): Promise<string> {
     if (getActiveBackend().backend.kind === "cloud") {
-      // Cloud SaaS exposes a per-conversation file endpoint; the sandbox
+      // Cloud exposes a per-conversation file endpoint; the sandbox
       // working dir is fixed (`/workspace/project`), so PLAN.md lives at
       // a known absolute path. Mirrors OpenHands' readConversationFile.
       const path = requirePathInsideDirectory(

--- a/src/api/event-service/event-service.api.ts
+++ b/src/api/event-service/event-service.api.ts
@@ -18,11 +18,11 @@ import type {
 
 /**
  * Cloud-mode REST calls are split between two upstream hosts (matching
- * OpenHands' SaaS frontend):
+ * OpenHands' cloud frontend):
  *
  *   - **App API** (`backend.host`, default in `callCloudProxy`):
  *     event *history* (`/api/v1/conversation/{id}/events/search`).
- *     Persisted by the SaaS — survives the runtime sandbox.
+ *     Persisted by the cloud backend — survives the runtime sandbox.
  *
  *   - **Runtime sandbox** (extracted from `conversation.conversation_url`
  *     and passed as `hostOverride`): live runtime endpoints like
@@ -32,7 +32,7 @@ import type {
  *
  * Both go through the bundled local agent-server's `/api/cloud-proxy`,
  * which sidesteps the cross-origin restrictions that block the GUI at
- * `localhost` from talking directly to either the SaaS or the runtime.
+ * `localhost` from talking directly to either the cloud backend or the runtime.
  *
  * Local mode keeps the existing typescript-client path: it targets the
  * conversation's host directly via typed client classes.
@@ -110,7 +110,7 @@ class EventService {
     const limit = options.limit ?? 100;
 
     if (active.kind === "cloud") {
-      // Event *history* lives on the SaaS App API, not the runtime
+      // Event *history* lives on the cloud App API, not the runtime
       // sandbox. Path is singular `conversation` and v1-prefixed.
       //
       // Full pagination params (sort_order, page_id, timestamp filters)

--- a/src/api/settings-service/settings-service.api.ts
+++ b/src/api/settings-service/settings-service.api.ts
@@ -219,7 +219,7 @@ class SettingsService {
    * Uses in-memory cache for performance.
    */
   static async getSettings(): Promise<Settings> {
-    // Cloud SaaS uses a different settings shape (flat top-level fields
+    // Cloud uses a different settings shape (flat top-level fields
     // including provider_tokens_set, llm_model, etc.). Branch out before
     // touching the local-only cache: cloud responses bypass the local
     // SettingsApiResponse shape and feed straight into syncDerivedSettings

--- a/src/api/suggestions-service/suggestions-service.api.ts
+++ b/src/api/suggestions-service/suggestions-service.api.ts
@@ -4,7 +4,7 @@ import { getCloudSuggestedTasks } from "../cloud/suggestions-service.api";
 
 export class SuggestionsService {
   /**
-   * Aggregate suggested tasks for the calling user. Cloud SaaS exposes
+   * Aggregate suggested tasks for the calling user. Cloud exposes
    * `/api/v1/git/suggested-tasks/search` which the proxy forwards to.
    * Local agent-server has no equivalent endpoint, so we return an
    * empty list there — the home page's `<TaskSuggestions />` already

--- a/src/components/features/backends/backend-selector.tsx
+++ b/src/components/features/backends/backend-selector.tsx
@@ -73,7 +73,7 @@ function buildOptions(
         prefix,
       });
     } else {
-      // Personal-workspace rule (per the SaaS contract): the org whose
+      // Personal-workspace rule (per the cloud contract): the org whose
       // id matches the calling user's id is the user's personal
       // workspace. We resolve `user_id` once per backend (via /me on any
       // one org) and apply it across all orgs of that backend.
@@ -174,7 +174,7 @@ export function BackendSelector({
   // (UI says "Local", APIs hit cloud). When we detect the drift, snap
   // the selection onto the personal-workspace org (or, lacking a /me
   // result, the first org). The selection is recorded locally only;
-  // the SaaS request scope follows from the API key's bound org and the
+  // the cloud request scope follows from the API key's bound org and the
   // X-Org-Id header sent by `callCloudProxy`, so the cloud UI's
   // org choice is never mutated as a side effect.
   React.useEffect(() => {

--- a/src/components/features/conversation/conversation-name-context-menu.tsx
+++ b/src/components/features/conversation/conversation-name-context-menu.tsx
@@ -115,7 +115,7 @@ export function ConversationNameContextMenu({
     backend.kind === "cloud"
       ? I18nKey.COMMON$CLOSE_CONVERSATION_STOP_RUNTIME
       : I18nKey.COMMON$STOP_CONVERSATION;
-  // Public sharing is a cloud-only SaaS feature; hide it on local backends.
+  // Public sharing is a cloud-only feature; hide it on local backends.
   const shouldShowPublicSharing =
     backend.kind === "cloud" && Boolean(onTogglePublic);
 

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -63,7 +63,7 @@ export const useCreateConversation = () => {
           agentType,
         );
 
-      // OpenHands SaaS pattern: when the start task isn't immediately
+      // OpenHands cloud pattern: when the start task isn't immediately
       // READY (cloud sandbox is still provisioning),
       // app_conversation_id is null. We return a `task-{id}` URL so the
       // conversation route's useTaskPolling can drive it to READY and
@@ -91,7 +91,7 @@ export const useCreateConversation = () => {
       queryClient.invalidateQueries({
         queryKey: ["user", "conversations"],
       });
-      // The cloud SaaS path returns a start task (no app_conversation_id
+      // The cloud path returns a start task (no app_conversation_id
       // yet); the sidebar surfaces those via `useStartTasks` which doesn't
       // poll, so invalidate it explicitly so the in-flight task shows up
       // in the conversation list immediately.

--- a/src/hooks/mutation/use-delete-conversation.ts
+++ b/src/hooks/mutation/use-delete-conversation.ts
@@ -42,7 +42,7 @@ export const useDeleteConversation = () => {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["user", "conversations"] });
-      // Mirror useCreateConversation: cloud SaaS surfaces in-flight
+      // Mirror useCreateConversation: cloud surfaces in-flight
       // conversations via useStartTasks, so invalidate that key too so the
       // panel refreshes regardless of whether the deleted item was a ready
       // conversation or a still-provisioning start task.

--- a/src/hooks/mutation/use-new-conversation-command.ts
+++ b/src/hooks/mutation/use-new-conversation-command.ts
@@ -24,7 +24,7 @@ export const useNewConversationCommand = () => {
       }
 
       // /new reuses the parent conversation's sandbox (matches OpenHands
-      // SaaS behavior); it is NOT a sub-conversation, so parent_conversation_id
+      // cloud behavior); it is NOT a sub-conversation, so parent_conversation_id
       // and agent_type stay undefined.
       const startTask = await AgentServerConversationService.createConversation(
         undefined,
@@ -43,7 +43,7 @@ export const useNewConversationCommand = () => {
         );
       }
 
-      // Cloud SaaS returns a WORKING task (no app_conversation_id yet);
+      // Cloud returns a WORKING task (no app_conversation_id yet);
       // navigate to /conversations/task-{id} so useTaskPolling drives it
       // to READY. Local creates synchronously — app_conversation_id is
       // already set, so we navigate straight to it.

--- a/src/hooks/query/use-app-installations.ts
+++ b/src/hooks/query/use-app-installations.ts
@@ -36,7 +36,7 @@ export const useAppInstallations = (selectedProvider: Provider | null) => {
       !!selectedProvider &&
       // Gate on providers length too: when settings haven't yet told
       // us which providers the user has connected we must not fire,
-      // otherwise we'd hit the SaaS for a provider it can't service.
+      // otherwise we'd hit the cloud backend for a provider it can't service.
       providers.length > 0 &&
       shouldUseInstallationRepos(selectedProvider, active.backend.kind),
     staleTime: 1000 * 60 * 5, // 5 minutes

--- a/src/hooks/query/use-backends-health.ts
+++ b/src/hooks/query/use-backends-health.ts
@@ -22,7 +22,7 @@ const PROBE_TIMEOUT_MS = 4000;
  *  - Local agent-server: GET `/server_info` via the typescript-client.
  *    That's the same endpoint the root compatibility check uses, so a
  *    healthy backend always answers it.
- *  - Cloud SaaS: GET `/api/keys/current` via the bundled local
+ *  - Cloud: GET `/api/keys/current` via the bundled local
  *    agent-server's `/api/cloud-proxy`. That endpoint is lightweight,
  *    requires auth, and `getCurrentCloudApiKey` already absorbs the
  *    legacy-key 400 fallback so we treat that as "connected" too.

--- a/src/hooks/query/use-cloud-current-user-id.ts
+++ b/src/hooks/query/use-cloud-current-user-id.ts
@@ -10,7 +10,7 @@ import { useAllCloudOrganizations } from "./use-cloud-organizations";
  * Resolve the current user's `user_id` per cloud backend with one
  * `/api/organizations/{orgId}/me` call per backend (NOT one per org).
  *
- * The SaaS contract: `/me` returns `{ org_id, user_id, … }`. `user_id`
+ * The cloud contract: `/me` returns `{ org_id, user_id, … }`. `user_id`
  * is identical regardless of which org you ask, so we make a single
  * call per backend.
  *

--- a/src/hooks/query/use-cloud-organizations.ts
+++ b/src/hooks/query/use-cloud-organizations.ts
@@ -21,7 +21,7 @@ export function useAllCloudOrganizations() {
     queries: cloudBackends.map((backend) => ({
       queryKey: ["cloud-organizations", backend.id],
       // Filter the user's full org membership down to the single org the
-      // backend's API key is bound to. The SaaS enforces one-key-one-org
+      // backend's API key is bound to. The cloud enforces one-key-one-org
       // server-side (HTTP 403 otherwise); without this filter the
       // selector would advertise orgs the key cannot use. Legacy keys
       // with no binding fall through unfiltered.

--- a/src/hooks/query/use-unified-vscode-url.ts
+++ b/src/hooks/query/use-unified-vscode-url.ts
@@ -28,7 +28,7 @@ export const useUnifiedVSCodeUrl = () => {
   const sandboxId = conversation?.sandbox_id ?? null;
   const isCloud = active.backend.kind === "cloud";
 
-  // Cloud mode: read VSCode URL from the SaaS-computed `exposed_urls` on
+  // Cloud mode: read VSCode URL from the cloud-computed `exposed_urls` on
   // the conversation's sandbox. The runtime's `/api/vscode/url` only
   // knows its internal `localhost:8001`, so calling it returned a URL
   // the user's browser couldn't reach.

--- a/src/hooks/use-conversation-name-context-menu.ts
+++ b/src/hooks/use-conversation-name-context-menu.ts
@@ -150,7 +150,7 @@ export function useConversationNameContextMenu({
   const shareUrl = React.useMemo(() => {
     if (!conversationId) return "";
     // On cloud backends, the shareable URL must point at the cloud
-    // environment's host (e.g. the SaaS app domain) rather than the local
+    // environment's host (e.g. the cloud app domain) rather than the local
     // dev origin so the link works for anyone the user shares it with.
     const origin =
       backend.kind === "cloud"

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -166,7 +166,7 @@ export const getFileExtension = (fileName: string): string => {
  * (`/api/v1/git/installations/search` → `/api/v1/git/repositories/search?installation_id=…`)
  * for the given provider/backend combo.
  *
- * Mirrors OpenHands' SaaS frontend (parameterized by `app_mode`):
+ * Mirrors OpenHands' cloud frontend (parameterized by `app_mode`):
  *   - bitbucket / bitbucket_data_center → always installation-based
  *   - github → installation-based ONLY when the active backend is cloud
  *   - gitlab / azure_devops / forgejo → direct (search) flow


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

`agent-canvas` is fully open source, but the codebase still uses the term `SaaS` in 79 places across 43 files as a synonym for OpenHands' hosted cloud backend (`app.all-hands.dev`). The branding is no longer appropriate and should be removed.

### Current behavior

A repo-wide search returns 79 hits:

```bash
grep -rni "saas" --exclude-dir=node_modules --exclude-dir=.git .
# 78 occurrences of "SaaS"
# 1 occurrence of "saas" (a test mock value)
```

Distribution:

- **Docs (2 files, 7 hits):** `AGENTS.md`, `.agents/skills/custom-codereview-guide.md`
- **Source comments / JSDoc (29 files, 56 hits):** mostly under `src/api/cloud/*`, `src/api/{event,settings,suggestions,conversation}-service/*`, `src/hooks/{mutation,query}/*`, plus `src/components/features/{backends,conversation}/*` and `src/utils/utils.ts`
- **Test files (12 files, 16 hits):** test names, inline comments, and one inert mock — `APP_MODE: "saas"` in `__tests__/components/conversation-events/chat/event-message-acp-tool-call.test.tsx:11`

All references are textual (comments, JSDoc, test descriptions, doc text, one unused mock value). No exported symbol, type field, runtime branch, or API parameter is named `SaaS`/`saas`, so this is a pure documentation/wording cleanup with no behavioral change.

### Expected behavior

- Zero occurrences of `SaaS`/`saas` (case-insensitive) anywhere in the repo, excluding `node_modules`/`.git`/`dist`.
- App continues to function correctly: type-check, lint, and existing test suite all pass.

### Acceptance criteria

- [ ] `grep -rni "saas" --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist .` returns no results.
- [ ] `npm run typecheck` passes.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes with no new failures.
- [ ] Manual smoke: `npm run dev`, then exercise the backend dropdown, create/open/delete a conversation in cloud mode, and open the conversation context menu. Behavior unchanged.

### Notes

- Replacement word is `cloud` — matches the existing `backend.kind = "local" | "cloud"` vocabulary.
- The single non-comment hit (`APP_MODE: "saas"` mock) is replaced with `"local"`, matching `__tests__/components/chat/message-display-continuity.test.tsx:113`. The `APP_MODE` property isn't part of `WebClientConfig` and isn't read by any code, so the value is inert.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Replaced all 79 occurrences of `SaaS`/`saas` with `cloud` (or related phrasing) across 43 files.
- All hits were textual — comments, JSDoc, doc files, test names/comments, and one inert mock value. No exported symbol, type field, runtime branch, or API parameter changes.
- `agent-canvas` is fully open source; the `SaaS` term was a leftover from the hosted product and no longer appropriate.

#### Why

The codebase already standardizes on `backend.kind = "local" | "cloud"`. The lingering `SaaS` references duplicated that concept with inconsistent wording (`cloud SaaS backend`, `the SaaS`, `SaaS-computed`, `OpenHands' SaaS`, …). Removing them aligns the prose with the runtime vocabulary and removes the product-name reference.

#### What changed

Replacement rules applied:

| Pattern                                                       | Replacement                            |
| ------------------------------------------------------------- | -------------------------------------- |
| `cloud SaaS`                                                  | `cloud`                                |
| `Cloud SaaS` / `Cloud (SaaS)`                                 | `Cloud`                                |
| `OpenHands' SaaS` / `OpenHands SaaS`                          | `OpenHands' cloud` / `OpenHands cloud` |
| `the SaaS`                                                    | `the cloud backend`                    |
| `SaaS-computed` / `SaaS-mutating`                             | `cloud-computed` / `cloud-mutating`    |
| `SaaS <noun>` (endpoint, API, contract, payload, frontend, …) | `cloud <noun>`                         |
| `APP_MODE: "saas"` mock value                                 | `APP_MODE: "local"`                    |

The `APP_MODE: "saas"` mock at `__tests__/components/conversation-events/chat/event-message-acp-tool-call.test.tsx:11` is the only non-comment hit. `APP_MODE` is not a property of `WebClientConfig` (`src/api/option-service/option.types.ts`) and no source file reads it, so the value is inert. Replaced with `"local"` to match the existing fixture style in `__tests__/components/chat/message-display-continuity.test.tsx:113`.

#### Files touched (43)

- Docs (2): `AGENTS.md`, `.agents/skills/custom-codereview-guide.md`
- `src/api/cloud/*` (9): `conversation-service.api.ts`, `organization-service.api.ts`, `settings-service.api.ts`, `auth-service.api.ts`, `sandbox-service.api.ts`, `skills-service.api.ts`, `secrets-service.api.ts`, `proxy.ts`, `types.ts`
- `src/api/*` (non-cloud, 7): `settings-service/settings-service.api.ts`, `suggestions-service/suggestions-service.api.ts`, `event-service/event-service.api.ts`, `conversation-service/agent-server-conversation-service.api.ts`, `backend-registry/active-store.ts`, `backend-registry/auth.ts`, `app-preferences-store.ts`, `agent-server-compatibility.ts`
- `src/hooks/*` (8): `mutation/use-create-conversation.ts`, `mutation/use-delete-conversation.ts`, `mutation/use-new-conversation-command.ts`, `query/use-cloud-current-user-id.ts`, `query/use-cloud-organizations.ts`, `query/use-app-installations.ts`, `query/use-backends-health.ts`, `query/use-unified-vscode-url.ts`, `use-conversation-name-context-menu.ts`
- `src/components/*` (2): `features/backends/backend-selector.tsx`, `features/conversation/conversation-name-context-menu.tsx`
- `src/utils/utils.ts` (1)
- `__tests__/*` (12): `components/backends/backend-selector.test.tsx`, `components/conversation-events/chat/event-message-acp-tool-call.test.tsx`, `hooks/use-unified-vscode-url.test.tsx`, `hooks/mutation/use-new-conversation-command.test.tsx`, `api/agent-server-conversation-service.test.ts`, `api/agent-server-compatibility-bundled-pin.test.ts`, `api/cloud/{sandbox,conversation-pause,conversation-delete,conversation-create,proxy,conversation-download}-service.test.ts`

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #547 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository.

2. Start the development server:

   ```bash
   npm run dev
   ```

3. Search the entire codebase for the term `SaaS`.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

#### Out of scope

No new TDD tests are added in this PR. The change is purely textual (comments, JSDoc, test names, doc files, one inert mock value) and is fully covered by the existing test suite; there is no behavior to assert against. If a follow-up wants regression coverage for the rename, it can land separately.