### PR TITLE
fix(frontend): restore hover highlight on automation KebabMenu items

### DIFF
--- a/src/components/features/automations/kebab-menu.tsx
+++ b/src/components/features/automations/kebab-menu.tsx
@@ -56,7 +56,7 @@ export function KebabMenu({ items }: KebabMenuProps) {
                 setOpen(false);
               }}
               className={cn(
-                "flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-sm hover:bg-surface-raised",
+                "flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-sm hover:bg-[var(--oh-interactive-hover)]",
                 item.variant === "danger" ? "text-danger" : "text-white",
               )}
             >


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

On the Automations pages, hovering over items in the `<KebabMenu />` produces no background change, breaking visual parity with every other context menu in the app.

### Steps to Reproduce

1. Start the dev environment:
   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```
2. Open `http://localhost:3001/automations`.
3. On the list page or an automation detail page, click the kebab (`⋮`) on an automation to open the context menu.
4. Hover over **Edit**, **Turn off / Turn on**, and **Delete**.

### Current Behavior

No background highlight appears on hover — the row looks identical at rest and on hover.

### Expected Behavior

Each menu item displays a visibly brighter background on hover, matching the conversation, tools, and dropdown menus elsewhere in the app.

### Root Cause

`src/components/features/automations/kebab-menu.tsx`:

- The dropdown container (line 48) is painted with `bg-surface-raised`.
- The menu-item buttons (line 59) hover to `hover:bg-surface-raised` — the **same** color as the container.

Result: the hover state visually changes nothing. This is a one-off hover color that diverges from the design-system token `var(--oh-interactive-hover)` used everywhere else (`DropdownMenu`, `ConversationNameContextMenuIconText`, etc.).

### Acceptance Criteria

- [ ] Hovering each item in the KebabMenu shows a visible background change on both the Automations list page and the detail page.
- [ ] The hover color matches the canonical `var(--oh-interactive-hover)` token used by other context menus.
- [ ] The **Delete** item retains its red (`text-danger`) text on hover.
- [ ] Tests cover open/close/item-click behavior.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The `<KebabMenu />` used on the Automations list and detail pages hovered each item to `bg-surface-raised`, but the dropdown container is already painted with `bg-surface-raised` — so the hover state was invisible.
- Replaced the menu-item hover with `hover:bg-[var(--oh-interactive-hover)]`, the same token used by `DropdownMenu` (`src/ui/dropdown/dropdown-menu.tsx`) and `ConversationNameContextMenuIconText` (`src/components/features/conversation/conversation-name-context-menu-icon-text.tsx`), giving the kebab consistent feedback with the rest of the app.
- One-line change in `src/components/features/automations/kebab-menu.tsx`; no API or call-site changes needed for `automation-card.tsx` or `detail-header.tsx`.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #618 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Start the dev environment:
   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```
2. Open `http://localhost:3001/automations`.
3. On the list page or an automation detail page, click the kebab (`⋮`) on an automation to open the context menu.
4. Hover over **Edit**, **Turn off / Turn on**, and **Delete**.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/5e21cf32-eaeb-434c-8319-3a5f0696e837

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
