### PR TITLE
fix(dev:docker): wire AUTOMATION_BASE_URL through agentHostAlias

### DIFF
--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -582,7 +582,16 @@ function startAutomationBackend(config) {
         AUTOMATION_AGENT_SERVER_URL: `http://localhost:${config.agentServerPort}`,
         AUTOMATION_AGENT_SERVER_API_KEY: config.sessionApiKey,
         AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(config.stateDir, "automations.db")}`,
-        AUTOMATION_BASE_URL: `http://localhost:${config.ingressPort}`,
+        // AUTOMATION_BASE_URL is the URL the automation backend stamps into
+        // the bash chain sent to the agent-server (it becomes
+        // AUTOMATION_API_URL and the callback URL). In dev:docker mode the
+        // bash chain runs *inside* the agent-server container, so it can't
+        // reach the host via "localhost" — it has to use the same alias
+        // the rest of the agent uses to talk to host services
+        // (host.docker.internal). dev-with-automation.mjs defaults
+        // agentHostAlias to "localhost", which is correct for the
+        // host-side (dockerless) mode.
+        AUTOMATION_BASE_URL: `http://${config.agentHostAlias ?? "localhost"}:${config.ingressPort}`,
         AUTOMATION_WORKSPACE_BASE: join(config.stateDir, "workspaces"),
         // Local API key for self-hosted auth (no cloud API needed)
         AUTOMATION_LOCAL_API_KEY: config.localApiKey,


### PR DESCRIPTION
_This PR was opened by an AI agent (OpenHands) on behalf of @tofarr. Please verify the empirical findings before merging._

## Symptom

On the `dev:docker` stack, every automation run failed in ~30 ms with:

```
[setup] ERROR: Failed to fetch SDK version from http://localhost:8000/api/automation/sdk-version
```

## Root cause

`dev:docker` mode runs the agent-server in a container; the automation backend runs on the host. The dispatcher tells the agent-server to execute `setup.sh`, which `curl`s `${AUTOMATION_API_URL}/sdk-version`. That env var is built from `AUTOMATION_BASE_URL`, which `dev-with-automation.mjs` hardcoded as `http://localhost:${ingressPort}`. From inside the agent-server container `localhost:8000` resolves to the agent-server itself — which doesn't serve `/api/automation/sdk-version` and returns **404**. `curl -sf` fails on the 404, setup.sh exits 1.

Confirmed empirically from inside the container (`docker exec`-equivalent):

| URL | Result |
|---|---|
| `http://localhost:8000/api/automation/sdk-version` | **404** (hits agent-server itself) |
| `http://host.docker.internal:8000/api/automation/sdk-version` | **200** |

## Fix

`main()` already accepts an `agentHostAlias` option that `dev-docker.mjs` populates with `"host.docker.internal"` (and everyone else defaults to `"localhost"`). Route `AUTOMATION_BASE_URL` through it — same pattern already used for `automationWorkspaceBase`. One line, plus comments.

Non-dockerless modes are unchanged (alias is still `"localhost"`).

## Companion PR (independent)

The verifier bug that *masked* this issue (the watchdog overwrote `error_detail` with another command's stderr, hiding the real `Failed to fetch SDK version` error) is fixed in [OpenHands/automation#122](https://github.com/OpenHands/automation/pull/122). The PRs are independent — this one fixes the operational failure; that one stops the verifier from misreporting *any* run's outcome.

This PR is also complementary to the existing `fix/automation-workspace-base-dev-docker` branch (which fixes the work-dir path); together they make `dev:docker` automations actually run end-to-end.

## Risk

Minimal. Single env-var construction change; default fallback preserves current behavior for the dockerless path.