### PR TITLE
feat: bump @openhands/extensions to add github-repo-monitor and slack-channel-monitor workflows

### DIFF
--- a/__tests__/components/automations/recommended-automations.test.tsx
+++ b/__tests__/components/automations/recommended-automations.test.tsx
@@ -141,7 +141,15 @@ describe("recommended automations", () => {
     );
     expect(cards[1]).toHaveAttribute(
       "data-testid",
+      "recommended-automation-card-github-repo-monitor",
+    );
+    expect(cards[2]).toHaveAttribute(
+      "data-testid",
       "recommended-automation-card-slack-standup-digest",
+    );
+    expect(cards[3]).toHaveAttribute(
+      "data-testid",
+      "recommended-automation-card-slack-channel-monitor",
     );
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#7b33f64ffccf95f7ccd2ec640aeae84ab1cc2c75",
+        "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#b8c1869ec9dea4467bb27d5754dc695d14e27889",
         "@openhands/typescript-client": "1.23.3",
         "@react-router/node": "7.14.2",
         "@react-router/serve": "7.14.2",
@@ -3441,8 +3441,8 @@
     },
     "node_modules/@openhands/extensions": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/OpenHands/extensions.git#7b33f64ffccf95f7ccd2ec640aeae84ab1cc2c75",
-      "integrity": "sha512-vozWq4MJiKoColb7zvXYgtxmWJsk7LdjdRH9SQebheHDOKvDAn7xy+sM7d0mEFRCk3QDEaVyR5HMH9w/1HH25Q==",
+      "resolved": "git+ssh://git@github.com/OpenHands/extensions.git#b8c1869ec9dea4467bb27d5754dc695d14e27889",
+      "integrity": "sha512-ZcV/2Kc9uWtgTKbCMpCOUfHo91EZR5CwN302gI8sQFdGYEDxKD7yqdF9oYwOuksjea/tdLxG/EC0PETM+3x3Ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#7b33f64ffccf95f7ccd2ec640aeae84ab1cc2c75",
+    "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#b8c1869ec9dea4467bb27d5754dc695d14e27889",
     "@openhands/typescript-client": "1.23.3",
     "@react-router/node": "7.14.2",
     "@react-router/serve": "7.14.2",


### PR DESCRIPTION
## What

Bumps the `@openhands/extensions` pin from `7b33f64` (May 19) to `b8c1869` (May 23),
which adds two new automation catalog entries that were missing from the `/automations` page:

- **GitHub repository monitor** — watches a repo for `@OpenHands` mentions in issues and PR comments, starts a conversation, and posts the agent reply back to GitHub
- **Slack channel monitor** — watches Slack channels for `@openhands` mentions, opens a conversation with the message context, and replies in the thread when the agent finishes

## Why

The `/automations` page renders recommended workflows from `@openhands/extensions/automations`.
The package was pinned to a commit that predated the addition of these two entries by four days,
so they never appeared in the UI.

The pin was advanced to `b8c1869` rather than the current HEAD (`c4d8d97`) because HEAD is a larger
breaking change that renames the entire `mcps/` module to `integrations/` — a separate migration
that requires its own PR.

## Changes

- `package.json` — updated `@openhands/extensions` commit hash
- `package-lock.json` — regenerated by `npm install`
- `__tests__/components/automations/recommended-automations.test.tsx` — updated the popularity-order
  test to cover all four top-ranked entries now that the catalog has 7 items (the two new entries slot
  in at ranks 98 and 92, shifting the existing assertions for positions 1–3)

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `3c92bab6407cfab24f1d72cb887dda32351986a9` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-3c92bab
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-3c92bab
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-3c92bab-amd64
ghcr.io/openhands/agent-canvas:fix-pin-openhands-sdk-version-amd64
ghcr.io/openhands/agent-canvas:pr-781-amd64
ghcr.io/openhands/agent-canvas:sha-3c92bab-arm64
ghcr.io/openhands/agent-canvas:fix-pin-openhands-sdk-version-arm64
ghcr.io/openhands/agent-canvas:pr-781-arm64
ghcr.io/openhands/agent-canvas:sha-3c92bab
ghcr.io/openhands/agent-canvas:fix-pin-openhands-sdk-version
ghcr.io/openhands/agent-canvas:pr-781
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-3c92bab`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-3c92bab-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->