### PR TITLE
Disconnect WebSockets on tab hidden, reconnect on tab visible

### DIFF
--- a/__tests__/hooks/use-websocket.test.ts
+++ b/__tests__/hooks/use-websocket.test.ts
@@ -12,6 +12,7 @@ import {
   it,
   expect,
   beforeAll,
+  beforeEach,
   afterAll,
   afterEach,
   vi,
@@ -402,6 +403,157 @@ describe("useWebSocket", () => {
     // Verify that WebSocket.send was called with the correct message
     expect(sendSpy).toHaveBeenCalledOnce();
     expect(sendSpy).toHaveBeenCalledWith("Hello WebSocket!");
+  });
+
+  describe("tab visibility", () => {
+    class MockWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+
+      readonly url: string;
+      readyState = MockWebSocket.CONNECTING;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(url: string) {
+        this.url = url;
+        queueMicrotask(() => {
+          this.readyState = MockWebSocket.OPEN;
+          this.onopen?.(new Event("open"));
+        });
+      }
+
+      send() {}
+
+      close(code = 1000, reason = "Normal closure") {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.(
+          new CloseEvent("close", { code, reason, wasClean: code === 1000 }),
+        );
+      }
+    }
+
+    let originalWebSocket: typeof WebSocket;
+    let instances: MockWebSocket[];
+
+    beforeEach(() => {
+      instances = [];
+      originalWebSocket = globalThis.WebSocket;
+      vi.stubGlobal(
+        "WebSocket",
+        class extends MockWebSocket {
+          constructor(url: string) {
+            super(url);
+            instances.push(this);
+          }
+        },
+      );
+    });
+
+    afterEach(() => {
+      globalThis.WebSocket = originalWebSocket;
+    });
+
+    it("closes the WebSocket when the tab becomes hidden", async () => {
+      const { result, unmount } = renderHook(() =>
+        useWebSocket("ws://acme.com/ws"),
+      );
+
+      await waitFor(() => expect(result.current.isConnected).toBe(true));
+
+      const closeSpy = vi.spyOn(instances[0], "close");
+
+      act(() => {
+        Object.defineProperty(document, "visibilityState", {
+          value: "hidden",
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      await waitFor(() => expect(result.current.isConnected).toBe(false));
+      expect(closeSpy).toHaveBeenCalledOnce();
+
+      unmount();
+    });
+
+    it("reconnects the WebSocket when the tab becomes visible again", async () => {
+      const { result, unmount } = renderHook(() =>
+        useWebSocket("ws://acme.com/ws"),
+      );
+
+      await waitFor(() => expect(result.current.isConnected).toBe(true));
+      expect(instances).toHaveLength(1);
+
+      // Hide the tab
+      act(() => {
+        Object.defineProperty(document, "visibilityState", {
+          value: "hidden",
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      await waitFor(() => expect(result.current.isConnected).toBe(false));
+
+      // Show the tab again
+      act(() => {
+        Object.defineProperty(document, "visibilityState", {
+          value: "visible",
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      // A second WebSocket instance should have been created
+      await waitFor(() => expect(instances).toHaveLength(2));
+      await waitFor(() => expect(result.current.isConnected).toBe(true));
+
+      unmount();
+    });
+
+    it("does not reconnect when disconnect() was called while the tab was hidden", async () => {
+      const { result, unmount } = renderHook(() =>
+        useWebSocket("ws://acme.com/ws"),
+      );
+
+      await waitFor(() => expect(result.current.isConnected).toBe(true));
+
+      // Hide the tab
+      act(() => {
+        Object.defineProperty(document, "visibilityState", {
+          value: "hidden",
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      await waitFor(() => expect(result.current.isConnected).toBe(false));
+
+      // Explicit user disconnect while hidden
+      act(() => {
+        result.current.disconnect();
+      });
+
+      // Show the tab again — should NOT reconnect
+      act(() => {
+        Object.defineProperty(document, "visibilityState", {
+          value: "visible",
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      // Still only one instance; still disconnected
+      expect(instances).toHaveLength(1);
+      expect(result.current.isConnected).toBe(false);
+
+      unmount();
+    });
   });
 
   it("should not send message when WebSocket is not connected", () => {

--- a/src/hooks/use-websocket.ts
+++ b/src/hooks/use-websocket.ts
@@ -25,6 +25,9 @@ export const useWebSocket = <T = string>(
   const attemptCountRef = React.useRef(0);
   const reconnectTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
   const shouldReconnectRef = React.useRef(true); // Only set to false by disconnect()
+  // Set to true when the socket was closed because the tab became hidden.
+  // Cleared (and a reconnect triggered) when the tab becomes visible again.
+  const pausedForVisibilityRef = React.useRef(false);
   // Track which WebSocket instances are allowed to reconnect using a WeakSet
   const allowedToReconnectRef = React.useRef<WeakSet<WebSocket>>(new WeakSet());
 
@@ -128,7 +131,47 @@ export const useWebSocket = <T = string>(
       connectWebSocket();
     }
 
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        // Suspend the connection while the tab is hidden.
+        pausedForVisibilityRef.current = true;
+        // Cancel any scheduled reconnect so it doesn't fire in the background.
+        if (reconnectTimeoutRef.current) {
+          clearTimeout(reconnectTimeoutRef.current);
+          reconnectTimeoutRef.current = null;
+        }
+        setIsReconnecting(false);
+        // Close the socket without allowing its onclose to trigger a reconnect.
+        if (wsRef.current) {
+          const wsToClose = wsRef.current;
+          wsRef.current = null;
+          allowedToReconnectRef.current.delete(wsToClose);
+          if (
+            wsToClose.readyState === WebSocket.CONNECTING ||
+            wsToClose.readyState === WebSocket.OPEN
+          ) {
+            wsToClose.close();
+          }
+        }
+        setIsConnected(false);
+      } else if (
+        pausedForVisibilityRef.current &&
+        shouldReconnectRef.current &&
+        url.trim() !== ""
+      ) {
+        // Tab is visible again after a visibility-pause — reconnect.
+        pausedForVisibilityRef.current = false;
+        attemptCountRef.current = 0;
+        connectWebSocket();
+      } else {
+        pausedForVisibilityRef.current = false;
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
     return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       // Disable reconnection on unmount to prevent reconnection attempts
       // This must be set BEFORE closing the socket, so the onclose handler sees it
       shouldReconnectRef.current = false;
@@ -180,6 +223,7 @@ export const useWebSocket = <T = string>(
 
   const reconnect = React.useCallback(() => {
     shouldReconnectRef.current = true;
+    pausedForVisibilityRef.current = false;
     attemptCountRef.current = 0;
     setIsReconnecting(true);
     setError(null);


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

WebSocket connections were staying open regardless of tab visibility, keeping server-side session slots and reconnection retries alive even when the user was not looking at the tab. Disconnecting while hidden reduces unnecessary load.

## Summary

- Add a `visibilitychange` listener inside `useWebSocket` that closes the socket (without triggering the auto-reconnect retry loop) when the tab is hidden, and reopens it when the tab becomes visible again.
- Guard the re-connect with `shouldReconnectRef` so an explicit `disconnect()` call made while the tab is hidden is still respected on the next visibility event.
- Clear `pausedForVisibilityRef` in `reconnect()` to prevent a double-connect if the caller manually reconnects while hidden.
- Add three focused tests: close on hide, reconnect on show, stay disconnected after explicit `disconnect()` while hidden.

## Issue Number

N/A

## How to Test

1. `npm install && npm run dev`
2. Open a conversation so the WebSocket connects (check the Network tab — you should see a `wss://` connection).
3. Switch to a different tab or minimise the window — the WebSocket connection should close.
4. Switch back — the WebSocket should reconnect and resume receiving events.

Unit tests: `npm test -- __tests__/hooks/use-websocket.test.ts`

## Video/Screenshots

N/A (behaviour is in the network layer, not the UI).

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

TanStack Query polling already pauses automatically when a tab is hidden because `refetchIntervalInBackground` defaults to `false` — no changes needed there.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `f2fc34f44f9371d3a28980ace89de586aeb3866a` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f2fc34f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f2fc34f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f2fc34f-amd64
ghcr.io/openhands/agent-canvas:openhands-1eb99be8-78d8-44ac-b5e4-ad2a36bd5f70-amd64
ghcr.io/openhands/agent-canvas:pr-804-amd64
ghcr.io/openhands/agent-canvas:sha-f2fc34f-arm64
ghcr.io/openhands/agent-canvas:openhands-1eb99be8-78d8-44ac-b5e4-ad2a36bd5f70-arm64
ghcr.io/openhands/agent-canvas:pr-804-arm64
ghcr.io/openhands/agent-canvas:sha-f2fc34f
ghcr.io/openhands/agent-canvas:openhands-1eb99be8-78d8-44ac-b5e4-ad2a36bd5f70
ghcr.io/openhands/agent-canvas:pr-804
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f2fc34f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f2fc34f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->