### PR TITLE
fix: pin openhands-sdk to the same version as other SDK packages

### DIFF
--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -321,6 +321,8 @@ describe("buildAgentServerCommand", () => {
       "--from",
       "openhands-agent-server==1.23.0",
       "--with",
+      "openhands-sdk==1.23.0",
+      "--with",
       "openhands-tools==1.23.0",
       "--with",
       "openhands-workspace==1.23.0",
@@ -338,6 +340,8 @@ describe("buildAgentServerCommand", () => {
     expect(cmd.args).toEqual([
       "--from",
       "openhands-agent-server==1.18.0",
+      "--with",
+      "openhands-sdk==1.18.0",
       "--with",
       "openhands-tools==1.18.0",
       "--with",

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -396,6 +396,8 @@ export function buildAgentServerCommand(env = process.env) {
       "--from",
       `${DEFAULT_AGENT_SERVER_PACKAGE}==${version}`,
       "--with",
+      `openhands-sdk==${version}`,
+      "--with",
       `openhands-tools==${version}`,
       "--with",
       `openhands-workspace==${version}`,
@@ -408,6 +410,8 @@ export function buildAgentServerCommand(env = process.env) {
     uvxArgs.push(
       "--from",
       `${DEFAULT_AGENT_SERVER_PACKAGE}==${DEFAULT_AGENT_SERVER_VERSION}`,
+      "--with",
+      `openhands-sdk==${DEFAULT_AGENT_SERVER_VERSION}`,
       "--with",
       `openhands-tools==${DEFAULT_AGENT_SERVER_VERSION}`,
       "--with",


### PR DESCRIPTION
## Summary

Implements the fix proposed in #767 by VascoSch92.

Adds `openhands-sdk==${VERSION}` to the `--with` list in both PyPI resolution branches (`version` and `default`) of `buildAgentServerCommand` in `scripts/dev-safe.mjs`, so all four packages are pinned to the same `versions.agentServer`:

- `openhands-agent-server`
- `openhands-sdk` ← was floating, now pinned
- `openhands-tools`
- `openhands-workspace`

## Changes

**`scripts/dev-safe.mjs`** — add `--with openhands-sdk==${VERSION}` to the version-pin and default branches of `buildAgentServerCommand`.

**`__tests__/scripts/dev-safe.test.ts`** — update the two affected unit-test cases to expect the new pinned `openhands-sdk` entry in the args array.

## What is unaffected

The `localPath` (editable) and `gitRef` branches are not changed — they already source all packages from the same checkout/ref, so they are inherently consistent.

Fixes #767

_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a3` |
| **Commit** | `b7cc4f3efe89e0b7433b75dcc9c7a6ccf44048c9` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-b7cc4f3
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-b7cc4f3
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-b7cc4f3-amd64
ghcr.io/openhands/agent-canvas:fix-pin-openhands-sdk-version-amd64
ghcr.io/openhands/agent-canvas:pr-772-amd64
ghcr.io/openhands/agent-canvas:sha-b7cc4f3-arm64
ghcr.io/openhands/agent-canvas:fix-pin-openhands-sdk-version-arm64
ghcr.io/openhands/agent-canvas:pr-772-arm64
ghcr.io/openhands/agent-canvas:sha-b7cc4f3
ghcr.io/openhands/agent-canvas:fix-pin-openhands-sdk-version
ghcr.io/openhands/agent-canvas:pr-772
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-b7cc4f3`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-b7cc4f3-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->