### PR TITLE
fix(frontend): open ellipsis menu by ignoring trigger in click-outside

### DIFF
--- a/__tests__/components/features/conversation/conversation-tabs.test.tsx
+++ b/__tests__/components/features/conversation/conversation-tabs.test.tsx
@@ -477,6 +477,30 @@ describe("ConversationTabs localStorage behavior", () => {
     });
   });
 
+  describe("ellipsis context menu", () => {
+    beforeEach(() => {
+      mockConversationId = REAL_CONVERSATION_ID;
+    });
+
+    it("opens the context menu when the ellipsis button is clicked", async () => {
+      const user = userEvent.setup();
+
+      render(<ConversationTabs />, {
+        wrapper: createWrapper(REAL_CONVERSATION_ID),
+      });
+
+      expect(
+        screen.queryByTestId("conversation-tabs-menu-open-files"),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByTestId("ellipsis-button"));
+
+      expect(
+        screen.getByTestId("conversation-tabs-menu-open-files"),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("tasklist tab", () => {
     beforeEach(() => {
       mockConversationId = REAL_CONVERSATION_ID;

--- a/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { ContextMenu } from "#/ui/context-menu";
 import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
@@ -24,13 +25,18 @@ import { cn } from "#/utils/utils";
 interface ConversationTabsContextMenuProps {
   isOpen: boolean;
   onClose: () => void;
+  ignoreOutsideClickRef?: React.RefObject<HTMLElement | null>;
 }
 
 export function ConversationTabsContextMenu({
   isOpen,
   onClose,
+  ignoreOutsideClickRef,
 }: ConversationTabsContextMenuProps) {
-  const ref = useClickOutsideElement<HTMLUListElement>(onClose);
+  const ref = useClickOutsideElement<HTMLUListElement>(
+    onClose,
+    ignoreOutsideClickRef,
+  );
   const { t } = useTranslation("openhands");
   const { conversationId } = useConversationId();
   const {

--- a/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
@@ -161,6 +161,7 @@ export function ConversationTabs({
   const tabsRowInnerRef = useRef<HTMLDivElement>(null);
   const measureRowRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLButtonElement>(null);
   const [inlineTabCount, setInlineTabCount] = useState(visibleTabs.length);
 
   useLayoutEffect(() => {
@@ -317,6 +318,7 @@ export function ConversationTabs({
             </div>
             <div ref={menuRef} className="relative shrink-0">
               <EllipsisButton
+                ref={anchorRef}
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
                 ariaLabel={t(I18nKey.COMMON$MORE_OPTIONS)}
                 iconClassName={
@@ -326,6 +328,7 @@ export function ConversationTabs({
               <ConversationTabsContextMenu
                 isOpen={isMenuOpen}
                 onClose={() => setIsMenuOpen(false)}
+                ignoreOutsideClickRef={anchorRef}
               />
             </div>
           </div>


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description:**

The "three vertical dots" overflow trigger in the conversation tab bar is non-functional. Clicking it never reveals the context menu (open/pin controls for the secondary tabs), so users cannot reach any tab that has been pushed into the overflow menu or toggle pin state on existing tabs.

**Steps to reproduce:**

1. Clone `agent-canvas` and start the dev server:
   ```bash
   npm run dev
   ```
2. Open the home page and create a new conversation.
3. Navigate to the conversation page.
4. In `<ConversationTabs />`, click `<EllipsisButton />` (the three vertical dots) to open `<ConversationTabsContextMenu />`.

**Current behavior:**
Clicking `<EllipsisButton />` does nothing visible — the menu either never appears or appears for a single frame and snaps closed.

**Expected behavior:**
Clicking `<EllipsisButton />` opens `<ConversationTabsContextMenu />` and leaves it open until the user picks an entry or clicks outside.

**Root cause:**
`ConversationTabsContextMenu` calls `useClickOutsideElement(onClose)` without an `ignoreOutsideClickRef`. The menu's `<ul>` and the trigger button are siblings inside `<ConversationTabs />`, so the click that flips `isMenuOpen` to `true` bubbles to the hook's document listener and is treated as "outside" — `onClose()` fires in the same tick and the menu closes immediately. The neighbor `<ConversationCardContextMenu />` already handles this correctly by accepting an `ignoreOutsideClickRef` for its trigger button; that pattern was just not applied here.

**Acceptance criteria:**

- [ ] Clicking the ellipsis button in `<ConversationTabs />` opens `<ConversationTabsContextMenu />`.
- [ ] The menu remains open until the user selects an entry, toggles a pin, clicks the ellipsis button again, or clicks outside both the button and the menu.
- [ ] Automated regression test covers the open-on-click behavior.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Restore the conversation-tab overflow menu: clicking `<EllipsisButton />` in `<ConversationTabs />` now opens `<ConversationTabsContextMenu />` and keeps it open.
- Root cause: `ConversationTabsContextMenu` called `useClickOutsideElement(onClose)` without `ignoreOutsideClickRef`, so the trigger click bubbled to the document listener and immediately closed the just-opened menu.
- Adopt the existing pattern from `ConversationCardContextMenu` / `ConversationCardActions`: thread an `anchorRef` for the `EllipsisButton` through the menu as `ignoreOutsideClickRef` so the hook skips clicks on the trigger.

### Files changed

- `src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx` — accept optional `ignoreOutsideClickRef`, forward to `useClickOutsideElement`.
- `src/components/features/conversation/conversation-tabs/conversation-tabs.tsx` — add `anchorRef`, attach to `<EllipsisButton />` (already `forwardRef`'d), pass to the menu.
- `__tests__/components/features/conversation/conversation-tabs.test.tsx` — add a regression test that the menu opens on ellipsis click.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #695 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository and start the development server:

   ```bash
   npm run dev
   ```

2. Open the home page and create a new conversation.

3. Navigate to the conversation page.

4. In `<ConversationTabs />`, click `<EllipsisButton />` to open `<ConversationTabsContextMenu />`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="838" alt="app-1886" src="https://github.com/user-attachments/assets/4117c192-c060-4e7e-aba8-7b49ba90e725" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `d011ac879e6b6445088ab1ffc76b785bcaad8b11` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-d011ac8
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-d011ac8
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-d011ac8-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1886-amd64
ghcr.io/openhands/agent-canvas:pr-696-amd64
ghcr.io/openhands/agent-canvas:sha-d011ac8-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1886-arm64
ghcr.io/openhands/agent-canvas:pr-696-arm64
ghcr.io/openhands/agent-canvas:sha-d011ac8
ghcr.io/openhands/agent-canvas:hieptl-app-1886
ghcr.io/openhands/agent-canvas:pr-696
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-d011ac8`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-d011ac8-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->