### PR TITLE
fix: remove hardcoded /workspace/project fallbacks from useLocalGitInfo

### DIFF
--- a/src/hooks/query/use-local-git-info.ts
+++ b/src/hooks/query/use-local-git-info.ts
@@ -124,19 +124,13 @@ export const useLocalGitInfo = () => {
           cwd,
           timeout,
         );
-      const candidateDirs = Array.from(
-        new Set([workingDir, "/workspace/project", "workspace/project"]),
-      );
+      const directInfo = await probeGitInfoAtDir(run, workingDir);
+      if (directInfo.repository || directInfo.branch) return directInfo;
 
-      for (const candidateDir of candidateDirs) {
-        const directInfo = await probeGitInfoAtDir(run, candidateDir);
-        if (directInfo.repository || directInfo.branch) return directInfo;
-
-        // Common local flow: user starts in a non-git parent workspace and
-        // clones a single repository into a child directory.
-        const nestedInfo = await probeNestedRepoInDir(run, candidateDir);
-        if (nestedInfo.repository || nestedInfo.branch) return nestedInfo;
-      }
+      // Common local flow: user starts in a non-git parent workspace and
+      // clones a single repository into a child directory.
+      const nestedInfo = await probeNestedRepoInDir(run, workingDir);
+      if (nestedInfo.repository || nestedInfo.branch) return nestedInfo;
 
       return EMPTY_LOCAL_GIT_INFO;
     },


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

`useLocalGitInfo` was probing three candidate directories on every 10-second tick: the configured `workingDir`, plus two hardcoded Docker-specific fallbacks (`/workspace/project` and `workspace/project`). For any conversation not backed by a git repo — or any non-Docker environment — this fired 6+ bash commands per cycle, two of which targeted a path that does not exist outside a container, producing constant errors in the dev-server logs.

## Summary

- Remove the `candidateDirs` array and its hardcoded `/workspace/project` / `workspace/project` entries introduced in #455.
- The probe now queries only `workingDir` (resolved from `conversation.workspace.working_dir` → `VITE_WORKING_DIR` - The probin default).
- The nested-repo `find` pass is retained for the common local-clone flow where the agent clones a repo into a subdirectory of the workspace.

####################################################################ocal agent server with a conversation that has **no g## repo** in its workspace.
2. Confirm no `cwd: "/workspace/project"` errors appear in the browser console or server logs.
3. Open a conversation whose workspace **does** contain a cloned git repo and confirm the git control bar still shows the correct remote and branch.

## Video/Screenshots

N/A — log-noise removal; no visible UI change.

## Type

- [x] Bug fix

## Notes

The Docker path was added in #455 as a workaround for cases where `conversation.workspThe Dockeng_dir` was not yet populated when the probe fired. That field is now reliably set by the agent server at conversation creation time, making the hardcoded fallback unnecessary.

_This PR was created by an AI agent (OpenHands) on behalf of the repository owner._
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.22.1-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `bfde744252b5ffe1f14f3867c29bfffae83f0ea2` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-bfde744
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-bfde744
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-bfde744-amd64
ghcr.io/openhands/agent-canvas:fix-remove-hardcoded-docker-workspace-fallback-amd64
ghcr.io/openhands/agent-canvas:pr-671-amd64
ghcr.io/openhands/agent-canvas:sha-bfde744-arm64
ghcr.io/openhands/agent-canvas:fix-remove-hardcoded-docker-workspace-fallback-arm64
ghcr.io/openhands/agent-canvas:pr-671-arm64
ghcr.io/openhands/agent-canvas:sha-bfde744
ghcr.io/openhands/agent-canvas:fix-remove-hardcoded-docker-workspace-fallback
ghcr.io/openhands/agent-canvas:pr-671
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-bfde744`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-bfde744-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->