### PR TITLE
perf(useLocalGitInfo): consolidate git probe into single bash round-trip

### DIFF
--- a/__tests__/hooks/query/use-local-git-info.test.tsx
+++ b/__tests__/hooks/query/use-local-git-info.test.tsx
@@ -117,17 +117,12 @@ describe("useLocalGitInfo", () => {
   it("probes git metadata via the bash runner on a local backend when conversation metadata is incomplete", async () => {
     // Arrange
     useActiveBackendMock.mockReturnValue(makeBackend("local"));
-    runCommandMock
-      .mockResolvedValueOnce({
-        exit_code: 0,
-        stdout: "git@github.com:acme/widgets.git\n",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exit_code: 0,
-        stdout: "main\n",
-        stderr: "",
-      });
+    // The consolidated script returns remote URL and branch on separate lines.
+    runCommandMock.mockResolvedValueOnce({
+      exit_code: 0,
+      stdout: "git@github.com:acme/widgets.git\nmain",
+      stderr: "",
+    });
 
     // Act
     const { result } = renderHook(() => useLocalGitInfo(), {
@@ -141,8 +136,10 @@ describe("useLocalGitInfo", () => {
       conversationWithoutRepo.session_api_key,
       true,
     );
+    // All git probing is now done in a single bash round-trip.
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
     expect(runCommandMock).toHaveBeenCalledWith(
-      "git remote get-url origin",
+      expect.stringContaining("git remote get-url origin"),
       "/workspace/project",
       10,
     );

--- a/src/hooks/query/use-local-git-info.ts
+++ b/src/hooks/query/use-local-git-info.ts
@@ -30,19 +30,38 @@ type RunCommand = (
   timeout: number,
 ) => Promise<CommandResult>;
 
-async function probeGitInfoAtDir(
+// Single shell script that replaces the former probeGitInfoAtDir +
+// probeNestedRepoInDir pair.  It runs as one bash WebSocket round-trip:
+//   1. Read the origin remote URL and current branch at the workspace root.
+//   2. If neither is set, search for exactly one nested git repo up to 4
+//      levels deep and repeat the probe there.
+// Output: two lines — <remote-url>\n<branch> — either may be empty.
+const GIT_INFO_COMMAND = [
+  "r=$(git remote get-url origin 2>/dev/null)",
+  "b=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)",
+  'if [ -z "$r$b" ]; then',
+  "n=$(find . -mindepth 2 -maxdepth 4 -name .git 2>/dev/null | cut -c3- | sed 's|/.git$||' | sort -u)",
+  'c=$(printf \'%s\\n\' "$n" | grep -c \'[^[:space:]]\')',
+  'if [ "$c" = "1" ] && [ -n "$n" ]; then',
+  'r=$(git -C "$n" remote get-url origin 2>/dev/null)',
+  'b=$(git -C "$n" rev-parse --abbrev-ref HEAD 2>/dev/null)',
+  "fi",
+  "fi",
+  'printf \'%s\\n%s\' "$r" "$b"',
+].join("\n");
+
+async function probeGitInfo(
   run: RunCommand,
   directory: string,
 ): Promise<LocalGitInfo> {
-  const [remoteResult, branchResult] = await Promise.all([
-    run("git remote get-url origin", directory, 10),
-    run("git rev-parse --abbrev-ref HEAD", directory, 10),
-  ]);
+  const result = await run(GIT_INFO_COMMAND, directory, 10);
+  if (result.exit_code !== 0) return EMPTY_LOCAL_GIT_INFO;
 
-  const remoteUrl =
-    remoteResult.exit_code === 0 ? remoteResult.stdout.trim() : "";
-  const rawBranch =
-    branchResult.exit_code === 0 ? branchResult.stdout.trim() : "";
+  const nl = result.stdout.indexOf("\n");
+  const remoteUrl = (
+    nl >= 0 ? result.stdout.slice(0, nl) : result.stdout
+  ).trim();
+  const rawBranch = (nl >= 0 ? result.stdout.slice(nl + 1) : "").trim();
   const branch = rawBranch && rawBranch !== "HEAD" ? rawBranch : null;
 
   if (!remoteUrl && !branch) return EMPTY_LOCAL_GIT_INFO;
@@ -56,37 +75,10 @@ async function probeGitInfoAtDir(
   };
 }
 
-async function probeNestedRepoInDir(
-  run: RunCommand,
-  directory: string,
-): Promise<LocalGitInfo> {
-  const nestedReposResult = await run(
-    "find . -mindepth 2 -maxdepth 4 -name .git 2>/dev/null | sed 's#^\\./##' | sed 's#/.git$##'",
-    directory,
-    10,
-  );
-
-  if (nestedReposResult.exit_code !== 0) return EMPTY_LOCAL_GIT_INFO;
-
-  const nestedRepos = Array.from(
-    new Set(
-      nestedReposResult.stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean),
-    ),
-  );
-
-  if (nestedRepos.length !== 1) return EMPTY_LOCAL_GIT_INFO;
-
-  const nestedDir = `${directory}/${nestedRepos[0]}`.replace(/\/+/g, "/");
-  return probeGitInfoAtDir(run, nestedDir);
-}
-
 /**
  * Probe git metadata for a **local** backend's workspace checkout by
- * shelling out via the agent server (`git remote get-url origin`,
- * `git rev-parse --abbrev-ref HEAD`).
+ * shelling out via the agent server using a single consolidated bash
+ * script (see `GIT_INFO_COMMAND`).
  *
  * Local-only by design. On cloud backends the conversation metadata
  * (`selected_repository`, `git_provider`, `selected_branch`) is the
@@ -154,15 +146,7 @@ export const useLocalGitInfo = () => {
     queryFn: async () => {
       const run: RunCommand = (command, cwd, timeout) =>
         runCommandRef.current(command, cwd, timeout);
-      const directInfo = await probeGitInfoAtDir(run, workingDir);
-      if (directInfo.repository || directInfo.branch) return directInfo;
-
-      // Common local flow: user starts in a non-git parent workspace and
-      // clones a single repository into a child directory.
-      const nestedInfo = await probeNestedRepoInDir(run, workingDir);
-      if (nestedInfo.repository || nestedInfo.branch) return nestedInfo;
-
-      return EMPTY_LOCAL_GIT_INFO;
+      return probeGitInfo(run, workingDir);
     },
     enabled: queryEnabled,
     retry: false,

--- a/src/hooks/query/use-local-git-info.ts
+++ b/src/hooks/query/use-local-git-info.ts
@@ -41,7 +41,7 @@ const GIT_INFO_COMMAND = [
   "b=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)",
   'if [ -z "$r$b" ]; then',
   "n=$(find . -mindepth 2 -maxdepth 4 -name .git 2>/dev/null | cut -c3- | sed 's|/.git$||' | sort -u)",
-  'c=$(printf \'%s\\n\' "$n" | grep -c \'[^[:space:]]\')',
+  "c=$(printf '%s\\n' \"$n\" | grep -c '[^[:space:]]')",
   'if [ "$c" = "1" ] && [ -n "$n" ]; then',
   'r=$(git -C "$n" remote get-url origin 2>/dev/null)',
   'b=$(git -C "$n" rev-parse --abbrev-ref HEAD 2>/dev/null)',


### PR DESCRIPTION
## Summary

Addresses the polling inefficiency noted in #776 by collapsing the 2–3 serial bash WebSocket round-trips that `useLocalGitInfo` issued on every 10-second tick into a **single** round-trip.

## Changes

### `src/hooks/query/use-local-git-info.ts`

Replaced `probeGitInfoAtDir` + `probeNestedRepoInDir` (which issued `Promise.all` of 2 bash calls, then conditionally a 3rd `find` + 2 more calls for nested repos) with:

- **`GIT_INFO_COMMAND`** — a single multi-line shell script that handles both the root and nested-repo cases in one `run()` call. It outputs two newline-separated lines: `<remote-url>\n<branch>`.
- **`probeGitInfo`** — a single replacement function that sends the script and splits the two-line output on the first `\n`.
- **`queryFn`** — simplified from the old two-step conditional chain to `return probeGitInfo(run, workingDir)`.

### `__tests__/hooks/query/use-local-git-info.test.tsx`

Updated the “local backend” test to:
- Mock one `runCommandMock` call returning `"git@github.com:acme/widgets.git\nmain"` (new two-line format)
- Assert `toHaveBeenCalledTimes(1)` (was previously two chained mock calls)
- Assert `expect.stringContaining("git remote get-url origin")` so the test confirms the git operations are still present without hard-coding the full script

## Before / After

| Scenario | Round-trips before | Round-trips after |
|---|---|---|
| Root is a git repo | 2 (`remote` + `branch` in parallel) | 1 |
| Root is not git, 1 nested repo | 3 (`find` → `remote` + `branch`) | 1 |
| Root is not git, 0 or 2+ nested repos | 1 (`find` only) | 1 |

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `d92ca3ee7fa6e2e95606aa943eb476d97a8a22fc` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-d92ca3e
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-d92ca3e
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-d92ca3e-amd64
ghcr.io/openhands/agent-canvas:fix-consolidate-git-info-command-amd64
ghcr.io/openhands/agent-canvas:pr-792-amd64
ghcr.io/openhands/agent-canvas:sha-d92ca3e-arm64
ghcr.io/openhands/agent-canvas:fix-consolidate-git-info-command-arm64
ghcr.io/openhands/agent-canvas:pr-792-arm64
ghcr.io/openhands/agent-canvas:sha-d92ca3e
ghcr.io/openhands/agent-canvas:fix-consolidate-git-info-command
ghcr.io/openhands/agent-canvas:pr-792
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-d92ca3e`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-d92ca3e-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->