### PR TITLE
Test PR: verify org-gated re-review workflow

### DIFF
--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -1,0 +1,71 @@
+---
+name: long-running-fork
+description: Repo-specific guidance for the long-running personal fork `smolpaws/agent-canvas` of `OpenHands/agent-canvas`. Auto-loaded for any task on the fork's `main` branch so changes stay easy to rebase onto upstream.
+triggers:
+- smolpaws/agent-canvas
+- long-running fork
+- merge upstream
+- rebase upstream
+---
+
+# Long-Running Fork — `smolpaws/agent-canvas`
+
+This repository is checked out from **`smolpaws/agent-canvas`**, a long-running
+personal fork of `OpenHands/agent-canvas` maintained by smolpaws (for Engel Nyst).
+The fork's default branch is **`main`**, which intentionally **diverges from
+upstream `main`** — it carries customizations on top of upstream and is rebased
+onto upstream periodically.
+
+### Remote setup
+
+- `origin` → `smolpaws/agent-canvas` — the fork. Push here.
+- `upstream` → `OpenHands/agent-canvas` — canonical. Fetch only.
+
+### The fork's #1 constraint
+
+**Stay easy to rebase onto upstream `main`.** Every change must minimize
+merge-conflict surface area.
+
+## Core Principles
+
+1. **Mark every fork-local edit** with a `smolpaws-mod:` comment in the
+   source so it can be grepped. Example:
+   ```ts
+   label: "Conversations", /* smolpaws-mod: was "Home" */
+   ```
+
+2. **Update the MODLOG in the same commit** as the fork-local code change.
+
+3. **Prefer additive changes** (new files, new config entries, appended
+   items) over in-place edits to upstream files.
+
+4. **Never reformat upstream code** — it creates false-positive conflicts.
+
+5. **One logical change per commit** for clean cherry-pick and revert.
+
+## MODLOG — Live Fork-Local Modifications
+
+_Empty — no fork-local modifications yet._
+
+## SYNCLOG — Upstream Sync History
+
+| Date | Upstream commit | Notes |
+|------|----------------|-------|
+| 2026-05-16 | `558b4bd` | Initial fork creation, branch point = upstream main HEAD |
+
+## Rebase Recipe
+
+```sh
+git fetch upstream
+git rebase upstream/main
+# Resolve conflicts, keeping smolpaws-mod markers
+# Update SYNCLOG with new upstream HEAD
+git push origin main --force-with-lease
+```
+
+## Escalation
+
+If the same upstream file conflicts on **2+ rebases** with the same
+structural edit, open an upstream issue proposing an extensibility hook
+(config flag, render slot, theme key, etc.). See the `create-fork` skill
+for the issue template.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You can work with any agent (e.g. Claude Code, Codex) or connect directly to an 
 
 If you have questions or feedback, please open a GitHub issue or join the [#proj-agent-canvas channel in Slack](https://openhands.dev/joinslack)
 
+_Test PR for re-review workflow validation._
+
 <img width="1509" height="826" alt="Screenshot 2026-05-11 at 10 13 19 AM" src="https://github.com/user-attachments/assets/71ef41ae-8f6d-4fbf-990f-d672175d93d1" />
 
 ## Quickstart


### PR DESCRIPTION
## Summary
- add a tiny disposable README note to create an untrusted PR for workflow validation
- target the `enyst/org-member-review-gate` branch so the updated PR-review workflow is active
- use this PR to verify that org members can re-request review while non-members cannot

## Notes
- This PR is for workflow testing only and is expected to be closed after validation.

_This PR was created by an AI agent (OpenHands) on behalf of the user._