### PR TITLE
fix: switch @openhands/typescript-client from git dep to npm registry

### DIFF
--- a/__tests__/package-library.test.ts
+++ b/__tests__/package-library.test.ts
@@ -12,6 +12,8 @@ const packageJson = JSON.parse(
   types: string;
   exports: Record<string, unknown>;
   scripts: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
 };
 
 describe("package library metadata", () => {
@@ -47,6 +49,29 @@ describe("package library metadata", () => {
         require: "./dist/i18n/index.cjs",
       },
     });
+  });
+
+  // Git dependencies break `npm install -g` because npm clones the repo and
+  // runs the prepare script without devDependencies. All packages should be
+  // referenced from a registry; only @openhands/extensions is allowed as a git
+  // dep until it is published to npm.
+  it("does not use git dependencies (except @openhands/extensions)", () => {
+    const GIT_DEP_PATTERN = /^(git\+|git:|github:|bitbucket:|gitlab:)/;
+    const ALLOWED_GIT_DEPS = new Set(["@openhands/extensions"]);
+
+    const allDeps = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    };
+
+    const violations = Object.entries(allDeps)
+      .filter(
+        ([name, version]) =>
+          GIT_DEP_PATTERN.test(version) && !ALLOWED_GIT_DEPS.has(name),
+      )
+      .map(([name, version]) => `${name}: ${version}`);
+
+    expect(violations).toEqual([]);
   });
 
   it("uses local dev commands without Docker", () => {

--- a/__tests__/package-library.test.ts
+++ b/__tests__/package-library.test.ts
@@ -56,7 +56,7 @@ describe("package library metadata", () => {
   // referenced from a registry; only @openhands/extensions is allowed as a git
   // dep until it is published to npm.
   it("does not use git dependencies (except @openhands/extensions)", () => {
-    const GIT_DEP_PATTERN = /^(git\+|git:|github:|bitbucket:|gitlab:)/;
+    const GIT_DEP_PATTERN = /^(git[+:]|github:|bitbucket:|gitlab:|[a-zA-Z0-9_-]+\/)/;
     const ALLOWED_GIT_DEPS = new Set(["@openhands/extensions"]);
 
     const allDeps = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
         "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#7b33f64ffccf95f7ccd2ec640aeae84ab1cc2c75",
-        "@openhands/typescript-client": "git+https://github.com/OpenHands/typescript-client.git#v1.23.2",
+        "@openhands/typescript-client": "1.23.3",
         "@react-router/node": "7.14.2",
         "@react-router/serve": "7.14.2",
         "@tailwindcss/vite": "4.2.4",
@@ -3454,9 +3454,9 @@
       }
     },
     "node_modules/@openhands/typescript-client": {
-      "version": "0.1.1",
-      "resolved": "git+ssh://git@github.com/OpenHands/typescript-client.git#082d4d46d4ae16f383b94884c7f0924640432203",
-      "integrity": "sha512-0OIRjvaAIhg4+yH245BCXoSiB9SDFPqxQ+HNsnG3CtZrszYXQkl9+x6nL/hoKuUff1NMVeeaT9Wucm1PqweYMg==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.23.3.tgz",
+      "integrity": "sha512-tkUt1XeGUfmgnmf8BYQvbhYfiDp4eC/g7VAbLmHEmoRTCNvoKjACBs/gc8q9XxdgjyUM4RJwYiVOugP/bHAtrQ==",
       "license": "MIT",
       "dependencies": {
         "@openrouter/sdk": "^0.12.35",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
     "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#7b33f64ffccf95f7ccd2ec640aeae84ab1cc2c75",
-    "@openhands/typescript-client": "git+https://github.com/OpenHands/typescript-client.git#v1.23.2",
+    "@openhands/typescript-client": "1.23.3",
     "@react-router/node": "7.14.2",
     "@react-router/serve": "7.14.2",
     "@tailwindcss/vite": "4.2.4",


### PR DESCRIPTION
## Problem

`npm install -g @openhands/agent-canvas` fails because `@openhands/typescript-client` is a git dependency. npm clones the repo and runs the `prepare` script, but `rimraf` (a devDependency) isn't available during global installs:

```
npm error sh: rimraf: command not found
```

## Solution

`@openhands/typescript-client@1.23.3` is now published on the public npm registry. Switch from the git URL to the registry package:

```diff
- "@openhands/typescript-client": "git+https://github.com/OpenHands/typescript-client.git#v1.23.2"
+ "@openhands/typescript-client": "1.23.3"
```

Verified: typecheck ✅, build ✅, lockfile now resolves to `https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.23.3.tgz`.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e6077edc-4933-4836-af79-2628406d59fa)

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `66e8baddd57ba95aeb6d48ba9679725f0774715e` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-66e8bad
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-66e8bad
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-66e8bad-amd64
ghcr.io/openhands/agent-canvas:fix-use-npm-typescript-client-amd64
ghcr.io/openhands/agent-canvas:pr-779-amd64
ghcr.io/openhands/agent-canvas:sha-66e8bad-arm64
ghcr.io/openhands/agent-canvas:fix-use-npm-typescript-client-arm64
ghcr.io/openhands/agent-canvas:pr-779-arm64
ghcr.io/openhands/agent-canvas:sha-66e8bad
ghcr.io/openhands/agent-canvas:fix-use-npm-typescript-client
ghcr.io/openhands/agent-canvas:pr-779
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-66e8bad`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-66e8bad-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->