### PR TITLE
chore: refresh stale 1.22.1 doc examples after agent-server bump to 1.23.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,10 +322,10 @@ return new ConversationClient(getAgentServerClientOptions()).someMethod(...);
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.22.1")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.23.0")
   - `OH_SECRET_KEY` — secret key for settings encryption; uses a static default for local dev since it's needed for reading persisted encrypted values across restarts
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.22.1` for agent-server SDK libraries
+  - Default: released PyPI version `1.23.0` for agent-server SDK libraries
 
 - Security: `scripts/dev-safe.mjs` and `scripts/dev-with-automation.mjs` auto-generate random API keys when needed and persist the defaults so static builds, localStorage, and restarted services stay in sync:
   - `SESSION_API_KEY` — 64-character hex (256-bit) for agent-server API authentication; persisted at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden via env var

--- a/__tests__/scripts/docs-version-sync.test.ts
+++ b/__tests__/scripts/docs-version-sync.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+//
+// Drift-detection: documented agent-server version examples must match the
+// authoritative `versions.agentServer` pin in `config/defaults.json`.
+//
+// PR #670 bumped the central pin to 1.23.0 but left stale `1.22.1` examples in
+// AGENTS.md and several script JSDocs. This test fails when those references
+// drift from the central pin so the next bump cannot silently leave docs
+// behind.
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+function read(rel: string): string {
+  return readFileSync(path.join(repoRoot, rel), "utf-8");
+}
+
+const config = JSON.parse(read("config/defaults.json")) as {
+  versions: { agentServer: string };
+};
+const v = config.versions.agentServer;
+
+describe("docs/example references stay in sync with config/defaults.json", () => {
+  it("AGENTS.md documents the current default version", () => {
+    const agentsMd = read("AGENTS.md");
+    expect(agentsMd).toContain(
+      `\`OH_AGENT_SERVER_VERSION\` — specific PyPI version (e.g., "${v}")`,
+    );
+    expect(agentsMd).toContain(
+      `Default: released PyPI version \`${v}\` for agent-server SDK libraries`,
+    );
+  });
+
+  it("scripts/dev-safe.mjs JSDoc example matches the current default", () => {
+    const devSafe = read("scripts/dev-safe.mjs");
+    expect(devSafe).toContain(
+      `OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "${v}")`,
+    );
+  });
+
+  it("scripts/check-sdk-version-sync.mjs examples match the current default", () => {
+    const src = read("scripts/check-sdk-version-sync.mjs");
+    expect(src).toContain(`EXPECTED_SDK_VERSION=${v}`);
+    expect(src).toContain(`"version": "${v}"`);
+    expect(src).toContain(`"openhands-sdk>=${v},<2.0.0"`);
+    expect(src).toContain(`"openhands-tools==${v}"`);
+    expect(src).toContain(`"openhands-workspace (>=${v})"`);
+    expect(src).toContain(
+      `">=${v}", "==${v}", "(>=${v})", "~=${v}"`,
+    );
+  });
+
+  it("scripts/check-acp-providers-sync.mjs --sdk-ref example matches the current default", () => {
+    const src = read("scripts/check-acp-providers-sync.mjs");
+    expect(src).toContain(`--sdk-ref v${v}`);
+  });
+});

--- a/scripts/check-acp-providers-sync.mjs
+++ b/scripts/check-acp-providers-sync.mjs
@@ -28,7 +28,7 @@
  *
  * Usage:
  *   node scripts/check-acp-providers-sync.mjs
- *   node scripts/check-acp-providers-sync.mjs --sdk-ref v1.22.1
+ *   node scripts/check-acp-providers-sync.mjs --sdk-ref v1.23.0
  *   node scripts/check-acp-providers-sync.mjs --sdk-file /path/to/acp_providers.py
  *
  * Options:

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.22.1 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.23.0 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -79,7 +79,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/agent-canvas/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.22.1"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.23.0"}}'
 `);
   process.exit(0);
 }
@@ -268,9 +268,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.22.1,<2.0.0"
- *   "openhands-tools==1.22.1"
- *   "openhands-workspace (>=1.22.1)"
+ *   "openhands-sdk>=1.23.0,<2.0.0"
+ *   "openhands-tools==1.23.0"
+ *   "openhands-workspace (>=1.23.0)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -284,7 +284,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.22.1", "==1.22.1", "(>=1.22.1)", "~=1.22.1"
+      // ">=1.23.0", "==1.23.0", "(>=1.23.0)", "~=1.23.0"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -337,7 +337,7 @@ export function validateFrontendDependencies(
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.22.1")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.23.0")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

PR #670 bumped `versions.agentServer` in `config/defaults.json` from `1.22.1` to `1.23.0` (and updated the default-version test assertions in `__tests__/scripts/dev-safe.test.ts`), but left several JSDoc and `AGENTS.md` examples still mentioning `1.22.1`. This drift makes the docs misleading for contributors who are pinning a specific version or running the version-sync script.

Following the pattern set by [agent-canvas PR #477](https://github.com/OpenHands/agent-canvas/pull/477) — which includes "refreshing documentation examples throughout the repository" as part of every version bump — refresh the stale references so they match the central pin.

`versions.automationSdk` (`1.22.1`) is intentionally left alone — it records the SDK version that the released `openhands-automation` PyPI package was built against and may lag `versions.agentServer` by design (see the header comment in `scripts/check-sdk-version-sync.mjs`).

### Acceptance criteria

- [x] `AGENTS.md` references to the agent-server default version read `1.23.0`.
- [x] `scripts/dev-safe.mjs`, `scripts/check-sdk-version-sync.mjs`, and `scripts/check-acp-providers-sync.mjs` JSDoc/comment examples read `1.23.0`.
- [x] A regression test fails if any documented example drifts from `versions.agentServer` in `config/defaults.json`.
- [x] `versions.automationSdk` is **not** touched.
- [x] CI version-sync check (`node scripts/check-sdk-version-sync.mjs`) still passes.

### Out of scope

- Bumping `versions.automationSdk` — separate concern, tied to the released automation PyPI package.
- Historical `1.18.0` examples in `.env.sample` / `DEVELOPMENT.md` — these are unrelated env-override illustrations, not default-version references.
- Test fixtures in `dev-safe.test.ts` / `check-sdk-version-sync.test.ts` / `option-service.test.ts` that pass arbitrary versions to assert env-override behavior.

### Links

- Upstream release: <https://github.com/OpenHands/software-agent-sdk/releases/tag/v1.23.0>
- Pattern PR: <https://github.com/OpenHands/agent-canvas/pull/477>
- Central bump (already merged): #670

## Summary

<!-- 1-3 bullets describing what changed. -->
- PR #670 bumped `versions.agentServer` to `1.23.0` in `config/defaults.json` but did not refresh the example version strings scattered across `AGENTS.md` and several script JSDocs. This PR completes that refresh.
- Adds a drift-detection test (`__tests__/scripts/docs-version-sync.test.ts`) so the next bump cannot silently leave docs behind.
- `versions.automationSdk` is intentionally left at `1.22.1` — it tracks the released `openhands-automation` PyPI package's SDK dependency and is allowed to lag `versions.agentServer`.

### Files changed

| File | Lines | What |
| --- | --- | --- |
| `AGENTS.md` | 2 | `OH_AGENT_SERVER_VERSION` env-var example + "Default: released PyPI version" sentence |
| `scripts/dev-safe.mjs` | 1 | JSDoc example for `OH_AGENT_SERVER_VERSION` |
| `scripts/check-sdk-version-sync.mjs` | 6 | Usage example, dispatch-payload curl, three pip-dep examples in JSDoc, inline parser comment |
| `scripts/check-acp-providers-sync.mjs` | 1 | `--sdk-ref` usage example |
| `__tests__/scripts/docs-version-sync.test.ts` | new | 4 drift-detection assertions read from `config/defaults.json` |

### Why this matters

The previous bump pattern ([agent-canvas #477](https://github.com/OpenHands/agent-canvas/pull/477)) explicitly included "refreshing documentation examples throughout the repository" as part of every version bump. Without that step, the canonical pin in `config/defaults.json` and the human-readable docs drift apart, which is exactly what happened between PR #670 and this PR.

The new test reads `versions.agentServer` from `config/defaults.json` at runtime and asserts every documented example matches, so the failure mode becomes a fast unit-test red instead of a silent doc rot.

### Out of scope

- Bumping `versions.automationSdk` (intentionally lags — see `scripts/check-sdk-version-sync.mjs` header).
- Historical `1.18.0` examples in `.env.sample` and `DEVELOPMENT.md` — these illustrate env-override usage and are not default-version references.
- Test fixtures that pass arbitrary version strings to assert env-override behavior (e.g., the `"1.18.0"` strings in `dev-safe.test.ts`).

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #693 

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

### Related

- Upstream release: <https://github.com/OpenHands/software-agent-sdk/releases/tag/v1.23.0>
- Pattern: <https://github.com/OpenHands/agent-canvas/pull/477>
- Central bump (already on `main`): #670
<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `30706eb304206cdfc5de8b4ab507686e01a83aad` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-30706eb
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-30706eb
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-30706eb-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1885-amd64
ghcr.io/openhands/agent-canvas:pr-694-amd64
ghcr.io/openhands/agent-canvas:sha-30706eb-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1885-arm64
ghcr.io/openhands/agent-canvas:pr-694-arm64
ghcr.io/openhands/agent-canvas:sha-30706eb
ghcr.io/openhands/agent-canvas:hieptl-app-1885
ghcr.io/openhands/agent-canvas:pr-694
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-30706eb`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-30706eb-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->