### PR TITLE
fix(frontend): align LLM profile switcher styling with Tools button

### DIFF
--- a/src/components/features/chat/switch-profile-button.tsx
+++ b/src/components/features/chat/switch-profile-button.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Typography } from "#/ui/typography";
 import { I18nKey } from "#/i18n/declaration";
 import ChevronDownSmallIcon from "#/icons/chevron-down-small.svg?react";
 import { useLlmProfiles } from "#/hooks/query/use-llm-profiles";
@@ -8,6 +7,7 @@ import { useSwitchLlmProfileAndLog } from "#/hooks/mutation/use-switch-llm-profi
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { useModelStore } from "#/stores/model-store";
+import { cn } from "#/utils/utils";
 import { SwitchProfileContextMenu } from "./switch-profile-context-menu";
 
 export function SwitchProfileButton() {
@@ -69,16 +69,21 @@ export function SwitchProfileButton() {
         title={activeProfileModel ?? undefined}
         aria-haspopup="menu"
         aria-expanded={contextMenuOpen}
-        className="flex items-center gap-1 border border-[#4B505F] rounded-[100px] transition-opacity cursor-pointer hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed pl-2 max-w-[200px]"
+        className={cn(
+          "inline-flex items-center gap-1 rounded-[100px] border border-transparent px-1.5 text-sm font-normal leading-5 text-[var(--oh-muted)] whitespace-nowrap min-w-0 transition-[border-color,color] max-w-[200px]",
+          "hover:text-white hover:bg-white/10 cursor-pointer",
+          "disabled:opacity-50 disabled:cursor-not-allowed",
+        )}
       >
-        <Typography.Text className="text-white text-sm not-italic font-normal leading-5 truncate">
+        <span className="truncate">
           {activeProfileName ?? t(I18nKey.LLM$SELECT_MODEL_PLACEHOLDER)}
-        </Typography.Text>
+        </span>
         <ChevronDownSmallIcon
-          width={24}
-          height={24}
-          color="#ffffff"
+          width={18}
+          height={18}
+          color="currentColor"
           className="shrink-0"
+          aria-hidden
         />
       </button>
       {contextMenuOpen && (

--- a/src/components/features/chat/switch-profile-context-menu.tsx
+++ b/src/components/features/chat/switch-profile-context-menu.tsx
@@ -14,11 +14,14 @@ import { cn } from "#/utils/utils";
 import type { ProfileInfo } from "#/api/profiles-service/profiles-service.api";
 
 const rowBaseClassName = cn(
-  "w-full flex gap-3 px-3 rounded",
-  "text-start hover:bg-white/10 cursor-pointer text-nowrap",
+  "w-full flex flex-col gap-0.5 p-2 rounded",
+  "text-start hover:bg-[var(--oh-interactive-hover)] cursor-pointer text-nowrap",
 );
-const profileRowClassName = cn(rowBaseClassName, "h-auto items-start py-2.5");
-const linkRowClassName = cn(rowBaseClassName, "h-10 items-center");
+const profileRowClassName = cn(rowBaseClassName, "h-auto");
+const linkRowClassName = cn(
+  "w-full flex items-center gap-2 p-2 rounded",
+  "text-start hover:bg-[var(--oh-interactive-hover)] cursor-pointer text-nowrap",
+);
 
 interface SwitchProfileContextMenuProps {
   profiles: ProfileInfo[];
@@ -60,9 +63,9 @@ export function SwitchProfileContextMenu({
       testId="switch-profile-context-menu"
       position="top"
       alignment="left"
-      className="z-[60] left-0 mb-2 bottom-full min-w-[280px] max-h-[60vh] overflow-y-auto p-1"
+      className="z-[60] left-0 mb-2 bottom-full min-w-[280px] max-h-[60vh] overflow-y-auto"
     >
-      <div className="px-3 pt-1 pb-0.5">
+      <div className="px-2 pt-1 pb-0.5">
         <Typography.Text className="text-[11px] font-medium text-[var(--oh-text-dim)] uppercase tracking-wide leading-4">
           {t(I18nKey.SETTINGS$AVAILABLE_PROFILES)}
         </Typography.Text>
@@ -74,22 +77,37 @@ export function SwitchProfileContextMenu({
             key={profile.name}
             testId={`switch-profile-option-${profile.name}`}
             onClick={(event) => handleSelect(event, profile.name)}
-            className={cn(profileRowClassName, isActive && "bg-[#5C5D62]")}
+            className={cn(
+              profileRowClassName,
+              isActive && "bg-[var(--oh-interactive-hover)]",
+            )}
           >
-            <CircuitIcon width={16} height={16} className="shrink-0" />
             <span
-              className="flex min-w-0 flex-1 flex-col gap-0.5"
+              className="flex items-center gap-2 min-w-0"
               title={profile.model ?? undefined}
             >
-              <span className="text-sm leading-5">{profile.name}</span>
-              {profile.model && (
-                <span className="truncate text-xs leading-4 text-[var(--oh-muted)]">
-                  {profile.model}
-                </span>
+              <CircuitIcon
+                width={16}
+                height={16}
+                className="shrink-0"
+                aria-hidden
+              />
+              <span className="flex-1 truncate text-sm leading-5">
+                {profile.name}
+              </span>
+              {isActive && (
+                <CheckIcon
+                  width={14}
+                  height={14}
+                  className="shrink-0"
+                  aria-hidden
+                />
               )}
             </span>
-            {isActive && (
-              <CheckIcon width={14} height={14} className="shrink-0" />
+            {profile.model && (
+              <span className="block truncate text-xs leading-4 text-[var(--oh-muted)] pl-6">
+                {profile.model}
+              </span>
             )}
           </ContextMenuListItem>
         );


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary

<img width="1440" height="838" alt="Image" src="https://github.com/user-attachments/assets/b52f278e-58f0-46e0-8dc6-fa15e57d1e6f" />

The LLM profile switcher button rendered next to the **Tools** button in the chat input does not match the rest of the chat input controls. Its trigger button has a visible border and a different hover state, and the popover menu's icon and profile title are visually misaligned, with menu styling that diverges from other context menus.

### Steps to reproduce

1. Start the agent canvas dev environment:

   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```

2. Open the home page or any conversation page (e.g. `http://localhost:3001/conversations`).
3. In the chat input, find the **LLM profile switcher** button next to **Tools**.
4. Hover the button. Then click it to open the **AVAILABLE PROFILES** menu.

### Current behavior

- The LLM profile button shows a visible pill **border + background**, with an **opacity-only hover** that does not match the borderless muted→white hover used by **Tools**.
- The popover menu's profile icon and profile title are vertically misaligned; the icon does not sit on the same horizontal line as the profile name.
- Row padding, hover color, and the active-row highlight all use different (sometimes hardcoded) values than the **Tools** menu and the cloud **Model** popover.

### Expected behavior

- The button matches the **Tools** button: no border, no background, same `hover:text-white hover:bg-white/10` state, same chevron size and color (`currentColor`).
- The popover places the cog icon, the profile name, and the active-state checkmark on a single, vertically-centered row; the model name appears as a smaller subtitle indented underneath the profile name.
- The menu's container padding, row padding, hover color, and active-row highlight match the existing **Tools** menu and the cloud **Model** popover (`hover:bg-[var(--oh-interactive-hover)]`, design-token colors only — no hardcoded hex).

### Scope

Frontend only. No behavioral changes — profile resolution, switching, optimistic UI, disabled-while-pending, and "Open LLM settings" navigation all remain identical.

### Files touched

- `src/components/features/chat/switch-profile-button.tsx`
- `src/components/features/chat/switch-profile-context-menu.tsx`

### Acceptance criteria

- [ ] The LLM profile button in the chat input is visually indistinguishable in shape/hover from the **Tools** button.
- [ ] Opening the menu shows the cog icon, profile name, and check icon on the same row, with the model name as an indented subtitle.
- [ ] Hover, active-row, and container styling visually match **Tools** / cloud **Model** menus; no remaining hardcoded `#4B505F` / `#5C5D62` / `#ffffff`.
- [ ] Existing `switch-profile-button.test.tsx` continues to pass.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Make the LLM profile switcher trigger button visually match the **Tools** / cloud **Model** buttons in the chat input (borderless pill, `text-[var(--oh-muted)]` → `hover:text-white hover:bg-white/10`, `currentColor` chevron at 18px).
- Restructure the **AVAILABLE PROFILES** popover row so the icon, profile name, and active-state checkmark share a single horizontal centerline, with the model name as an indented subtitle underneath.
- Replace hardcoded colors (`#4B505F`, `#5C5D62`, `#ffffff`) with the same design tokens used by `ToolsContextMenu` and the cloud Model popover.

No behavior changes.

## Before / after

|                   | Before                                                                                      | After                                                                                                                                             |
| ----------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| Trigger button    | Pill with `border-[#4B505F]`, `hover:opacity-80`, hardcoded `text-white`, asymmetric `pl-2` | Borderless pill matching `ChatInputModel` and `Tools`: `border-transparent`, muted text, `hover:text-white hover:bg-white/10`, symmetric `px-1.5` |
| Menu row layout   | Icon was a sibling of a two-line column with `items-start`; rendered visually misaligned    | Row is `flex-col`; inner `flex items-center gap-2` holds `[icon] [name] [check]`; model is a subtitle indented by `pl-6` (= icon width + gap)     |
| Menu row hover    | `hover:bg-white/10`                                                                         | `hover:bg-[var(--oh-interactive-hover)]` (matches `ToolsContextMenuIconText` and the Model popover)                                               |
| Active-row color  | hardcoded `bg-[#5C5D62]`                                                                    | `bg-[var(--oh-interactive-hover)]`                                                                                                                |
| Container padding | `p-1` override on `ContextMenu`                                                             | default `py-[6px] px-1` from the shared `ContextMenu` variants                                                                                    |

## Files changed

- `src/components/features/chat/switch-profile-button.tsx`
- `src/components/features/chat/switch-profile-context-menu.tsx`

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #616 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Start the agent canvas dev environment:

   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```

2. Open the home page or any conversation page (e.g. `http://localhost:3001/conversations`).
3. In the chat input, find the **LLM profile switcher** button next to **Tools**.
4. Hover the button. Then click it to open the **AVAILABLE PROFILES** menu.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="838" alt="app-1840" src="https://github.com/user-attachments/assets/b1b92253-404a-43a2-be97-63f90dc4f236" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

