### PR TITLE
fix: stop clearing error banner on every non-error WebSocket message

### DIFF
--- a/src/contexts/conversation-websocket-context.tsx
+++ b/src/contexts/conversation-websocket-context.tsx
@@ -159,10 +159,6 @@ export function ConversationWebSocketProvider({
   const isPlanFilePath = (path: string | null): boolean =>
     path?.toUpperCase().endsWith("PLAN.MD") ?? false;
 
-  const handleNonErrorEvent = useCallback(() => {
-    removeErrorMessage();
-  }, [removeErrorMessage]);
-
   // Helper function to update metrics from stats event
   const updateMetricsFromStats = useCallback(
     (event: ConversationStateUpdateEventStats) => {
@@ -406,8 +402,6 @@ export function ConversationWebSocketProvider({
               posthog,
             });
             setErrorMessage(errorEvent.detail);
-          } else {
-            handleNonErrorEvent();
           }
 
           // Track credit limit reached if AgentErrorEvent has budget-related error
@@ -519,7 +513,6 @@ export function ConversationWebSocketProvider({
       appendInput,
       appendOutput,
       updateMetricsFromStats,
-      handleNonErrorEvent,
       posthog,
     ],
   );
@@ -567,8 +560,6 @@ export function ConversationWebSocketProvider({
               posthog,
             });
             setErrorMessage(errorEvent.detail);
-          } else {
-            handleNonErrorEvent();
           }
 
           // Handle AgentErrorEvent specifically
@@ -696,7 +687,6 @@ export function ConversationWebSocketProvider({
       readConversationFile,
       setPlanContent,
       updateMetricsFromStats,
-      handleNonErrorEvent,
       posthog,
     ],
   );


### PR DESCRIPTION
## Problem

Error banners (e.g. budget-exceeded, `LLMBadRequestError`) received over the WebSocket were disappearing before the user could see them. The message would only become visible after a page refresh.

## Root cause

`ConversationWebSocketProvider` had a `handleNonErrorEvent` helper that called `removeErrorMessage()` for **every** WebSocket message that was not a `ConversationErrorEvent` / `ServerErrorEvent`. This created a race:

1. `ConversationErrorEvent` arrives → `setErrorMessage("litellm.BadRequestError: …")` → banner shown
2. `ConversationStateUpdateEvent` (e.g. `execution_status: "STOPPED"`) arrives almost immediately after → `handleNonErrorEvent()` → `removeErrorMessage()` → **banner gone before the user sees it**

On page refresh the history comes from the REST API (which does not go through `handleNonErrorEvent`), so the error persisted there — explaining why a refresh made it visible.

## Fix

Remove `handleNonErrorEvent` entirely. Error messages are already cleared in all the correct places:

| Where | When |
|---|---|
| `onOpen` (main & planning WS) | WebSocket (re)connects — handles connection-error recovery |
| `<ErrorMessageBanner onDismiss>` | User explicitly closes the banner |
| `conversation.tsx` | Navigating to a different conversation |
| `use-unified-start-conversation` | Starting a new conversation |

There is no scenario where clearing the error on every passing non-error live event was correct.

## Changes

- Removed `handleNonErrorEvent` function definition
- Removed its two call sites (`handleMainMessage` and `handlePlanningMessage`)
- Removed it from the two `useCallback` dependency arrays

_This PR was created by an AI agent (OpenHands) on behalf of the user._