### PR TITLE
fix(frontend): align Skills search input styling with MCP page

### DIFF
--- a/src/components/features/skills/skills-toolbar.tsx
+++ b/src/components/features/skills/skills-toolbar.tsx
@@ -41,6 +41,11 @@ export function SkillsToolbar({
           onChange={(e) => onSearchChange(e.target.value)}
           placeholder={t(I18nKey.SETTINGS$SKILLS_SEARCH_PLACEHOLDER)}
           aria-label={t(I18nKey.SETTINGS$SKILLS_SEARCH_PLACEHOLDER)}
+          className={cn(
+            "flex-1 min-w-0 bg-transparent border-0 outline-none",
+            "px-3 py-2 text-sm placeholder:text-tertiary-alt",
+            "[&::-webkit-search-cancel-button]:hidden",
+          )}
         />
         {search ? (
           <button


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

The search input on the Skills page (`/skills`) renders with inconsistent styling compared to the MCP Servers page (`/mcp`), and its placeholder text is visibly truncated.

### Steps to Reproduce

1. Clone `agent-canvas`.
2. Start the dev server: `npm run dev`.
3. Navigate to `http://localhost:3001/skills`.
4. Observe the search input at the top of the page.

### Current Behavior

- The search input shows browser-default `<input type="search">` chrome (white background, native border, native focus ring).
- The placeholder text `"Search skills by name, description, or trigger"` is truncated because the input has no explicit width/padding and falls back to the user-agent default size (~150px).
- Visual treatment does not match the rest of the page (font size, placeholder color, padding all differ).

### Expected Behavior

The search input should match the MCP Servers page (`/mcp`) search input in:

- Transparent background and borderless integration into the rounded container.
- `text-sm` font size with `text-tertiary-alt` placeholder color.
- `px-3 py-2` internal padding.
- Full-width flex behavior so the placeholder is never clipped.
- Only the custom `X` clear button is shown (WebKit-native search clear is hidden).

### Root Cause

`src/components/features/skills/skills-toolbar.tsx` renders the `<input>` element without a `className`. The MCP toolbar (`src/components/features/mcp-page/mcp-toolbar.tsx`) applies an explicit className that the Skills version is missing.

### Acceptance Criteria

- [ ] Skills page search input is visually indistinguishable from the MCP page search input.
- [ ] Full placeholder text is visible at default viewport widths.
- [ ] Only one clear control is visible when text is entered (the custom `X`, not the WebKit-native one).
- [ ] Lint, typecheck, and existing tests stay green.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The search `<input>` in `src/components/features/skills/skills-toolbar.tsx` had no `className`, so the browser's default `<input type="search">` styling leaked through (white background, native border/focus ring, intrinsic ~150px width) and clipped the long placeholder text.
- Applied the same Tailwind classes the MCP toolbar already uses so both pages render an identical search field.
- No other files changed; `cn` was already imported in the toolbar.

### Before / After

|                     | Before                                        | After                                           |
| ------------------- | --------------------------------------------- | ----------------------------------------------- |
| Background / border | Browser-default white box                     | Transparent inside the shared rounded container |
| Padding             | None                                          | `px-3 py-2`                                     |
| Font size           | Browser default                               | `text-sm`                                       |
| Placeholder color   | Browser default                               | `text-tertiary-alt` (muted)                     |
| Width               | UA intrinsic (~150px) — placeholder truncated | `flex-1 min-w-0` — placeholder fully visible    |
| Clear control       | Native WebKit `x` + custom `X` (two controls) | Custom `X` only                                 |

### Changes

- `src/components/features/skills/skills-toolbar.tsx` — add `className` to the search `<input>` mirroring `src/components/features/mcp-page/mcp-toolbar.tsx`.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #751 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository.
2. Start the development server:

```bash
npm run dev
```

3. Navigate to the Skills page:

`http://localhost:3001/skills`

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/785fcc97-09d1-420b-aad2-909cf8b14467

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- The clear-button hover color difference (`hover:text-white` on Skills vs `hover:text-content-1` on MCP) — not changed in this PR.
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `1c73f0acd7577dec6de60fb02ba8c809bb2f40f5` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-1c73f0a
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-1c73f0a
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-1c73f0a-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1915-amd64
ghcr.io/openhands/agent-canvas:pr-752-amd64
ghcr.io/openhands/agent-canvas:sha-1c73f0a-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1915-arm64
ghcr.io/openhands/agent-canvas:pr-752-arm64
ghcr.io/openhands/agent-canvas:sha-1c73f0a
ghcr.io/openhands/agent-canvas:hieptl-app-1915
ghcr.io/openhands/agent-canvas:pr-752
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-1c73f0a`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-1c73f0a-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->