### PR TITLE
refactor(settings): port verification-settings to schema rendering

### DIFF
--- a/__tests__/routes/verification-settings.test.tsx
+++ b/__tests__/routes/verification-settings.test.tsx
@@ -1,10 +1,57 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsService from "#/api/settings-service/settings-service.api";
 import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import VerificationSettingsScreen from "#/routes/verification-settings";
 import { Settings } from "#/types/settings";
+
+const VERIFICATION_SCHEMA: NonNullable<Settings["conversation_settings_schema"]> =
+  {
+    model_name: "ConversationSettings",
+    sections: [
+      {
+        key: "verification",
+        label: "Verification",
+        fields: [
+          {
+            key: "confirmation_mode",
+            label: "Confirmation mode",
+            description:
+              "Pause for confirmation before the agent performs high-risk actions.",
+            section: "verification",
+            section_label: "Verification",
+            value_type: "boolean",
+            default: false,
+            choices: [],
+            depends_on: [],
+            prominence: "major",
+            secret: false,
+            required: true,
+          },
+          {
+            key: "security_analyzer",
+            label: "Security analyzer",
+            description:
+              "Choose how OpenHands should analyze actions before asking for confirmation.",
+            section: "verification",
+            section_label: "Verification",
+            value_type: "string",
+            default: "llm",
+            choices: [
+              { label: "llm", value: "llm" },
+              { label: "none", value: "none" },
+            ],
+            depends_on: ["confirmation_mode"],
+            prominence: "major",
+            secret: false,
+            required: false,
+          },
+        ],
+      },
+    ],
+  };
 
 function buildSettings(overrides: Partial<Settings> = {}): Settings {
   return {
@@ -14,9 +61,9 @@ function buildSettings(overrides: Partial<Settings> = {}): Settings {
       ...MOCK_DEFAULT_USER_SETTINGS.conversation_settings,
       ...overrides.conversation_settings,
     },
-    conversation_settings_schema:
-      overrides.conversation_settings_schema ??
-      MOCK_DEFAULT_USER_SETTINGS.conversation_settings_schema,
+    conversation_settings_schema: "conversation_settings_schema" in overrides
+      ? overrides.conversation_settings_schema
+      : VERIFICATION_SCHEMA,
   };
 }
 
@@ -39,13 +86,116 @@ beforeEach(() => {
 });
 
 describe("VerificationSettingsScreen", () => {
-  it("keeps the confirmation controls visible in the basic view", async () => {
-    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(buildSettings());
+  it("renders schema fields and saves conversation settings", async () => {
+    let settings = buildSettings({
+      conversation_settings: {
+        confirmation_mode: true,
+        security_analyzer: "llm",
+      },
+    });
+    vi.spyOn(SettingsService, "getSettings").mockImplementation(
+      async () => settings,
+    );
+    const saveSettingsSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockImplementation(async (payload) => {
+        settings = buildSettings({
+          ...settings,
+          conversation_settings: {
+            ...settings.conversation_settings,
+            ...(payload.conversation_settings_diff as NonNullable<
+              Settings["conversation_settings"]
+            >),
+          },
+        });
+        return true;
+      });
 
     renderVerificationSettingsScreen();
 
     await screen.findByTestId("verification-settings-screen");
 
-    expect(screen.getByTestId("confirmation-mode-toggle")).toBeInTheDocument();
+    const confirmationToggle = screen.getByTestId(
+      "sdk-settings-confirmation_mode",
+    );
+    expect(confirmationToggle).toBeChecked();
+    expect(
+      screen.getByRole("combobox", { name: /security analyzer/i }),
+    ).toBeInTheDocument();
+
+    await userEvent.click(confirmationToggle.closest("label")!);
+    await userEvent.click(screen.getByTestId("save-button"));
+
+    await waitFor(() => {
+      expect(saveSettingsSpy).toHaveBeenCalledWith({
+        conversation_settings_diff: {
+          confirmation_mode: false,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("sdk-settings-confirmation_mode"),
+      ).not.toBeChecked();
+    });
+    expect(
+      screen.queryByRole("combobox", { name: /security analyzer/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("skips verification fields that are absent from the schema", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        conversation_settings_schema: {
+          ...VERIFICATION_SCHEMA,
+          sections: [
+            {
+              ...VERIFICATION_SCHEMA.sections[0],
+              fields: VERIFICATION_SCHEMA.sections[0].fields.filter(
+                (field) => field.key !== "security_analyzer",
+              ),
+            },
+          ],
+        },
+        conversation_settings: {
+          confirmation_mode: true,
+          security_analyzer: "llm",
+        },
+      }),
+    );
+
+    renderVerificationSettingsScreen();
+
+    await screen.findByTestId("verification-settings-screen");
+
+    expect(
+      screen.getByTestId("sdk-settings-confirmation_mode"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: /security analyzer/i }),
+    ).not.toBeInTheDocument();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows the shared schema-unavailable state when the schema request fails", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({ conversation_settings_schema: null }),
+    );
+    vi.spyOn(SettingsService, "getConversationSettingsSchema").mockRejectedValue(
+      new Error("schema unavailable"),
+    );
+
+    renderVerificationSettingsScreen();
+
+    expect(
+      await screen.findByText("SETTINGS$SDK_SCHEMA_UNAVAILABLE"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("verification-settings-screen"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/routes/verification-settings.tsx
+++ b/src/routes/verification-settings.tsx
@@ -1,96 +1,6 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
-import { SettingsDropdownInput } from "#/components/features/settings/settings-dropdown-input";
-import { SettingsSwitch } from "#/components/features/settings/settings-switch";
-import {
-  SdkSectionHeaderProps,
-  SdkSectionPage,
-} from "#/components/features/settings/sdk-settings/sdk-section-page";
-import { useSettings } from "#/hooks/query/use-settings";
-import { I18nKey } from "#/i18n/declaration";
-import { DEFAULT_SETTINGS } from "#/services/settings";
+import { SdkSectionPage } from "#/components/features/settings/sdk-settings/sdk-section-page";
 import { SettingsScope } from "#/types/settings";
-
-const VERIFICATION_SCHEMA_EXCLUDE_KEYS = new Set([
-  "confirmation_mode",
-  "security_analyzer",
-]);
-
-function VerificationSettingsHeader({
-  confirmationMode,
-  securityAnalyzer,
-  isConversationSettingsDisabled,
-  onConfirmationModeChange,
-  onSecurityAnalyzerChange,
-  renderTopContent,
-}: {
-  confirmationMode: boolean;
-  securityAnalyzer: string | null;
-  isConversationSettingsDisabled: boolean;
-  onConfirmationModeChange: (value: boolean) => void;
-  onSecurityAnalyzerChange: (value: string | null) => void;
-  renderTopContent?: () => React.ReactNode;
-}) {
-  const { t } = useTranslation("openhands");
-
-  const securityAnalyzerItems = React.useMemo(
-    () => [
-      {
-        key: "llm",
-        label: t(I18nKey.SETTINGS$SECURITY_ANALYZER_LLM_DEFAULT),
-      },
-      {
-        key: "none",
-        label: t(I18nKey.SETTINGS$SECURITY_ANALYZER_NONE),
-      },
-    ],
-    [t],
-  );
-
-  const showSecurityAnalyzer = confirmationMode;
-
-  return (
-    <div className="flex flex-col gap-6">
-      {renderTopContent?.()}
-
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-1.5">
-          <SettingsSwitch
-            testId="confirmation-mode-toggle"
-            isToggled={confirmationMode}
-            onToggle={onConfirmationModeChange}
-            isDisabled={isConversationSettingsDisabled}
-          >
-            {t(I18nKey.SETTINGS_FORM$ENABLE_CONFIRMATION_MODE_LABEL)}
-          </SettingsSwitch>
-          <p className="text-tertiary-alt text-xs leading-5">
-            {t(I18nKey.SETTINGS$CONFIRMATION_MODE_TOOLTIP)}
-          </p>
-        </div>
-
-        {showSecurityAnalyzer ? (
-          <div className="flex flex-col gap-1.5">
-            <SettingsDropdownInput
-              testId="security-analyzer-input"
-              name="security_analyzer"
-              label={t(I18nKey.SETTINGS_FORM$SECURITY_ANALYZER_LABEL)}
-              items={securityAnalyzerItems}
-              selectedKey={securityAnalyzer ?? undefined}
-              placeholder={t(I18nKey.SETTINGS$SECURITY_ANALYZER_PLACEHOLDER)}
-              isDisabled={isConversationSettingsDisabled}
-              onSelectionChange={(key) =>
-                onSecurityAnalyzerChange(key ? String(key) : null)
-              }
-            />
-            <p className="text-tertiary-alt text-xs leading-5">
-              {t(I18nKey.SETTINGS$SECURITY_ANALYZER_DESCRIPTION)}
-            </p>
-          </div>
-        ) : null}
-      </div>
-    </div>
-  );
-}
 
 export function VerificationSettingsScreen({
   scope = "personal",
@@ -101,72 +11,9 @@ export function VerificationSettingsScreen({
   renderTopContent?: () => React.ReactNode;
   testId?: string;
 }) {
-  const { data: settings } = useSettings(scope);
-  const [confirmationMode, setConfirmationMode] = React.useState(
-    DEFAULT_SETTINGS.confirmation_mode,
-  );
-  const [securityAnalyzer, setSecurityAnalyzer] = React.useState<string | null>(
-    DEFAULT_SETTINGS.security_analyzer,
-  );
-  const [confirmationModeDirty, setConfirmationModeDirty] =
-    React.useState(false);
-  const [securityAnalyzerDirty, setSecurityAnalyzerDirty] =
-    React.useState(false);
-
-  React.useEffect(() => {
-    setConfirmationMode(
-      settings?.confirmation_mode ?? DEFAULT_SETTINGS.confirmation_mode,
-    );
-    setSecurityAnalyzer(
-      settings?.security_analyzer ?? DEFAULT_SETTINGS.security_analyzer,
-    );
-    setConfirmationModeDirty(false);
-    setSecurityAnalyzerDirty(false);
-  }, [settings?.confirmation_mode, settings?.security_analyzer]);
-
-  const buildHeader = React.useCallback(
-    ({ isDisabled }: SdkSectionHeaderProps) => (
-      <VerificationSettingsHeader
-        confirmationMode={confirmationMode}
-        securityAnalyzer={securityAnalyzer}
-        isConversationSettingsDisabled={isDisabled}
-        onConfirmationModeChange={(value) => {
-          setConfirmationMode(value);
-          setConfirmationModeDirty(true);
-        }}
-        onSecurityAnalyzerChange={(value) => {
-          setSecurityAnalyzer(value);
-          setSecurityAnalyzerDirty(true);
-        }}
-        renderTopContent={renderTopContent}
-      />
-    ),
-    [confirmationMode, renderTopContent, securityAnalyzer],
-  );
-
-  const buildPayload = React.useCallback(
-    (basePayload: Record<string, unknown>) => {
-      const payload = { ...basePayload };
-
-      if (confirmationModeDirty) {
-        payload.confirmation_mode = confirmationMode;
-      }
-      if (
-        securityAnalyzerDirty ||
-        (confirmationMode && settings?.security_analyzer !== securityAnalyzer)
-      ) {
-        payload.security_analyzer = securityAnalyzer;
-      }
-
-      return { conversation_settings_diff: payload };
-    },
-    [
-      confirmationMode,
-      confirmationModeDirty,
-      securityAnalyzer,
-      securityAnalyzerDirty,
-      settings?.security_analyzer,
-    ],
+  const header = React.useMemo(
+    () => (renderTopContent ? () => renderTopContent() : undefined),
+    [renderTopContent],
   );
 
   return (
@@ -174,14 +21,8 @@ export function VerificationSettingsScreen({
       scope={scope}
       settingsSource="conversation_settings"
       sectionKeys={["verification"]}
-      excludeKeys={VERIFICATION_SCHEMA_EXCLUDE_KEYS}
-      header={buildHeader}
-      extraDirty={confirmationModeDirty || securityAnalyzerDirty}
-      buildPayload={buildPayload}
-      onSaveSuccess={() => {
-        setConfirmationModeDirty(false);
-        setSecurityAnalyzerDirty(false);
-      }}
+      header={header}
+      getInitialView={() => "advanced"}
       testId={testId}
     />
   );

--- a/tests/e2e/snapshots/verification-settings.snapshot.spec.ts
+++ b/tests/e2e/snapshots/verification-settings.snapshot.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, Page } from "@playwright/test";
+import { seedLocalStorage } from "./support/seed-local-storage";
+
+const VERIFICATION_SCHEMA = {
+  model_name: "ConversationSettings",
+  sections: [
+    {
+      key: "verification",
+      label: "Verification",
+      fields: [
+        {
+          key: "confirmation_mode",
+          label: "Confirmation mode",
+          description:
+            "Pause for confirmation before the agent performs high-risk actions.",
+          section: "verification",
+          section_label: "Verification",
+          value_type: "boolean",
+          default: false,
+          choices: [],
+          depends_on: [],
+          prominence: "major",
+          secret: false,
+          required: true,
+        },
+        {
+          key: "security_analyzer",
+          label: "Security analyzer",
+          description:
+            "Choose how OpenHands should analyze actions before asking for confirmation.",
+          section: "verification",
+          section_label: "Verification",
+          value_type: "string",
+          default: "llm",
+          choices: [
+            { label: "llm", value: "llm" },
+            { label: "none", value: "none" },
+          ],
+          depends_on: ["confirmation_mode"],
+          prominence: "major",
+          secret: false,
+          required: false,
+        },
+      ],
+    },
+  ],
+};
+
+const SETTINGS_WITH_CONSENT = {
+  llm_model: "anthropic/claude-sonnet-4-20250514",
+  llm_base_url: "",
+  agent: "CodeActAgent",
+  language: "en",
+  llm_api_key: null,
+  llm_api_key_set: true,
+  search_api_key_set: false,
+  confirmation_mode: true,
+  security_analyzer: "llm",
+  remote_runtime_resource_factor: 1,
+  provider_tokens_set: { github: "" },
+  enable_default_condenser: true,
+  condenser_max_size: 240,
+  enable_sound_notifications: false,
+  user_consents_to_analytics: false,
+  enable_proactive_conversation_starters: false,
+  enable_solvability_analysis: false,
+  max_budget_per_task: null,
+  conversation_settings_schema: VERIFICATION_SCHEMA,
+  conversation_settings: {
+    confirmation_mode: true,
+    security_analyzer: "llm",
+  },
+};
+
+async function setupMocks(page: Page) {
+  await seedLocalStorage(page);
+
+  await page.route("**/api/settings", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(SETTINGS_WITH_CONSENT),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.route("**/api/settings/agent-schema", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.route("**/api/settings/conversation-schema", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(VERIFICATION_SCHEMA),
+    });
+  });
+
+  await page.route("**/api/conversations*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ results: [] }),
+    });
+  });
+
+  await page.route("**/api/file/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ path: "/home", subdirs: [] }),
+    });
+  });
+}
+
+test.describe("Verification Settings Visual Snapshot", () => {
+  test.setTimeout(60000);
+
+  test("Verification settings page renders correctly", async ({ page }) => {
+    await setupMocks(page);
+    await page.goto("/settings/verification");
+
+    const rootLayout = page.getByTestId("root-layout");
+    await expect(rootLayout).toBeVisible({ timeout: 15000 });
+    await page.waitForLoadState("networkidle");
+
+    const screen = page.getByTestId("verification-settings-screen");
+    await expect(screen).toBeVisible({ timeout: 15000 });
+
+    // Click Advanced tab to surface the schema-rendered fields.
+    await page.getByRole("tab", { name: "Advanced" }).click();
+    await page.waitForLoadState("networkidle");
+
+    await expect(rootLayout).toHaveScreenshot(
+      "verification-settings-page.png",
+      {
+        maxDiffPixelRatio: 0.01,
+        animations: "disabled",
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

1. Read upstream PR `OpenHands/OpenHands#13978` to extract the canonical schema-rendering pattern. Identify the renderer component upstream uses (likely `<SchemaSettings>` or equivalent) and check whether the same helper already exists in agent-canvas or needs to be ported alongside. If it already exists (likely, given the codebase has been porting upstream patterns), reuse it directly; if not, do the smallest port that keeps the public API of `verification-settings.tsx` unchanged.
2. Rewrite `src/routes/verification-settings.tsx` to:
   - Fetch the agent-server schema via the same client method used elsewhere in the codebase (search for existing `/api/settings/agent-schema` consumers - the Skills settings page likely uses one).
   - Filter the schema to verification-relevant fields (the upstream PR will name them).
   - Render via the schema-driven component instead of the hand-rolled ladder.
   - Preserve every existing toggle and dropdown - this is purely a refactor, not a behaviour change.
3. Gate on schema presence: if the running agent-server omits a verification field, the renderer should skip it gracefully rather than hardcoding a fallback. This matches the issue's acceptance criterion ("gate on schema presence rather than hardcoding fallbacks").
4. Port `__tests__/routes/verification-settings.test.tsx` to match. Mock the schema response with the realistic shape from the live agent-server (capture once from `npm run dev`) so the test exercises the real code path.

## Why this matters

Issue #133 asks to port [OpenHands/OpenHands#13978 - "Refactor verification settings to use schema rendering"](https://github.com/OpenHands/OpenHands/pull/13978) into agent-canvas. Today `src/routes/verification-settings.tsx` is a hand-rolled ladder of `SettingsDropdownInput` / `SettingsSwitch` controls. Upstream replaced this with a schema-driven renderer that reuses agent-server's settings schema (`/api/settings/agent-schema`), trimming +40/-159 lines and keeping the page in sync with backend schema changes automatically.

The prerequisite is already satisfied: agent-canvas requires agent-server >=1.17.0, where `/api/settings/agent-schema` was introduced. The issue was AI-filed on 2026-05-07, has no claiming PR, no assignee, no closed-by reference, and the file is only 5.9KB - small surface area. Labels are `enhancement` + `frontend`.

## Testing

- Schema present, all fields: every existing verification toggle/dropdown renders, saves, and round-trips through the agent-server settings store.
- Schema missing a field: that field is skipped, no console error, and the rest of the page renders normally.
- Schema unreachable (network 5xx): the page degrades to an empty state or an error banner consistent with how other schema-rendered settings pages handle this in agent-canvas today.
- Lint/typecheck/test: `npm run typecheck && npm run lint && npm test -- verification-settings` clean.
- Manual: in `npm run dev`, navigate to Settings > Verification, toggle each control, refresh, confirm persistence. Capture an animated GIF per the issue's acceptance criteria and per the repo PR template ("Video/Screenshots" section is required).

AI usage disclosure (per repo PR template): planning was assisted; implementer must hand-author the diff, reproduce the upstream behaviour locally, and verify the agent-schema endpoint shape in the live agent-server before relying on it. Include the manual GIF in the PR.

Fixes #133

AI was used for assistance.
