### PR TITLE
Add BM-004 through BM-008 backend management specs and @spec tags

### DIFF
--- a/__tests__/api/backend-registry/last-conversation-store.test.ts
+++ b/__tests__/api/backend-registry/last-conversation-store.test.ts
@@ -14,6 +14,7 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
+// @spec BM-008 — Per-backend conversation memory
 describe("last-conversation-store", () => {
   it("returns null when nothing has been remembered for a backend", () => {
     expect(getLastConversationId("backend-a", null)).toBeNull();

--- a/__tests__/components/backends/backend-selector.test.tsx
+++ b/__tests__/components/backends/backend-selector.test.tsx
@@ -365,6 +365,7 @@ describe("BackendSelector", () => {
     });
   });
 
+  // @spec BM-005 — Switch active backend
   it("switches the active backend when an option is selected", async () => {
     renderWithProviders(
       <TestSeed
@@ -536,6 +537,7 @@ describe("BackendSelector", () => {
     ).toBeInTheDocument();
   });
 
+  // @spec BM-006 — Remove a backend
   it("opens the manage backends modal and removes a backend", async () => {
     renderWithProviders(
       <TestSeed

--- a/__tests__/contexts/active-backend-context.test.tsx
+++ b/__tests__/contexts/active-backend-context.test.tsx
@@ -52,6 +52,7 @@ describe("ActiveBackendProvider", () => {
     });
   });
 
+  // @spec BM-004 — Add a backend
   it("addBackend persists and exposes the new backend alongside the seeded default", () => {
     const { result } = renderHook(() => useActiveBackendContext(), {
       wrapper: makeWrapper(),
@@ -100,6 +101,7 @@ describe("ActiveBackendProvider", () => {
     expect(result.current.backends.find((b) => b.id === DEFAULT_LOCAL_BACKEND_ID)).toBeDefined();
   });
 
+  // @spec BM-005 — Switch active backend
   it("setActive switches the active backend without touching unrelated React Query cache entries", () => {
     const queryClient = new QueryClient();
     queryClient.setQueryData(["dummy"], { value: 1 });
@@ -131,6 +133,7 @@ describe("ActiveBackendProvider", () => {
     expect(queryClient.getQueryData(["dummy"])).toEqual({ value: 1 });
   });
 
+  // @spec BM-006 — Remove a backend
   // @spec BM-003 — Fallback on active backend removal
   it("removeBackend falls back to the seeded default when the active backend is removed", () => {
     const { result } = renderHook(() => useActiveBackendContext(), {
@@ -160,6 +163,7 @@ describe("ActiveBackendProvider", () => {
     expect(result.current.backends[0].id).toBe(DEFAULT_LOCAL_BACKEND_ID);
   });
 
+  // @spec BM-006 — Remove a backend
   // @spec BM-003 — Fallback on active backend removal
   it("removeBackend allows removing the seeded default and falls back to a synthesized env-derived backend", () => {
     const { result } = renderHook(() => useActiveBackendContext(), {
@@ -227,6 +231,7 @@ describe("ActiveBackendProvider", () => {
     expect(getBackendHealthEntry(id)).toBeNull();
   });
 
+  // @spec BM-006 — Remove a backend
   it("removeBackend drops the backend's persisted health entry", () => {
     // Arrange
     const { result } = renderHook(() => useActiveBackendContext(), {

--- a/specs/backend-management.md
+++ b/specs/backend-management.md
@@ -10,3 +10,18 @@
 
 ### BM-003: Fallback on active backend removal
 - [x] Removing the currently active backend shall fall back to a remaining local backend. The user shall never be left without an active backend.
+
+### BM-004: Add a backend
+- [x] The user shall be able to add a new backend (local or cloud) with host and API key.
+
+### BM-005: Switch active backend
+- [x] The user shall be able to switch the active backend from a list of registered backends.
+
+### BM-006: Remove a backend
+- [x] The user shall be able to remove a registered backend.
+
+### BM-007: Default backend API key stays in sync with env
+- [x] If the launcher rotates the session API key, the stored default backend shall pick up the new key on next page load.
+
+### BM-008: Per-backend conversation memory
+- [x] Switching back to a previously-used backend shall resume the last active conversation for that backend.

--- a/src/api/backend-registry/last-conversation-store.ts
+++ b/src/api/backend-registry/last-conversation-store.ts
@@ -1,3 +1,4 @@
+// @spec BM-008 — Per-backend conversation memory
 // Per-(backend, org) memory of the most recently selected conversation.
 //
 // Used by `BackendSelector` so that flipping from backend A → B while a

--- a/src/api/backend-registry/storage.ts
+++ b/src/api/backend-registry/storage.ts
@@ -29,6 +29,7 @@ function normalizeHostForComparison(host: string): string {
   }
 }
 
+// @spec BM-007 — Default backend API key stays in sync with env
 function syncDefaultLocalBackendAuth(backend: Backend): Backend {
   const defaultBackend = makeDefaultLocalBackend();
 

--- a/src/contexts/active-backend-context.tsx
+++ b/src/contexts/active-backend-context.tsx
@@ -51,6 +51,7 @@ export function ActiveBackendProvider({
     getSnapshot,
   );
 
+  // @spec BM-005 — Switch active backend
   const setActive = React.useCallback(
     (backendId: string, orgId?: string | null) => {
       const prevBackendId = getActiveSelection()?.backendId ?? null;
@@ -73,6 +74,7 @@ export function ActiveBackendProvider({
     [],
   );
 
+  // @spec BM-004 — Add a backend
   // @spec BM-001 — Auto-switch to newly connected backend
   const addBackend = React.useCallback(
     (backend: Omit<Backend, "id">): Backend => {
@@ -111,6 +113,7 @@ export function ActiveBackendProvider({
     [],
   );
 
+  // @spec BM-006 — Remove a backend
   const removeBackend = React.useCallback((id: string) => {
     const list = getRegisteredBackends().filter((b) => b.id !== id);
     setRegisteredBackends(list);


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The backend management spec file only covered 3 behavioral specs (BM-001–BM-003). Several core backend operations (add, switch, remove) plus env-key sync and conversation memory had no formal specs or traceability tags.

## Summary

- Add 5 new specs: BM-004 (Add a backend), BM-005 (Switch active backend), BM-006 (Remove a backend), BM-007 (Default backend API key stays in sync with env), BM-008 (Per-backend conversation memory).
- Tag all relevant implementation code and tests with `@spec BM-0XX` comments for grep-based traceability.

## How to Test

```bash
# Verify all tags are present
grep -rn '@spec BM-' src/ __tests__/

# Run the tagged tests
npm test -- --run \
  __tests__/contexts/active-backend-context.test.tsx \
  __tests__/components/backends/backend-selector.test.tsx \
  __tests__/api/backend-registry/last-conversation-store.test.ts
```

All 33 tests pass. No behavioral or code changes — only spec file additions and comment annotations.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

BM-007 (`syncDefaultLocalBackendAuth`) is the only spec with no dedicated test coverage yet — it's a private helper in `storage.ts` that runs during `readStoredBackends()`.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0a61f6b6-f5c8-4088-9a3d-b3442eee0cbe)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `f242f32d6ae39605d9874f09d846cbeca70678b5` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f242f32
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f242f32
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f242f32-amd64
ghcr.io/openhands/agent-canvas:specs-backend-management-2-amd64
ghcr.io/openhands/agent-canvas:pr-728-amd64
ghcr.io/openhands/agent-canvas:sha-f242f32-arm64
ghcr.io/openhands/agent-canvas:specs-backend-management-2-arm64
ghcr.io/openhands/agent-canvas:pr-728-arm64
ghcr.io/openhands/agent-canvas:sha-f242f32
ghcr.io/openhands/agent-canvas:specs-backend-management-2
ghcr.io/openhands/agent-canvas:pr-728
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f242f32`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f242f32-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->