### PR TITLE
fix(frontend): stop frontend bash probes on cloud runtimes

### DIFF
--- a/__tests__/hooks/query/use-has-git-commits.test.tsx
+++ b/__tests__/hooks/query/use-has-git-commits.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import AgentServerRuntimeService from "#/api/runtime-service/agent-server-runtime-service";
+import { useHasGitCommits } from "#/hooks/query/use-has-git-commits";
+
+const useActiveBackendMock = vi.fn();
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => useActiveBackendMock(),
+}));
+
+const useActiveConversationMock = vi.fn();
+vi.mock("#/hooks/query/use-active-conversation", () => ({
+  useActiveConversation: () => useActiveConversationMock(),
+}));
+
+const useRuntimeIsReadyMock = vi.fn();
+vi.mock("#/hooks/use-runtime-is-ready", () => ({
+  useRuntimeIsReady: () => useRuntimeIsReadyMock(),
+}));
+
+const executeCommandSpy = vi.spyOn(AgentServerRuntimeService, "executeCommand");
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function HasGitCommitsTestWrapper({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+const makeBackend = (kind: "local" | "cloud") => ({
+  backend: {
+    id: "backend-id",
+    name: kind === "local" ? "Local" : "Production",
+    host:
+      kind === "local" ? "http://127.0.0.1:8000" : "https://app.all-hands.dev",
+    apiKey: "test-key",
+    kind,
+  },
+  orgId: null,
+});
+
+const conversation = {
+  id: "conv-1",
+  conversation_url: "https://runtime.example.com/api/conversations/conv-1",
+  session_api_key: "session-key",
+  workspace: { working_dir: "/workspace/project" },
+};
+
+describe("useHasGitCommits", () => {
+  beforeEach(() => {
+    useActiveBackendMock.mockReset();
+    useActiveConversationMock.mockReset();
+    useRuntimeIsReadyMock.mockReset();
+    executeCommandSpy.mockReset();
+
+    useRuntimeIsReadyMock.mockReturnValue(true);
+    useActiveConversationMock.mockReturnValue({ data: conversation });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not call executeCommand on a cloud backend", async () => {
+    // Arrange
+    useActiveBackendMock.mockReturnValue(makeBackend("cloud"));
+
+    // Act
+    const { result } = renderHook(() => useHasGitCommits(), {
+      wrapper: makeWrapper(),
+    });
+
+    // Assert: probe stays disabled; hasCommits remains null.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(executeCommandSpy).not.toHaveBeenCalled();
+    expect(result.current.hasCommits).toBeNull();
+  });
+
+  it("probes HEAD via executeCommand on a local backend and returns true when the repo has commits", async () => {
+    // Arrange
+    useActiveBackendMock.mockReturnValue(makeBackend("local"));
+    executeCommandSpy.mockResolvedValue({
+      exit_code: 0,
+      stdout: "abcdef0\n",
+      stderr: "",
+    });
+
+    // Act
+    const { result } = renderHook(() => useHasGitCommits(), {
+      wrapper: makeWrapper(),
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(executeCommandSpy).toHaveBeenCalledWith(
+      conversation.conversation_url,
+      conversation.session_api_key,
+      "git rev-parse --verify HEAD",
+      "/workspace/project",
+      10,
+    );
+    expect(result.current.hasCommits).toBe(true);
+  });
+});

--- a/__tests__/hooks/query/use-local-git-info.test.tsx
+++ b/__tests__/hooks/query/use-local-git-info.test.tsx
@@ -3,7 +3,6 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import AgentServerRuntimeService from "#/api/runtime-service/agent-server-runtime-service";
 import { useLocalGitInfo } from "#/hooks/query/use-local-git-info";
 
 const useActiveBackendMock = vi.fn();
@@ -21,7 +20,15 @@ vi.mock("#/hooks/use-runtime-is-ready", () => ({
   useRuntimeIsReady: () => useRuntimeIsReadyMock(),
 }));
 
-const executeCommandSpy = vi.spyOn(AgentServerRuntimeService, "executeCommand");
+const runCommandMock = vi.fn();
+const useBashCommandRunnerMock = vi.fn();
+vi.mock("#/hooks/use-bash-command-runner", () => ({
+  useBashCommandRunner: (
+    conversationUrl: string | null | undefined,
+    sessionApiKey: string | null | undefined,
+    enabled: boolean,
+  ) => useBashCommandRunnerMock(conversationUrl, sessionApiKey, enabled),
+}));
 
 function makeWrapper() {
   const client = new QueryClient({
@@ -65,13 +72,15 @@ describe("useLocalGitInfo", () => {
     useActiveBackendMock.mockReset();
     useActiveConversationMock.mockReset();
     useRuntimeIsReadyMock.mockReset();
-    executeCommandSpy.mockReset();
+    runCommandMock.mockReset();
+    useBashCommandRunnerMock.mockReset();
+    useBashCommandRunnerMock.mockImplementation(() => runCommandMock);
 
     useRuntimeIsReadyMock.mockReturnValue(true);
     useActiveConversationMock.mockReturnValue({
       data: conversationWithoutRepo,
     });
-    executeCommandSpy.mockResolvedValue({
+    runCommandMock.mockResolvedValue({
       exit_code: 0,
       stdout: "git@github.com:acme/widgets.git\n",
       stderr: "",
@@ -82,7 +91,7 @@ describe("useLocalGitInfo", () => {
     vi.clearAllMocks();
   });
 
-  it("does not call executeCommand on a cloud backend even when conversation metadata is incomplete", async () => {
+  it("does not call the bash runner on a cloud backend even when conversation metadata is incomplete", async () => {
     // Arrange
     useActiveBackendMock.mockReturnValue(makeBackend("cloud"));
 
@@ -96,13 +105,19 @@ describe("useLocalGitInfo", () => {
       setTimeout(resolve, 20);
     });
     expect(result.current.fetchStatus).toBe("idle");
-    expect(executeCommandSpy).not.toHaveBeenCalled();
+    expect(runCommandMock).not.toHaveBeenCalled();
+    // The bash command runner should be created in a disabled state on cloud.
+    expect(useBashCommandRunnerMock).toHaveBeenCalledWith(
+      conversationWithoutRepo.conversation_url,
+      conversationWithoutRepo.session_api_key,
+      false,
+    );
   });
 
-  it("probes git metadata via executeCommand on a local backend when conversation metadata is incomplete", async () => {
+  it("probes git metadata via the bash runner on a local backend when conversation metadata is incomplete", async () => {
     // Arrange
     useActiveBackendMock.mockReturnValue(makeBackend("local"));
-    executeCommandSpy
+    runCommandMock
       .mockResolvedValueOnce({
         exit_code: 0,
         stdout: "git@github.com:acme/widgets.git\n",
@@ -121,9 +136,12 @@ describe("useLocalGitInfo", () => {
 
     // Assert
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(executeCommandSpy).toHaveBeenCalledWith(
+    expect(useBashCommandRunnerMock).toHaveBeenCalledWith(
       conversationWithoutRepo.conversation_url,
       conversationWithoutRepo.session_api_key,
+      true,
+    );
+    expect(runCommandMock).toHaveBeenCalledWith(
       "git remote get-url origin",
       "/workspace/project",
       10,

--- a/__tests__/hooks/query/use-local-git-info.test.tsx
+++ b/__tests__/hooks/query/use-local-git-info.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import AgentServerRuntimeService from "#/api/runtime-service/agent-server-runtime-service";
+import { useLocalGitInfo } from "#/hooks/query/use-local-git-info";
+
+const useActiveBackendMock = vi.fn();
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => useActiveBackendMock(),
+}));
+
+const useActiveConversationMock = vi.fn();
+vi.mock("#/hooks/query/use-active-conversation", () => ({
+  useActiveConversation: () => useActiveConversationMock(),
+}));
+
+const useRuntimeIsReadyMock = vi.fn();
+vi.mock("#/hooks/use-runtime-is-ready", () => ({
+  useRuntimeIsReady: () => useRuntimeIsReadyMock(),
+}));
+
+const executeCommandSpy = vi.spyOn(AgentServerRuntimeService, "executeCommand");
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function LocalGitInfoTestWrapper({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+const makeBackend = (kind: "local" | "cloud") => ({
+  backend: {
+    id: "backend-id",
+    name: kind === "local" ? "Local" : "Production",
+    host:
+      kind === "local" ? "http://127.0.0.1:8000" : "https://app.all-hands.dev",
+    apiKey: "test-key",
+    kind,
+  },
+  orgId: null,
+});
+
+const conversationWithoutRepo = {
+  id: "conv-1",
+  conversation_url: "https://runtime.example.com/api/conversations/conv-1",
+  session_api_key: "session-key",
+  workspace: { working_dir: "/workspace/project" },
+  selected_repository: null,
+  git_provider: null,
+  selected_branch: null,
+};
+
+describe("useLocalGitInfo", () => {
+  beforeEach(() => {
+    useActiveBackendMock.mockReset();
+    useActiveConversationMock.mockReset();
+    useRuntimeIsReadyMock.mockReset();
+    executeCommandSpy.mockReset();
+
+    useRuntimeIsReadyMock.mockReturnValue(true);
+    useActiveConversationMock.mockReturnValue({
+      data: conversationWithoutRepo,
+    });
+    executeCommandSpy.mockResolvedValue({
+      exit_code: 0,
+      stdout: "git@github.com:acme/widgets.git\n",
+      stderr: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not call executeCommand on a cloud backend even when conversation metadata is incomplete", async () => {
+    // Arrange
+    useActiveBackendMock.mockReturnValue(makeBackend("cloud"));
+
+    // Act
+    const { result } = renderHook(() => useLocalGitInfo(), {
+      wrapper: makeWrapper(),
+    });
+
+    // Assert: query stays disabled (no fetch, no data); bash endpoint not driven.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(executeCommandSpy).not.toHaveBeenCalled();
+  });
+
+  it("probes git metadata via executeCommand on a local backend when conversation metadata is incomplete", async () => {
+    // Arrange
+    useActiveBackendMock.mockReturnValue(makeBackend("local"));
+    executeCommandSpy
+      .mockResolvedValueOnce({
+        exit_code: 0,
+        stdout: "git@github.com:acme/widgets.git\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        exit_code: 0,
+        stdout: "main\n",
+        stderr: "",
+      });
+
+    // Act
+    const { result } = renderHook(() => useLocalGitInfo(), {
+      wrapper: makeWrapper(),
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(executeCommandSpy).toHaveBeenCalledWith(
+      conversationWithoutRepo.conversation_url,
+      conversationWithoutRepo.session_api_key,
+      "git remote get-url origin",
+      "/workspace/project",
+      10,
+    );
+    expect(result.current.data).toMatchObject({
+      repository: "acme/widgets",
+      branch: "main",
+    });
+  });
+});

--- a/src/hooks/query/use-has-git-commits.ts
+++ b/src/hooks/query/use-has-git-commits.ts
@@ -1,12 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 
 import AgentServerRuntimeService from "#/api/runtime-service/agent-server-runtime-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 
 /**
  * Probes whether the conversation's working-directory git repository has
  * at least one commit reachable from HEAD.
+ *
+ * Local-only by design: we deliberately avoid driving
+ * `/api/bash/execute_bash_command` from the frontend on cloud backends.
+ * On cloud, `hasCommits` stays `null` and the Files tab keeps its
+ * optimistic diff-view default — fine in practice since cloud
+ * conversations almost always have an attached repo with commits.
  *
  * Used by the Files tab to decide whether the diff view is a sensible
  * default: an attached source (repo or local workspace) with no commits
@@ -23,6 +30,8 @@ export function useHasGitCommits(options?: { enabled?: boolean }): {
 } {
   const { data: conversation } = useActiveConversation();
   const runtimeIsReady = useRuntimeIsReady();
+  const { backend } = useActiveBackend();
+  const isLocalBackend = backend.kind === "local";
 
   const conversationId = conversation?.id;
   const conversationUrl = conversation?.conversation_url;
@@ -31,6 +40,7 @@ export function useHasGitCommits(options?: { enabled?: boolean }): {
 
   const enabled =
     (options?.enabled ?? true) &&
+    isLocalBackend &&
     runtimeIsReady &&
     !!conversationId &&
     !!workingDir;

--- a/src/hooks/query/use-local-git-info.ts
+++ b/src/hooks/query/use-local-git-info.ts
@@ -3,6 +3,7 @@ import { useRef } from "react";
 
 import type { CommandResult } from "#/api/runtime-service/agent-server-runtime-service";
 import { getAgentServerWorkingDir } from "#/api/agent-server-config";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 import { useBashCommandRunner } from "#/hooks/use-bash-command-runner";
@@ -83,25 +84,29 @@ async function probeNestedRepoInDir(
 }
 
 /**
- * Probe git metadata directly from the workspace checkout via the agent
- * server's bash-events WebSocket (`git remote get-url origin`,
+ * Probe git metadata for a **local** backend's workspace checkout by
+ * shelling out via the agent server (`git remote get-url origin`,
  * `git rev-parse --abbrev-ref HEAD`).
  *
- * We intentionally keep this probe enabled until the active conversation has
- * a complete repo tuple (`selected_repository`, `git_provider`,
- * `selected_branch`) so the control bar can recover from partial metadata
- * hydration after connect/clone flows.
+ * Local-only by design. On cloud backends the conversation metadata
+ * (`selected_repository`, `git_provider`, `selected_branch`) is the
+ * source of truth, and probing via `/api/bash/execute_bash_command`
+ * would (a) leak the user's local `getAgentServerWorkingDir()` path to
+ * the cloud runtime when `workspace.working_dir` is missing, and
+ * (b) hit a bash endpoint we don't want the frontend driving on cloud.
  *
- * Commands are executed over a persistent WebSocket connection
- * (`/sockets/bash-events`) rather than individual REST calls, which avoids
- * the per-request HTTP overhead of the previous polling approach.
+ * On local, we keep the probe enabled until the active conversation
+ * has a complete repo tuple so the control bar can recover from
+ * partial metadata hydration after connect/clone flows.
  *
- * Returns `null` fields when the working dir is not a git checkout — callers
- * should treat that the same as "no repo detected".
+ * Returns `null` fields when the working dir is not a git checkout —
+ * callers should treat that the same as "no repo detected".
  */
 export const useLocalGitInfo = () => {
   const { data: conversation } = useActiveConversation();
   const runtimeIsReady = useRuntimeIsReady();
+  const { backend } = useActiveBackend();
+  const isLocalBackend = backend.kind === "local";
 
   const conversationId = conversation?.id;
   const conversationUrl = conversation?.conversation_url;
@@ -113,6 +118,7 @@ export const useLocalGitInfo = () => {
   const hasConversationBranch = !!conversation?.selected_branch;
 
   const queryEnabled =
+    isLocalBackend &&
     runtimeIsReady &&
     !!conversationId &&
     (!hasConversationRepo ||


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

When a user is connected to a Cloud backend (e.g. OpenHands Cloud production) and creates a new conversation, the frontend immediately fires `/api/bash/execute_bash_command` on the cloud runtime to probe git metadata. The `cwd` in that request is a **local** filesystem path read from `localStorage` (e.g. `/Users/<user>/.openhands/agent-canvas/workspaces`), which leaks the host filesystem layout to the cloud runtime and resolves to nothing meaningful there.

### Steps to reproduce

1. `npm run dev` in `agent-canvas`.
2. Open the `<BackendSelector />` and click **Add Backend**.
3. Configure a Cloud backend pointing at OpenHands Cloud production with a Personal Workspace API key.
4. Switch to the cloud backend, create a new conversation, send a message.
5. In the Network panel, observe:

```http
POST http://<runtime-host>.staging-runtime.all-hands.dev/api/bash/execute_bash_command
{
  "command": "git remote get-url origin",
  "cwd": "/Users/<user>/.openhands/agent-canvas/workspaces",
  "timeout": 10
}
```

### Expected behavior

`/api/bash/execute_bash_command` is not driven by the frontend on cloud backends. Cloud uses conversation metadata (`selected_repository`, `git_provider`, `selected_branch`) as the source of truth for the chat's git control bar.

### Root cause

`useLocalGitInfo` (`src/hooks/query/use-local-git-info.ts`) and `useHasGitCommits` (`src/hooks/query/use-has-git-commits.ts`) had no backend-kind gate on their `enabled` predicate. On cloud, `AgentServerRuntimeService.executeCommand` routes through `callCloudProxy` to `/api/bash/execute_bash_command`. `useLocalGitInfo` additionally falls back to `getAgentServerWorkingDir()` (local config) when the conversation's `workspace.working_dir` is missing — that's the leak path.

### Fix

Gate both hooks on `backend.kind === "local"`. `useWorkspaceFiles` is intentionally left untouched (it powers the Files tab's file-list sub-view; needs a cloud-native replacement endpoint as a follow-up).

### Acceptance criteria

- No `/api/bash/execute_bash_command` requests are issued from the frontend when the active backend is cloud.
- The git control bar on cloud still renders repo/branch/provider from conversation metadata.
- Local-backend conversations continue to probe `git remote get-url origin` / `git rev-parse --abbrev-ref HEAD` / `git rev-parse --verify HEAD` as before.
- Tests cover both the cloud-disabled and local-enabled paths for each hook.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Gate `useLocalGitInfo` and `useHasGitCommits` on `backend.kind === "local"` so the frontend no longer drives `/api/bash/execute_bash_command` on cloud runtimes.
- Eliminates a privacy/leak bug where the user's local FS path (from `getAgentServerWorkingDir()` localStorage) was sent as `cwd` to a cloud sandbox.
- Cloud git metadata continues to come from the conversation payload (`selected_repository`, `git_provider`, `selected_branch`) — no UX regression in the chat's git control bar.
- `useWorkspaceFiles` is intentionally **not** gated; it powers the Files tab's file-list sub-view and there is no cloud-native replacement endpoint yet. Tracked as a follow-up.

### Root cause

`AgentServerRuntimeService.executeCommand` is cloud-aware: on cloud it routes through `callCloudProxy` to `/api/bash/execute_bash_command`. The two probe hooks called this service with no backend gate, so they fired on cloud immediately after a new conversation was created. `useLocalGitInfo` made it worse by falling back to `getAgentServerWorkingDir()` (a local-machine path read from localStorage) when the cloud conversation hadn't yet populated `workspace.working_dir`, leaking that host path to the remote runtime.

### Changes

- `src/hooks/query/use-local-git-info.ts`
  - Import `useActiveBackend`, derive `isLocalBackend`, and AND it into the `enabled` predicate.
  - Tighten the docblock: explicit "local-only" intent, and rationale (leak + invariant).
- `src/hooks/query/use-has-git-commits.ts`
  - Same gate pattern + docblock note. On cloud, `hasCommits` stays `null` and the Files tab keeps its optimistic diff-view default — fine in practice since cloud conversations almost always have an attached repo with commits.
- `__tests__/hooks/query/use-local-git-info.test.tsx` (new)
  - Cloud backend + incomplete metadata → `executeCommand` not called (regression test).
  - Local backend + incomplete metadata → `executeCommand` called with the expected git probe and parsed result.
- `__tests__/hooks/query/use-has-git-commits.test.tsx` (new)
  - Cloud backend → `executeCommand` not called; `hasCommits` is `null`.
  - Local backend → `executeCommand` called for `git rev-parse --verify HEAD`; `hasCommits` resolves to `true`.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #760 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev` in `agent-canvas`.
2. Open the `<BackendSelector />` and click **Add Backend**.
3. Configure a Cloud backend pointing at OpenHands Cloud production with a Personal Workspace API key.
4. Switch to the cloud backend, create a new conversation, send a message.
5. In the Network panel, observe:

```http
POST http://<runtime-host>.staging-runtime.all-hands.dev/api/bash/execute_bash_command
{
  "command": "git remote get-url origin",
  "cwd": "/Users/<user>/.openhands/agent-canvas/workspaces",
  "timeout": 10
}
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `6a8534cade7c585de432bfff711ad02ef038ddac` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-6a8534c
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-6a8534c
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-6a8534c-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1926-amd64
ghcr.io/openhands/agent-canvas:pr-761-amd64
ghcr.io/openhands/agent-canvas:sha-6a8534c-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1926-arm64
ghcr.io/openhands/agent-canvas:pr-761-arm64
ghcr.io/openhands/agent-canvas:sha-6a8534c
ghcr.io/openhands/agent-canvas:hieptl-app-1926
ghcr.io/openhands/agent-canvas:pr-761
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-6a8534c`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-6a8534c-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->