### PR TITLE
fix(frontend): stop calling /api/auth/workspace-session on cloud backends

### DIFF
--- a/__tests__/hooks/query/use-workspace-file-content.test.tsx
+++ b/__tests__/hooks/query/use-workspace-file-content.test.tsx
@@ -30,6 +30,18 @@ vi.mock("#/hooks/use-runtime-is-ready", () => ({
   useRuntimeIsReady: () => useRuntimeIsReadyMock(),
 }));
 
+const getActiveBackendMock = vi.fn();
+vi.mock("#/api/backend-registry/active-store", () => ({
+  getActiveBackend: () => getActiveBackendMock(),
+}));
+
+const downloadFileMock = vi.fn();
+vi.mock("#/api/runtime-service/agent-server-runtime-service", () => ({
+  default: {
+    downloadFile: (...args: unknown[]) => downloadFileMock(...args),
+  },
+}));
+
 const fetchMock = vi.fn();
 
 function makeWrapper() {
@@ -58,6 +70,8 @@ describe("useWorkspaceFileContent", () => {
     useWorkspaceSessionMock.mockReset();
     useActiveConversationMock.mockReset();
     useRuntimeIsReadyMock.mockReset();
+    getActiveBackendMock.mockReset();
+    downloadFileMock.mockReset();
     useRuntimeIsReadyMock.mockReturnValue(true);
     useActiveConversationMock.mockReturnValue({
       data: {
@@ -71,6 +85,10 @@ describe("useWorkspaceFileContent", () => {
       isLoading: false,
       isError: false,
       error: null,
+    });
+    getActiveBackendMock.mockReturnValue({
+      backend: { id: "local-1", kind: "local", host: "http://localhost:8000" },
+      orgId: null,
     });
     useWorkspaceMutationCounter.setState({ count: 0 });
   });
@@ -244,5 +262,71 @@ describe("useWorkspaceFileContent", () => {
         message: "Failed to read missing.txt: 404",
       }),
     );
+  });
+
+  describe("cloud backend", () => {
+    beforeEach(() => {
+      getActiveBackendMock.mockReturnValue({
+        backend: {
+          id: "cloud-1",
+          kind: "cloud",
+          host: "https://app.all-hands.dev",
+        },
+        orgId: "org-1",
+      });
+      // useWorkspaceSession self-disables on cloud — its data is null.
+      useWorkspaceSessionMock.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+    });
+
+    it("fetches text via downloadFile and exposes a data: URI staticUrl", async () => {
+      downloadFileMock.mockResolvedValue(arrayBufferFromString("# Hello"));
+
+      const { result } = renderHook(
+        () => useWorkspaceFileContent("docs/readme.md"),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(downloadFileMock).toHaveBeenCalledWith(
+        "https://agent.example.com/api/conversations/conv-1",
+        "session-key",
+        "docs/readme.md",
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result.current.data).toEqual({
+        path: "docs/readme.md",
+        kind: "text",
+        text: "# Hello",
+        staticUrl: `data:text/markdown;charset=utf-8;base64,${btoa("# Hello")}`,
+        mimeType: "text/markdown",
+      });
+    });
+
+    it("renders images via base64 data URI bytes from downloadFile", async () => {
+      const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
+      downloadFileMock.mockResolvedValue(imageBytes);
+
+      const { result } = renderHook(
+        () => useWorkspaceFileContent("assets/logo.png"),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result.current.data).toEqual({
+        path: "assets/logo.png",
+        kind: "image",
+        text: null,
+        staticUrl: `data:image/png;base64,${btoa("\x89PNG")}`,
+        mimeType: "image/png",
+      });
+    });
   });
 });

--- a/__tests__/hooks/query/use-workspace-session.test.tsx
+++ b/__tests__/hooks/query/use-workspace-session.test.tsx
@@ -142,7 +142,7 @@ describe("useWorkspaceSession", () => {
   });
 
   describe("cloud backend", () => {
-    it("routes through callCloudProxy with correct path and auth", async () => {
+    it("does not fire any request — workspace-session is local-only", async () => {
       getActiveBackendMock.mockReturnValue({
         backend: {
           id: "cloud-1",
@@ -158,59 +158,14 @@ describe("useWorkspaceSession", () => {
           session_api_key: "cloud-key-xyz",
         },
       });
-      callCloudProxyMock.mockResolvedValue({
-        base_url: "https://abc123.prod-runtime.all-hands.dev/api/conversations/conv-cloud/workspace/",
-      });
 
       const { result } = renderHook(() => useWorkspaceSession(), {
         wrapper: makeWrapper(),
       });
 
-      await waitFor(() => {
-        expect(result.current.data?.baseUrl).toBe(
-          "https://abc123.prod-runtime.all-hands.dev/api/conversations/conv-cloud/workspace/",
-        );
-      });
-
-      expect(callCloudProxyMock).toHaveBeenCalledTimes(1);
-      const proxyCall = callCloudProxyMock.mock.calls[0][0];
-      expect(proxyCall.backend.id).toBe("cloud-1");
-      expect(proxyCall.method).toBe("POST");
-      expect(proxyCall.path).toBe("/api/auth/workspace-session");
-      expect(proxyCall.body).toEqual({ conversation_id: "conv-cloud" });
-      expect(proxyCall.authMode).toBe("session-api-key");
-      expect(proxyCall.sessionApiKey).toBe("cloud-key-xyz");
-      // buildHttpBaseUrl uses the browser's protocol, which in jsdom is http:
-      expect(proxyCall.hostOverride).toBe(
-        "http://abc123.prod-runtime.all-hands.dev",
-      );
-      expect(RemoteWorkspace).not.toHaveBeenCalled();
-    });
-
-    it("surfaces the error when the cloud workspace-session POST fails", async () => {
-      getActiveBackendMock.mockReturnValue({
-        backend: {
-          id: "cloud-1",
-          kind: "cloud",
-          host: "https://app.all-hands.dev",
-        },
-      });
-      useActiveConversationMock.mockReturnValue({
-        data: {
-          id: "conv-cloud",
-          conversation_url:
-            "https://abc123.prod-runtime.all-hands.dev/api/conversations/conv-cloud",
-          session_api_key: "bad-key",
-        },
-      });
-      callCloudProxyMock.mockRejectedValue(new Error("401 Unauthorized"));
-
-      const { result } = renderHook(() => useWorkspaceSession(), {
-        wrapper: makeWrapper(),
-      });
-
-      await waitFor(() => expect(result.current.isError).toBe(true));
-      expect(result.current.error?.message).toMatch(/401/);
+      await flushScheduler();
+      expect(callCloudProxyMock).not.toHaveBeenCalled();
+      expect(startWorkspaceSessionMock).not.toHaveBeenCalled();
       expect(result.current.data).toBeNull();
     });
   });

--- a/src/hooks/query/use-workspace-file-content.ts
+++ b/src/hooks/query/use-workspace-file-content.ts
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { getActiveBackend } from "#/api/backend-registry/active-store";
+import AgentServerRuntimeService from "#/api/runtime-service/agent-server-runtime-service";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 import {
@@ -108,6 +110,21 @@ function isLikelyBinary(buffer: ArrayBuffer): boolean {
   return false;
 }
 
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  // Chunk to stay under the call-stack limit of `String.fromCharCode(...arr)`
+  // for larger files (>~100KB) while avoiding per-byte allocation.
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      bytes.subarray(i, i + CHUNK) as unknown as number[],
+    );
+  }
+  return btoa(binary);
+}
+
 /**
  * Reads a single file out of the active conversation's workspace via the
  * agent server's static workspace fileserver and classifies it as
@@ -137,24 +154,72 @@ export function useWorkspaceFileContent(relativePath: string | null) {
 
   const conversationId = conversation?.id;
   const conversationUrl = conversation?.conversation_url;
+  const sessionApiKey = conversation?.session_api_key;
   const baseUrl = workspaceSession?.baseUrl;
+  const isCloud = getActiveBackend().backend.kind === "cloud";
 
   return useQuery<WorkspaceFileContent>({
     queryKey: [
       "workspace-file-content",
       conversationId,
       conversationUrl,
-      baseUrl,
+      sessionApiKey,
+      isCloud ? "cloud" : baseUrl,
       relativePath,
       workspaceMutationCount,
     ],
     queryFn: async () => {
       if (!relativePath) throw new Error("No path");
+
+      const kind = classifyKind(relativePath);
+      const mimeType = guessMimeType(relativePath);
+
+      if (isCloud) {
+        // Cloud: no static fileserver cookie path is reachable from the
+        // browser. Fetch bytes server-side through callCloudProxy and
+        // hand the consumer a self-contained `data:` URI for iframe /
+        // <img> rendering.
+        const buffer = await AgentServerRuntimeService.downloadFile(
+          conversationUrl,
+          sessionApiKey,
+          relativePath,
+        );
+        if (kind === "text") {
+          if (isLikelyBinary(buffer)) {
+            return {
+              path: relativePath,
+              kind: "binary",
+              text: null,
+              staticUrl: `data:application/octet-stream;base64,${arrayBufferToBase64(buffer)}`,
+              mimeType: "application/octet-stream",
+            };
+          }
+          const text = new TextDecoder("utf-8", { fatal: false }).decode(
+            buffer,
+          );
+          return {
+            path: relativePath,
+            kind: "text",
+            text,
+            staticUrl: `data:${mimeType};charset=utf-8;base64,${arrayBufferToBase64(buffer)}`,
+            mimeType,
+          };
+        }
+        return {
+          path: relativePath,
+          kind,
+          text: null,
+          staticUrl: `data:${mimeType};base64,${arrayBufferToBase64(buffer)}`,
+          mimeType,
+        };
+      }
+
+      // Local: rely on the workspace-session cookie minted by
+      // useWorkspaceSession to authenticate the same-origin static
+      // fileserver fetch.
       if (!baseUrl) throw new Error("No workspace session");
 
       const staticUrl = joinWorkspaceUrl(baseUrl, relativePath);
-      const kind = classifyKind(relativePath);
-      const mimeType = guessMimeType(relativePath);
 
       // Image / PDF: don't fetch the bytes — the consumer renders them
       // directly via `staticUrl` in an iframe or <img>. The browser
@@ -203,7 +268,11 @@ export function useWorkspaceFileContent(relativePath: string | null) {
         mimeType,
       };
     },
-    enabled: runtimeIsReady && !!conversationId && !!baseUrl && !!relativePath,
+    enabled:
+      runtimeIsReady &&
+      !!conversationId &&
+      !!relativePath &&
+      (isCloud || !!baseUrl),
     retry: false,
     staleTime: 1000 * 5,
     gcTime: 1000 * 60,

--- a/src/hooks/query/use-workspace-session.ts
+++ b/src/hooks/query/use-workspace-session.ts
@@ -2,8 +2,6 @@ import { RemoteWorkspace } from "@openhands/typescript-client/workspace/remote-w
 import { useQuery } from "@tanstack/react-query";
 
 import { getActiveBackend } from "#/api/backend-registry/active-store";
-import { callCloudProxy } from "#/api/cloud/proxy";
-import { buildHttpBaseUrl } from "#/utils/websocket-url";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
@@ -27,6 +25,14 @@ export interface WorkspaceSession {
  * navigations — which it cannot do when the only credential is a custom
  * request header.
  *
+ * Local-only. The cookie flow is useless on cloud: the POST would be a
+ * server-side hop through `callCloudProxy` (so the `Set-Cookie` never
+ * reaches the browser jar), and the runtime sandbox is cross-origin with
+ * the GUI (so `fetch(staticUrl, { credentials: "include" })` couldn't
+ * attach the cookie anyway). On cloud, `useWorkspaceFileContent` fetches
+ * bytes through `callCloudProxy` directly and renders binary kinds as
+ * `data:` URIs, so this hook stays disabled and returns `data: null`.
+ *
  * We treat the call as cache-once-per-conversation: the cookie lives in
  * the browser jar, so re-issuing the POST on every component remount is
  * wasted work. `staleTime: Infinity` keeps the cached `baseUrl` in place
@@ -49,8 +55,9 @@ export function useWorkspaceSession(): {
   const conversationId = conversation?.id;
   const conversationUrl = conversation?.conversation_url;
   const sessionApiKey = conversation?.session_api_key;
+  const isLocal = getActiveBackend().backend.kind === "local";
 
-  const enabled = runtimeIsReady && !!conversationId;
+  const enabled = runtimeIsReady && !!conversationId && isLocal;
 
   const query = useQuery<WorkspaceSession>({
     queryKey: [
@@ -60,24 +67,6 @@ export function useWorkspaceSession(): {
       sessionApiKey,
     ],
     queryFn: async () => {
-      const active = getActiveBackend().backend;
-
-      if (active.kind === "cloud" && conversationUrl) {
-        // Cloud conversations: route through callCloudProxy to avoid CORS
-        // restrictions on direct browser → runtime sandbox calls.
-        const response = await callCloudProxy<{ base_url: string }>({
-          backend: active,
-          method: "POST",
-          hostOverride: buildHttpBaseUrl(conversationUrl),
-          path: "/api/auth/workspace-session",
-          body: { conversation_id: conversationId },
-          authMode: "session-api-key",
-          sessionApiKey,
-        });
-        return { baseUrl: response.base_url };
-      }
-
-      // Local conversations: use the SDK client directly.
       const workspace = new RemoteWorkspace(
         getAgentServerClientOptions({
           conversationUrl,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

**Summary**

When a user opens the **Files** tab on a conversation running against a cloud backend (e.g. `Production - Personal Workspace`), the frontend issues a `POST /api/auth/workspace-session` against the conversation's runtime sandbox (routed server-side through `callCloudProxy`). The call is structurally useless on cloud — it produces dead network traffic on every cloud conversation that opens the Files tab, and the file-content fetch that depends on its result is silently broken on cloud.

**Steps to reproduce**

1. `npm run dev` in `agent-canvas`.
2. Open the `<BackendSelector />`, click **Add Backend**, and configure:
   - **Host Name:** Production
   - **Host:** `https://app.all-hands.dev`
   - **Type:** Cloud
   - **API Key:** Personal-Workspace API key from OpenHands production
3. Select `Production - Personal Workspace`, create a new conversation.
4. Send: `Write a hello world script in bash`.
5. After the agent finishes, open the **Files** tab.
6. Inspect DevTools Network panel.

**Current behavior**

The endpoint `http://<id>.staging-runtime.all-hands.dev/api/auth/workspace-session` is called (visible in the `/api/cloud-proxy` envelope and in upstream logs).

**Expected behavior**

`/api/auth/workspace-session` should not be called on cloud. The Files tab should still render file lists and file content.

**Root cause**

`useWorkspaceSession` exists to mint an `oh_workspace_session_key` cookie so the _browser_ can attach it to subsequent same-origin `<iframe src>` / `<img src>` / `fetch(credentials: "include")` calls against the static workspace fileserver. That flow only works for **local** backends.

On cloud:

1. The POST is made server-side through `callCloudProxy`, so any upstream `Set-Cookie` lands at the local agent-server and never reaches the browser jar.
2. Even if it did, the static fileserver is on `*.staging-runtime.all-hands.dev` and the GUI runs on `localhost` — `fetch(staticUrl, { credentials: "include" })` cannot carry the cookie cross-origin.

So `useWorkspaceSession` fires a POST that does nothing, and `useWorkspaceFileContent` builds a `staticUrl` whose cookie-authenticated fetch can never succeed.

**Fix**

Mirror the pattern used in the original OpenHands frontend: do not mint a workspace session on cloud. Fetch file bytes through `callCloudProxy` (which already attaches `X-Session-API-Key` server-side), and render binary kinds as base64 `data:` URIs.

**Acceptance criteria**

- Opening the Files tab on a cloud conversation produces **zero** `/api/auth/workspace-session` calls (browser-direct or wrapped in `/api/cloud-proxy`).
- The file list still renders on cloud.
- Text/HTML/Markdown/image/PDF previews still render on cloud (via `data:` URIs).
- Local conversations still mint the workspace-session cookie exactly as before.
- "Open in new window" still works on both backends.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Disable `useWorkspaceSession` on cloud backends — the cookie it mints is unusable cross-origin and the POST was pure dead traffic.
- Route cloud file content through `AgentServerRuntimeService.downloadFile` (already proxied with `X-Session-API-Key`). Binary kinds become base64 `data:` URIs.
- `WorkspaceFileContent` shape unchanged — `file-content-viewer.tsx` and `files-tab.tsx` don't need to branch on backend kind.

### Why

`POST /api/auth/workspace-session` exchanges `X-Session-API-Key` for an `oh_workspace_session_key` cookie scoped to `/api/conversations`. The browser then auto-attaches that cookie to same-origin `<iframe src>` / `<img src>` / `fetch(credentials: "include")` against the static workspace fileserver.

That flow works on **local**, where the GUI and the agent server share an origin. On **cloud** it breaks at two points:

1. The POST is dispatched server-side through `callCloudProxy`, so the upstream `Set-Cookie` is received by the local agent-server, not the browser.
2. Even if the cookie made it back, the static fileserver is on `*.staging-runtime.all-hands.dev` and the GUI on `localhost` — a cross-origin `fetch(credentials: "include")` won't attach a cookie set on a different origin.

So the POST was dead traffic and `useWorkspaceFileContent`'s follow-up fetch was silently broken on every cloud conversation that opened the Files tab.

The pattern used by the original OpenHands frontend (`/Users/hieple/Documents/openhands/OpenHands/frontend`) is to fetch file bytes via authenticated HTTP using `X-Session-API-Key` and render images as base64 `data:` URIs. This PR adopts that pattern on cloud.

### Changes

**`src/hooks/query/use-workspace-session.ts`**

- Gate `enabled` on `kind === "local"`. The hook returns `{ data: null, ... }` on cloud — no POST fires.
- Removed the now-dead cloud branch (the one that built upstream calls via `callCloudProxy` with `hostOverride`).
- Removed unused `callCloudProxy` / `buildHttpBaseUrl` imports.
- Updated the docstring to call out the local-only contract.

**`src/hooks/query/use-workspace-file-content.ts`**

- Added a cloud branch in `queryFn` that fetches bytes via `AgentServerRuntimeService.downloadFile(conversationUrl, sessionApiKey, relativePath)` (already routes through `callCloudProxy` and supplies `X-Session-API-Key`).
- For text on cloud: NUL-byte sniff → UTF-8 decode (same heuristic as local), plus `staticUrl` set to a `data:${mimeType};charset=utf-8;base64,...` URI so the "open in new window" link in `files-tab.tsx` still works.
- For image/PDF/binary on cloud: `staticUrl` set to a `data:${mimeType};base64,...` URI.
- `enabled` no longer requires `baseUrl` on cloud (`isCloud || !!baseUrl`).
- Query key keys off `"cloud"` instead of `baseUrl` on cloud, so cache identity is correct across backend switches.
- Added a chunked `arrayBufferToBase64` helper that avoids the `String.fromCharCode(...arr)` call-stack limit on larger files.

**`src/components/features/files-tab/file-content-viewer.tsx`, `src/routes/files-tab.tsx`** — unchanged. `data:` URIs render in `<img src>` / `<iframe src>` / `<a href>` like any other URL.

### Tests

Following the project's testing rules (mock underlying services, not the hook; one assertion per behavior; extend existing files):

**`__tests__/hooks/query/use-workspace-session.test.tsx`**

- Replaced the two old cloud tests (which asserted the now-removed `callCloudProxy` routing) with one test verifying cloud does **not** fire any request and `data` stays `null`.

**`__tests__/hooks/query/use-workspace-file-content.test.tsx`**

- Added a `cloud backend` `describe` block.
- Mocked `getActiveBackend` (set to cloud) and `AgentServerRuntimeService.downloadFile` — the underlying dependencies, not the hook itself.
- Test 1: cloud + text file → `downloadFile` is called with the expected args, no browser `fetch` call, returned `text` is decoded, `staticUrl` is a `data:text/markdown;charset=utf-8;base64,...` URI.
- Test 2: cloud + image file → `downloadFile` is called, `kind: "image"`, `staticUrl` is a `data:image/png;base64,...` URI, no browser `fetch` call.

```
Test Files  3 passed (3)
Tests       34 passed (34)
```

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #762 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev` in `agent-canvas`.
2. Open the `<BackendSelector />`, click **Add Backend**, and configure:
   - **Host Name:** Production
   - **Host:** `https://app.all-hands.dev`
   - **Type:** Cloud
   - **API Key:** Personal-Workspace API key from OpenHands production
3. Select `Production - Personal Workspace`, create a new conversation.
4. Send: `Write a hello world script in bash`.
5. After the agent finishes, open the **Files** tab.
6. Inspect DevTools Network panel.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `50e005bde95e0e1b4d0f3a2db39f50d549c0edcd` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-50e005b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-50e005b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-50e005b-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1927-amd64
ghcr.io/openhands/agent-canvas:pr-763-amd64
ghcr.io/openhands/agent-canvas:sha-50e005b-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1927-arm64
ghcr.io/openhands/agent-canvas:pr-763-arm64
ghcr.io/openhands/agent-canvas:sha-50e005b
ghcr.io/openhands/agent-canvas:hieptl-app-1927
ghcr.io/openhands/agent-canvas:pr-763
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-50e005b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-50e005b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->