### PR TITLE
chore: bump automation version to 1.0.0a5

### DIFF
--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -412,7 +412,7 @@ describe("default constants", () => {
   });
 
   it("has expected default automation version", () => {
-    expect(DEFAULT_AUTOMATION_VERSION).toBe("1.0.0a3");
+    expect(DEFAULT_AUTOMATION_VERSION).toBe("1.0.0a5");
   });
 
   it("has expected default backend port", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -3,7 +3,7 @@
 
   "versions": {
     "agentServer": "1.23.0",
-    "automation": "1.0.0a3",
+    "automation": "1.0.0a5",
     "automationSdk": "1.22.1"
   },
 


### PR DESCRIPTION
Bump `openhands-automation` version pin from `1.0.0a3` → `1.0.0a5` to pick up the latest release.

### Changes
- `config/defaults.json` — updated `versions.automation` to `1.0.0a5`
- `__tests__/scripts/dev-with-automation.test.ts` — updated test expectation to match

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8a27ef02-f93c-4704-aeba-8298991fd074)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `bd989c01d0b97e5eba07bac2615202da26f36f3f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-bd989c0
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-bd989c0
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-bd989c0-amd64
ghcr.io/openhands/agent-canvas:chore-bump-automation-version-1.0.0a5-amd64
ghcr.io/openhands/agent-canvas:pr-774-amd64
ghcr.io/openhands/agent-canvas:sha-bd989c0-arm64
ghcr.io/openhands/agent-canvas:chore-bump-automation-version-1.0.0a5-arm64
ghcr.io/openhands/agent-canvas:pr-774-arm64
ghcr.io/openhands/agent-canvas:sha-bd989c0
ghcr.io/openhands/agent-canvas:chore-bump-automation-version-1.0.0a5
ghcr.io/openhands/agent-canvas:pr-774
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-bd989c0`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-bd989c0-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->