### PR TITLE
fix(profiles): start API key field empty to prevent redacted value being saved

### DIFF
--- a/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
+++ b/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
@@ -307,10 +307,17 @@ export function LlmSettingsLocalView() {
         }
         embedded
         hideSaveButton
+        apiKeyIsSet={
+          viewMode === "edit"
+            ? (editingProfile?.profile.api_key_set ?? false)
+            : false
+        }
         initialValueOverrides={
           viewMode === "edit" && editingProfile?.initialValues
-            ? // Edit mode: use the existing profile values
-              editingProfile.initialValues
+            ? // Edit mode: start the API key field empty so users see a clean
+              // input; the encrypted key is preserved in editingProfile.initialValues
+              // and used as a fallback in handleSave when the field is left blank.
+              { ...editingProfile.initialValues, "llm.api_key": "" }
             : // Create mode: start with empty fields for a fresh profile
               { "llm.model": "", "llm.api_key": "", "llm.base_url": "" }
         }

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -101,6 +101,7 @@ export function LlmSettingsScreen({
   embedded,
   hideSaveButton,
   onSaveControlChange,
+  apiKeyIsSet,
 }: {
   scope?: SettingsScope;
   /** Optional hook fired after a successful save (e.g. advance an onboarding step). */
@@ -113,6 +114,13 @@ export function LlmSettingsScreen({
   hideSaveButton?: boolean;
   /** Forwarded to {@link SdkSectionPage}. */
   onSaveControlChange?: (control: SdkSectionSaveControl) => void;
+  /**
+   * When provided, overrides `settings.llm_api_key_set` for the API key
+   * field placeholder. Pass the profile's own `api_key_set` value when
+   * embedding this form inside a profile editor so the placeholder reflects
+   * the profile's key status rather than the global settings.
+   */
+  apiKeyIsSet?: boolean;
 }) {
   const { t } = useTranslation("openhands");
 
@@ -156,6 +164,7 @@ export function LlmSettingsScreen({
           ? values["llm.base_url"]
           : "";
       const showOpenHandsApiKeyHelp = modelValue.startsWith("openhands/");
+      const keyIsSet = apiKeyIsSet ?? settings?.llm_api_key_set ?? false;
 
       const renderApiKeyInput = (testId: string, helpTestId: string) => (
         <>
@@ -169,13 +178,11 @@ export function LlmSettingsScreen({
                 ? values["llm.api_key"]
                 : ""
             }
-            placeholder={settings?.llm_api_key_set ? "<hidden>" : ""}
+            placeholder={keyIsSet ? "**********" : ""}
             onChange={(value) => onChange("llm.api_key", value)}
             isDisabled={isDisabled}
             startContent={
-              settings?.llm_api_key_set ? (
-                <KeyStatusIcon isSet={settings.llm_api_key_set} />
-              ) : undefined
+              keyIsSet ? <KeyStatusIcon isSet={keyIsSet} /> : undefined
             }
           />
 
@@ -257,7 +264,7 @@ export function LlmSettingsScreen({
         </div>
       );
     },
-    [defaultModel, settings?.llm_api_key_set, t],
+    [defaultModel, settings?.llm_api_key_set, t, apiKeyIsSet],
   );
 
   const buildPayload = React.useCallback(


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

When editing an LLM profile the API key password field was pre-populated with the encrypted transport token (`gAAAAA...`) as its live form value, fetched via `GET /profiles/{name}?exposeSecrets=encrypted`. This caused two failure modes that both result in the profile silently losing its API key:

1. **Redacted sentinel written to disk.** `SdkSectionPage` computes `initialValues` as `{ ...base, ...initialValueOverrides }` where `base['llm.api_key']` is `'**********'` (the redacted value returned by the settings API). A React Query background refetch of `useSettings` produces a new `settings` object reference, causing the `initialVal1. **Redacted sentinel written to disk.** `SdkSectionP to fire `setValues(initialValues)`, overwriting whatever the user typed. In the worst case the override is not yet applied and `'**********'` reaches the form state, gets submitted to `POST /profiles/{name}`, and `validate_secret()` recognises it as `REDACTED_SECRET_VALUE` on the next load, returning `None` and silently clearing the key.

2. **Corrupted Fernet token double-encrypted.** A paste into the 100-dot password field without a prior select-all appends the new key to the ciphertext. The result starts with `'gAAAAA'` but is not a valid Fernet token; server-side decryption fails silently and the blob is re-encrypted, permanently breaking the profile.

## Summary

- In `llm-settings-local-view.tsx`, pass `''` as `initialValueOverrides['llm.api_key']` so the password field always renders empty. The encrypted key is preserved in `editingProfile.initialValues['llm.api_key']` and the existing `handleSave` fallback (`else if apiKey === ''`) already round-trips it to the server unchanged.
- Add an `apiKeyIsSet?: boolean` prop to `LlmSettingsScreen` so the profile's own `api_key_set` flag (not the global settings') controls the placeholder visibility.
- Change the API key placeholder text from `'<hidden>'` to `'**********'`.

## Issue Number

## How to Test

1. Start the dev stack (`npm run dev`).
2. Create a profile with a valid API key and save it.
3. Click Edit on the profile — the API key field should be **empty** with `**********` shown as placeholder text.
4. Leave the field blank and save — the key should be preserved (round-tripped as the encrypted token).
5. Type a new key, save, and re-open the profile — the new key should5. Type ae.
6. While the edit form is open, trigger a React Query refetch (switch browser tabs and back) — the field should remain empty rather than resetting.

## Video/Screenshots

## Type

- [x] Bug fix

## Notes

The `handleSave` fallback that round-trips the encrypted key when the field is left blank was already present; this PR simply ensures that the only value that can enter `values['llm.api_key']` is either empty (no change) or a key the user deliberately typed/pasted.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.22.1-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `7f093c57333411a34abaf1d99317c4fdd29c8149` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-7f093c5
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-7f093c5
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-7f093c5-amd64
ghcr.io/openhands/agent-canvas:fix-profile-api-key-field-starts-empty-amd64
ghcr.io/openhands/agent-canvas:pr-659-amd64
ghcr.io/openhands/agent-canvas:sha-7f093c5-arm64
ghcr.io/openhands/agent-canvas:fix-profile-api-key-field-starts-empty-arm64
ghcr.io/openhands/agent-canvas:pr-659-arm64
ghcr.io/openhands/agent-canvas:sha-7f093c5
ghcr.io/openhands/agent-canvas:fix-profile-api-key-field-starts-empty
ghcr.io/openhands/agent-canvas:pr-659
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-7f093c5`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-7f093c5-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->