### PR TITLE
fix(docker): tag `latest` for all versioned releases including pre-releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -142,7 +142,7 @@ jobs:
             VERSION_BASE="${VERSION%%-*}"
             VERSION_BASE="${VERSION_BASE%%+*}"
 
-            # Only create abbreviated + latest tags for stable (non-pre-release) versions
+            # Abbreviated major.minor / major tags only for stable (non-pre-release) versions
             if [[ "$VERSION" != *"-"* ]] && [[ "$VERSION" != *"+"* ]]; then
               # major.minor
               MINOR="${VERSION_BASE%.*}"
@@ -154,8 +154,10 @@ jobs:
               if [ "$MAJOR" != "$VERSION_BASE" ] && [ "$MAJOR" != "$MINOR" ]; then
                 add_tag "$MAJOR"
               fi
-              add_tag "latest"
             fi
+
+            # Always tag `latest` for any versioned release (including pre-releases)
+            add_tag "latest"
           fi
 
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
@@ -314,12 +316,12 @@ jobs:
             create_manifest "$MANIFEST_TAG"
           done
 
-          # `latest` multi-arch manifest is created automatically above when a
-          # stable version tag is pushed (the per-arch build adds `latest-{arch}`
-          # tags for non-pre-release tags, and the loop above merges them into a
-          # `latest` manifest). We intentionally do NOT alias main to latest here
-          # so that `latest` always points at the highest stable tagged release,
-          # not at unreleased main-branch code.
+          # `latest` multi-arch manifest is created automatically above when any
+          # version tag is pushed (including pre-releases). The per-arch build
+          # adds `latest-{arch}` tags and the loop above merges them into a
+          # `latest` manifest. We do NOT alias main to latest here so that
+          # `latest` always points at the most recent tagged release, not at
+          # unreleased main-branch code.
 
           MANIFEST_TAG_CSV=$(IFS=,; echo "${MANIFEST_TAGS[*]}")
           echo "manifest_tags=$MANIFEST_TAG_CSV" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The Docker workflow only tags `latest` for stable (non-pre-release) versions. Since we're currently publishing alpha releases, `docker pull ghcr.io/openhands/agent-canvas:latest` doesn't point at the most recent release — users have to know the exact version tag.

## Fix

Move `add_tag "latest"` outside the stable-only `if` guard so that **any** versioned release (`v*` tag) updates the `latest` Docker image — including alpha, beta, and rc releases.

Abbreviated tags (`1.0`, `1`) remain stable-only since those imply semver compatibility.

### Before
```
v1.0.0-alpha.6 → tags: 1.0.0-alpha.6, sha-abc1234
v1.0.0         → tags: 1.0.0, 1.0, 1, latest, sha-abc1234
```

### After
```
v1.0.0-alpha.6 → tags: 1.0.0-alpha.6, latest, sha-abc1234
v1.0.0         → tags: 1.0.0, 1.0, 1, latest, sha-abc1234
```

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/861dd288-0751-4c01-b4fa-cce2468332fb)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `47cf00b39c9048be42df2bc3d2db01fc988eba54` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-47cf00b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-47cf00b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-47cf00b-amd64
ghcr.io/openhands/agent-canvas:fix-docker-latest-for-prereleases-amd64
ghcr.io/openhands/agent-canvas:pr-794-amd64
ghcr.io/openhands/agent-canvas:sha-47cf00b-arm64
ghcr.io/openhands/agent-canvas:fix-docker-latest-for-prereleases-arm64
ghcr.io/openhands/agent-canvas:pr-794-arm64
ghcr.io/openhands/agent-canvas:sha-47cf00b
ghcr.io/openhands/agent-canvas:fix-docker-latest-for-prereleases
ghcr.io/openhands/agent-canvas:pr-794
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-47cf00b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-47cf00b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->