### PR TITLE
fix(frontend): refetch list on revisit so agent-created automations appear

### DIFF
--- a/__tests__/routes/automations-list.test.tsx
+++ b/__tests__/routes/automations-list.test.tsx
@@ -71,12 +71,14 @@ const listResponse: AutomationsResponse = {
   total: 1,
 };
 
-function renderList() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
+function renderList(queryClient?: QueryClient) {
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
   return render(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={client}>
       <ActiveBackendProvider>
         <MemoryRouter initialEntries={["/automations"]}>
           <AutomationsList />
@@ -312,5 +314,42 @@ describe("AutomationsList — Run now toasts", () => {
       expect(displayErrorToast).toHaveBeenCalledWith("dispatch failed");
     });
     expect(displaySuccessToast).not.toHaveBeenCalled();
+  });
+});
+
+describe("AutomationsList — list freshness on remount", () => {
+  it("surfaces automations created since the last visit without a manual refresh", async () => {
+    // Arrange — share a QueryClient across two mounts to simulate the user
+    // navigating away from /automations and back. Between the two mounts an
+    // agent has created a new automation, so the service starts returning
+    // it on the next call. Previously, the cached list was treated as fresh
+    // for 5 minutes and the second mount would have re-rendered the stale
+    // list without refetching.
+    const newAutomation: Automation = {
+      ...automation,
+      id: "auto-2",
+      name: "Hello World",
+    };
+    vi.mocked(AutomationService.getAutomations)
+      .mockReset()
+      .mockResolvedValueOnce(listResponse)
+      .mockResolvedValueOnce({
+        automations: [automation, newAutomation],
+        total: 2,
+      });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    // Act — first mount lands on the original list, then unmount and remount
+    // against the same QueryClient (the cache the bug used to serve stale).
+    const first = renderList(queryClient);
+    await screen.findByText(automation.name);
+    first.unmount();
+    renderList(queryClient);
+
+    // Assert — the remount refetched and surfaced the newly created
+    // automation, which is the user-observable behavior the bug blocked.
+    await screen.findByText(newAutomation.name);
   });
 });

--- a/src/hooks/query/use-automations.ts
+++ b/src/hooks/query/use-automations.ts
@@ -26,7 +26,7 @@ export function useAutomations(options: UseAutomationsOptions = {}) {
       active.orgId,
     ],
     queryFn: () => AutomationService.getAutomations(limit, offset),
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
     enabled,
   });
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

Newly created automations do not appear on the `/automations` page until the user hard-refreshes the browser. This affects every entry point that creates an automation outside the page's own mutation hooks — most notably the home-page agent flow, where the **agent** (not the frontend) calls `POST /api/automation/v1/preset/prompt`.

### Steps to reproduce

1. Clone `agent-server` and run `npm run dev`.
2. Visit `http://localhost:3001/automations` once (so the list is in the React Query cache, even if empty).
3. Return to the home page and send the following prompt to the agent, then wait for it to finish:

   ```
   Create a prompt-based automation that simply returns "Hello World" as its output.

   Refer to the available APIs in the documentation at http://localhost:8000/api/automation/docs to implement the required functionality correctly.
   ```

4. Navigate back to `http://localhost:3001/automations`.

### Expected

The newly created automation appears in the list immediately.

### Actual

The list still shows the previously cached state. A manual browser refresh is required for the new automation to appear.

### Root cause

`useAutomations` in `src/hooks/query/use-automations.ts` is configured with `staleTime: 5 * 60 * 1000`. With React Query's default `refetchOnMount: true` semantics, "fresh" cached data is reused without a refetch on remount within that 5-minute window. Because the frontend is not the actor that created the automation (the agent is), no mutation hook fires `queryClient.invalidateQueries` to clear that cache, so the page mounts against stale data.

### Fix

Set `staleTime: 0` on the `useAutomations` query so every visit (and React Query's default window-focus / reconnect refetches) revalidates against the backend. The automations list is small and bounded, so the extra fetches are negligible.

### Acceptance criteria

- Following the repro above, the newly created automation appears on `/automations` without a manual browser refresh.
- Tabbing back to a `/automations` tab after creating an automation elsewhere refetches the list.
- All existing automation mutations (toggle, update, delete, dispatch) continue to invalidate the list as before.
- Unit test in `__tests__/routes/automations-list.test.tsx` proves the remount refetch behavior end-to-end and would fail against the previous `staleTime` value.

### Out of scope / follow-ups

- Live in-page updates while the user is already viewing `/automations` and the agent creates one in the background. Not in the original repro. If this becomes a complaint, layer on a WebSocket-driven `invalidateQueries({ queryKey: AUTOMATIONS_QUERY_KEY })` from the `ExecutionStatus.FINISHED` handler in `src/contexts/conversation-websocket-context.tsx`. The current fix does not preclude this.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Set `staleTime: 0` on `useAutomations` (`src/hooks/query/use-automations.ts`) so the automations list refetches on every mount instead of serving up-to-5-minute-old cached data.
- Add a unit test in `__tests__/routes/automations-list.test.tsx` that exercises mount → unmount → remount against a shared `QueryClient` and verifies the newly created automation surfaces on the remount. The test fails against the previous code and passes with the fix.

### Why

The home-page agent flow creates automations by calling `POST /api/automation/v1/preset/prompt` from the agent, not from the frontend. None of the existing frontend mutations (`useToggleAutomation`, `useUpdateAutomation`, `useDeleteAutomation`, `useDispatchAutomation`) fire in this flow, so nothing invalidates the `["automations"]` query key. With the previous five-minute `staleTime`, React Query treated the cached list as fresh and skipped a refetch when the user navigated back to `/automations`. The user had to hard-refresh the browser to see the automation they just created.

The fix removes the artificial freshness window. React Query's defaults then handle every relevant refetch trigger — mount, window focus, network reconnect — and the list always reflects the backend on every visit.

### Tradeoffs / considered alternatives

- **WebSocket-driven invalidation on `ExecutionStatus.FINISHED`.** This was the first design we explored: when the agent transitions to FINISHED, invalidate `AUTOMATIONS_QUERY_KEY`. It handles the live-update case (user is already on `/automations` while the agent creates one in the background) but introduces coupling between the conversation WebSocket context and an unrelated feature's cache. We chose the simpler approach since the reported bug is navigation-time freshness, not live-update freshness, and the live-update path can be layered on later without conflict if it becomes a real complaint.
- **Reducing `staleTime` to a smaller positive value (e.g. 5s).** Would mask the bug some of the time but not deterministically. Not worth the cognitive overhead.

### Files changed

- `src/hooks/query/use-automations.ts` — one-line production change (`staleTime: 5 * 60 * 1000` → `staleTime: 0`).
- `__tests__/routes/automations-list.test.tsx` — extend `renderList` to accept an optional `QueryClient` and add a new `describe("AutomationsList — list freshness on remount", …)` block with one test.

### Not changed

- Mutation hooks and their `invalidateQueries` calls.
- The `AUTOMATIONS_QUERY_KEY` constant.
- The automations list page itself.
- The WebSocket conversation context.
- The `AutomationService` API client.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #777

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone `agent-server` and run `npm run dev`.
2. Visit `http://localhost:3001/automations` once (so the list is in the React Query cache, even if empty).
3. Return to the home page and send the following prompt to the agent, then wait for it to finish:

   ```
   Create a prompt-based automation that simply returns "Hello World" as its output.

   Refer to the available APIs in the documentation at http://localhost:8000/api/automation/docs to implement the required functionality correctly.
   ```

4. Navigate back to `http://localhost:3001/automations`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/6732b535-545a-4d17-b70a-2cfafd8ca5fe

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `f50cec534aecaa045cde8ddb4174b1ba9edeaf34` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f50cec5
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f50cec5
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f50cec5-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1947-amd64
ghcr.io/openhands/agent-canvas:pr-805-amd64
ghcr.io/openhands/agent-canvas:sha-f50cec5-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1947-arm64
ghcr.io/openhands/agent-canvas:pr-805-arm64
ghcr.io/openhands/agent-canvas:sha-f50cec5
ghcr.io/openhands/agent-canvas:hieptl-app-1947
ghcr.io/openhands/agent-canvas:pr-805
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f50cec5`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f50cec5-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->