### PR TITLE
fix(frontend): portal ModalBackdrop to document.body

### DIFF
--- a/__tests__/components/shared/modals/modal-backdrop.test.tsx
+++ b/__tests__/components/shared/modals/modal-backdrop.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
+
+describe("ModalBackdrop", () => {
+  it("portals out of a transformed ancestor so position: fixed resolves against the viewport", () => {
+    // Arrange: a transformed ancestor would otherwise become the
+    // containing block for `position: fixed` descendants and trap the
+    // modal inside it (the OnboardingModal / InstallServerModal bug).
+    render(
+      <div data-testid="transformed-ancestor" style={{ transform: "translateX(0)" }}>
+        <ModalBackdrop onClose={vi.fn()}>
+          <p>modal content</p>
+        </ModalBackdrop>
+      </div>,
+    );
+
+    // Act
+    const dialog = screen.getByRole("dialog");
+    const transformedAncestor = screen.getByTestId("transformed-ancestor");
+
+    // Assert
+    expect(transformedAncestor.contains(dialog)).toBe(false);
+    expect(document.body.contains(dialog)).toBe(true);
+  });
+
+  it("calls onClose when the user presses Escape", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <ModalBackdrop onClose={onClose}>
+        <p>modal content</p>
+      </ModalBackdrop>,
+    );
+
+    // Act
+    await user.keyboard("{Escape}");
+
+    // Assert
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the backdrop is clicked but not when the content is clicked", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <ModalBackdrop onClose={onClose}>
+        <button type="button">inside content</button>
+      </ModalBackdrop>,
+    );
+
+    // Act: click the content first — this must NOT close.
+    await user.click(screen.getByRole("button", { name: "inside content" }));
+    const callsAfterContentClick = onClose.mock.calls.length;
+
+    // Act: now click the backdrop overlay (the dialog root's backdrop child).
+    const dialog = screen.getByRole("dialog");
+    const backdrop = dialog.firstElementChild as HTMLElement;
+    await user.click(backdrop);
+
+    // Assert
+    expect(callsAfterContentClick).toBe(0);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/shared/modals/modal-backdrop.tsx
+++ b/src/components/shared/modals/modal-backdrop.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { createPortal } from "react-dom";
 
 interface ModalBackdropProps {
   children: React.ReactNode;
@@ -28,7 +29,14 @@ export function ModalBackdrop({
     if (e.target === e.currentTarget) onClose?.(); // only close if the click was on the backdrop
   };
 
-  return (
+  if (typeof document === "undefined") return null;
+
+  // Portal to document.body so the modal's `position: fixed` resolves
+  // against the viewport. Otherwise a transformed ancestor (e.g. the
+  // onboarding slide rail) would become the containing block and the
+  // modal would render trapped inside it instead of overlapping its
+  // parent modal.
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -40,6 +48,7 @@ export function ModalBackdrop({
         className="fixed inset-0 bg-black opacity-60"
       />
       <div className="relative">{children}</div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

<img width="1440" height="838" alt="Image" src="https://github.com/user-attachments/assets/11607397-d85f-497f-8d32-55b758bb876f" />

In the onboarding flow, clicking a recommended automation tile whose required MCP server is not yet installed causes the "Connect MCP Server" dialog (`InstallServerModal`) to render **inside** the onboarding modal's content box, between the progress bar and the Back/Send buttons, rather than as a full-viewport overlay on top of the onboarding modal.

### Steps to reproduce

1. Clone `agent-canvas` and run `npm run dev`.
2. In the `OnboardingModal`, advance to `SayHelloStep`.
3. Click an automation tile in `RecommendedAutomationsSection` that requires an uninstalled MCP server (e.g. GitHub).

### Current behavior

The install dialog appears trapped inside the onboarding modal's body, clipped to the slide rail. Layout looks broken.

### Expected behavior

The install dialog should appear as a top-level modal overlapping the entire viewport, with its backdrop dimming the onboarding modal underneath.

### Root cause

The shared `ModalBackdrop` primitive (`src/components/shared/modals/modal-backdrop.tsx`) renders inline in the DOM. The onboarding slide rail applies `transform: translateX(...)` to each step slide so the rail can animate between steps (`src/components/features/onboarding/onboarding-modal.tsx:47`). Per the CSS spec, a non-`none` `transform` on an ancestor establishes a containing block for `position: fixed` descendants, so the nested install modal's `fixed inset-0` is anchored to the slide's box rather than the viewport. The `overflow-clip` slide rail and `overflow-y-auto` scroll area then clip it. Raising z-index cannot fix this — z-index only resolves within a stacking context, and the modal's fixed rectangle never reaches the viewport in the first place.

### Fix

Render `ModalBackdrop`'s output through `createPortal(..., document.body)` so the modal escapes any transformed/clipped ancestor and resolves `position: fixed` against the viewport. SSR-guarded with `typeof document === "undefined"`. Same pattern already used by `EnvironmentSwitchOverlay` (`src/components/features/backends/environment-switch-overlay.tsx:150`).

### Acceptance criteria

- [ ] In the onboarding flow, clicking an automation that requires an uninstalled MCP server renders the install dialog as a full-viewport overlay on top of the onboarding modal, with its backdrop dimming the entire viewport.
- [ ] All existing `ModalBackdrop` consumers (settings, backends, conversation panel, MCP page, etc.) continue to render and close correctly via Escape and backdrop click.
- [ ] Regression test in `__tests__/components/shared/modals/modal-backdrop.test.tsx` asserts the modal mounts under `document.body` even when wrapped in a transformed ancestor.

## Summary

<!-- 1-3 bullets describing what changed. -->

- Wrap the shared `ModalBackdrop` primitive in `createPortal(..., document.body)` (SSR-guarded) so a modal's `position: fixed` resolves against the viewport even when rendered inside a transformed or overflow-clipped ancestor.
- Fixes the onboarding bug where the "Connect MCP Server" dialog rendered inside `OnboardingModal` → `SayHelloStep` instead of overlapping it.
- Adds a regression test for the portal behavior plus Escape / backdrop-click close handling.

### Root cause

`ModalBackdrop` rendered inline. The onboarding slide rail applies `transform: translateX(...)` to each slide (`src/components/features/onboarding/onboarding-modal.tsx:47`) to animate between onboarding steps. Per the CSS spec, a non-`none` `transform` on an ancestor establishes a containing block for `position: fixed` descendants — so the install dialog's `fixed inset-0` anchored to the slide's box rather than the viewport, and got clipped by the slide rail's `overflow-clip`. This is why the install card showed up trapped inside the onboarding modal's body in the screenshot. Bumping z-index does not help, because z-index only resolves within a stacking context and the fixed rectangle is already constrained to the slide.

### Fix

```tsx
// src/components/shared/modals/modal-backdrop.tsx
if (typeof document === "undefined") return null;
return createPortal(
  <div role="dialog" aria-modal="true" ... className="fixed inset-0 ... z-60">
    <div onClick={handleClick} className="fixed inset-0 bg-black opacity-60" />
    <div className="relative">{children}</div>
  </div>,
  document.body,
);
```

Mirrors the SSR-safe pattern already used by `EnvironmentSwitchOverlay` (`src/components/features/backends/environment-switch-overlay.tsx:150`). Public API of `ModalBackdrop` is unchanged; all ~25 callers benefit from correct behavior over any transformed / overflow-clipped ancestor.

### Why fix the primitive instead of lifting `InstallServerModal` out of `RecommendedAutomationsLauncher`

Lifting the install modal up the tree would require hoisting install state across the onboarding/launcher boundary and would leave the primitive broken for the next caller that mounts a modal inside a transformed ancestor. Patching the primitive is a single-file change that addresses the entire class of bug.

### Files changed

- `src/components/shared/modals/modal-backdrop.tsx` — portal the rendered output to `document.body`.
- `__tests__/components/shared/modals/modal-backdrop.test.tsx` — new regression tests.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #687

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository and start the development server:

   ```bash
   npm run dev
   ```

2. In the `<OnboardingModal />` modal, navigate to `<SayHelloStep />` and click `<RecommendedAutomationsSection />`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="838" alt="output" src="https://github.com/user-attachments/assets/5c89806d-1b2a-4528-9631-53d8bc07a20b" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.22.1-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `1c62db2a5779ecc6cca41b7f8f77abe5f54520d4` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-1c62db2
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-1c62db2
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-1c62db2-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1879-amd64
ghcr.io/openhands/agent-canvas:pr-688-amd64
ghcr.io/openhands/agent-canvas:sha-1c62db2-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1879-arm64
ghcr.io/openhands/agent-canvas:pr-688-arm64
ghcr.io/openhands/agent-canvas:sha-1c62db2
ghcr.io/openhands/agent-canvas:hieptl-app-1879
ghcr.io/openhands/agent-canvas:pr-688
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-1c62db2`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-1c62db2-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->