### PR TITLE
fix(files-tab): render HTML previews via srcDoc with allow-scripts

### DIFF
--- a/__tests__/routes/files-tab.test.tsx
+++ b/__tests__/routes/files-tab.test.tsx
@@ -367,7 +367,7 @@ describe("FilesTab", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("uses the browser preview URL as the iframe src for HTML files", async () => {
+  it("renders HTML files via srcDoc with a script-only sandbox", async () => {
     useHasAttachedSourceMock.mockReturnValue({
       hasAttachedSource: false,
       isLoading: false,
@@ -376,13 +376,13 @@ describe("FilesTab", () => {
       data: ["index.html"],
       isLoading: false,
     });
-    const staticUrl = "blob:preview-url";
+    const html = "<!doctype html><body>hi</body>";
     useWorkspaceFileContentMock.mockReturnValue({
       data: {
         path: "index.html",
         kind: "text",
-        text: "<!doctype html><body>hi</body>",
-        staticUrl,
+        text: html,
+        staticUrl: "blob:preview-url",
         mimeType: "text/html",
       },
       isLoading: false,
@@ -393,15 +393,15 @@ describe("FilesTab", () => {
 
     const iframe = await screen.findByTestId("file-content-viewer-iframe");
     expect(iframe).toBeInTheDocument();
-    // The iframe src uses the hook-provided browser preview URL directly;
-    // mutation freshness is handled by the hook's query key, not by mutating
-    // Blob URLs with cache-buster query params.
-    expect(iframe).toHaveAttribute("src", staticUrl);
-    // The iframe is sandboxed with `allow-same-origin` only: `<script>` /
-    // inline event handlers inside the previewed file are inert. We deliberately
-    // do NOT add `allow-scripts` — a workspace HTML file's scripts must not run
-    // in the canvas's context.
-    expect(iframe).toHaveAttribute("sandbox", "allow-same-origin");
+    // We use `srcDoc` rather than the blob: `staticUrl` so inline
+    // <style>/<script> and absolute-URL assets resolve the same way they do
+    // when the file is opened directly in a browser.
+    expect(iframe).toHaveAttribute("srcdoc", html);
+    expect(iframe).not.toHaveAttribute("src");
+    // `allow-scripts` without `allow-same-origin` gives the iframe an opaque
+    // origin: the page's JS runs, but it cannot reach the canvas's cookies,
+    // storage, or parent DOM.
+    expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
   });
 
   it("switches between rich and plain content modes", async () => {

--- a/src/components/features/files-tab/file-content-viewer.tsx
+++ b/src/components/features/files-tab/file-content-viewer.tsx
@@ -130,16 +130,17 @@ export function FileContentViewer({ path, viewMode }: FileContentViewerProps) {
 
   // Text-like content.
   if (mimeType === "text/html" || HTML_LIKE_EXTS.has(getExtension(path))) {
-    // Sandbox the preview iframe. The absence of `allow-scripts` means any
-    // `<script>` (or `onerror=…`, inline event handler, …) inside the
-    // previewed file is inert. This is exactly the safe-preview posture we
-    // want — users can look at their HTML without it executing in the
-    // canvas's context.
+    // Render via `srcDoc` (not a blob: `src`) so inline `<style>`/`<script>`
+    // and absolute-URL assets behave the way they do when the file is opened
+    // directly in a browser. `sandbox="allow-scripts"` lets the page's own
+    // JS run but — crucially — without `allow-same-origin` the iframe gets
+    // an opaque origin, so its scripts cannot touch the canvas's cookies,
+    // storage, or parent DOM.
     return (
       <iframe
         title={path}
-        src={staticUrl}
-        sandbox="allow-same-origin"
+        srcDoc={text ?? ""}
+        sandbox="allow-scripts"
         data-testid="file-content-viewer-iframe"
         className="h-full w-full bg-white"
       />


### PR DESCRIPTION
## Summary
- Closes #626. The HTML preview iframe in `FileContentViewer` was loaded from a `blob:` URL with `sandbox="allow-same-origin"` (no `allow-scripts`), so an agent-generated `index.html` with inline `<style>`/`<script>` or relative-URL assets rendered broken in the canvas while opening the same file in a browser looked correct.
- Switches the HTML branch to `srcDoc` (the decoded file text) with `sandbox="allow-scripts"` so inline CSS/JS and absolute-URL assets behave the same way they do in a browser.

## Security note
Dropping `allow-same-origin` while adding `allow-scripts` is the standard safe-preview posture: scripts can run, but the iframe gets an opaque origin and cannot touch the canvas's cookies, storage, or parent DOM. Net isolation of the parent app is strictly stronger than before (the previous `allow-same-origin` would have been a foot-gun if anyone later added `allow-scripts`).

## Screenshot
<img width="1916" height="950" alt="Screenshot 2026-05-19 at 16 19 08" src="https://github.com/user-attachments/assets/7a382f56-bc0b-4ad0-88d9-9cff78150f0c" />


## Test plan
- [x] `npx vitest run __tests__/routes/files-tab.test.tsx` — updated assertion now checks `srcdoc` + `sandbox="allow-scripts"`.
- [ ] Manually preview an agent-generated `index.html` with inline `<style>`/`<script>` in the canvas and confirm it matches the browser rendering from the screen recording on #626.