### PR TITLE
fix(dev:docker): use localhost for host-side AUTOMATION_AGENT_SERVER_URL; split sandbox URL

### DIFF
--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -432,6 +432,16 @@ if (isMainModule) {
     // to the host ingress. Use the cross-container hostname instead.
     // Users can still override by setting AUTOMATION_BASE_URL.
     automationApiHost: "host.docker.internal",
+    // URL the in-sandbox bash chain uses to reach the agent-server from
+    // *inside* the agent-server container itself (where automation runs
+    // execute in local mode). The agent-server always listens on 8000
+    // inside the container (see `dockerArgs.push("-p", "<host>:8000")`
+    // above), so 127.0.0.1:8000 is the most direct route and avoids
+    // bouncing through the host port-forward (which would require
+    // host.docker.internal to resolve on the host — it doesn't on
+    // OrbStack/colima/Linux). Users can still override by setting
+    // AUTOMATION_SANDBOX_AGENT_SERVER_URL.
+    sandboxAgentServerUrl: "http://127.0.0.1:8000",
     defaultStaticMode: true,
     buildStaticFrontend: buildFrontend,
     // The agent-server runs inside a Docker container in this mode, so

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -579,29 +579,55 @@ function startAutomationBackend(config) {
     {
       cwd: config.stateDir,
       env: {
-        // The automation backend uses this to call the agent-server's REST
-        // API for uploads and bash dispatch (host-side) AND it propagates
-        // the same value into the in-sandbox bash command as the
-        // `AGENT_SERVER_URL` env var that main.py reads to connect back.
+        // The URL the automation backend itself uses to call the
+        // agent-server's REST API (tarball upload + bash dispatch). It runs
+        // on the host in every dev mode (including dev:docker), so the
+        // published agent-server port on `localhost` is always reachable.
         //
-        // In dev:docker that script runs inside the agent-server container,
-        // so the URL has to be reachable from *both* the host and the
-        // container. `host.docker.internal:${agentServerPort}` satisfies
-        // both: from the host it's a loopback alias, and from inside the
-        // container Docker's host-gateway routes back through the published
-        // port. A little wasteful (the in-container script bounces through
-        // the host port-forward) but it's the only single value that works
-        // both ways without changes to the automation backend.
+        // NOTE: we deliberately do *not* use `host.docker.internal` here,
+        // even in dev:docker. That hostname is only seeded into the host's
+        // /etc/hosts on Docker Desktop macOS; on OrbStack / colima / Linux
+        // hosts it doesn't resolve, and the dispatcher's very first
+        // `_upload` call fails with `[Errno 8] nodename nor servname
+        // provided` — dispatch never reaches `_start_bash`, so
+        // `bash_command_id` stays NULL on every run.
+        //
+        // The companion `AUTOMATION_SANDBOX_AGENT_SERVER_URL` below
+        // controls the URL exported into the in-sandbox bash chain, which
+        // does need to be reachable from inside the agent-server container.
         //
         // Priority:
         //   1. AUTOMATION_AGENT_SERVER_URL explicitly set in the user's env
-        //   2. launcher-provided host (dev-docker.mjs sets
-        //      `automationApiHost: "host.docker.internal"`)
-        //   3. `localhost` (correct for dockerless mode where backend and
-        //      agent-server both run on the host)
+        //   2. `localhost:<agentServerPort>` (the published port, works
+        //      from the host in every dev mode)
         AUTOMATION_AGENT_SERVER_URL:
           process.env.AUTOMATION_AGENT_SERVER_URL ||
-          `http://${config.automationApiHost ?? "localhost"}:${config.agentServerPort}`,
+          `http://localhost:${config.agentServerPort}`,
+        // The URL exported into the in-sandbox bash chain as
+        // `AGENT_SERVER_URL` (read by main.py / setup.sh to call back into
+        // the agent-server). Only meaningful when the bash chain runs in a
+        // different network namespace than the host — i.e. dev:docker.
+        // In that mode the bash chain runs inside the agent-server
+        // container, where the agent-server is at 127.0.0.1:8000.
+        //
+        // Requires automation backend support for
+        // AUTOMATION_SANDBOX_AGENT_SERVER_URL (OpenHands/automation#125).
+        // Older backends ignore it and fall back to
+        // AUTOMATION_AGENT_SERVER_URL.
+        //
+        // Priority:
+        //   1. AUTOMATION_SANDBOX_AGENT_SERVER_URL explicitly set in env
+        //   2. launcher-provided value (dev-docker.mjs)
+        //   3. unset — backend falls back to AUTOMATION_AGENT_SERVER_URL,
+        //      which is correct for dockerless modes
+        ...(process.env.AUTOMATION_SANDBOX_AGENT_SERVER_URL ||
+        config.sandboxAgentServerUrl
+          ? {
+              AUTOMATION_SANDBOX_AGENT_SERVER_URL:
+                process.env.AUTOMATION_SANDBOX_AGENT_SERVER_URL ||
+                config.sandboxAgentServerUrl,
+            }
+          : {}),
         AUTOMATION_AGENT_SERVER_API_KEY: config.sessionApiKey,
         AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(config.stateDir, "automations.db")}`,
         // The automation backend uses this as its publicly-reachable base
@@ -922,6 +948,14 @@ async function main(options = {}) {
     // the host ingress; dockerless mode leaves it undefined and the
     // default `localhost` applies.
     automationApiHost,
+    // Value exported as `AUTOMATION_SANDBOX_AGENT_SERVER_URL` to the
+    // automation backend. This is the URL the in-sandbox bash chain uses
+    // to reach the agent-server from *inside* whatever environment it
+    // runs in. dev-docker sets this to `http://127.0.0.1:8000` (the
+    // agent-server's in-container loopback) so the sandbox doesn't have
+    // to bounce out through the host port-forward. Dockerless modes leave
+    // it undefined and the backend falls back to AUTOMATION_AGENT_SERVER_URL.
+    sandboxAgentServerUrl,
     staticMode: staticModeOverride,
     defaultStaticMode = false,
     buildStaticFrontend,
@@ -968,6 +1002,9 @@ async function main(options = {}) {
   }
   if (automationApiHost) {
     config.automationApiHost = automationApiHost;
+  }
+  if (sandboxAgentServerUrl) {
+    config.sandboxAgentServerUrl = sandboxAgentServerUrl;
   }
   // Stamp the dev-mode label, host alias, and frontend kind on the config
   // so downstream helpers (Vite spawn, static build) can produce a


### PR DESCRIPTION
## Summary

Restore `AUTOMATION_AGENT_SERVER_URL` to `http://localhost:<hostPort>` in every dev mode (it's only ever consumed by the host-side automation backend), and introduce a new launcher option `sandboxAgentServerUrl` that gets exported as `AUTOMATION_SANDBOX_AGENT_SERVER_URL` for the in-sandbox bash chain. In `dev:docker` it is set to `http://127.0.0.1:8000` — the agent-server's own in-container loopback — so the sandbox doesn't need any cross-namespace hostname resolution.

Pairs with OpenHands/automation#125 which adds the backend half of the split.

## Why

#603 tried to make `host.docker.internal:<hostPort>` serve as a single URL that works **both** from the host (where the automation backend runs) and from inside the agent-server container (where the bash chain runs). That works on Docker Desktop on macOS, which seeds `host.docker.internal` into the host's `/etc/hosts`. It does **not** work on OrbStack, colima, or Linux hosts — `host.docker.internal` only exists inside containers there.

On those hosts the dispatcher's first call (the tarball upload) hits:

```
[Errno 8] nodename nor servname provided, or not known
```

Dispatch never reaches `_start_bash`, so every run ends with:

```
status:           FAILED
bash_command_id:  NULL
error_detail:     [Errno 8] nodename nor servname provided, or not known
```

That's exactly the breakage that was reported as "automations aren't storing bash_command_id."

## Changes

- **`scripts/dev-with-automation.mjs`**
  - Default `AUTOMATION_AGENT_SERVER_URL` is back to `http://localhost:<agentServerPort>`. The published agent-server port on `localhost` is reachable from the host in every dev mode — including dev:docker — so this is universally correct for the host-side backend.
  - New `AUTOMATION_SANDBOX_AGENT_SERVER_URL` env var, only emitted when set by the user or by a launcher (avoids regressing dockerless modes).
  - New `sandboxAgentServerUrl` option in `main()` opts, plumbed onto `config` (mirrors `automationApiHost` / `automationWorkspaceBase`).
  - Verbose comments documenting both URLs and the OrbStack failure mode.

- **`scripts/dev-docker.mjs`**
  - `sandboxAgentServerUrl: "http://127.0.0.1:8000"` — that's the agent-server's loopback address from inside its own container (it always listens on container port 8000 regardless of how the host port is mapped). The bash chain runs in the same container, so no cross-namespace hop is needed.

- Dockerless modes (`dev`, `dev:automation`) don't pass `sandboxAgentServerUrl`, so the backend falls back to `AUTOMATION_AGENT_SERVER_URL` — same behaviour as before.

## Forward / backward compatibility

- The new env var is **only** consumed by an automation backend that supports it. Older backend versions ignore the unrecognised env var and fall back to `AUTOMATION_AGENT_SERVER_URL`. With the old backend + this change in dev:docker, the user is back to the pre-#603 behaviour (the in-sandbox callback bounces through the host port-forward and may need `host.docker.internal` resolution on the host) but at least the host-side dispatch no longer fails.
- Once OpenHands/automation#125 lands and pins, dev:docker will route the in-sandbox callback through `127.0.0.1:8000` and avoid the `/etc/hosts` dependency entirely.

## Test plan

- `node --check scripts/dev-with-automation.mjs scripts/dev-docker.mjs` — clean.
- `npx vitest run __tests__/scripts/dev-static.test.ts` — passes (existing dev-static.mjs path is unchanged).
- `npx prettier --check scripts/dev-with-automation.mjs scripts/dev-docker.mjs` — clean.
- Manual: matches the env values surfaced in the live failing runs' `error_detail` column (`localhost:18000` resolves from host, `127.0.0.1:8000` resolves from inside the agent-server container).

---

_This PR was opened by an AI agent (OpenHands) on behalf of the user._
