### PR TITLE
fix(frontend): drop low-contrast placeholders from LLM provider/model dropdowns

### DIFF
--- a/__tests__/components/modals/settings/model-selector.test.tsx
+++ b/__tests__/components/modals/settings/model-selector.test.tsx
@@ -137,4 +137,14 @@ describe("ModelSelector", () => {
     });
   });
 
+  it("should not render placeholder text on the provider or model inputs", () => {
+    renderWithQuery(<ModelSelector />);
+
+    const providerInput = screen.getByLabelText("LLM Provider");
+    const modelInput = screen.getByLabelText("LLM Model");
+
+    expect(providerInput.getAttribute("placeholder") ?? "").toBe("");
+    expect(modelInput.getAttribute("placeholder") ?? "").toBe("");
+  });
+
 });

--- a/src/components/shared/modals/settings/model-selector.tsx
+++ b/src/components/shared/modals/settings/model-selector.tsx
@@ -132,7 +132,6 @@ export function ModelSelector({
           name="llm-provider-input"
           isDisabled={isDisabled}
           aria-label={t(I18nKey.LLM$PROVIDER)}
-          placeholder={t(I18nKey.LLM$SELECT_PROVIDER_PLACEHOLDER)}
           isClearable={false}
           onSelectionChange={(e) => {
             if (e?.toString()) handleChangeProvider(e.toString());
@@ -150,7 +149,7 @@ export function ModelSelector({
           inputProps={{
             classNames: {
               inputWrapper:
-                "bg-tertiary border border-[var(--oh-border-input)] h-10 w-full rounded-sm p-2 placeholder:italic",
+                "bg-tertiary border border-[var(--oh-border-input)] h-10 w-full rounded-sm p-2",
             },
           }}
         >
@@ -204,7 +203,6 @@ export function ModelSelector({
           isLoading={isLoadingModels}
           name="llm-model-input"
           aria-label={t(I18nKey.LLM$MODEL)}
-          placeholder={t(I18nKey.LLM$SELECT_MODEL_PLACEHOLDER)}
           isClearable={false}
           onSelectionChange={(e) => {
             if (e?.toString()) handleChangeModel(e.toString());
@@ -222,7 +220,7 @@ export function ModelSelector({
           inputProps={{
             classNames: {
               inputWrapper:
-                "bg-tertiary border border-[var(--oh-border-input)] h-10 w-full rounded-sm p-2 placeholder:italic",
+                "bg-tertiary border border-[var(--oh-border-input)] h-10 w-full rounded-sm p-2",
             },
           }}
         >


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description**

<img width="1440" height="802" alt="Image" src="https://github.com/user-attachments/assets/69741f9e-8547-4199-8d5b-d826f4067ec5" />

On the **Add LLM Profile** page (`/settings/llm` → *Add LLM Profile*), the **Basic** tab shows two dropdowns — **LLM Provider** and **LLM Model**. Both render placeholder text ("Select a provider", "Select a model") in HeroUI's default placeholder color, which on our dark theme is noticeably darker than the muted grey used by surrounding inputs (e.g. "Enter profile name"). The result reads as a contrast/legibility issue.

The labels rendered directly above each input already provide the necessary context ("LLM Provider", "LLM Model"), so the placeholder text is redundant.

**Steps to reproduce**

1. `npm run dev`
2. Open `http://localhost:3001/settings/llm` → click **Add LLM Profile**.
3. On the **Basic** tab, observe the **LLM Provider** and **LLM Model** dropdowns.

**Expected**

The two dropdowns render with no faint placeholder text. The labels above them convey what each field is for. Other inputs on the form are unchanged.

**Actual**

Both dropdowns show low-contrast placeholder text that is hard to read against the dark background.

**Acceptance criteria**

- [ ] No placeholder text is rendered on the LLM Provider input on the Basic tab.
- [ ] No placeholder text is rendered on the LLM Model input on the Basic tab.
- [ ] The Advanced and All tabs are unaffected.
- [ ] The `LLM$SELECT_MODEL_PLACEHOLDER` translation key remains available (still consumed as a fallback label in `switch-profile-button.tsx`).
- [ ] Existing model-selector tests continue to pass; a new test asserts no placeholder attribute is rendered on either input.

## Summary

<!-- 1-3 bullets describing what changed. -->
- On the **Add LLM Profile** → **Basic** view, the **LLM Provider** and **LLM Model** `Autocomplete` dropdowns showed placeholders ("Select a provider", "Select a model") in HeroUI's default placeholder color, which is hard to read on our dark theme.
- Removed the `placeholder` prop from both `Autocomplete` components in `src/components/shared/modals/settings/model-selector.tsx`. The labels above each input already provide the needed context, so no replacement copy is required.
- Also dropped the now-dead `placeholder:italic` Tailwind modifier from each input wrapper className.
- Left the `LLM$SELECT_*_PLACEHOLDER` i18n keys in place — `LLM$SELECT_MODEL_PLACEHOLDER` is still used as a fallback label by `switch-profile-button.tsx:97`.

### Before / After

| | Before | After |
|---|---|---|
| LLM Provider input | shows dim "*Select a provider*" placeholder | renders empty until the user types / selects |
| LLM Model input    | shows dim "*Select a model*" placeholder    | renders empty until a provider is chosen   |

### Tests

- Extended `__tests__/components/modals/settings/model-selector.test.tsx` with one focused regression test that asserts neither the provider nor the model input exposes a non-empty `placeholder` attribute.
- All 6 tests in the file pass locally (`npx vitest run __tests__/components/modals/settings/model-selector.test.tsx`).

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #705

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository and start the development server:

   ```bash
   npm run dev
   ```

2. Navigate to the "Add LLM profile" page at `http://localhost:3001/settings/llm`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="802" alt="image" src="https://github.com/user-attachments/assets/c02634e8-edcc-41c6-97cc-363d2b9ad851" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `cc06f59755155f6756db2dc7d33fa1190ca7f470` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-cc06f59
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-cc06f59
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-cc06f59-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1891-amd64
ghcr.io/openhands/agent-canvas:pr-706-amd64
ghcr.io/openhands/agent-canvas:sha-cc06f59-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1891-arm64
ghcr.io/openhands/agent-canvas:pr-706-arm64
ghcr.io/openhands/agent-canvas:sha-cc06f59
ghcr.io/openhands/agent-canvas:hieptl-app-1891
ghcr.io/openhands/agent-canvas:pr-706
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-cc06f59`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-cc06f59-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->