### PR TITLE
fix(frontend): align agent settings save button label with other settings pages

### DIFF
--- a/__tests__/routes/agent-settings.test.tsx
+++ b/__tests__/routes/agent-settings.test.tsx
@@ -60,6 +60,30 @@ describe("AgentSettingsScreen", () => {
     expect(screen.queryByTestId("agent-command-input")).not.toBeInTheDocument();
   });
 
+  it("labels the save button 'Save Changes' for consistency with other settings pages", async () => {
+    // Arrange — render with any valid settings; the label is independent
+    // of the form's state.
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        agent_settings: {
+          ...MOCK_DEFAULT_USER_SETTINGS.agent_settings,
+          agent_kind: "openhands",
+        },
+      }),
+    );
+
+    // Act
+    renderAgentSettingsScreen();
+    await screen.findByTestId("agent-settings-screen");
+
+    // Assert — t() is stubbed to return the key, so the rendered text is
+    // the translation key. SETTINGS$SAVE_CHANGES = "Save Changes" in
+    // public/locales/en/openhands.json; BUTTON$SAVE = "Save" (the bug).
+    expect(screen.getByTestId("agent-save-button")).toHaveTextContent(
+      "SETTINGS$SAVE_CHANGES",
+    );
+  });
+
   it("saves enable_sub_agents when toggling on the OpenHands path", async () => {
     const user = userEvent.setup();
     vi.spyOn(SettingsService, "getSettings").mockResolvedValue(

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -377,7 +377,9 @@ function AgentSettingsScreen() {
           isDisabled={isSaving || !effectiveIsDirty || isAcpInvalid}
           onClick={handleSave}
         >
-          {isSaving ? t(I18nKey.SETTINGS$SAVING) : t(I18nKey.BUTTON$SAVE)}
+          {isSaving
+            ? t(I18nKey.SETTINGS$SAVING)
+            : t(I18nKey.SETTINGS$SAVE_CHANGES)}
         </BrandButton>
       </div>
     </div>


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

The primary action button on `/settings/agent` is labeled **"Save"**, while every other settings page (LLM, Condenser, Verification, Application) uses **"Save Changes"**. This inconsistency makes the Agent page feel like a one-off and slightly undermines the visual rhythm of the settings area.

### Steps to reproduce

1. Clone `agent-canvas` and run `npm run dev`.
2. Navigate to `http://localhost:3001/settings/agent`.
3. Observe the button at the bottom of the form.

### Current behavior

The button reads **"Save"**.

### Expected behavior

The button should read **"Save Changes"**, matching `/settings/llm`, `/settings/condenser`, `/settings/verification`, and `/settings/application`.

### Root cause

`src/routes/agent-settings.tsx:380` renders the button using the i18n key `I18nKey.BUTTON$SAVE` (= `"Save"`). The Agent screen is the only settings page implemented as a custom screen rather than via the shared `SdkSectionPage` component, and it was wired up to the wrong key. Other pages use `I18nKey.SETTINGS$SAVE_CHANGES` (= `"Save Changes"`), either through `SdkSectionPage` (`src/components/features/settings/sdk-settings/sdk-section-page.tsx:498`) or directly (`src/routes/app-settings.tsx:203`).

Both keys already exist in `public/locales/en/openhands.json` — no locale work needed.

### Acceptance criteria

- [ ] The button on `/settings/agent` reads "Save Changes" in the idle state.
- [ ] The button still reads "Saving…" while a save is in flight.
- [ ] The button continues to be disabled when the form is pristine, saving, or the ACP command is invalid.
- [ ] Other settings pages are unchanged.
- [ ] A test guards against future regression of the label.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The Save button on `/settings/agent` now reads **"Save Changes"** instead of **"Save"**, matching the rest of the settings area (LLM, Condenser, Verification, Application).
- One-line change in `src/routes/agent-settings.tsx` — swaps `I18nKey.BUTTON$SAVE` for the existing `I18nKey.SETTINGS$SAVE_CHANGES`.
- Adds a regression test in `__tests__/routes/agent-settings.test.tsx` that pins the label via the translation key.

## Why

`/settings/agent` was the only settings page implemented as a custom screen rather than through the shared `SdkSectionPage` component, and it was wired to a different i18n key (`BUTTON$SAVE` = "Save") than every sibling page (`SETTINGS$SAVE_CHANGES` = "Save Changes"). The mismatch is purely cosmetic but makes the Agent page feel off-pattern.

## Changes

- `src/routes/agent-settings.tsx` — replaced `t(I18nKey.BUTTON$SAVE)` with `t(I18nKey.SETTINGS$SAVE_CHANGES)` on the primary button. The "Saving…" state and all disabled/onClick logic are untouched.
- `__tests__/routes/agent-settings.test.tsx` — added one test asserting the button text resolves to `SETTINGS$SAVE_CHANGES`. With the i18n mock returning keys verbatim, this is the unit-test-level equivalent of asserting "Save Changes" is on screen, and it would fail under the prior `BUTTON$SAVE` wiring.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #690 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

<img width="1440" height="838" alt="app-1882" src="https://github.com/user-attachments/assets/4d0a1a6a-34e1-44dd-bb6c-73da879eeaa2" />

1. Clone the `agent-server-gui` repository and start the development server:

   ```bash
   npm run dev
   ```

2. Navigate to `http://localhost:3001/settings/agent`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->



## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- Refactoring the Agent settings screen to use the shared `SdkSectionPage` component. That's a larger architectural change; this PR fixes only the user-visible label.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.22.1-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `0ddbffbda4c8735e6d2386b56e60bba956e988bb` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-0ddbffb
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-0ddbffb
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-0ddbffb-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1882-amd64
ghcr.io/openhands/agent-canvas:pr-691-amd64
ghcr.io/openhands/agent-canvas:sha-0ddbffb-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1882-arm64
ghcr.io/openhands/agent-canvas:pr-691-arm64
ghcr.io/openhands/agent-canvas:sha-0ddbffb
ghcr.io/openhands/agent-canvas:hieptl-app-1882
ghcr.io/openhands/agent-canvas:pr-691
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-0ddbffb`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-0ddbffb-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->