### PR TITLE
fix: bump agent-server SDK to 1.23.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,10 +387,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.23.0")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.23.1")
   - `OH_SECRET_KEY` — secret key for settings encryption; uses a static default for local dev since it's needed for reading persisted encrypted values across restarts
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.23.0` for agent-server SDK libraries
+  - Default: released PyPI version `1.23.1` for agent-server SDK libraries
 
 - Security: `scripts/dev-safe.mjs` and `scripts/dev-with-automation.mjs` auto-generate random API keys when needed and persist the defaults so static builds, localStorage, and restarted services stay in sync:
   - `SESSION_API_KEY` — 64-character hex (256-bit) for agent-server API authentication; persisted at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden via env var

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -319,16 +319,16 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.23.0",
+      "openhands-agent-server==1.23.1",
       "--with",
-      "openhands-sdk==1.23.0",
+      "openhands-sdk==1.23.1",
       "--with",
-      "openhands-tools==1.23.0",
+      "openhands-tools==1.23.1",
       "--with",
-      "openhands-workspace==1.23.0",
+      "openhands-workspace==1.23.1",
       "agent-server",
     ]);
-    expect(cmd.source).toBe("PyPI (1.23.0, default)");
+    expect(cmd.source).toBe("PyPI (1.23.1, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -2,7 +2,7 @@
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
 
   "versions": {
-    "agentServer": "1.23.0",
+    "agentServer": "1.23.1",
     "automation": "1.0.0a5",
     "automationSdk": "1.22.1"
   },

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.23.0 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.23.1 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -79,7 +79,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/agent-canvas/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.23.0"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.23.1"}}'
 `);
   process.exit(0);
 }
@@ -268,9 +268,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.23.0,<2.0.0"
- *   "openhands-tools==1.23.0"
- *   "openhands-workspace (>=1.23.0)"
+ *   "openhands-sdk>=1.23.1,<2.0.0"
+ *   "openhands-tools==1.23.1"
+ *   "openhands-workspace (>=1.23.1)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -284,7 +284,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.23.0", "==1.23.0", "(>=1.23.0)", "~=1.23.0"
+      // ">=1.23.1", "==1.23.1", "(>=1.23.1)", "~=1.23.1"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -337,7 +337,7 @@ export function validateFrontendDependencies(
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.23.0")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.23.1")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a

--- a/src/mocks/settings-handlers.ts
+++ b/src/mocks/settings-handlers.ts
@@ -488,7 +488,7 @@ const MOCK_VERIFIED_MODELS_BY_PROVIDER = MOCK_MODELS.reduce<
   return acc;
 }, {});
 
-const MOCK_AGENT_SERVER_VERSION = "1.23.0";
+const MOCK_AGENT_SERVER_VERSION = "1.23.1";
 
 // --- Handlers for options/config/settings ---
 // Uses wildcard "*" prefix to match both relative paths and absolute URLs


### PR DESCRIPTION
## Summary

Bumps the agent-server SDK version pin from `1.23.0` → `1.23.1` in `config/defaults.json`.

This fixes **two upstream SDK bugs** that caused `500 Internal Server Error` on `POST /api/conversations` — particularly affecting Docker-based installs:

### Bug 1: LLM registry duplicate `usage_id` (blocks conversation creation)

```
ValueError: Usage ID 'default' already exists in registry.
Use a different usage_id on the LLM or call get() to retrieve the existing LLM.
```

**Root cause:** When starting a conversation, the agent-server creates two LLM instances — one for the main agent and one for the condenser. Both used `usage_id='default'`, and the registry rejected the duplicate.

**Fix in v1.23.1:** `local_conversation.py` now checks `if llm.usage_id not in registered` before calling `registry.add()`, so duplicates are silently skipped.

### Bug 2: Validation error handler crash (masks real errors)

```
TypeError: Object of type ValueError is not JSON serializable
```

**Root cause:** The `_validation_exception_handler` tried to JSON-serialize raw `ValueError` objects from Pydantic validation contexts, turning what should be informative `422` responses into opaque `500` errors.

**Fix in v1.23.1:** The handler now uses `_sanitize_validation_errors()` to strip non-serializable objects and redact secrets before returning a clean `422` response.

## Testing

- Built Docker image from main with v1.23.0 and reproduced both errors via `curl`
- Verified v1.23.1 SDK source contains the fixes
- `npm run typecheck` passes

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c70d0abf-629a-43bc-9ad3-a301b27f1e23)

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `a9298bcd88d10d5051b855e341f11548f5665c06` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-a9298bc
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-a9298bc
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-a9298bc-amd64
ghcr.io/openhands/agent-canvas:fix-bump-agent-server-1.23.1-amd64
ghcr.io/openhands/agent-canvas:pr-782-amd64
ghcr.io/openhands/agent-canvas:sha-a9298bc-arm64
ghcr.io/openhands/agent-canvas:fix-bump-agent-server-1.23.1-arm64
ghcr.io/openhands/agent-canvas:pr-782-arm64
ghcr.io/openhands/agent-canvas:sha-a9298bc
ghcr.io/openhands/agent-canvas:fix-bump-agent-server-1.23.1
ghcr.io/openhands/agent-canvas:pr-782
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-a9298bc`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-a9298bc-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->