### PR TITLE
feat(frontend): edit automations from the list row kebab

### DIFF
--- a/__tests__/routes/automations-list.test.tsx
+++ b/__tests__/routes/automations-list.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { I18nKey } from "#/i18n/declaration";
+
+import AutomationService from "#/api/automation-service/automation-service.api";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import AutomationsList from "#/routes/automations-list";
+import type { Backend } from "#/api/backend-registry/types";
+import type { Automation, AutomationsResponse } from "#/types/automation";
+
+vi.mock("#/api/automation-service/automation-service.api", () => ({
+  default: {
+    getAutomations: vi.fn(),
+    updateAutomation: vi.fn(),
+    toggleAutomation: vi.fn(),
+    deleteAutomation: vi.fn(),
+    checkHealth: vi.fn(),
+  },
+}));
+
+const localBackend: Backend = {
+  id: "local-1",
+  name: "Local 1",
+  host: "http://localhost:8000",
+  apiKey: "session-key",
+  kind: "local",
+};
+
+const cloudBackend: Backend = {
+  id: "cloud-1",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "bearer-key",
+  kind: "cloud",
+};
+
+const automation: Automation = {
+  id: "auto-1",
+  name: "Daily digest",
+  prompt: "Summarize yesterday's PRs",
+  trigger: { type: "cron", schedule: "0 9 * * *", schedule_human: "Daily" },
+  enabled: true,
+  repository: "acme/repo",
+  model: "Claude",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const listResponse: AutomationsResponse = {
+  automations: [automation],
+  total: 1,
+};
+
+function renderList() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ActiveBackendProvider>
+        <MemoryRouter initialEntries={["/automations"]}>
+          <AutomationsList />
+        </MemoryRouter>
+      </ActiveBackendProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  vi.mocked(AutomationService.checkHealth).mockReset();
+  vi.mocked(AutomationService.checkHealth).mockResolvedValue({ status: "ok" });
+  vi.mocked(AutomationService.getAutomations).mockReset();
+  vi.mocked(AutomationService.getAutomations).mockResolvedValue(listResponse);
+  vi.mocked(AutomationService.updateAutomation).mockReset();
+  setRegisteredBackends([localBackend, cloudBackend]);
+  setActiveSelection({ backendId: localBackend.id });
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+});
+
+describe("AutomationsList — Edit from the row kebab is local-only", () => {
+  it("opens the Edit modal pre-filled with the row's values when the active backend is local", async () => {
+    // Arrange — local backend is active (default beforeEach); render the list
+    // and wait for the row to appear.
+    const user = userEvent.setup();
+    renderList();
+    await waitFor(() => {
+      expect(AutomationService.getAutomations).toHaveBeenCalledTimes(1);
+    });
+    await screen.findByText(automation.name);
+
+    // Act — open the row kebab and pick Edit.
+    await user.click(screen.getByLabelText("Automation actions"));
+    await user.click(
+      screen.getByRole("button", { name: I18nKey.AUTOMATIONS$EDIT }),
+    );
+
+    // Assert — the shared Edit modal mounts wired to this row (name input is
+    // pre-filled with that row's name, proving the list page passed the right
+    // automation through).
+    const nameInput = (await screen.findByTestId(
+      "edit-automation-name",
+    )) as HTMLInputElement;
+    expect(nameInput.value).toBe(automation.name);
+  });
+
+  it("hides Edit in the row kebab when the active backend is cloud", async () => {
+    // Arrange — switch to the cloud backend before mounting so the page sees
+    // it as the active backend on first render.
+    setActiveSelection({ backendId: cloudBackend.id });
+    const user = userEvent.setup();
+    renderList();
+    await waitFor(() => {
+      expect(AutomationService.getAutomations).toHaveBeenCalledTimes(1);
+    });
+    await screen.findByText(automation.name);
+
+    // Act — open the row kebab.
+    await user.click(screen.getByLabelText("Automation actions"));
+
+    // Assert — Edit must not appear on cloud; Delete still does, proving the
+    // menu actually opened and we didn't merely fail to render it.
+    expect(
+      screen.queryByRole("button", { name: I18nKey.AUTOMATIONS$EDIT }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: I18nKey.AUTOMATIONS$DELETE }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/features/automations/automation-card.tsx
+++ b/src/components/features/automations/automation-card.tsx
@@ -12,17 +12,20 @@ import ClockIcon from "#/icons/clock.svg?react";
 import SparkleIcon from "#/icons/sparkle.svg?react";
 import PowerIcon from "#/icons/power.svg?react";
 import TrashIcon from "#/icons/trash.svg?react";
+import EditIcon from "#/icons/u-edit.svg?react";
 
 interface AutomationCardProps {
   automation: Automation;
   onToggle: (id: string, enabled: boolean) => void;
   onDelete: (id: string) => void;
+  onEdit?: (id: string) => void;
 }
 
 export function AutomationCard({
   automation,
   onToggle,
   onDelete,
+  onEdit,
 }: AutomationCardProps) {
   const { navigate } = useNavigation();
   const { t } = useTranslation("openhands");
@@ -32,6 +35,15 @@ export function AutomationCard({
     automation.trigger.schedule_human || automation.trigger.type;
 
   const menuItems: KebabMenuItem[] = [
+    ...(onEdit
+      ? [
+          {
+            label: t(I18nKey.AUTOMATIONS$EDIT),
+            icon: <EditIcon className="size-4" />,
+            onClick: () => onEdit(automation.id),
+          },
+        ]
+      : []),
     {
       label: automation.enabled
         ? t(I18nKey.AUTOMATIONS$TURN_OFF)

--- a/src/components/features/automations/automation-group.tsx
+++ b/src/components/features/automations/automation-group.tsx
@@ -8,6 +8,7 @@ interface AutomationGroupProps {
   automations: Automation[];
   onToggle: (id: string, enabled: boolean) => void;
   onDelete: (id: string) => void;
+  onEdit?: (id: string) => void;
 }
 
 export function AutomationGroup({
@@ -16,6 +17,7 @@ export function AutomationGroup({
   automations,
   onToggle,
   onDelete,
+  onEdit,
 }: AutomationGroupProps) {
   if (automations.length === 0) return null;
 
@@ -32,6 +34,7 @@ export function AutomationGroup({
             automation={automation}
             onToggle={onToggle}
             onDelete={onDelete}
+            onEdit={onEdit}
           />
         ))}
       </div>

--- a/src/routes/automations-list.tsx
+++ b/src/routes/automations-list.tsx
@@ -7,6 +7,7 @@ import {
   useDeleteAutomation,
 } from "#/hooks/query/use-automations";
 import { useAutomationHealth } from "#/hooks/query/use-automation-health";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { SearchInput } from "#/components/features/automations/search-input";
 import { AutomationGroup } from "#/components/features/automations/automation-group";
 import { AutomationCardSkeleton } from "#/components/features/automations/automation-card-skeleton";
@@ -14,7 +15,9 @@ import { EmptyState } from "#/components/features/automations/empty-state";
 import { ErrorState } from "#/components/features/automations/error-state";
 import { BackendNotConfigured } from "#/components/features/automations/backend-not-configured";
 import { DeleteConfirmationModal } from "#/components/features/automations/delete-confirmation-modal";
+import { EditAutomationModal } from "#/components/features/automations/detail/edit-automation-modal";
 import { CreateInstructions } from "#/components/features/automations/create-instructions";
+import type { Automation } from "#/types/automation";
 
 const PAGE_SIZE = 50;
 
@@ -26,6 +29,12 @@ export default function AutomationsList() {
     id: string;
     name: string;
   } | null>(null);
+  const [editTarget, setEditTarget] = useState<Automation | null>(null);
+
+  const active = useActiveBackend();
+  // Edit is a local-backend-only feature in MVP — cloud automations
+  // are managed elsewhere and we don't yet surface them here.
+  const canEdit = active.backend.kind === "local";
 
   const {
     data: healthData,
@@ -57,7 +66,10 @@ export default function AutomationsList() {
     );
   }, [data?.automations, searchQuery]);
 
-  const active = useMemo(() => filtered.filter((a) => a.enabled), [filtered]);
+  const activeAutomations = useMemo(
+    () => filtered.filter((a) => a.enabled),
+    [filtered],
+  );
   const inactive = useMemo(
     () => filtered.filter((a) => !a.enabled),
     [filtered],
@@ -71,6 +83,13 @@ export default function AutomationsList() {
     const automation = data?.automations.find((a) => a.id === id);
     if (automation) {
       setDeleteTarget({ id, name: automation.name });
+    }
+  };
+
+  const handleEditRequest = (id: string) => {
+    const automation = data?.automations.find((a) => a.id === id);
+    if (automation) {
+      setEditTarget(automation);
     }
   };
 
@@ -160,10 +179,11 @@ export default function AutomationsList() {
 
               <AutomationGroup
                 title={t(I18nKey.AUTOMATIONS$ACTIVE)}
-                count={active.length}
-                automations={active}
+                count={activeAutomations.length}
+                automations={activeAutomations}
                 onToggle={handleToggle}
                 onDelete={handleDeleteRequest}
+                onEdit={canEdit ? handleEditRequest : undefined}
               />
               <AutomationGroup
                 title={t(I18nKey.AUTOMATIONS$INACTIVE)}
@@ -171,6 +191,7 @@ export default function AutomationsList() {
                 automations={inactive}
                 onToggle={handleToggle}
                 onDelete={handleDeleteRequest}
+                onEdit={canEdit ? handleEditRequest : undefined}
               />
 
               {hasMore && (
@@ -193,6 +214,15 @@ export default function AutomationsList() {
           onConfirm={handleDeleteConfirm}
           onCancel={() => setDeleteTarget(null)}
         />
+
+        {/* Edit modal — local backends only */}
+        {editTarget && (
+          <EditAutomationModal
+            automation={editTarget}
+            isOpen={editTarget !== null}
+            onClose={() => setEditTarget(null)}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

Today, editing an automation requires clicking into its detail page first. PR #611 added an `EditAutomationModal` on the detail page; this ticket exposes the same modal directly from the Automations list page so users can rename or reschedule without an extra navigation hop.

### User story

> As an OpenHands user on a local backend, when I am scanning my list of automations at `/automations`, I want to edit any row in place from its kebab menu so I do not have to navigate into each automation just to change its name or schedule.

### Acceptance criteria

- [ ] On `/automations`, each row's kebab menu shows an **Edit** entry above **Turn on/off** and **Delete** when the active backend is local.
- [ ] Selecting **Edit** opens the same modal used on the automation detail page, pre-filled with that row's name, prompt, frequency, and time-of-day.
- [ ] Saving applies the change via the existing `useUpdateAutomation` mutation; on success the modal closes, a success toast is shown, and the list row reflects the new values (cache invalidation already handled by the hook).
- [ ] Cancel, backdrop click, and Escape close the modal without mutating.
- [ ] The **Edit** entry is **not** rendered when the active backend is `cloud`; **Turn on/off** and **Delete** remain available.
- [ ] No new i18n keys, icons, or hooks are introduced — the existing `AUTOMATIONS$EDIT` key, `u-edit.svg` icon, and `EditAutomationModal` are reused as-is.
- [ ] Automated tests cover the local-vs-cloud visibility split and the modal-wiring round-trip from the list row.

### Out of scope

- Cloud-backend editing (tracked separately as part of the MVP follow-up for cloud automation management).
- Any change to the Edit modal's internal behaviour, validation, or schedule parsing.
- Inline / row-level editing without a modal.

### Notes for the implementer

- Mirror the prop-drilling pattern already used for `onDelete`: thread an optional `onEdit?: (id: string) => void` through `AutomationGroup` → `AutomationCard`.
- Hoist modal state to `routes/automations-list.tsx` the same way `deleteTarget` is hoisted, so the local-vs-cloud check lives in one place and a single modal instance is reused across cards.
- Local-vs-cloud detection: `useActiveBackend().backend.kind === "local"` (see `src/contexts/active-backend-context.tsx`).

## Summary

<!-- 1-3 bullets describing what changed. -->
- Adds an optional `onEdit` prop to `AutomationCard` / `AutomationGroup` that, when provided, prepends an **Edit** entry to the row kebab menu (above Turn on/off and Delete, mirroring `DetailHeader`).
- Hoists `editTarget` state and the local-vs-cloud check (`active.backend.kind === "local"`) to `routes/automations-list.tsx`, reusing the single `EditAutomationModal` and the existing `useUpdateAutomation` mutation (which already invalidates the list cache on success).
- Adds two TDD tests in `__tests__/routes/automations-list.test.tsx` covering visibility and modal wiring; no changes to the modal itself, so its existing test suite stays authoritative for its internals.

### Files changed

- `src/components/features/automations/automation-card.tsx`
- `src/components/features/automations/automation-group.tsx`
- `src/routes/automations-list.tsx`
- `__tests__/routes/automations-list.test.tsx` (new)

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #612 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic`
2. Open <http://localhost:3001/automations>.
3. With a **local** backend selected: click the kebab on any row → confirm **Edit** appears above Turn on/off and Delete. Click it → the same modal used on the detail page opens, pre-filled with that row's values. Rename, save → modal closes, success toast appears, and the row reflects the new name.
4. Switch the backend selector to a **cloud** backend → return to `/automations` → open a row's kebab. Confirm **Edit** is no longer present; Turn on/off and Delete remain.
5. Automated coverage:
   - `npx vitest run __tests__/routes/automations-list.test.tsx`
   - Regression check: `npx vitest run __tests__/routes/automation-detail.test.tsx __tests__/components/automations/detail/edit-automation-modal.test.tsx`
   - `npm run typecheck`

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/d35bac87-a215-4d42-be55-b5183eeacacc

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- No new i18n keys, icons, or hooks — reuses `AUTOMATIONS$EDIT`, `u-edit.svg`, `EditAutomationModal`, and `useUpdateAutomation`.
- One incidental rename inside `routes/automations-list.tsx`: the existing `active` memo (enabled automations) was renamed to `activeAutomations` to free up the `active` identifier for the new `useActiveBackend()` binding. No behaviour change.
- Cloud-backend Edit support remains out of scope for MVP; tracked separately.