### PR TITLE
ci(snapshot-tests): support pull_request events from forks

### DIFF
--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -35,7 +35,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
+          # On `pull_request` events `github.head_ref` is the head branch
+          # name — but it lives on the PR head repo, which is a fork for
+          # cross-repo PRs. Without `repository` set, actions/checkout
+          # defaults to `github.repository` (the upstream repo) and fails
+          # to find the branch. Resolve both the head repo and head SHA
+          # from the PR event payload so fork PRs check out cleanly.
+          # Falls back to the workflow's own ref for `push` /
+          # `workflow_dispatch` events where there's no PR payload.
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 

--- a/tests/e2e/snapshots/scripts/post-snapshot-comment.mjs
+++ b/tests/e2e/snapshots/scripts/post-snapshot-comment.mjs
@@ -475,7 +475,20 @@ async function main() {
   }
 
   const body = buildComment(changed, newSnapshots, unchanged, commitSha);
-  await postFreshComment(body);
+  // Commenting requires `pull-requests: write`. GitHub silently downgrades
+  // that to `read` for `pull_request` runs triggered from a fork, so the
+  // POST below 403s on cross-repo PRs. Treat the failure the same way
+  // publishImages already treats its push failure: log it and keep going
+  // so the workflow can still write `has_changes` and let the
+  // "Fail if differences" step do its job.
+  try {
+    await postFreshComment(body);
+  } catch (err) {
+    console.error(
+      "Warning: failed to post PR comment (expected on fork PRs):",
+      err.message,
+    );
+  }
 
   // Tell the workflow whether there are actual pixel-diff failures so the
   // "Fail if differences" step can distinguish changed snapshots (should


### PR DESCRIPTION
## What

Make `.github/workflows/snapshot-tests.yml` work correctly when a PR is opened from a fork. Today the job fails before it can even start the snapshot run.

## Why

I hit this opening #632 from `rbren/agent-canvas`. The Snapshot Tests run failed with:

```
Error: Cannot find module '/home/runner/work/agent-canvas/agent-canvas/tests/e2e/snapshots/scripts/post-snapshot-comment.mjs'
```

Pulling the run's log shows the real cause is one step earlier — the checkout:

```
Run actions/checkout@v6
with:
  ref: ci/<head-branch>
  repository: OpenHands/agent-canvas
[command] git branch --list --remote origin/<head-branch>
[command] git tag --list <head-branch>
##[error]A branch or tag with the name '<head-branch>' could not be found
```

The workflow assumed every PR's head branch lives on the upstream repo, so it does:

```yaml
- uses: actions/checkout@v6
  with:
    ref: ${{ github.head_ref || github.ref_name }}
    # no `repository:` ⇒ defaults to github.repository = OpenHands/agent-canvas
```

For a fork PR, `github.head_ref` is the head branch name on the **fork** (e.g. `ci/snapshot-tests-fork-pr-support`), but checkout still looks for it in the upstream repo and dies. The next "Post snapshot report to PR" step has `if: always()`, runs in an empty working directory, and fails on `Cannot find module …post-snapshot-comment.mjs` — which is the surface error in the CI log.

A second, more subtle problem comes right after the checkout fix: `pull_request` runs triggered from a fork get a `GITHUB_TOKEN` that GitHub silently downgrades to read-only regardless of the `permissions:` block. So `post-snapshot-comment.mjs` would POST a PR comment, get 403, and `process.exit(1)` — taking the whole workflow with it. The sibling `publishImages` path is already wrapped in `try/catch` and degrades to a warning; the comment-post step should match that contract.

## Changes

1. **`.github/workflows/snapshot-tests.yml`** — point the checkout at the PR head explicitly:
   ```yaml
   repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
   ref:        ${{ github.event.pull_request.head.sha || github.ref_name }}
   ```
   For `pull_request` events this resolves to the PR's head repo + head SHA (works equally well whether the head is on this repo or a fork). For `push` / `workflow_dispatch` events the `||` fallbacks preserve the previous behavior. Pinning PR runs to the exact head SHA is also slightly more robust than the old branch-name ref.

2. **`tests/e2e/snapshots/scripts/post-snapshot-comment.mjs`** — wrap `postFreshComment` in `try/catch` and log a warning on failure. `has_changes` is still written to `$GITHUB_OUTPUT`, so the downstream "Fail if snapshot comparison found differences" gate keeps working on fork PRs even though no comment gets posted.

## Out of scope

Making the workflow actually able to **post** comments or **push** snapshot-artifact images for fork PRs. That requires switching to `pull_request_target` (or a separate post-run workflow), which is a real supply-chain change and worth its own discussion. This PR's only goal is: stop snapshot-tests from failing because of where the branch is hosted.

## Verification

- `node --check tests/e2e/snapshots/scripts/post-snapshot-comment.mjs` clean.
- YAML loads.
- Failing run that motivated this PR: <https://github.com/OpenHands/agent-canvas/actions/runs/26107308329/job/76774646587> (Snapshot Tests on #632).

---

_This PR was created by an AI agent (OpenHands) on behalf of @rbren._
