### PR TITLE
fix(frontend): keep composer pinned at the bottom on narrow viewports

### DIFF
--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -460,7 +460,7 @@ export function ChatInterface() {
             maybeLoadOlder(e.currentTarget);
           }}
           onWheel={handleWheelForPagination}
-          className="custom-scrollbar-always flex grow flex-col gap-2 overflow-x-hidden overflow-y-auto px-0 pt-4 pb-8 md:px-4"
+          className="custom-scrollbar-always flex min-h-0 grow flex-col gap-2 overflow-x-hidden overflow-y-auto px-0 pt-4 pb-8 md:px-4"
         >
           {isChatLoading && isReturningToConversation && (
             <ChatMessagesSkeleton />
@@ -515,7 +515,7 @@ export function ChatInterface() {
           <PendingUserMessages />
         </div>
 
-        <div className="flex flex-col gap-[6px]">
+        <div className="flex shrink-0 flex-col gap-[6px]">
           <BtwMessages conversationId={conversationId} />
           {errorMessage && (
             <ErrorMessageBanner

--- a/src/components/features/conversation/conversation-main/chat-interface-wrapper.tsx
+++ b/src/components/features/conversation/conversation-main/chat-interface-wrapper.tsx
@@ -9,7 +9,7 @@ export function ChatInterfaceWrapper({
 }: ChatInterfaceWrapperProps) {
   return (
     <div className="flex justify-center w-full h-full">
-      <div className="w-full min-w-0 max-w-[800px] transition-all duration-300 ease-in-out">
+      <div className="w-full min-w-0 max-w-[800px] h-full flex flex-col min-h-0 transition-all duration-300 ease-in-out">
         <ChatInterface />
       </div>
     </div>

--- a/src/components/features/conversation/conversation-main/conversation-main.tsx
+++ b/src/components/features/conversation/conversation-main/conversation-main.tsx
@@ -43,7 +43,7 @@ export function ConversationMain() {
     <div
       className={cn(
         isMobile
-          ? "relative flex-1 flex flex-col"
+          ? "relative min-h-0 flex-1 flex flex-col"
           : "h-full flex flex-col overflow-hidden",
       )}
     >


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Problem

<img width="968" height="795" alt="Image" src="https://github.com/user-attachments/assets/5b9c485f-d274-4063-b82e-b0eee7d64207" />

On `/conversations/:id`, when the browser window is narrower than ~1024px, the chat input ("What do you want to build?") is no longer pinned to the bottom of the chat panel. The whole page becomes scrollable and the input rides along with the message history — users have to scroll all the way down to reach the composer.

The expected behavior is the standard chat layout: the **messages list scrolls inside itself** while the **input stays fixed** at the bottom.

### Steps to reproduce

1. `npm run dev`
2. Open the home page and start a new conversation.
3. Send: `Write a hello world script in bash`
4. Wait for the response, then resize the browser narrower than ~1024px (the `useBreakpoint()` mobile cutoff) and shorter than the message column.

**Actual:** The page itself scrolls. The composer is pushed below the viewport.
**Expected:** Only the messages region scrolls. The composer stays pinned.

### Root cause

A broken height chain caused by flex items whose `min-height: auto` default lets them expand to their content's min-content size and overflow upward until they reach the only ancestor that _can_ scroll — `#root-outlet` (`relative flex-1 overflow-auto`).

Three flex links in the chain were missing `min-h-0`:

1. **`ConversationMain` mobile branch** (the primary trigger): at viewport width ≤ 1024px, `useBreakpoint()` switches `ConversationMain` to `relative flex-1 flex flex-col`. As a flex column item of `app-route`, its default `min-height: auto` resolves to the content's min-content size. DOM inspection at 900×400 showed `ConversationMain` rendered at 1296px in a 400px slot — exactly the overflow that `#root-outlet` started scrolling.
2. **`ChatInterface` messages scroll container** (`grow overflow-y-auto`) — classic flexbox-scrollable pitfall; the `overflow-y-auto` is inert until the item is allowed to shrink below its content.
3. **`ChatInterfaceWrapper`'s inner `max-w-[800px]` div** — no explicit height + no flex column, so the height didn't propagate cleanly to `ChatInterface`'s `h-full`.

### Verification

Reproduced and fixed at four viewport sizes via Playwright DOM inspection:

| Viewport   | Before                                                  | After                            |
| ---------- | ------------------------------------------------------- | -------------------------------- |
| 1400 × 600 | `docScrollH=600`, input visible                         | `docScrollH=600`, input visible  |
| 1100 × 400 | `docScrollH=400`, input visible                         | `docScrollH=400`, input visible  |
| 900 × 400  | `docScrollH=400`, `rootOut.scrollH=1296` (page scrolls) | `docScrollH=400`, no page scroll |
| 1100 × 300 | `docScrollH=300`, input visible                         | `docScrollH=300`, input visible  |

After the fix, `document.scrollHeight === viewport.height` at every size, and the input remains in the viewport.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Pin the conversation composer to the bottom of the chat panel at every viewport size — previously, at widths ≤ 1024px the entire page scrolled and the composer was pushed below the fold.
- Tighten three flex column items in the height chain (`ConversationMain` mobile branch, `ChatInterface` messages scroll, `ChatInterfaceWrapper` inner wrapper) so `min-h-0` / `shrink-0` prevent `min-height: auto` from expanding them past their flex allotment.

### Root cause

The conversation page's height chain (`#root-outlet → app-route → ConversationMain → … → ChatInterface → messages scroll`) is built on `h-full` + `flex-1` constraints. Flex column items default to `min-height: auto`, which resolves to **content's min-content size**. When any link in the chain is missing `min-h-0` (or `overflow-hidden`), that link can grow past its allotted flex space, propagating overflow upward until it reaches the first ancestor that can actually scroll — `#root-outlet`, which has `overflow-auto`. The whole page then scrolls and the composer (a sibling of the messages region) rides along.

Three links were broken:

1. **`ConversationMain` mobile branch** — the primary trigger. The desktop class string is `h-full flex flex-col overflow-hidden` (already self-constraining via `overflow-hidden`), but the mobile string was `relative flex-1 flex flex-col` with no `min-h-0`. DOM inspection at 900×400 showed `ConversationMain` rendered at **1296px inside a 400px slot** — exactly the overflow `#root-outlet` was scrolling.
2. **`ChatInterface` messages scroll container** — `grow overflow-y-auto` without `min-h-0` is the classic flexbox-scrollable pitfall: the `overflow-y-auto` is inert until the item is allowed to shrink below its content.
3. **`ChatInterfaceWrapper` inner `max-w-[800px]` div** — no `h-full` and not a flex column, so `ChatInterface`'s `h-full` had nothing definite to resolve against.

### Changes

- `src/components/features/conversation/conversation-main/conversation-main.tsx` — add `min-h-0` to the mobile class string.
- `src/components/features/chat/chat-interface.tsx` — add `min-h-0` to the messages scroll container; add `shrink-0` to the composer wrapper so it can never be squeezed.
- `src/components/features/conversation/conversation-main/chat-interface-wrapper.tsx` — add `h-full flex flex-col min-h-0` to the inner wrapper so the height chain stays definite all the way down.

No logic changes.

### Verified

Playwright DOM inspection at 1400×600, 1100×400, **900×400** (the previously broken case), and 1100×300:

| Viewport   | `docScrollH` | `#root-outlet` `scrollH` / `clientH` | Composer in viewport |
| ---------- | ------------ | ------------------------------------ | -------------------- |
| 1400 × 600 | 600          | 600 / 600                            | yes                  |
| 1100 × 400 | 400          | 400 / 400                            | yes                  |
| 900 × 400  | 400          | 400 / 400                            | yes (was 1296 / 400) |
| 1100 × 300 | 300          | 300 / 300                            | yes                  |

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #764 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev`
2. Open the home page and start a new conversation.
3. Send: `Write a hello world script in bash`
4. Wait for the response, then resize the browser narrower than ~1024px (the `useBreakpoint()` mobile cutoff) and shorter than the message column.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/5b41a182-da76-4f38-aafb-93c4450c5e46

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `6c4571fce7cbb14e709bd2066b8c0cd3375068b8` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-6c4571f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-6c4571f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-6c4571f-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1931-amd64
ghcr.io/openhands/agent-canvas:pr-765-amd64
ghcr.io/openhands/agent-canvas:sha-6c4571f-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1931-arm64
ghcr.io/openhands/agent-canvas:pr-765-arm64
ghcr.io/openhands/agent-canvas:sha-6c4571f
ghcr.io/openhands/agent-canvas:hieptl-app-1931
ghcr.io/openhands/agent-canvas:pr-765
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-6c4571f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-6c4571f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->