### PR TITLE
fix(dev-docker): set AUTOMATION_WORKSPACE_BASE to the in-container path

### DIFF
--- a/bin/agent-canvas.mjs
+++ b/bin/agent-canvas.mjs
@@ -95,6 +95,12 @@ main({
   extraPrereqs: checkDockerPrereqs,
   startAgentServer: startAgentServerDocker,
   viteWorkingDir: CONTAINER_WORKSPACES_DIR,
+  // The automation backend ships `mkdir -p {work_dir} && tar xzf …` to
+  // the agent-server's bash API, so the work-dir base must be valid
+  // inside the agent-server's container. Use the in-container path
+  // (bind-mounted from the host's ~/.openhands/agent-canvas/workspaces)
+  // — the host's stateDir path doesn't exist inside the Linux container.
+  automationWorkspaceBase: CONTAINER_WORKSPACES_DIR,
   staticMode: true,
   staticDir: BUILD_DIR,
   // Agent-server runs in a Docker container; host services are reached

--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -402,6 +402,14 @@ if (isMainModule) {
     extraPrereqs: checkDockerPrereqs,
     startAgentServer: startAgentServerDocker,
     viteWorkingDir: CONTAINER_WORKSPACES_DIR,
+    // The automation backend computes per-run work dirs under this path
+    // and ships `mkdir -p` + tarball-extraction commands to the agent-
+    // server's bash API. Use the in-container path (bind-mounted from
+    // the host's ~/.openhands/agent-canvas/workspaces) so the agent-
+    // server can actually create the directory — the host's stateDir
+    // path (e.g. /Users/<user>/... on macOS) doesn't exist inside the
+    // Linux container and would fail with `Permission denied`.
+    automationWorkspaceBase: CONTAINER_WORKSPACES_DIR,
     defaultStaticMode: true,
     buildStaticFrontend: buildFrontend,
     // The agent-server runs inside a Docker container in this mode, so

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -583,7 +583,16 @@ function startAutomationBackend(config) {
         AUTOMATION_AGENT_SERVER_API_KEY: config.sessionApiKey,
         AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(config.stateDir, "automations.db")}`,
         AUTOMATION_BASE_URL: `http://localhost:${config.ingressPort}`,
-        AUTOMATION_WORKSPACE_BASE: join(config.stateDir, "workspaces"),
+        // The automation backend hands this path to the agent-server via
+        // `mkdir -p {work_dir} && tar xzf … && cd … && bash setup.sh && …`
+        // over HTTP, so the path must be valid inside the agent-server's
+        // filesystem. dev-docker.mjs overrides this with the in-container
+        // path because the agent-server runs in a Linux container where
+        // the host's stateDir (e.g. /Users/<user>/… on macOS) doesn't
+        // exist. See main()'s `automationWorkspaceBase` option.
+        AUTOMATION_WORKSPACE_BASE:
+          config.automationWorkspaceBase ??
+          join(config.stateDir, "workspaces"),
         // Local API key for self-hosted auth (no cloud API needed)
         AUTOMATION_LOCAL_API_KEY: config.localApiKey,
         // CORS: allow localhost origins for dev
@@ -871,6 +880,15 @@ async function main(options = {}) {
     // agent-server runs in a container and the host is not "localhost"
     // from its perspective.
     agentHostAlias = "localhost",
+    // Override for AUTOMATION_WORKSPACE_BASE. The automation backend
+    // generates a per-run work dir under this path and sends `mkdir -p`
+    // plus tarball-extraction commands to the agent-server's bash API,
+    // so the path must be valid *inside* the agent-server's filesystem
+    // namespace. dev-docker.mjs overrides this to the in-container path
+    // (~/.openhands/agent-canvas/workspaces, which is bind-mounted from
+    // the host) because the host's stateDir resolves to e.g. /Users/...
+    // on macOS, which doesn't exist inside the Linux container.
+    automationWorkspaceBase,
     // Human-readable label for the dev mode, surfaced in the agent's
     // <RUNTIME_SERVICES> system-prompt block.
     mode = "dev:automation",
@@ -903,6 +921,8 @@ async function main(options = {}) {
   // Build config with dynamic port allocation
   const config = await buildConfig(args);
   if (viteWorkingDir) config.viteWorkingDir = viteWorkingDir;
+  if (automationWorkspaceBase)
+    config.automationWorkspaceBase = automationWorkspaceBase;
   // Stamp the dev-mode label, host alias, and frontend kind on the config
   // so downstream helpers (Vite spawn, static build) can produce a
   // runtime-services info object describing what the agent can reach.


### PR DESCRIPTION
## Problem

Every automation run created in `dev:docker` mode (and via the published `npx @openhands/agent-canvas` CLI) fails without ever starting a conversation. Runs show `conversation_id: null` and `sandbox_id: null`, the UI surfaces "Conversation not Started", and the cron schedule fires nothing into Slack / wherever the prompt was supposed to act.

The captured stderr is the smoking gun:

```
exit_code=1
stderr: mkdir: cannot create directory '/Users': Permission denied
```

## Root cause

In `dev:docker` mode the **agent-server runs inside a Linux container** while the **automation backend runs natively on the host**. The automation backend (`backends/local.py` in `OpenHands/automation`) generates a per-run work dir under `$AUTOMATION_WORKSPACE_BASE` and ships a single bash command to the agent-server's `/api/bash/execute_bash_command` API:

```
mkdir -p {work_dir} && tar xzf {TARBALL_PATH} -C {work_dir} && cd {work_dir} && bash setup.sh && {entrypoint}
```

So **the work-dir path string is evaluated on the host but executed inside the container**. It must be valid in the agent-server's filesystem namespace.

All three docker-mode launchers (`scripts/dev-docker.mjs`, the shared `startAutomationBackend` in `scripts/dev-with-automation.mjs`, and `bin/agent-canvas.mjs`) set:

```js
AUTOMATION_WORKSPACE_BASE: join(config.stateDir, "workspaces"),
```

…where `stateDir = ${homedir()}/.openhands/agent-canvas`. On macOS this becomes `/Users/<user>/.openhands/agent-canvas/workspaces`. Inside the Linux container that path doesn't exist and the agent-server runs as a non-root user, so `mkdir -p /Users/…` fails with `Permission denied` and the entrypoint never runs. Every run then sits idle until the 10-minute timeout, gets marked FAILED (or, occasionally, COMPLETED with a null `conversation_id` if the no-op exit path is taken), and produces no observable output.

The exact same problem already existed for the frontend's working-dir handling and was solved by `viteWorkingDir: CONTAINER_WORKSPACES_DIR` — this PR applies the same pattern to the automation backend.

## Fix

The host's `~/.openhands/agent-canvas/workspaces` is **already bind-mounted into the container** at `/home/openhands/.openhands/agent-canvas/workspaces`, so we don't need new mounts or path translation — the two processes write to the same physical directory; they just need to refer to it by the path that is valid in each context.

- **`scripts/dev-with-automation.mjs`**
  - Add an `automationWorkspaceBase` option to `main()` (mirrors the existing `viteWorkingDir` knob).
  - Stash it on `config.automationWorkspaceBase`.
  - Use it in `startAutomationBackend` with a fallback to the existing host-path default, so dockerless launchers keep working unchanged.
- **`scripts/dev-docker.mjs`** — pass `automationWorkspaceBase: CONTAINER_WORKSPACES_DIR` to `main()`.
- **`bin/agent-canvas.mjs`** — same override for the published `@openhands/agent-canvas` CLI (which also dockerizes the agent-server and is affected by the same bug).

The dockerless launchers (`scripts/dev-static.mjs` and `scripts/dev-with-automation.mjs` invoked directly) are unchanged: both processes share the host filesystem and the existing default continues to work.

## Diff stats

```
 bin/agent-canvas.mjs            |  6 ++++++
 scripts/dev-docker.mjs          |  8 ++++++++
 scripts/dev-with-automation.mjs | 22 +++++++++++++++++++++-
 3 files changed, 35 insertions(+), 1 deletion(-)
```

Most of the +35 is comment lines explaining the host-vs-container path contract — the behavioural change is essentially one line per launcher.

## How to verify

1. `npm run dev:docker` on macOS (the most affected host OS).
2. Create any automation via `POST /api/automation/v1/preset/prompt`.
3. Wait for one cron tick.
4. The run should show a non-null `conversation_id` and `sandbox_id` and the entrypoint should actually execute (visible in agent-server logs).
5. Before this PR the run hits the 10-minute timeout with `mkdir: cannot create directory '/Users': Permission denied`.

## Out of scope

The `error: No such remote 'origin'` stderr seen on some runs is a separate, secondary failure inside the prompt-preset's generated `setup.sh` (probably a `git remote …` call on a workspace that wasn't initialised with an origin). It only surfaces because the `mkdir` failure was masking it — worth a follow-up against `OpenHands/automation` once this PR lands and we can see fresh runs.

---
_This PR was opened by an AI agent (OpenHands) on behalf of @tofarr, based on an interactive debugging session that traced a failing every-5-minute automation back to the host/container path mismatch._