### PR TITLE
fix(frontend): hide Change Agent button on home page chat input

### DIFF
--- a/__tests__/components/features/chat/components/chat-input-actions.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-actions.test.tsx
@@ -159,4 +159,20 @@ describe("ChatInputActions", () => {
 
     expect(screen.getByTestId("change-agent-button-stub")).toBeInTheDocument();
   });
+
+  it("hides the Change Agent button on the home page on a cloud backend", () => {
+    setRegisteredBackends([cloudBackend]);
+    setActiveSelection({ backendId: cloudBackend.id });
+
+    renderWithProviders(
+      <ActiveBackendProvider>
+        <ChatInputActions disabled={false} />
+      </ActiveBackendProvider>,
+      { navigation: { conversationId: null } },
+    );
+
+    expect(
+      screen.queryByTestId("change-agent-button-stub"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/features/chat/components/chat-input-actions.tsx
+++ b/src/components/features/chat/components/chat-input-actions.tsx
@@ -74,6 +74,10 @@ export function ChatInputActions({
     ? (labelForAcpModel(conversation?.acp_server, conversation?.llm_model) ??
       conversation?.llm_model)
     : conversation?.llm_model;
+  // The change-agent button can never be enabled on the home page (no
+  // conversation → no WebSocket → permanently disabled), so hide it there
+  // entirely. It is still shown inside a conversation on cloud backends.
+  const showChangeAgentButton = isCloud && Boolean(conversationId);
   const webSocketStatus = useUnifiedWebSocketStatus();
   const { curAgentState } = useAgentState();
   const { conversationMode, setConversationMode } = useConversationStore();
@@ -111,7 +115,7 @@ export function ChatInputActions({
       !rightEl ||
       !addEl ||
       !modelEl ||
-      (isCloud && !codeEl) ||
+      (showChangeAgentButton && !codeEl) ||
       typeof ResizeObserver === "undefined"
     ) {
       return;
@@ -149,7 +153,7 @@ export function ChatInputActions({
     syncWidths();
 
     return () => observer.disconnect();
-  }, [isCloud]);
+  }, [showChangeAgentButton]);
 
   const handlePauseAgent = () => {
     if (!conversationId) return;
@@ -176,7 +180,7 @@ export function ChatInputActions({
         showModelInline: false,
       };
 
-      if (isCloud && remaining >= codeWidth) {
+      if (showChangeAgentButton && remaining >= codeWidth) {
         next.showCodeInline = true;
         remaining -= codeWidth + INLINE_GAP;
       }
@@ -187,7 +191,7 @@ export function ChatInputActions({
 
       return next;
     },
-    [isCloud, codeWidth, modelWidth],
+    [showChangeAgentButton, codeWidth, modelWidth],
   );
 
   const leftBaseWidth =
@@ -195,20 +199,24 @@ export function ChatInputActions({
 
   const fitWithoutOverflow = fitOptionalItems(leftBaseWidth);
   const allOptionalFit =
-    (!isCloud || fitWithoutOverflow.showCodeInline) &&
+    (!showChangeAgentButton || fitWithoutOverflow.showCodeInline) &&
     fitWithoutOverflow.showModelInline;
 
   const fitWithOverflow = allOptionalFit
     ? fitWithoutOverflow
     : fitOptionalItems(leftBaseWidth - OVERFLOW_BUTTON_WIDTH - INLINE_GAP);
 
-  const showCodeInline = !isCloud ? false : fitWithOverflow.showCodeInline;
+  const showCodeInline = !showChangeAgentButton
+    ? false
+    : fitWithOverflow.showCodeInline;
   const showModelInline = fitWithOverflow.showModelInline;
   const showAddFileInline = true;
   const showAgentStatusInline = actionsRowWidth >= 360;
 
   const hasOverflowItems =
-    !showAddFileInline || (isCloud && !showCodeInline) || !showModelInline;
+    !showAddFileInline ||
+    (showChangeAgentButton && !showCodeInline) ||
+    !showModelInline;
 
   React.useEffect(() => {
     if (!hasOverflowItems) {
@@ -269,7 +277,7 @@ export function ChatInputActions({
       alignment="left"
       className="!static !top-auto !bottom-auto !left-auto !right-auto !mt-0 overflow-visible min-w-[200px]"
     >
-      {isCloud && !showCodeInline && (
+      {showChangeAgentButton && !showCodeInline && (
         <div className="relative group/overflow-agent">
           <ContextMenuListItem
             testId="overflow-agent-button"
@@ -417,7 +425,7 @@ export function ChatInputActions({
               handleFileIconClick={onAddFileClick}
             />
           </div>
-          {isCloud && (
+          {showChangeAgentButton && (
             <div ref={codeRef} className={cn(!showCodeInline && "hidden")}>
               <ChangeAgentButton />
             </div>


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

**Steps to reproduce**

1. `npm run dev`.
2. In the UI, open `<BackendSelector />` → **Add Backend** and configure a cloud backend pointing at the OpenHands Cloud production environment:
   - Host Name: `Production`
   - Host: `https://app.all-hands.dev`
   - Type: `Cloud`
   - API Key: `<api_key>` for **Personal Workspace** in the OpenHands production environment
3. Verify the cloud backend is added successfully and switch to it.
4. From the local UI, select the **Production – Personal Workspace** environment.
5. Look at the chat input on the home page.

**Current behavior**

While connected to a cloud environment, the Change Agent button is **visible but permanently disabled** on the home page chat input. It is greyed out with a `cursor-not-allowed` state and can never be enabled from this page.

**Expected behavior**

| Backend | Home page chat input                          | Conversation page chat input                     |
| ------- | --------------------------------------------- | ------------------------------------------------ |
| Cloud   | Hide the Change Agent button                  | Show the Change Agent button (existing behavior) |
| Local   | Hide the Change Agent button (already hidden) | Hide the Change Agent button (already hidden)    |

**Root cause**

`src/components/features/chat/components/chat-input-actions.tsx` decides whether to render `<ChangeAgentButton />` purely from `backend.kind === "cloud"`. The button's own enable conditions (`isAgentRunning`, `isCreatingConversation`, `isWebSocketConnected`) can never be satisfied on the home page because there is no active conversation and therefore no unified WebSocket — leaving the button stuck in a disabled-forever state.

**Proposed fix**

Gate the button render (and the related ResizeObserver / inline-fit / overflow-menu math) on `isCloud && Boolean(conversationId)`, where `conversationId` comes from the existing `useOptionalConversationId()` (already used in the same component to gate `<AgentStatus />`). No prop drilling needed — the home page and conversation page already differ at the URL layer.

**Acceptance criteria**

- [ ] On a cloud backend, the Change Agent button is not rendered on the home page chat input (not just disabled).
- [ ] On a cloud backend, the Change Agent button is rendered on the conversation page chat input and toggles between Code/Plan as before.
- [ ] On a local backend, the Change Agent button is not rendered on either page.
- [ ] Existing `ChatInputModel` / `SwitchProfileButton` behavior is unchanged.
- [ ] Tests cover the new branch.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The Change Agent button was rendered next to the home page chat input on cloud backends but could never be enabled there: it requires an OPEN unified WebSocket, and there is no active conversation on the home page. The result was a permanently disabled, greyed-out button.
- Gate the button render on `isCloud && Boolean(conversationId)` so it only shows on a conversation route. `conversationId` comes from `useOptionalConversationId()`, which the same component already uses to gate `<AgentStatus />`, so no prop drilling is needed.
- Behavior matrix:

  | Backend | Home page              | Conversation page  |
  | ------- | ---------------------- | ------------------ |
  | Cloud   | Hidden (was: disabled) | Shown (unchanged)  |
  | Local   | Hidden (unchanged)     | Hidden (unchanged) |

- `isCloud` is still used for the unrelated concerns it already drives — the LLM destination label and `<ChatInputModel />` vs. `<SwitchProfileButton />` — so those are untouched.

## Changes

- `src/components/features/chat/components/chat-input-actions.tsx` — introduce a `showChangeAgentButton` derived flag (`isCloud && Boolean(conversationId)`) and route every Change-Agent–specific `isCloud` reference through it: the render itself, the overflow-menu entry, the `ResizeObserver` early-return guard, the inline-fit width math, `hasOverflowItems`, and the `useEffect` / `useCallback` deps.
- `__tests__/components/features/chat/components/chat-input-actions.test.tsx` — add a test for the only branch the existing suite did not exercise (cloud + no route conversationId → button hidden), opting into the `navigation` override that `renderWithProviders` already supports. The existing "shows … on a cloud backend" case still covers cloud + conversation because the test util defaults `conversationId` to `"test-conversation-id"`.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #797 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev`.
2. In the UI, open `<BackendSelector />` → **Add Backend** and configure a cloud backend pointing at the OpenHands Cloud production environment:
   - Host Name: `Production`
   - Host: `https://app.all-hands.dev`
   - Type: `Cloud`
   - API Key: `<api_key>` for **Personal Workspace** in the OpenHands production environment
3. Verify the cloud backend is added successfully and switch to it.
4. From the local UI, select the **Production – Personal Workspace** environment.
5. Look at the chat input on the home page.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `fcf074d397d428803e5a8c14d557ff666e68292c` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-fcf074d
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-fcf074d
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-fcf074d-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1967-amd64
ghcr.io/openhands/agent-canvas:pr-798-amd64
ghcr.io/openhands/agent-canvas:sha-fcf074d-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1967-arm64
ghcr.io/openhands/agent-canvas:pr-798-arm64
ghcr.io/openhands/agent-canvas:sha-fcf074d
ghcr.io/openhands/agent-canvas:hieptl-app-1967
ghcr.io/openhands/agent-canvas:pr-798
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-fcf074d`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-fcf074d-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->