### PR TITLE
fix(frontend): sort full visible list when ordering by Created

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -17,6 +17,7 @@ import { createRoutesStub } from "react-router";
 import React from "react";
 import { renderWithProviders } from "test-utils";
 import { ConversationPanel } from "#/components/features/conversation-panel/conversation-panel";
+import { useConversationPanelPreferencesStore } from "#/stores/conversation-panel-preferences-store";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
 import { ExecutionStatus } from "#/types/agent-server/core";
@@ -532,6 +533,75 @@ describe("ConversationPanel", () => {
       expect(searchConversationsSpy).toHaveBeenCalledWith(20, "page-2");
     });
     expect(await screen.findByText("Paged Conversation")).toBeInTheDocument();
+  });
+
+  it("orders the entire visible list by created_at when Created sort is selected, across the recent/older partition", async () => {
+    // Arrange: three conversations whose `created_at` ordering diverges
+    // from `updated_at` across the 1-hour partition cutoff. If the panel
+    // honored only the within-bucket sort, "Old Touched" (created 10d ago
+    // but touched 30m ago) would render in the recent bucket *above* the
+    // "Mid Stale" / "Newest Stale" entries that live in the older bucket
+    // but were created more recently. Created-sort must order the whole
+    // visible list by `created_at`, not just within each partition.
+    const now = Date.now();
+    const isoMinutesAgo = (m: number) =>
+      new Date(now - m * 60 * 1000).toISOString();
+    const isoDaysAgo = (d: number) =>
+      new Date(now - d * 24 * 60 * 60 * 1000).toISOString();
+
+    useConversationPanelPreferencesStore.setState({
+      conversationSort: "updated",
+      organizeMode: "chronological",
+      showOlderConversations: true,
+    });
+
+    vi.spyOn(
+      AgentServerConversationService,
+      "searchConversations",
+    ).mockResolvedValue({
+      items: [
+        createMockConversation({
+          id: "old-touched",
+          title: "Old Touched",
+          created_at: isoDaysAgo(10),
+          updated_at: isoMinutesAgo(30),
+        }),
+        createMockConversation({
+          id: "newest-stale",
+          title: "Newest Stale",
+          created_at: isoDaysAgo(1),
+          updated_at: isoDaysAgo(1),
+        }),
+        createMockConversation({
+          id: "mid-stale",
+          title: "Mid Stale",
+          created_at: isoDaysAgo(3),
+          updated_at: isoDaysAgo(3),
+        }),
+      ],
+      next_page_id: null,
+    });
+
+    const user = userEvent.setup();
+    renderConversationPanel();
+    await screen.findByText("Old Touched");
+
+    // Act: open the filter menu and switch sort to Created.
+    await user.click(screen.getByTestId("older-conversations-filter-toggle"));
+    await user.click(
+      screen.getByRole("menuitemradio", {
+        name: /CONVERSATION_PANEL\$SORT_CREATED/,
+      }),
+    );
+
+    // Assert: rendered cards are in strict created_at desc order across
+    // the full visible list, regardless of which partition they came from.
+    const cards = await screen.findAllByTestId("conversation-card");
+    expect(cards.map((card) => card.textContent ?? "")).toEqual([
+      expect.stringContaining("Newest Stale"),
+      expect.stringContaining("Mid Stale"),
+      expect.stringContaining("Old Touched"),
+    ]);
   });
 
   it("should cancel stopping a conversation", async () => {

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -191,15 +191,18 @@ export function ConversationPanel({
     [scopedConversations],
   );
 
-  const sortedRecent = React.useMemo(
-    () => sortConversationsByField(recentScoped, conversationSort),
-    [recentScoped, conversationSort],
-  );
-
-  const sortedOlder = React.useMemo(
-    () => sortConversationsByField(olderScoped, conversationSort),
-    [olderScoped, conversationSort],
-  );
+  // Sort the full visible set as one list. The recent/older partition is
+  // still computed (it gates the "Show older" toggle and "Load more"
+  // visibility), but the rendering must not use it as a visual boundary —
+  // when sorting by `created`, a stale-but-recently-touched conversation
+  // would otherwise land in `recent` and render above an actually-newer-
+  // by-`created_at` conversation sitting in `older`.
+  const sortedVisibleConversations = React.useMemo(() => {
+    const visible = showOlderConversations
+      ? [...recentScoped, ...olderScoped]
+      : recentScoped;
+    return sortConversationsByField(visible, conversationSort);
+  }, [recentScoped, olderScoped, showOlderConversations, conversationSort]);
 
   const groupLabels = React.useMemo(
     () => ({
@@ -248,9 +251,7 @@ export function ConversationPanel({
     [conversationSort, recentScoped],
   );
 
-  const visibleFlatCount =
-    sortedRecent.length +
-    (!compact && showOlderConversations ? sortedOlder.length : 0);
+  const visibleFlatCount = sortedVisibleConversations.length;
 
   const visibleGroupedCount = React.useMemo(() => {
     if (!conversationGroups) {
@@ -631,12 +632,7 @@ export function ConversationPanel({
         {!showInitialSkeleton &&
         !compact &&
         organizeMode === "chronological" ? (
-          <>
-            {sortedRecent.map(renderConversationCard)}
-            {showOlderConversations
-              ? sortedOlder.map(renderConversationCard)
-              : null}
-          </>
+          <>{sortedVisibleConversations.map(renderConversationCard)}</>
         ) : null}
 
         {/* Explicit "Load more" trigger. Only shown when more pages exist


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary

When a user opens the sidebar filter menu and selects **Sort by → Created**, the list is not strictly ordered by `created_at`. Conversations created more recently can appear *below* older conversations that were merely touched in the last hour.

### Steps to reproduce

1. Start the dev stack against persisted data:
   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```
   (this mounts `~/.openhands` into the container, so any prior conversations persist across sessions — exactly the data shape needed to reveal the bug)
2. Make sure you have at least one **older** conversation from a previous session (untouched today).
3. In the sidebar, click `<ConversationPanelNewThreadPicker />` and create one or more new conversations against any workspace.
4. Re-open one of the older conversations briefly so its `updated_at` is bumped to within the last hour, then return to the sidebar.
5. Open `<ConversationPanelFilterMenu />` → **Sort by → Created**.

### Expected

Visible list strictly ordered by `created_at` descending across the entire visible range, regardless of which partition each conversation falls into.

### Actual

The older conversation whose `updated_at` was just bumped appears *above* newly created conversations, even though those new ones have a later `created_at`.

### Root cause

`src/components/features/conversation-panel/conversation-panel.tsx` partitions the visible list into recent / older buckets by `updated_at < now − 1h`, then renders `sortedRecent` followed by `sortedOlder` as two independently-sorted lists in chronological mode. When the sort field is `created`, the boundary between the two rendered lists is still determined by `updated_at`, so the global `created_at` ordering breaks across that boundary.

The helper `sortConversationsByField` itself is correct (and unit-tested). The bug lives at the composition layer in the panel component. Grouped mode was already correct because it merges before delegating to `groupConversations`, which sorts globally.

### Fix

Render chronological mode from a single `sortedVisibleConversations` list — sort the union of `recentScoped` + (visible `olderScoped`) by the chosen field. `partitionByCutoff` is kept as-is because the "Show older conversations" toggle and "Load more" gating both still want an `updated_at`-based notion of inactivity.

### Acceptance criteria

- [ ] Created sort returns a strictly `created_at`-descending list across the recent / older boundary.
- [ ] Updated sort behavior is unchanged.
- [ ] "Show older conversations" toggle continues to hide / reveal items based on `updated_at`.
- [ ] Grouped mode ordering is unchanged.
- [ ] A regression test asserts the cross-partition `created_at` ordering and would fail against the pre-fix code.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Fix Created sort in the sidebar so the visible list is strictly ordered by `created_at` across the recent/older partition boundary.
- Replace `sortedRecent` + `sortedOlder` in chronological mode with a single `sortedVisibleConversations` memo that sorts the union of visible entries.
- Keep `partitionByCutoff` as-is so "Show older conversations" and the "Load more" trigger continue to use `updated_at` for inactivity gating.

### Why

`partitionByCutoff` always splits the list by `updated_at < now − 1h`. Chronological mode rendered the two buckets sequentially, each sorted independently by the chosen field. When the user picked **Sort by → Created**, the boundary between the rendered lists was still determined by `updated_at`, so the global `created_at` order broke whenever a conversation's `updated_at` and `created_at` straddled the cutoff differently.

Concrete failure case (now covered by a regression test):

| id            | created_at  | updated_at  | bucket | with bug renders at | should render at |
|---------------|-------------|-------------|--------|---------------------|------------------|
| Old Touched   | 10 d ago    | 30 m ago    | recent | #1                  | #3               |
| Newest Stale  | 1 d ago     | 1 d ago     | older  | #2                  | #1               |
| Mid Stale     | 3 d ago     | 3 d ago     | older  | #3                  | #2               |

The helper `sortConversationsByField` is correct on its own — the bug was at the composition layer.

### Changes

- `src/components/features/conversation-panel/conversation-panel.tsx`
  - Replace `sortedRecent` / `sortedOlder` memos with `sortedVisibleConversations`, which sorts `recentScoped` + (`olderScoped` when `showOlderConversations`) as one list.
  - Simplify `visibleFlatCount` to `sortedVisibleConversations.length`.
  - Render chronological mode from the single sorted list.
- `__tests__/components/features/conversation-panel/conversation-panel.test.tsx`
  - Add a regression test that asserts cross-partition `created_at` order. Verified to fail against the pre-fix renderer.

`partitionByCutoff`, `recentScoped`, `olderScoped`, `olderHidden`, compact mode, and grouped mode are unchanged.

### Considered alternatives

- *Re-key `partitionByCutoff` on the chosen sort field (e.g. partition by `created_at` when sort is Created).* Rejected — the "Over 1 hour" filter-menu hint describes inactivity, not creation age. Coupling partition semantics to the sort would change what the hide toggle does, and items would jump between visible and hidden as users switch sorts.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #572 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-canvas` repository and start the development server:

   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```

   This command launches the agent server inside a Docker container.

2. In the sidebar, click the `<ConversationPanelNewThreadPicker />` component.

3. Select a workspace to create a new conversation.

4. Repeat steps 2 and 3 using the same workspace to create multiple conversations.

5. Create an additional conversation using a different workspace.

6. Open the `<ConversationPanelFilterMenu />` component.

7. Select the `Created` sorting option.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/5fe7f29f-521c-4187-a16e-74557c817f60

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
