### PR TITLE
fix(frontend): disable view toggle when no automations exist

### DIFF
--- a/__tests__/components/automations/automation-view-toggle.test.tsx
+++ b/__tests__/components/automations/automation-view-toggle.test.tsx
@@ -23,4 +23,24 @@ describe("AutomationViewToggle", () => {
 
     expect(onChange).toHaveBeenCalledWith("list");
   });
+
+  it("does not open the menu or fire onChange when disabled", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <AutomationViewToggle view="grid" onChange={onChange} disabled />,
+    );
+    const trigger = screen.getByTestId("automations-view-toggle");
+
+    // Act — try to open the menu
+    await user.click(trigger);
+
+    // Assert — menu items never render and onChange stays untouched
+    expect(trigger).toBeDisabled();
+    expect(
+      screen.queryByTestId("automations-view-toggle-list"),
+    ).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/routes/automations-list.test.tsx
+++ b/__tests__/routes/automations-list.test.tsx
@@ -166,4 +166,27 @@ describe("AutomationsList — view mode toggle", () => {
       "list",
     );
   });
+
+  it("disables the view-mode toggle when the user has no automations", async () => {
+    // Arrange — service returns an empty list, so the page lands on EmptyState.
+    vi.mocked(AutomationService.getAutomations).mockResolvedValue({
+      automations: [],
+      total: 0,
+    });
+    const user = userEvent.setup();
+    renderList();
+    await waitFor(() => {
+      expect(AutomationService.getAutomations).toHaveBeenCalledTimes(1);
+    });
+
+    // Act — try to open the toggle's grid/list menu.
+    const trigger = await screen.findByTestId("automations-view-toggle");
+    await user.click(trigger);
+
+    // Assert — toggle is disabled and clicking it does not reveal the menu.
+    expect(trigger).toBeDisabled();
+    expect(
+      screen.queryByTestId("automations-view-toggle-list"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/features/automations/automation-view-toggle.tsx
+++ b/src/components/features/automations/automation-view-toggle.tsx
@@ -11,6 +11,7 @@ import type { AutomationViewMode } from "./automation-view-mode";
 interface AutomationViewToggleProps {
   view: AutomationViewMode;
   onChange: (view: AutomationViewMode) => void;
+  disabled?: boolean;
 }
 
 const VIEW_OPTIONS: {
@@ -59,6 +60,7 @@ function ViewMenuItemContent({
 export function AutomationViewToggle({
   view,
   onChange,
+  disabled = false,
 }: AutomationViewToggleProps) {
   const { t } = useTranslation("openhands");
   const [open, setOpen] = useState(false);
@@ -156,9 +158,15 @@ export function AutomationViewToggle({
         aria-label={t(I18nKey.AUTOMATIONS$VIEW_MODE)}
         aria-haspopup="menu"
         aria-expanded={open}
-        onClick={() => setOpen((current) => !current)}
+        aria-disabled={disabled}
+        disabled={disabled}
+        onClick={() => {
+          if (disabled) return;
+          setOpen((current) => !current);
+        }}
         className={cn(
           "inline-flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border border-[var(--oh-border)] bg-base-secondary text-white transition-colors hover:bg-[var(--oh-interactive-hover)] focus-visible:border-white/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20",
+          "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-base-secondary",
         )}
       >
         <ActiveIcon className="size-4" aria-hidden />

--- a/src/routes/automations-list.tsx
+++ b/src/routes/automations-list.tsx
@@ -124,6 +124,8 @@ export default function AutomationsList() {
   }, []);
 
   const hasMore = data ? data.total > data.automations.length : false;
+  const hasNoAutomations =
+    !isLoading && !isError && data?.automations.length === 0;
 
   // Show loading state while checking health
   if (isHealthLoading) {
@@ -193,6 +195,7 @@ export default function AutomationsList() {
           <AutomationViewToggle
             view={viewMode}
             onChange={handleViewModeChange}
+            disabled={hasNoAutomations}
           />
         </div>
 
@@ -208,9 +211,7 @@ export default function AutomationsList() {
 
           {isError && !isLoading && <ErrorState onRetry={refetch} />}
 
-          {!isLoading && !isError && data?.automations.length === 0 && (
-            <EmptyState />
-          )}
+          {hasNoAutomations && <EmptyState />}
 
           {!isLoading && !isError && data && data.automations.length > 0 && (
             <>


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary

On the `/automations` page, the grid/list view-mode toggle next to the search input remains clickable even when the user has not created any automations. Toggling between grid and list has no visible effect (the page only renders `<EmptyState />`), so the affordance is misleading and inaccessible — assistive tech still announces it as an active control.

### Steps to reproduce

1. Clone `agent-canvas` and run `npm run dev`.
2. Open `http://localhost:3001/automations` with an account / backend that has zero automations.
3. Click the view-toggle button beside the search input.

### Current behaviour

The toggle opens its menu and `onChange` fires. The selected view mode is persisted to `localStorage`, but the page still shows `<EmptyState />`. The control reports as enabled in the accessibility tree.

### Expected behaviour

When `data.automations.length === 0` after a successful load, the toggle is disabled:

- `disabled` and `aria-disabled` are set on the trigger button.
- Clicking it does not open the menu and does not fire `onChange`.
- Visual state communicates the disabled affordance (reduced opacity, `cursor-not-allowed`).
- Once the user creates an automation, the toggle becomes enabled again.

### Acceptance criteria

- [ ] Empty state: toggle is disabled and unresponsive to clicks.
- [ ] Non-empty state: toggle behaves as before (opens menu, switches views, persists to `localStorage`).
- [ ] Loading state: toggle is not flashed as disabled before the response arrives.
- [ ] Tests cover both the component-level disabled behaviour and the page-level wiring against an empty service response.

### Notes

The empty condition already gates `<EmptyState />` at `src/routes/automations-list.tsx:211`. The fix should hoist that condition into a single variable and reuse it for the toggle so the two stay in lockstep.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `<AutomationViewToggle />` now accepts an optional `disabled` prop that forwards `disabled` + `aria-disabled` to the trigger button and short-circuits the click handler so the menu cannot open.
- `automations-list.tsx` derives `hasNoAutomations = !isLoading && !isError && data?.automations.length === 0` once and reuses it for both the toggle's `disabled` prop and the existing `<EmptyState />` branch, so the two affordances can never disagree.
- The toggle is _not_ disabled during the initial skeleton load — only after the response confirms the list is empty — to avoid a brief flash of a disabled control on first paint.

## Why

On `/automations` with zero automations, the user saw `<EmptyState />` but the view-toggle button next to the search input was still active. Clicking it opened a grid/list menu that had no effect on the page and was announced as an active control by assistive tech. The toggle should be inactive whenever there is nothing to view.

## Changes

- `src/components/features/automations/automation-view-toggle.tsx` — add `disabled?: boolean` prop; forward to the `<button>`, set `aria-disabled`, no-op the `onClick`, and add disabled-state classes via `cn(...)`.
- `src/routes/automations-list.tsx` — compute `hasNoAutomations` once, pass it to `<AutomationViewToggle />`, and reuse it for `<EmptyState />`.
- `__tests__/components/automations/automation-view-toggle.test.tsx` — new test: clicking the trigger while `disabled` does not open the menu and does not fire `onChange`.
- `__tests__/routes/automations-list.test.tsx` — new test: with `AutomationService.getAutomations` resolving to an empty list, the toggle is disabled and clicking it does not reveal the list menu item.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #748 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository.
2. Start the development server:

```
npm run dev
```

3. Open the automations page at `http://localhost:3001/automations`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/ba26f2d5-fe2e-4360-a035-bb98b567a000

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- The empty condition deliberately excludes the loading and error branches. Using `(data?.automations.length ?? 0) === 0` would disable the toggle during the initial skeleton render, which is jarring. The chosen condition matches the existing `<EmptyState />` guard.
- The toggle component remains presentational — it does not learn about `useAutomations`; the page owns the wiring.
- No styling assertions in tests, per the project's testing rules. Tests cover behaviour only (`toBeDisabled`, menu not rendered, `onChange` not called).
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `57151a0b89decd9634b28d69e6d7da2c73eda61a` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-57151a0
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-57151a0
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-57151a0-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1914-amd64
ghcr.io/openhands/agent-canvas:pr-749-amd64
ghcr.io/openhands/agent-canvas:sha-57151a0-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1914-arm64
ghcr.io/openhands/agent-canvas:pr-749-arm64
ghcr.io/openhands/agent-canvas:sha-57151a0
ghcr.io/openhands/agent-canvas:hieptl-app-1914
ghcr.io/openhands/agent-canvas:pr-749
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-57151a0`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-57151a0-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->