### PR TITLE
docs: add Docker and NPM install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ code review and dependency updates, then have your personal agents running on yo
 ### Option 1: Docker
 
 ```sh
-docker pull ghcr.io/openhands/agent-canvas:latest
+docker pull ghcr.io/openhands/agent-canvas:1.0.0-alpha.6
 ```
 
 ```sh
@@ -52,7 +52,7 @@ docker run -it --rm \
   -p 8000:8000 \
   -v ~/.openhands:/home/openhands/.openhands \
   -v ${PROJECTS_PATH}:/projects \
-  ghcr.io/openhands/agent-canvas:latest
+  ghcr.io/openhands/agent-canvas:1.0.0-alpha.6
 ```
 
 Set `PROJECTS_PATH` to the directory containing your project folders (e.g. `~/projects`).

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ docker pull ghcr.io/openhands/agent-canvas:1.0.0-alpha.6
 ```
 
 ```sh
+export PROJECTS_PATH=~/projects  # directory containing your project folders
+```
+
+```sh
 docker run -it --rm \
   -p 8000:8000 \
   -v ~/.openhands:/home/openhands/.openhands \
@@ -55,8 +59,7 @@ docker run -it --rm \
   ghcr.io/openhands/agent-canvas:1.0.0-alpha.6
 ```
 
-Set `PROJECTS_PATH` to the directory containing your project folders (e.g. `~/projects`).
-The agent will be able to access any project under that path.
+The agent will be able to access any project under `PROJECTS_PATH`.
 
 ### Option 2: NPM
 
@@ -64,6 +67,10 @@ The agent will be able to access any project under that path.
 
 ```sh
 npm install -g @openhands/agent-canvas
+```
+
+```sh
+export PROJECTS_PATH=~/projects  # directory containing your project folders
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ If you have questions or feedback, please open a GitHub issue or join the [#proj
 
 ## Quickstart
 
-### Direct Install
-
 You can install OpenHands to run agents on any machine: on your laptop, on a dedicated computer like a Mac Mini,
 or on a server in the cloud.
 
@@ -41,13 +39,40 @@ them from the same Agent Canvas frontend. E.g. you can share an Agent Server wit
 code review and dependency updates, then have your personal agents running on your laptop.
 
 > [!WARNING]
-> This runs the agent-server directly on the machine you're installing on--the agent will have full access to your filesystem!
+> This runs the agent-server directly on the machine you're installing on — the agent will have full access to your filesystem!
 
-**Prerequisites**:
+### Option 1: Docker
 
-- Node.js 22.12.x or later
-- `npm`
-- `uv` (for running the agent server via `uvx`)
+```sh
+docker pull ghcr.io/openhands/agent-canvas:latest
+```
+
+```sh
+docker run -it --rm \
+  -p 8000:8000 \
+  -v ~/.openhands:/home/openhands/.openhands \
+  -v ${PROJECTS_PATH}:/projects \
+  ghcr.io/openhands/agent-canvas:latest
+```
+
+Set `PROJECTS_PATH` to the directory containing your project folders (e.g. `~/projects`).
+The agent will be able to access any project under that path.
+
+### Option 2: NPM
+
+**Prerequisites**: Node.js 22.12.x or later, `uv`
+
+```sh
+npm install -g @openhands/agent-canvas
+```
+
+```sh
+agent-canvas
+```
+
+### Option 3: From Source
+
+**Prerequisites**: Node.js 22.12.x or later, `npm`, `uv` (for running the agent server via `uvx`)
 
 ```sh
 git clone https://github.com/OpenHands/agent-canvas.git
@@ -55,6 +80,8 @@ cd agent-canvas
 npm install
 npm run dev
 ```
+
+---
 
 Access the UI at [http://localhost:8000](http://localhost:8000). You can add additional backends directly from the UI.
 


### PR DESCRIPTION
## Summary

Adds the two primary installation methods (Docker and NPM) to the README Quickstart section, alongside the existing from-source workflow.

### Changes

The Quickstart section now presents three clearly labeled options:

1. **Docker** — `docker pull` + `docker run` with volume mounts for settings persistence and project access
2. **NPM** — `npm install -g @openhands/agent-canvas` + `agent-canvas`
3. **From Source** — existing `git clone` / `npm install` / `npm run dev` workflow (unchanged)

The introductory paragraphs (overview, self-hosting link, multi-backend note, filesystem warning) are preserved and now apply to all three options rather than being nested under a single "Direct Install" heading.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/370b16dd-7750-4a68-8ddb-27a46036228a)


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `9bf13d0a38eb844e2966375e340d2315da917a0f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-9bf13d0
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-9bf13d0
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-9bf13d0-amd64
ghcr.io/openhands/agent-canvas:readme-install-instructions-amd64
ghcr.io/openhands/agent-canvas:pr-806-amd64
ghcr.io/openhands/agent-canvas:sha-9bf13d0-arm64
ghcr.io/openhands/agent-canvas:readme-install-instructions-arm64
ghcr.io/openhands/agent-canvas:pr-806-arm64
ghcr.io/openhands/agent-canvas:sha-9bf13d0
ghcr.io/openhands/agent-canvas:readme-install-instructions
ghcr.io/openhands/agent-canvas:pr-806
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-9bf13d0`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-9bf13d0-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->