### PR TITLE
fix(frontend): validate OH_AGENT_SERVER_LOCAL_PATH in dev-with-automation

### DIFF
--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -450,9 +450,65 @@ describe("dev-with-automation CLI", () => {
     expect(output).toContain("--static");
     expect(output).toContain("--dynamic");
     expect(output).toContain("OH_AUTOMATION_GIT_REF");
+    expect(output).toContain("OH_AGENT_SERVER_LOCAL_PATH");
     expect(output).toContain("AUTOMATION_LOCAL_API_KEY");
     expect(output).toContain("OPENHANDS_AUTOMATION_API_KEY");
     expect(output).toContain("SECRETS:");
+  });
+
+  it("fails fast with a clear error when OH_AGENT_SERVER_LOCAL_PATH is invalid", async () => {
+    // Arrange: an absolute but empty directory — `validateLocalAgentServerPath`
+    // requires the four workspace subdirs (openhands-agent-server, openhands-sdk,
+    // openhands-tools, openhands-workspace) and must reject this.
+    const emptyDir = mkdtempSync(path.join(tmpdir(), "bad-sdk-"));
+
+    // Act: spawn `dev-with-automation.mjs` with that path set. Inherit PATH so
+    // `uvx`/`npm` prerequisite checks pass — the validation guard must trip
+    // *after* those checks but *before* port allocation, so we can assert on
+    // both the error message and the absence of side effects.
+    const child = spawn(process.execPath, ["scripts/dev-with-automation.mjs"], {
+      cwd: repoRoot,
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: process.env.HOME ?? "",
+        OH_AGENT_SERVER_LOCAL_PATH: emptyDir,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+
+    const exitResult = await Promise.race([
+      once(child, "exit").then(([code, signal]) => ({
+        code,
+        signal,
+        timedOut: false,
+      })),
+      delay(10_000).then(() => ({ code: null, signal: null, timedOut: true })),
+    ]);
+
+    if (exitResult.timedOut) {
+      child.kill("SIGKILL");
+    }
+
+    try {
+      // Assert: process exits non-zero, surfaces the validator's error, and
+      // never reaches `buildConfig` (no `[ports] Allocating ports...` log).
+      expect(exitResult.timedOut).toBe(false);
+      expect(exitResult.code).toBe(1);
+      expect(output).toContain(
+        "OH_AGENT_SERVER_LOCAL_PATH is missing expected workspace package",
+      );
+      expect(output).not.toContain("Allocating ports");
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
   });
 
   it("exits promptly when uvx is missing", async () => {

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -8,7 +8,7 @@
 import net from "node:net";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -462,14 +462,23 @@ describe("dev-with-automation CLI", () => {
     // openhands-tools, openhands-workspace) and must reject this.
     const emptyDir = mkdtempSync(path.join(tmpdir(), "bad-sdk-"));
 
-    // Act: spawn `dev-with-automation.mjs` with that path set. Inherit PATH so
-    // `uvx`/`npm` prerequisite checks pass — the validation guard must trip
-    // *after* those checks but *before* port allocation, so we can assert on
-    // both the error message and the absence of side effects.
+    // Stub a no-op `uvx` on PATH so `checkPrerequisites` passes even on CI
+    // runners that don't have uv installed. The prerequisite check must
+    // succeed so the LOCAL_PATH validation guard (the actual subject of this
+    // test, which runs immediately after) is exercised.
+    const stubBinDir = mkdtempSync(path.join(tmpdir(), "stub-bin-"));
+    writeFileSync(path.join(stubBinDir, "uvx"), "#!/bin/sh\nexit 0\n", {
+      mode: 0o755,
+    });
+
+    // Act: spawn `dev-with-automation.mjs` with that path set. Stubbed `uvx`
+    // is prepended to PATH so the prerequisite check passes; the validation
+    // guard must trip *after* those checks but *before* port allocation, so
+    // we can assert on both the error message and the absence of side effects.
     const child = spawn(process.execPath, ["scripts/dev-with-automation.mjs"], {
       cwd: repoRoot,
       env: {
-        PATH: process.env.PATH ?? "",
+        PATH: `${stubBinDir}:${process.env.PATH ?? ""}`,
         HOME: process.env.HOME ?? "",
         OH_AGENT_SERVER_LOCAL_PATH: emptyDir,
       },
@@ -508,6 +517,7 @@ describe("dev-with-automation CLI", () => {
       expect(output).not.toContain("Allocating ports");
     } finally {
       rmSync(emptyDir, { recursive: true, force: true });
+      rmSync(stubBinDir, { recursive: true, force: true });
     }
   });
 

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -29,6 +29,11 @@
  * Environment variables:
  *   - PORT: Ingress port (default: 8000)
  *   - OH_AUTOMATION_GIT_REF: Git ref for automation (default: main)
+ *   - OH_AGENT_SERVER_LOCAL_PATH: Absolute path to a local software-agent-sdk
+ *     checkout. Highest precedence for agent-server source selection: rebuilds
+ *     the agent-server from local source and installs openhands-sdk,
+ *     openhands-tools and openhands-workspace as editable so source edits are
+ *     picked up without manual reinstall.
  *   - OH_AGENT_SERVER_GIT_REF: Git ref for agent-server
  *   - AUTOMATION_LOCAL_API_KEY: Custom API key for automation backend auth
  *   - OH_AUTOMATION_API_KEY_PATH: Override persisted default automation key path
@@ -56,6 +61,7 @@ import {
   findFreePorts,
   getOrCreatePersistedApiKey,
   validateFrontendDependencies,
+  validateLocalAgentServerPath,
 } from "./dev-safe.mjs";
 import {
   createShutdownHookRegistry,
@@ -203,6 +209,7 @@ ENVIRONMENT VARIABLES:
   PORT                        Alternative to --port
   OH_AUTOMATION_GIT_REF       Git ref for automation (overrides default version)
   OH_AUTOMATION_VERSION       Specific PyPI version for automation (default: ${DEFAULT_AUTOMATION_VERSION})
+  OH_AGENT_SERVER_LOCAL_PATH  Absolute path to a local software-agent-sdk checkout (highest precedence)
   OH_AGENT_SERVER_GIT_REF     Git ref for agent-server SDK (overrides default version)
   OH_AGENT_SERVER_VERSION     Specific PyPI version for agent-server
   OH_SECRET_KEY               Secret key for sessions
@@ -965,6 +972,19 @@ async function main(options = {}) {
     checkFrontendDependencies:
       !useStaticMode || typeof buildStaticFrontend === "function",
   });
+
+  // Fail fast on an obviously bad OH_AGENT_SERVER_LOCAL_PATH so we don't waste
+  // time allocating ports / generating keys / launching uvx with a path that
+  // would only produce a cryptic build error. Mirrors dev-safe.mjs and
+  // dev-extra-backend.mjs.
+  if (process.env.OH_AGENT_SERVER_LOCAL_PATH) {
+    try {
+      validateLocalAgentServerPath(process.env.OH_AGENT_SERVER_LOCAL_PATH);
+    } catch (error) {
+      logError(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  }
 
   // Build config with dynamic port allocation
   const config = await buildConfig(args);


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description:**

After PR #635 ("Remove Docker dependency from dev workflow") rewired `npm run dev` from `dev-docker.mjs` to `scripts/dev-with-automation.mjs`, the local-SDK developer workflow regressed:

- `scripts/dev-with-automation.mjs` does not call `validateLocalAgentServerPath(process.env.OH_AGENT_SERVER_LOCAL_PATH)` — unlike `dev-safe.mjs` (line 841) and `dev-extra-backend.mjs` (line 120) which both validate up front.
- A relative `OH_AGENT_SERVER_LOCAL_PATH` only blows up deep inside `buildAgentServerCommand` _after_ prerequisites/ports/keys are provisioned, so the failure looks like an unrelated startup crash.
- A missing or incomplete checkout (e.g. one of the four workspace subdirs absent) is not caught at all — `uvx` fails later with a cryptic build error and developers can't tell whether the env var was even read.
- Neither the top-of-file docstring nor the `--help` output mentions `OH_AGENT_SERVER_LOCAL_PATH`, so anyone discovering the workflow from the script itself won't know it's supported.

**Steps to reproduce:**

```bash
# (mis)typed bad path — should fail fast, currently fails late & confusingly
OH_AGENT_SERVER_LOCAL_PATH=./relative-path npm run dev
```

**Expected behavior:**

- `npm run dev` validates `OH_AGENT_SERVER_LOCAL_PATH` immediately after the prerequisite checks and before any side effects (port allocation, persisted API key generation, child-process spawning).
- Invalid paths exit with a clear, actionable message identifying which workspace subdirectory is missing.
- `--help` and the in-script docstring list `OH_AGENT_SERVER_LOCAL_PATH` alongside the other agent-server source-selection variables.

**Acceptance criteria:**

- [x] `scripts/dev-with-automation.mjs` calls `validateLocalAgentServerPath` before `buildConfig`.
- [x] `OH_AGENT_SERVER_LOCAL_PATH` is documented in the docstring and `--help`.
- [x] Test coverage in `__tests__/scripts/dev-with-automation.test.ts` confirms the validation wiring (bad path → exit 1, error surfaced, no port allocation).
- [x] `--help` test updated to assert the new env var is listed.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Wire `validateLocalAgentServerPath` into `scripts/dev-with-automation.mjs` so `npm run dev` fails fast on a bad `OH_AGENT_SERVER_LOCAL_PATH` instead of dying later inside `uvx`. Matches the long-standing behavior in `dev-safe.mjs` and `dev-extra-backend.mjs`.
- Document `OH_AGENT_SERVER_LOCAL_PATH` in the script's top-of-file docstring and `--help` output so the developer workflow for testing agent-server changes locally is discoverable from the script itself.
- Extend `__tests__/scripts/dev-with-automation.test.ts` with a subprocess test that exercises the new validation wiring end-to-end.

## Why

After PR #635 ("Remove Docker dependency from dev workflow") rewired `npm run dev` to `dev-with-automation.mjs`, the local-SDK developer workflow regressed. `dev-with-automation.mjs` calls `buildAgentServerCommand(process.env)` which _does_ honor `OH_AGENT_SERVER_LOCAL_PATH`, but it skipped the upfront validation guard that `dev-safe.mjs` had — so:

- Relative paths only failed deep in `buildAgentServerCommand` after ports/keys had been provisioned.
- Missing/incomplete checkouts produced cryptic `uvx` build errors with no indication the env var had been read.
- The docstring and `--help` never mentioned the variable.

The fix is minimal and parity-driven: re-use the already-exported `validateLocalAgentServerPath` from `dev-safe.mjs`, document the variable in this script's own docs, and add focused test coverage for the wiring.

## What changed

| File                                            | Change                                                                                                                                                                           |
| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `scripts/dev-with-automation.mjs`               | Import `validateLocalAgentServerPath`; call it in `main()` between `checkPrerequisites` and `buildConfig`; add `OH_AGENT_SERVER_LOCAL_PATH` to the docstring and `--help` block. |
| `__tests__/scripts/dev-with-automation.test.ts` | New subprocess test: bad LOCAL_PATH → exit 1 + error surfaced + no `Allocating ports` log. `--help` test gains one assertion for the new env var.                                |

```
 __tests__/scripts/dev-with-automation.test.ts | 56 +++++++++++++++++++++++++++
 scripts/dev-with-automation.mjs               | 20 ++++++++++
 2 files changed, 76 insertions(+)
```

## How to test

```bash
# Bad path → fast fail with clear error, no side effects
OH_AGENT_SERVER_LOCAL_PATH=./relative npm run dev
OH_AGENT_SERVER_LOCAL_PATH=/tmp npm run dev

# Happy path: should print
#   [agent-server] Using local (/Users/.../software-agent-sdk)
# and the local workspaces_router.py routes should appear at
#   http://localhost:8000/docs
OH_AGENT_SERVER_LOCAL_PATH=/abs/path/to/software-agent-sdk npm run dev

# --help advertises the variable
node scripts/dev-with-automation.mjs --help | grep OH_AGENT_SERVER_LOCAL_PATH

# Tests
npx vitest run __tests__/scripts/dev-with-automation.test.ts
```

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #649 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

```bash
# (mis)typed bad path — should fail fast, currently fails late & confusingly
OH_AGENT_SERVER_LOCAL_PATH=./relative-path npm run dev
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

### Out of scope / follow-ups

The shared `buildAgentServerCommand` path passes `--reinstall` to `uvx`, which `uvx` ≥ 0.4 warns is a no-op for the `--from` package (the "tool"): _"Tools cannot be reinstalled via uvx"_. After the first invocation, the cached tool environment is reused, so source edits to `openhands-agent-server` itself may not be picked up on subsequent `npm run dev` runs without a `uv cache prune`. `--with-editable` for `openhands-sdk`, `openhands-tools`, and `openhands-workspace` still works as expected. This is present in `dev-safe.mjs` too and is out of scope for this PR (the user explicitly asked to match `dev-safe.mjs` behavior). Tracked as a separate follow-up.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.22.1-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `896125c5cbd7461434941fb7ba570f483e09134f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-896125c
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-896125c
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-896125c-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1853-amd64
ghcr.io/openhands/agent-canvas:pr-650-amd64
ghcr.io/openhands/agent-canvas:sha-896125c-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1853-arm64
ghcr.io/openhands/agent-canvas:pr-650-arm64
ghcr.io/openhands/agent-canvas:sha-896125c
ghcr.io/openhands/agent-canvas:hieptl-app-1853
ghcr.io/openhands/agent-canvas:pr-650
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-896125c`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-896125c-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->