### PR TITLE
chore: bump version to 1.0.0-alpha.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openhands/agent-canvas",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openhands/agent-canvas",
-      "version": "1.0.0-alpha.6",
+      "version": "1.0.0-alpha.7",
       "license": "MIT",
       "dependencies": {
         "@heroui/react": "2.8.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhands/agent-canvas",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "description": "Agent Canvas UI for OpenHands - run AI coding agents with a visual interface",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Release v1.0.0-alpha.7

Bumps version from `1.0.0-alpha.6` → `1.0.0-alpha.7`.

### What's Changed since v1.0.0-alpha.6

#### 🐛 Bug Fixes
- fix: show local time on Pending run rows instead of Jan 1, 1970 (#812)
- fix: inject runtime session key into index.html for published binary (#795)
- fix: refetch list on revisit so agent-created automations appear (#805)
- fix(frontend): render Settings icon as a link so it supports Open in new tab (#802)
- fix: disable Run Now when the automation is turned off (#800)
- fix(skills): prefer frontmatter description over body content in slash command menu (#673)
- fix: hide Change Agent button on home page chat input (#798)
- fix: route LLM errors inline and keep conversation/server errors visible in the banner (#787)

#### ⚡ Performance
- perf(useLocalGitInfo): consolidate git probe into single bash round-trip (#792)

#### 📝 Docs & Chores
- Add GitHub bug report issue template (#813)
- chore: remove PR review GitHub Actions workflow (#814)
- docs: add Docker and NPM install instructions to README (#806)

---

### Release Checklist
> **Do not merge until ready to cut the release.** Merging this PR does NOT publish — the release is triggered by pushing the `v1.0.0-alpha.7` tag after merge.

- [ ] Review changelog above
- [ ] Merge this PR
- [ ] Tag the merge commit: `git tag v1.0.0-alpha.7 && git push origin v1.0.0-alpha.7`
- [ ] Confirm [npm publish workflow](https://github.com/OpenHands/agent-canvas/actions/workflows/npm-publish.yml) succeeds
- [ ] Confirm [Docker build workflow](https://github.com/OpenHands/agent-canvas/actions/workflows/docker.yml) succeeds
- [ ] Create GitHub Release from the tag

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0ea2eeb2-4854-4744-b34f-9066d616949a)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `05218c24a519f0435ed3c4d70a6c9be86b0b8398` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-05218c2
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-05218c2
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-05218c2-amd64
ghcr.io/openhands/agent-canvas:release-v1.0.0-alpha.7-amd64
ghcr.io/openhands/agent-canvas:pr-822-amd64
ghcr.io/openhands/agent-canvas:sha-05218c2-arm64
ghcr.io/openhands/agent-canvas:release-v1.0.0-alpha.7-arm64
ghcr.io/openhands/agent-canvas:pr-822-arm64
ghcr.io/openhands/agent-canvas:sha-05218c2
ghcr.io/openhands/agent-canvas:release-v1.0.0-alpha.7
ghcr.io/openhands/agent-canvas:pr-822
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-05218c2`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-05218c2-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->