### PR TITLE
fix(docker): ensure `latest` tag always points to latest stable release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -314,12 +314,12 @@ jobs:
             create_manifest "$MANIFEST_TAG"
           done
 
-          # Preserve a latest alias on main pushes.
-          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            LATEST_TAG="latest"
-            create_manifest "$LATEST_TAG" "main"
-            MANIFEST_TAGS+=("$LATEST_TAG")
-          fi
+          # `latest` multi-arch manifest is created automatically above when a
+          # stable version tag is pushed (the per-arch build adds `latest-{arch}`
+          # tags for non-pre-release tags, and the loop above merges them into a
+          # `latest` manifest). We intentionally do NOT alias main to latest here
+          # so that `latest` always points at the highest stable tagged release,
+          # not at unreleased main-branch code.
 
           MANIFEST_TAG_CSV=$(IFS=,; echo "${MANIFEST_TAGS[*]}")
           echo "manifest_tags=$MANIFEST_TAG_CSV" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The `latest` Docker tag was being overwritten on every push to `main`, meaning users who `docker pull ghcr.io/openhands/agent-canvas:latest` could get unreleased main-branch code instead of the most recent stable tagged version.

The `merge-manifests` job had this block that ran on every `main` push:

```bash
if [ "${{ github.ref }}" == "refs/heads/main" ]; then
  create_manifest "latest" "main"
fi
```

This unconditionally overwrote the `latest` multi-arch manifest to point at `main-amd64` + `main-arm64` — whatever HEAD of main was at the time.

## Summary

- Removed the `main → latest` alias in the `merge-manifests` job so that `latest` is only produced by stable version tag pushes (e.g. `v1.2.3`).
- The per-arch build job already correctly adds `latest-{arch}` tags exclusively for non-pre-release version tags (line 146-158), and the merge loop correctly creates the `latest` multi-arch manifest from those. The removed block was redundant for tag pushes and incorrect for plain main pushes.

## How to Test

1. Review the tagging logic in the workflow:
   - **Tag push** (`v1.2.3`): per-arch build adds `latest-amd64`/`latest-arm64` → merge loop creates `latest` manifest ✅
   - **Pre-release tag** (`v1.2.3-rc.1`): per-arch build skips `latest-{arch}` → no `latest` manifest created ✅
   - **Main push**: only `sha-*` and `main` tags created, no `latest` override ✅ (this is the fix)
2. Can be validated by triggering a `workflow_dispatch` or waiting for the next main push + tag push cycle.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

_This PR was created by an AI agent (OpenHands) on behalf of the user._


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6f188efd-86b4-4479-8a42-e6526ee34d0c)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `dd23853dc106cd0cea34d3e64670aabbfaf463c3` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-dd23853
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-dd23853
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-dd23853-amd64
ghcr.io/openhands/agent-canvas:fix-docker-latest-tag-stable-release-amd64
ghcr.io/openhands/agent-canvas:pr-780-amd64
ghcr.io/openhands/agent-canvas:sha-dd23853-arm64
ghcr.io/openhands/agent-canvas:fix-docker-latest-tag-stable-release-arm64
ghcr.io/openhands/agent-canvas:pr-780-arm64
ghcr.io/openhands/agent-canvas:sha-dd23853
ghcr.io/openhands/agent-canvas:fix-docker-latest-tag-stable-release
ghcr.io/openhands/agent-canvas:pr-780
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-dd23853`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-dd23853-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->