### PR TITLE
fix(frontend): render Settings icon as a link so it supports Open in new tab

### DIFF
--- a/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -310,7 +310,7 @@ describe("Sidebar", () => {
     const { navigate } = renderSidebar("/conversations");
 
     fireEvent.click(screen.getByTestId("collapsed-settings-link"));
-    expect(navigate).toHaveBeenCalledWith("/settings");
+    expect(navigate).toHaveBeenCalledWith("/settings", { replace: false });
   });
 
   it("opens the backend popover when hovering the collapsed backend icon", async () => {

--- a/src/components/features/backends/backend-selector.tsx
+++ b/src/components/features/backends/backend-selector.tsx
@@ -21,6 +21,7 @@ import {
   ENVIRONMENT_SWITCH_SETACTIVE_DELAY_MS,
   triggerEnvironmentSwitch,
 } from "#/components/features/backends/environment-switch-store";
+import { NavigationLink } from "#/components/shared/navigation-link";
 import { StyledTooltip } from "#/components/shared/buttons/styled-tooltip";
 import { useConversationStore } from "#/stores/conversation-store";
 import { AddBackendModal } from "./add-backend-modal";
@@ -336,12 +337,11 @@ export function BackendSelector({
             placement={settingsTooltipPlacement}
             offset={10}
           >
-            <button
-              type="button"
+            <NavigationLink
+              to="/settings"
               data-testid="backend-selector-settings-link"
               data-active={isSettingsActive}
               aria-label={settingsLabel}
-              onClick={() => navigate("/settings")}
               className={
                 isSettingsActive
                   ? cn(
@@ -355,7 +355,7 @@ export function BackendSelector({
               }
             >
               <Settings width={16} height={16} />
-            </button>
+            </NavigationLink>
           </StyledTooltip>
         ) : null}
       </div>

--- a/src/components/features/sidebar/sidebar-rail-body.tsx
+++ b/src/components/features/sidebar/sidebar-rail-body.tsx
@@ -8,6 +8,7 @@ import {
   Settings,
 } from "lucide-react";
 import { OpenHandsLogoButton } from "#/components/shared/buttons/openhands-logo-button";
+import { NavigationLink } from "#/components/shared/navigation-link";
 import { SidebarCollapsedIconSlot } from "./sidebar-collapsed-icon-slot";
 import { SidebarNavLink } from "./sidebar-nav-link";
 import { I18nKey } from "#/i18n/declaration";
@@ -44,7 +45,6 @@ export interface SidebarRailBodyProps {
   showCollapsedExpandButton: boolean;
   isExtensionsActive: boolean;
   currentPath: string;
-  navigate: (path: string) => void;
   activeBackendHealth: { isConnected: boolean | null } | undefined;
   collapsedBackendPopoverOpen: boolean;
   setCollapsedBackendPopoverOpen: (open: boolean) => void;
@@ -68,7 +68,6 @@ export function SidebarRailBody({
   showCollapsedExpandButton,
   isExtensionsActive,
   currentPath,
-  navigate,
   activeBackendHealth,
   collapsedBackendPopoverOpen,
   setCollapsedBackendPopoverOpen,
@@ -224,11 +223,10 @@ export function SidebarRailBody({
             content={t(I18nKey.SIDEBAR$SETTINGS)}
             placement="right"
           >
-            <button
-              type="button"
+            <NavigationLink
+              to="/settings"
               data-testid="collapsed-settings-link"
               aria-label={t(I18nKey.SIDEBAR$SETTINGS)}
-              onClick={() => navigate("/settings")}
               className={sidebarNavRowClassName({ collapsed: true })}
             >
               <SidebarCollapsedIconSlot
@@ -239,7 +237,7 @@ export function SidebarRailBody({
               <span className={sidebarNavLabelClassName(true)}>
                 {t(I18nKey.SIDEBAR$SETTINGS)}
               </span>
-            </button>
+            </NavigationLink>
           </StyledTooltip>
           <div
             className="relative"

--- a/src/components/features/sidebar/sidebar.tsx
+++ b/src/components/features/sidebar/sidebar.tsx
@@ -38,7 +38,7 @@ const MOBILE_DRAWER_TRANSITION_MS = 250;
 
 export function Sidebar() {
   const { t } = useTranslation("openhands");
-  const { currentPath, navigate } = useNavigation();
+  const { currentPath } = useNavigation();
   const { data: config } = useConfig();
   const {
     data: settings,
@@ -194,7 +194,6 @@ export function Sidebar() {
     showCollapsedExpandButton,
     isExtensionsActive,
     currentPath,
-    navigate,
     activeBackendHealth,
     collapsedBackendPopoverOpen,
     setCollapsedBackendPopoverOpen,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary

<img width="1440" height="795" alt="Image" src="https://github.com/user-attachments/assets/4298e3cd-441b-47c9-bfeb-c4d8d16a69c9" />

Right-clicking the Settings (gear) icon in the sidebar shows the browser's generic page context menu — there's no "Open Link in New Tab" option. Cmd/Ctrl-click and middle-click also fail to open Settings in a new tab. This affects both the expanded sidebar (gear next to the "Local" backend status) and the collapsed sidebar (gear at the bottom of the rail).

### Steps to reproduce
1. Clone `agent-canvas` and run `npm run dev`.
2. Open `http://localhost:3001` and ensure the sidebar is visible.
3. Right-click the Settings gear icon at the bottom of the sidebar.

### Actual behavior
The browser shows the generic page context menu (Back, Forward, Reload, Save As…, Print…, etc.). "Open Link in New Tab" is not present. Cmd/Ctrl-click and middle-click do nothing useful either.

### Expected behavior
Right-clicking the Settings icon should expose the standard link context menu, including "Open Link in New Tab". Cmd/Ctrl-click and middle-click should open `/settings` in a new tab, matching the behavior of the other sidebar entries (New Chat, Customize, Automate).

### Root cause
Both Settings entry points were rendered as `<button onClick={() => navigate("/settings")}>`. Browsers only expose link-style context menu options and honor modifier-clicks for `<a>` elements with an `href`. Other sidebar items don't have this issue because they go through `SidebarNavLink` → `NavigationLink`, which renders a proper `<a href="…">` while still intercepting plain left-clicks for SPA navigation.

Affected elements:
- `src/components/features/backends/backend-selector.tsx` — Settings gear shown next to the backend dropdown (expanded sidebar).
- `src/components/features/sidebar/sidebar-rail-body.tsx` — Settings icon at the bottom of the collapsed sidebar.

### Acceptance criteria
- Right-click on either Settings icon shows "Open Link in New Tab" in the browser context menu.
- Cmd-click (macOS) / Ctrl-click (Linux/Windows) opens `/settings` in a new tab without disrupting the current tab.
- Middle-click opens `/settings` in a new tab.
- Plain left-click still navigates in-place to `/settings` via SPA routing (no full reload).
- Active-state styling on `/settings` and its sub-routes is preserved.
- Existing sidebar test suite passes (the one test that asserts the navigate call signature is updated to match `NavigationLink`'s `(to, { replace })` shape).

## Summary

<!-- 1-3 bullets describing what changed. -->
- Right-clicking the Settings gear in the sidebar did not show "Open Link in New Tab", and modifier/middle clicks couldn't open Settings in a new tab.
- Both Settings entry points (the expanded-sidebar gear next to the backend dropdown, and the collapsed-sidebar Settings icon) were rendered as `<button onClick={navigate(...)}>`. Browsers only treat `<a href>` elements as links for context-menu and modifier-click purposes.
- Replaced both buttons with the existing `NavigationLink` component (already used by New Chat / Customize / Automate). It renders a real `<a href="/settings">` while intercepting plain left-clicks for SPA navigation, so the click-to-navigate behavior, active styling, and tooltip wrapping are unchanged — only right-click / modifier-click / middle-click now do the right thing.
- Removed the now-unused `navigate` prop from `SidebarRailBody` (and the pass-through in `Sidebar`).

### Files changed
- `src/components/features/backends/backend-selector.tsx`
- `src/components/features/sidebar/sidebar-rail-body.tsx`
- `src/components/features/sidebar/sidebar.tsx`

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #801 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository and start the development server using `npm run dev`.
2. Open the sidebar.
3. Right-click the Settings icon.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="795" alt="output" src="https://github.com/user-attachments/assets/16c72f2e-4a87-4829-86c2-1baed92320de" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `be4a38b0fcb04aaee681e7861c6ff6b7495825b8` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-be4a38b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-be4a38b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-be4a38b-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1970-amd64
ghcr.io/openhands/agent-canvas:pr-802-amd64
ghcr.io/openhands/agent-canvas:sha-be4a38b-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1970-arm64
ghcr.io/openhands/agent-canvas:pr-802-arm64
ghcr.io/openhands/agent-canvas:sha-be4a38b
ghcr.io/openhands/agent-canvas:hieptl-app-1970
ghcr.io/openhands/agent-canvas:pr-802
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-be4a38b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-be4a38b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->