### PR TITLE
feat: add `openhands` as primary CLI command alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/OpenHands/agent-canvas/issues"
   },
   "bin": {
+    "openhands": "bin/agent-canvas.mjs",
     "agent-canvas": "bin/agent-canvas.mjs"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Adds `openhands` as a CLI bin entry so users can install and launch with:

```bash
npm install -g @openhands/agent-canvas@alpha
openhands
```

The existing `agent-canvas` command continues to work for backward compatibility. Both aliases point to the same `bin/agent-canvas.mjs` entry point.

## Changes

- Added `"openhands"` key to the `bin` field in `package.json`, listed first as the primary command

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/aba838c6-4f86-43ec-b1c7-826042dfbcc5)