### PR TITLE
fix(frontend): restore cursor-pointer on buttons after Tailwind v4 upgrade

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -154,6 +154,13 @@
   --field-shadow: var(--oh-field-shadow);
 }
 
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+}
+
 .button-base {
   @apply bg-tertiary border border-[var(--oh-border)] rounded-xs;
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

After the upgrade to Tailwind CSS v4 (`tailwindcss@4.2.4`), several interactive `<button>` elements no longer show the pointer cursor on hover. Tailwind v4's preflight removed the v3 default that applied `cursor: pointer` to buttons, so any button that didn't explicitly add the `cursor-pointer` utility now inherits the default cursor.

### Steps to Reproduce

1. Clone `agent-canvas` and start the dev environment:
   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```
2. Open `http://localhost:3001`.
3. Hover over each of the elements listed below.

### Current Behavior

The following elements do **not** show `cursor: pointer` on hover:

- `<ConversationPanelNewThreadPicker />` — new-thread folder button in the conversation panel header
- `<ConversationPanelFilterMenu />` — filter (funnel) trigger button
- `MenuRow` items inside `<ConversationPanelFilterMenu />` (organize/sort/show/metadata rows)
- "Toggle older conversations" row inside the filter menu
- "Delete all" row inside the filter menu (enabled state)
- "How to create an automation" collapsible button on the Automations list page
- "Load more" button on the Automations list page

### Expected Behavior

All non-disabled interactive buttons should display `cursor: pointer` on hover. Disabled buttons should continue to display `cursor: not-allowed`.

### Acceptance Criteria

- [ ] Pointer cursor restored on every affected button listed above.
- [ ] Disabled state (`disabled` attribute / `aria-disabled="true"`) continues to show `cursor: not-allowed`.
- [ ] Existing `disabled:cursor-not-allowed` / `cursor-not-allowed` utility overrides still take precedence.
- [ ] Functional tests added for the affected controls (no CSS assertions).

### Root Cause

Tailwind v4 dropped the v3 preflight rule that gave `<button>` `cursor: pointer` by default. The codebase relied on that default in several places.

### Proposed Fix

Add a single `@layer base` rule in `src/tailwind.css` restoring the v3 behavior for non-disabled buttons. This fixes every affected control in one place and prevents recurrence on future buttons.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Restores `cursor: pointer` on every non-disabled `<button>` and non-aria-disabled `[role="button"]` via a single base-layer rule in `src/tailwind.css`.
- Fixes the reported missing pointer cursor on `ConversationPanelNewThreadPicker`, `ConversationPanelFilterMenu` (trigger + rows), the "How to create an automation" collapsible, and several other buttons surfaced during the audit.
- Preserves existing `disabled:cursor-not-allowed` / `cursor-not-allowed` overrides — the selector excludes `:disabled` and `[aria-disabled="true"]`, and Tailwind utilities outrank the `base` layer.

### Root Cause

The project upgraded to `tailwindcss@4.2.4`. Tailwind v4's new preflight no longer applies `cursor: pointer` to `<button>` elements (v3 did). Buttons that never added the `cursor-pointer` utility silently lost their pointer cursor app-wide. The four reported components are symptoms of this single regression; a scan found additional affected buttons:

- `src/components/features/conversation-panel/conversation-panel-new-thread-picker.tsx`
- `src/components/features/conversation-panel/conversation-panel-filter-menu.tsx` (trigger, `MenuRow`, toggle-older-conversations, delete-all)
- `src/components/features/automations/create-instructions.tsx`
- `src/routes/automations-list.tsx` (Load more)

### Change

`src/tailwind.css` — add a base-layer rule:

```css
@layer base {
  button:not(:disabled),
  [role="button"]:not([aria-disabled="true"]) {
    cursor: pointer;
  }
}
```

That's the entire code change. No component files are touched.

### Why a Global Rule

- One fix covers every affected button and any future button that forgets the utility.
- Disabled-state utilities still win:
  - `:disabled` / `[aria-disabled="true"]` are explicitly excluded by the selector.
  - Tailwind utility layers outrank `base`, so any explicit `cursor-*` class continues to take precedence.
- Native `<a href>` and `<input type="submit">` already get the pointer cursor from user-agent styles; we don't need to extend the selector.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #622 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-canvas` and start the dev environment:
   ```bash
   export PROJECTS_PATH=~/Documents/openhands && npm run dev:docker:dynamic
   ```
2. Open `http://localhost:3001`.
3. Hover over each of the elements listed below.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/e3f2001f-1fff-4063-bcdf-6ce19565cc90

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

### Risk

Very low — single base-layer rule, scoped to non-disabled buttons, with utility classes still able to override.
