### PR TITLE
fix: route LLM errors inline and keep conversation/server errors visible in the banner

### DIFF
--- a/__tests__/stores/error-message-store.test.ts
+++ b/__tests__/stores/error-message-store.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useErrorMessageStore } from "#/stores/error-message-store";
+
+const getState = () => useErrorMessageStore.getState();
+
+describe("error message store", () => {
+  beforeEach(() => {
+    useErrorMessageStore.setState({ errorMessage: null, errorType: null });
+  });
+
+  it("defaults to a sticky conversation error", () => {
+    getState().setErrorMessage("boom");
+    expect(getState().errorMessage).toBe("boom");
+    expect(getState().errorType).toBe("conversation");
+  });
+
+  it("tags connection errors when the type is provided", () => {
+    getState().setErrorMessage("offline", "connection");
+    expect(getState().errorType).toBe("connection");
+  });
+
+  it("removeErrorMessage clears any error regardless of type", () => {
+    getState().setErrorMessage("boom");
+    getState().removeErrorMessage();
+    expect(getState().errorMessage).toBeNull();
+    expect(getState().errorType).toBeNull();
+  });
+
+  it("clearConnectionError clears a transient connection error", () => {
+    getState().setErrorMessage("offline", "connection");
+    getState().clearConnectionError();
+    expect(getState().errorMessage).toBeNull();
+    expect(getState().errorType).toBeNull();
+  });
+
+  it("clearConnectionError preserves a sticky conversation error", () => {
+    getState().setErrorMessage("bad api key");
+    getState().clearConnectionError();
+    expect(getState().errorMessage).toBe("bad api key");
+    expect(getState().errorType).toBe("conversation");
+  });
+
+  it("clearConnectionError is a no-op when there is no error", () => {
+    getState().clearConnectionError();
+    expect(getState().errorMessage).toBeNull();
+    expect(getState().errorType).toBeNull();
+  });
+});

--- a/src/contexts/conversation-websocket-context.tsx
+++ b/src/contexts/conversation-websocket-context.tsx
@@ -133,7 +133,8 @@ export function ConversationWebSocketProvider({
   const queryClient = useQueryClient();
   const addEvent = useEventStore((state) => state.addEvent);
   const addEvents = useEventStore((state) => state.addEvents);
-  const { setErrorMessage, removeErrorMessage } = useErrorMessageStore();
+  const { setErrorMessage, removeErrorMessage, clearConnectionError } =
+    useErrorMessageStore();
   const consumeMatchingPendingMessage = useOptimisticUserMessageStore(
     (state) => state.consumeMatchingPendingMessage,
   );
@@ -169,8 +170,10 @@ export function ConversationWebSocketProvider({
     path?.toUpperCase().endsWith("PLAN.MD") ?? false;
 
   const handleNonErrorEvent = useCallback(() => {
-    removeErrorMessage();
-  }, [removeErrorMessage]);
+    // A normal event means connectivity recovered: clear a transient connection
+    // error, but keep sticky conversation errors (e.g. a wrong API key).
+    clearConnectionError();
+  }, [clearConnectionError]);
 
   // Helper function to update metrics from stats event
   const updateMetricsFromStats = useCallback(
@@ -426,7 +429,8 @@ export function ConversationWebSocketProvider({
             handleNonErrorEvent();
           }
 
-          // Track credit limit reached if AgentErrorEvent has budget-related error
+          // LLM errors render inline in the chat (see ErrorEventMessage); track
+          // them for analytics but keep them out of the banner above the chat box.
           if (isAgentErrorEvent(event)) {
             trackError({
               message: event.error,
@@ -438,7 +442,6 @@ export function ConversationWebSocketProvider({
               },
               posthog,
             });
-            setErrorMessage(event.error);
           }
 
           // Clear optimistic user message when a user message is confirmed.
@@ -608,7 +611,8 @@ export function ConversationWebSocketProvider({
             handleNonErrorEvent();
           }
 
-          // Handle AgentErrorEvent specifically
+          // LLM errors render inline in the chat (see ErrorEventMessage); track
+          // them for analytics but keep them out of the banner above the chat box.
           if (isAgentErrorEvent(event)) {
             trackError({
               message: event.error,
@@ -620,7 +624,6 @@ export function ConversationWebSocketProvider({
               },
               posthog,
             });
-            setErrorMessage(event.error);
           }
 
           // Clear optimistic user message when a user message is confirmed.
@@ -761,7 +764,7 @@ export function ConversationWebSocketProvider({
       onOpen: () => {
         setMainConnectionState("OPEN");
         hasConnectedRefMain.current = true; // Mark that we've successfully connected
-        removeErrorMessage(); // Clear any previous error messages on successful connection
+        clearConnectionError(); // Clear a previous connection error; keep sticky conversation errors
       },
       onClose: () => {
         setMainConnectionState("CLOSED");
@@ -770,7 +773,7 @@ export function ConversationWebSocketProvider({
         setMainConnectionState("CLOSED");
         // Only show error message if we've previously connected successfully
         if (hasConnectedRefMain.current) {
-          setErrorMessage(SERVER_CONNECTION_ERROR_MESSAGE);
+          setErrorMessage(SERVER_CONNECTION_ERROR_MESSAGE, "connection");
         }
       },
       onMessage: handleMainMessage,
@@ -778,7 +781,7 @@ export function ConversationWebSocketProvider({
   }, [
     handleMainMessage,
     setErrorMessage,
-    removeErrorMessage,
+    clearConnectionError,
     sessionApiKey,
     initialAfterTimestamp,
   ]);
@@ -802,7 +805,7 @@ export function ConversationWebSocketProvider({
       onOpen: async () => {
         setPlanningConnectionState("OPEN");
         hasConnectedRefPlanning.current = true; // Mark that we've successfully connected
-        removeErrorMessage(); // Clear any previous error messages on successful connection
+        clearConnectionError(); // Clear a previous connection error; keep sticky conversation errors
 
         // Fetch expected event count for history loading detection
         if (
@@ -834,7 +837,7 @@ export function ConversationWebSocketProvider({
         setPlanningConnectionState("CLOSED");
         // Only show error message if we've previously connected successfully
         if (hasConnectedRefPlanning.current) {
-          setErrorMessage(SERVER_CONNECTION_ERROR_MESSAGE);
+          setErrorMessage(SERVER_CONNECTION_ERROR_MESSAGE, "connection");
         }
       },
       onMessage: handlePlanningMessage,
@@ -842,7 +845,7 @@ export function ConversationWebSocketProvider({
   }, [
     handlePlanningMessage,
     setErrorMessage,
-    removeErrorMessage,
+    clearConnectionError,
     sessionApiKey,
     subConversations,
   ]);

--- a/src/stores/error-message-store.ts
+++ b/src/stores/error-message-store.ts
@@ -1,30 +1,50 @@
 import { create } from "zustand";
 
+/**
+ * "connection" errors auto-clear once connectivity recovers; "conversation"
+ * errors (e.g. a wrong API key) are sticky and clear only on an explicit user
+ * action (dismiss, retry, new message).
+ */
+export type ErrorMessageType = "connection" | "conversation";
+
 interface ErrorMessageState {
   errorMessage: string | null;
+  errorType: ErrorMessageType | null;
 }
 
 interface ErrorMessageActions {
-  setErrorMessage: (message: string) => void;
+  setErrorMessage: (message: string, type?: ErrorMessageType) => void;
   removeErrorMessage: () => void;
+  /** Clears the error only when it is a transient connection error. */
+  clearConnectionError: () => void;
 }
 
 type ErrorMessageStore = ErrorMessageState & ErrorMessageActions;
 
 const initialState: ErrorMessageState = {
   errorMessage: null,
+  errorType: null,
 };
 
 export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
   ...initialState,
 
-  setErrorMessage: (message: string) =>
+  setErrorMessage: (message: string, type: ErrorMessageType = "conversation") =>
     set(() => ({
       errorMessage: message,
+      errorType: type,
     })),
 
   removeErrorMessage: () =>
     set(() => ({
       errorMessage: null,
+      errorType: null,
     })),
+
+  clearConnectionError: () =>
+    set((state) =>
+      state.errorType === "connection"
+        ? { errorMessage: null, errorType: null }
+        : state,
+    ),
 }));


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why

Two problems:

  1. AgentErrorEvents were being pushed into the banner via setErrorMessage(event.error) and rendered inline, so LLM errors showed up in two places. The inline render already exists
   (ErrorEventMessage), so the banner duplicate was removed.
  2. A wrong-API-key error (a ConversationErrorEvent) flashed in the banner for a moment and then disappeared. The error store had a single errorMessage and removeErrorMessage()
  wiped everything, and two over-eager paths called it:
    - handleNonErrorEvent cleared the banner on every non-error event, so the next event after the error (e.g. a ConversationStateUpdateEvent) erased it.
    - Both websocket onOpen handlers cleared the banner on every (re)connection.

  These auto-clears are correct for transient connection errors but wrong for persistent backend errors that should stay until the user dismisses, retries, or sends a new message.

## Summary

- error-message-store.ts: added an errorType ("connection" | "conversation") and a clearConnectionError() action that only clears transient connection errors. setErrorMessage
  defaults to "conversation" (sticky).
- conversation-websocket-context.tsx: the auto-clear paths (handleNonErrorEvent, both onOpen handlers) now call clearConnectionError() instead of removeErrorMessage(); connection
  errors are tagged "connection"; removed the setErrorMessage(event.error) calls for AgentErrorEvent (kept the PostHog trackError).

## Issue Number
Closes #640 

## Testing
- Added __tests__/stores/error-message-store.test.ts covering the default sticky behavior, connection tagging, removeErrorMessage, and clearConnectionError (clears connection
  errors, preserves conversation errors, no-op when empty) — 6 tests, all passing.
- npm run typecheck — no new errors in the changed files.
- ESLint — clean on all changed files.

## Video/Screenshots

<img width="1465" height="812" alt="Screenshot 2026-05-26 at 22 21 21" src="https://github.com/user-attachments/assets/e19e5a79-c8c4-4b23-88b8-e1b0f9c5a401" />


## Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `88b8ab0ef54a5dc7de0d4740b083295906ac768a` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-88b8ab0
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-88b8ab0
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-88b8ab0-amd64
ghcr.io/openhands/agent-canvas:vasco-errors-amd64
ghcr.io/openhands/agent-canvas:pr-787-amd64
ghcr.io/openhands/agent-canvas:sha-88b8ab0-arm64
ghcr.io/openhands/agent-canvas:vasco-errors-arm64
ghcr.io/openhands/agent-canvas:pr-787-arm64
ghcr.io/openhands/agent-canvas:sha-88b8ab0
ghcr.io/openhands/agent-canvas:vasco-errors
ghcr.io/openhands/agent-canvas:pr-787
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-88b8ab0`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-88b8ab0-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->