### PR TITLE
fix(frontend): disable Run Now when the automation is turned off

### DIFF
--- a/__tests__/routes/automation-detail.test.tsx
+++ b/__tests__/routes/automation-detail.test.tsx
@@ -197,4 +197,22 @@ describe("AutomationDetail — backend-change guard", () => {
     });
     expect(AutomationService.dispatchAutomation).toHaveBeenCalledTimes(1);
   });
+
+  it("does not dispatch when Run now is clicked on a disabled automation", async () => {
+    // Arrange — the detail page loads a turned-off automation.
+    vi.mocked(AutomationService.getAutomation).mockResolvedValue({
+      ...automation,
+      enabled: false,
+    });
+    const user = userEvent.setup();
+    renderDetail();
+    const runNow = await screen.findByRole("button", { name: "Run now" });
+
+    // Act — userEvent honors the disabled attribute and suppresses the click.
+    await user.click(runNow);
+
+    // Assert — the off-state gate prevents the dispatch API from firing.
+    expect(runNow).toBeDisabled();
+    expect(AutomationService.dispatchAutomation).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/routes/automations-list.test.tsx
+++ b/__tests__/routes/automations-list.test.tsx
@@ -246,6 +246,53 @@ describe("AutomationsList — Run now toasts", () => {
     expect(displayErrorToast).not.toHaveBeenCalled();
   });
 
+  it("does not dispatch when Run now is clicked on a disabled automation (grid view)", async () => {
+    // Arrange — single automation that is turned off.
+    const disabledAutomation: Automation = { ...automation, enabled: false };
+    vi.mocked(AutomationService.getAutomations).mockResolvedValue({
+      automations: [disabledAutomation],
+      total: 1,
+    });
+    const user = userEvent.setup();
+    renderList();
+    const button = await screen.findByTestId(
+      `automation-run-now-${disabledAutomation.id}`,
+    );
+
+    // Act — userEvent honors the disabled attribute, so the click is suppressed.
+    await user.click(button);
+
+    // Assert — the off-state gate prevents the dispatch API from firing.
+    expect(button).toBeDisabled();
+    expect(AutomationService.dispatchAutomation).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch when Run now is clicked on a disabled automation (list view)", async () => {
+    // Arrange — pre-seed the stored view mode so the page mounts in list view,
+    // then return a single disabled automation.
+    window.localStorage.setItem("openhands-automations-view", "list");
+    const disabledAutomation: Automation = { ...automation, enabled: false };
+    vi.mocked(AutomationService.getAutomations).mockResolvedValue({
+      automations: [disabledAutomation],
+      total: 1,
+    });
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByTestId(
+      `automation-list-row-${disabledAutomation.id}`,
+    );
+    const button = screen.getByTestId(
+      `automation-run-now-${disabledAutomation.id}`,
+    );
+
+    // Act
+    await user.click(button);
+
+    // Assert
+    expect(button).toBeDisabled();
+    expect(AutomationService.dispatchAutomation).not.toHaveBeenCalled();
+  });
+
   it("shows an error toast when the dispatch API rejects", async () => {
     // Arrange — service rejects with a plain Error so the fallback branch fires.
     vi.mocked(AutomationService.dispatchAutomation).mockRejectedValue(

--- a/src/components/features/automations/automation-card.tsx
+++ b/src/components/features/automations/automation-card.tsx
@@ -97,7 +97,7 @@ export function AutomationCard({
               type="button"
               data-testid={`automation-run-now-${automation.id}`}
               aria-busy={isRunPending}
-              disabled={isRunPending}
+              disabled={isRunPending || !automation.enabled}
               onClick={(event) => {
                 event.stopPropagation();
                 onRunNow(automation.id);

--- a/src/components/features/automations/automation-list-row.tsx
+++ b/src/components/features/automations/automation-list-row.tsx
@@ -108,7 +108,7 @@ export function AutomationListRow({
                 data-testid={`automation-run-now-${automation.id}`}
                 aria-label={t(I18nKey.AUTOMATIONS$RUN_NOW)}
                 aria-busy={isRunPending}
-                disabled={isRunPending}
+                disabled={isRunPending || !automation.enabled}
                 onClick={(event) => {
                   event.stopPropagation();
                   onRunNow(automation.id);

--- a/src/components/features/automations/build-automation-menu-items.tsx
+++ b/src/components/features/automations/build-automation-menu-items.tsx
@@ -37,7 +37,7 @@ export function buildAutomationMenuItems({
             label: t(I18nKey.AUTOMATIONS$RUN_NOW),
             icon: <PlayIcon className="size-4" />,
             onClick: () => onRunNow(automation.id),
-            disabled: isRunPending,
+            disabled: isRunPending || !automation.enabled,
           },
         ]
       : []),

--- a/src/components/features/automations/detail/detail-header.tsx
+++ b/src/components/features/automations/detail/detail-header.tsx
@@ -80,7 +80,7 @@ export function DetailHeader({
             <button
               type="button"
               className="rounded-md border border-[var(--oh-border)] px-3 py-1.5 text-sm font-medium text-content transition-colors hover:bg-surface-raised disabled:cursor-not-allowed disabled:opacity-60"
-              disabled={isRunningNow}
+              disabled={isRunningNow || !automation.enabled}
               onClick={onRunNow}
             >
               {isRunningNow ? "Starting…" : "Run now"}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

#### Summary

On the automations list page (`/automations`) and the automation details page (`/automations/:id`), the **Run Now** button (and its kebab-menu counterpart) remains enabled even when the automation's toggle is off. Clicking it dispatches a one-off run, contradicting the toggle state shown right next to the button.

#### Steps to reproduce

1. Clone `agent-canvas` and start the dev server: `npm run dev`.
2. Open `http://localhost:3001/automations`.
3. Find an automation in the **Inactive** group (or toggle one off).
4. Click **Run Now** on the card, on the list row icon button, in the row's kebab menu, or on the detail page header.

#### Actual behavior

The dispatch fires and a "run started" toast appears even though the automation is turned off.

#### Expected behavior

When `enabled === false`, every "Run Now" entry point is non-actionable. The toggle is the single source of truth for whether the automation can run.

#### Root cause

All four "Run Now" entry points only gate their `disabled` predicate on the in-flight mutation state (`isRunPending` / `isRunningNow`) and never read `automation.enabled`:

- `src/components/features/automations/automation-card.tsx` (grid view button)
- `src/components/features/automations/automation-list-row.tsx` (list view icon button)
- `src/components/features/automations/detail/detail-header.tsx` (detail page button)
- `src/components/features/automations/build-automation-menu-items.tsx` (kebab "Run Now" item shared by card + row)

#### Proposed fix

Extend each `disabled` predicate to OR with `!automation.enabled`. Keep the button visible (greyed out via the existing `disabled:opacity-60` styling) so the affordance still communicates "turn it on first" instead of disappearing on toggle.

#### Acceptance criteria

- [ ] Card "Run Now" is disabled when the automation is off; enabling re-activates it.
- [ ] List-row icon "Run Now" is disabled when off; enabling re-activates it.
- [ ] Kebab-menu "Run Now" item is disabled when off; enabling re-activates it.
- [ ] Detail page header "Run now" button is disabled when off; enabling re-activates it.
- [ ] No `dispatchAutomation` call is made when the user tries to click a disabled entry point.
- [ ] Tests cover the new gate on the grid card, the list row, and the detail page.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The "Run Now" entry points on the automations list (card + list row + kebab) and the automation detail header all gated `disabled` purely on the in-flight mutation state, so an automation that had just been toggled off could still be dispatched.
- Extend each `disabled` predicate to also OR with `!automation.enabled`. The button stays visible (greyed out) so users still see the affordance and learn why it's inactive, matching the existing `disabled:opacity-60` styling on the detail header button.
- Adds three TDD tests — one per UI surface — that assert the dispatch API is not called when the user tries to click "Run Now" on a turned-off automation.

### Files changed

- `src/components/features/automations/automation-card.tsx` — grid card primary "Run Now" button.
- `src/components/features/automations/automation-list-row.tsx` — list view icon-only "Run Now" button.
- `src/components/features/automations/detail/detail-header.tsx` — detail page header "Run now" button.
- `src/components/features/automations/build-automation-menu-items.tsx` — kebab "Run Now" item shared by card and list row.
- `__tests__/routes/automations-list.test.tsx` — two new tests (grid view + list view).
- `__tests__/routes/automation-detail.test.tsx` — one new test for the detail page.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #799 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-canvas` and start the dev server: `npm run dev`.
2. Open `http://localhost:3001/automations`.
3. Find an automation in the **Inactive** group (or toggle one off).
4. Click **Run Now** on the card, on the list row icon button, in the row's kebab menu, or on the detail page header.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/73a65a3b-8fa3-4787-988c-dae56e73ae9c

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- We intentionally did **not** add a defensive `if (!automation.enabled) return;` to the `handleRunNow` callbacks in `src/routes/automations-list.tsx` and `src/routes/automation-detail.tsx`. The `disabled` attribute already prevents the click, the dispatch API is not a security boundary the frontend is enforcing, and the extra guard would add a code path the UI never reaches.
- No changes to the dispatch service or the React Query mutation hooks — the fix is purely at the UI gate.


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `d10ccacbf56533022377a1ee6f202952a87a800f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-d10ccac
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-d10ccac
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-d10ccac-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1968-amd64
ghcr.io/openhands/agent-canvas:pr-800-amd64
ghcr.io/openhands/agent-canvas:sha-d10ccac-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1968-arm64
ghcr.io/openhands/agent-canvas:pr-800-arm64
ghcr.io/openhands/agent-canvas:sha-d10ccac
ghcr.io/openhands/agent-canvas:hieptl-app-1968
ghcr.io/openhands/agent-canvas:pr-800
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-d10ccac`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-d10ccac-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->