### PR TITLE
fix(frontend): transparent background for automation detail prompt section

### DIFF
--- a/src/components/features/automations/detail/prompt-section.tsx
+++ b/src/components/features/automations/detail/prompt-section.tsx
@@ -15,11 +15,9 @@ export function PromptSection({ prompt }: PromptSectionProps) {
       icon={<TerminalIcon className="size-4" />}
       title={t(I18nKey.AUTOMATIONS$DETAIL$PROMPT)}
     >
-      <div className="rounded-xl bg-[var(--oh-surface-deep)]">
-        <p className="whitespace-pre-wrap text-sm leading-6 text-content">
-          {prompt}
-        </p>
-      </div>
+      <p className="whitespace-pre-wrap text-sm leading-6 text-content">
+        {prompt}
+      </p>
     </SectionCard>
   );
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description:**

On the Automation detail page (`/automations/[id]`), the prompt text is rendered inside an inner container with a near-black background (`#05070A`) that visually clashes with the surrounding `SectionCard`. The prompt section should match the visual treatment of the sibling sections (Configuration, Activity, Activity Log), which render their content directly on the card with a transparent background.

**Steps to reproduce:**

1. Start the dev environment:
   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```
2. Open the Automations page from the sidebar: `http://localhost:3001/automations`.
3. Open any automation's detail page.

**Current behavior:**

The prompt text (e.g. `Print the text "Hello OpenHands" using Python print statement`) appears inside a dark, nearly-black box nested inside the card.

**Expected behavior:**

The prompt text should sit flush with the card background (transparent inner container), consistent with the Configuration, Activity, and Activity Log sections on the same page.

**Root cause:**

In `src/components/features/automations/detail/prompt-section.tsx`, the prompt `<p>` is wrapped in a `<div className="rounded-xl bg-[var(--oh-surface-deep)]">`. The `--oh-surface-deep` token (`var(--cool-grey-975)` = `#05070A`) is documented for "deep inset, context menus" use cases — not for read-only sections already nested inside a `SectionCard` (which uses `--oh-surface` = `#21252F`). The regression was introduced when the prompt-section wrapper was migrated from `bg-muted-overlay` to `bg-[var(--oh-surface-deep)]` during the cool-grey palette / token-system cleanup.

**Acceptance criteria:**

- The prompt text in the automation detail page renders with a transparent background that matches the surrounding `SectionCard`.
- Multi-line prompts continue to wrap and preserve newlines.
- No other section on the detail page changes visually.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Remove the inner `<div className="rounded-xl bg-[var(--oh-surface-deep)]">` wrapper in `PromptSection`, so the prompt text inherits the surrounding `SectionCard` background.
- Aligns the prompt section's visual treatment with the sibling sections on the automation detail page (Configuration, Activity, Activity Log), which render content directly on the card.

### Why

`--oh-surface-deep` (`#05070A`) is intended for deeply-inset surfaces (context menus, etc.) — using it inside a `SectionCard` produces a near-black box that visually clashes with the rest of the page. The wrapper was introduced during the cool-grey palette / token-system cleanup but was the only section to add an inner colored container.

### Screenshots

| Before | After |
| --- | --- |
| Prompt text inside a dark `#05070A` box | Prompt text flush with the card background |

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #614 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Start the dev environment:
   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```
2. Open the Automations page from the sidebar: `http://localhost:3001/automations`.
3. Open any automation's detail page.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="838" alt="app-1839" src="https://github.com/user-attachments/assets/0e592e64-3a3c-4a72-aafb-372f59cb009e" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
