### PR TITLE
chat: prevent typing indicator from overlapping last message

### DIFF
--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -431,7 +431,7 @@ export function ChatInterface() {
             maybeLoadOlder(e.currentTarget);
           }}
           onWheel={handleWheelForPagination}
-          className="custom-scrollbar-always flex grow flex-col gap-2 overflow-x-hidden overflow-y-auto px-0 pt-4 md:px-4"
+          className="custom-scrollbar-always flex grow flex-col gap-2 overflow-x-hidden overflow-y-auto px-0 pt-4 pb-8 md:px-4"
         >
           {isChatLoading && isReturningToConversation && (
             <ChatMessagesSkeleton />


### PR DESCRIPTION
Closes #731

The three-dots `TypingIndicator` is rendered as an absolutely-positioned overlay above the chat input (`bottom-full mb-1 z-20`), so it floats up into the scrollable conversation area. With no bottom padding on the scrollable messages container, the last message could scroll right up under the dots and get visually clipped/overlapped (see screenshot in the issue).

This adds `pb-8` (~32px) to the scroll area so the bottom message keeps a small gap from the floating indicator.

### Changed
- `src/components/features/chat/chat-interface.tsx` — add `pb-8` to the messages scroll container.

---
_PR opened by an AI agent (OpenHands) on behalf of @rbren._