### PR TITLE
fix(frontend): keep Activity Log in sync while a run is Pending/Running

### DIFF
--- a/__tests__/components/automations/detail/activity-log-item.test.tsx
+++ b/__tests__/components/automations/detail/activity-log-item.test.tsx
@@ -135,6 +135,57 @@ describe("ActivityLogItem — logs button", () => {
   });
 });
 
+describe("ActivityLogItem — Conversation not created label", () => {
+  beforeEach(() => {
+    __resetActiveStoreForTests();
+    setRegisteredBackends([localBackend]);
+    setActiveSelection({ backendId: localBackend.id });
+  });
+
+  afterEach(() => {
+    __resetActiveStoreForTests();
+  });
+
+  it("hides the 'Conversation not created' label while the run is Pending without a conversation", () => {
+    // Arrange: a freshly-dispatched run that hasn't yet been linked to a
+    // conversation by the backend. The label would falsely imply terminal
+    // failure during this transient window.
+    const run = makeRun({
+      status: AutomationRunStatus.PENDING,
+      conversation_id: null,
+      bash_command_id: null,
+    });
+
+    // Act
+    renderItem(run);
+
+    // Assert
+    expect(
+      screen.queryByText((content) => content.includes("NO_CONVERSATION")),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the 'Conversation not created' label when the run has Failed without a conversation", () => {
+    // Arrange: a run that reached a terminal state without ever creating a
+    // conversation (e.g. sandbox provisioning error) — here the label is
+    // accurate and useful.
+    const run = makeRun({
+      status: AutomationRunStatus.FAILED,
+      conversation_id: null,
+      bash_command_id: null,
+      completed_at: "2026-01-01T10:00:30Z",
+    });
+
+    // Act
+    renderItem(run);
+
+    // Assert
+    expect(
+      screen.queryByText((content) => content.includes("NO_CONVERSATION")),
+    ).toBeInTheDocument();
+  });
+});
+
 describe("ActivityLogItem — timestamp fallback", () => {
   beforeEach(() => {
     __resetActiveStoreForTests();

--- a/__tests__/hooks/query/use-automations-backend-switch.test.tsx
+++ b/__tests__/hooks/query/use-automations-backend-switch.test.tsx
@@ -14,19 +14,24 @@ import {
   useAutomations,
   useDispatchAutomation,
 } from "#/hooks/query/use-automations";
-import { useAutomationDetail } from "#/hooks/query/use-automation-detail";
+import {
+  useAutomationDetail,
+  useAutomationRuns,
+} from "#/hooks/query/use-automation-detail";
 import type { Backend } from "#/api/backend-registry/types";
 import { AutomationRunStatus } from "#/types/automation";
 import type {
   Automation,
   AutomationRun,
   AutomationsResponse,
+  AutomationRunsResponse,
 } from "#/types/automation";
 
 vi.mock("#/api/automation-service/automation-service.api", () => ({
   default: {
     getAutomations: vi.fn(),
     getAutomation: vi.fn(),
+    getAutomationRuns: vi.fn(),
     dispatchAutomation: vi.fn(),
   },
 }));
@@ -92,6 +97,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   vi.mocked(AutomationService.getAutomations).mockReset();
   vi.mocked(AutomationService.getAutomation).mockReset();
+  vi.mocked(AutomationService.getAutomationRuns).mockReset();
   vi.mocked(AutomationService.dispatchAutomation).mockReset();
   vi.mocked(AutomationService.dispatchAutomation).mockResolvedValue(
     automationRun,
@@ -154,4 +160,73 @@ describe("automation hooks — backend switch", () => {
 
     expect(AutomationService.dispatchAutomation).toHaveBeenCalledWith("auto-1");
   });
+});
+
+describe("useAutomationRuns — polling", () => {
+  const pendingRun: AutomationRun = {
+    id: "run-pending",
+    status: AutomationRunStatus.PENDING,
+    conversation_id: null,
+    bash_command_id: null,
+    error_detail: null,
+    started_at: "2026-01-02T00:00:00Z",
+    completed_at: null,
+  };
+  const completedRun: AutomationRun = {
+    id: "run-pending",
+    status: AutomationRunStatus.COMPLETED,
+    conversation_id: "conv-1",
+    bash_command_id: "cmd-1",
+    error_detail: null,
+    started_at: "2026-01-02T00:00:00Z",
+    completed_at: "2026-01-02T00:00:30Z",
+  };
+
+  it(
+    "re-fetches while a run is non-terminal, and stops once all runs are terminal",
+    async () => {
+      // Arrange: first fetch returns a PENDING run (polling should engage);
+      // subsequent fetches return a COMPLETED run (polling should then stop).
+      const pendingResponse: AutomationRunsResponse = {
+        runs: [pendingRun],
+        total: 1,
+      };
+      const completedResponse: AutomationRunsResponse = {
+        runs: [completedRun],
+        total: 1,
+      };
+      vi.mocked(AutomationService.getAutomationRuns)
+        .mockResolvedValueOnce(pendingResponse)
+        .mockResolvedValue(completedResponse);
+
+      // Act
+      renderHook(
+        () => useAutomationRuns({ id: "auto-1", limit: 20, offset: 0 }),
+        { wrapper: makeWrapper() },
+      );
+
+      // Assert: the initial fetch fires once.
+      await waitFor(() => {
+        expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(1);
+      });
+
+      // The cached data still contains a PENDING run, so refetchInterval
+      // engages and a second fetch arrives within the poll window.
+      await waitFor(
+        () => {
+          expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(2);
+        },
+        { timeout: 5000 },
+      );
+
+      // The second fetch returned a COMPLETED run, so polling should stop.
+      // Give the would-be next poll window plenty of slack and assert no
+      // further calls happen.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 4000);
+      });
+      expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(2);
+    },
+    15000,
+  );
 });

--- a/src/components/features/automations/detail/activity-log-item.tsx
+++ b/src/components/features/automations/detail/activity-log-item.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import TerminalIcon from "#/icons/terminal.svg?react";
-import type { AutomationRun } from "#/types/automation";
+import { AutomationRunStatus, type AutomationRun } from "#/types/automation";
 import { RunStatusBadge } from "./run-status-badge";
 import { RunLogsModal } from "./run-logs-modal";
 
@@ -37,6 +37,16 @@ export function ActivityLogItem({ run }: ActivityLogItemProps) {
   const { t, i18n } = useTranslation("openhands");
   const hasConversation = !!run.conversation_id;
   const hasBashCommand = !!run.bash_command_id;
+  // Only surface "Conversation not created" when the run has reached a
+  // terminal status without a conversation — i.e. the conversation truly
+  // will not be created (e.g. sandbox provisioning failed). While
+  // PENDING/RUNNING the conversation may still be in the process of being
+  // created, and the status badge already communicates the in-progress
+  // state.
+  const isTerminal =
+    run.status === AutomationRunStatus.COMPLETED ||
+    run.status === AutomationRunStatus.FAILED;
+  const showNoConversationLabel = !hasConversation && isTerminal;
   const [logsOpen, setLogsOpen] = useState(false);
   // The backend leaves started_at unset (epoch/zero) while a run is Pending
   // and only populates it once execution begins. Show the user's local time
@@ -81,7 +91,7 @@ export function ActivityLogItem({ run }: ActivityLogItemProps) {
     <>
       <div className="flex items-center gap-3">
         <span className="text-sm text-content">{formattedTimestamp}</span>
-        {!hasConversation && (
+        {showNoConversationLabel && (
           <span className="text-xs text-muted italic">
             ({t(I18nKey.AUTOMATIONS$DETAIL$NO_CONVERSATION)})
           </span>

--- a/src/hooks/query/use-automation-detail.ts
+++ b/src/hooks/query/use-automation-detail.ts
@@ -1,6 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import AutomationService from "#/api/automation-service/automation-service.api";
 import { useActiveBackend } from "#/contexts/active-backend-context";
+import {
+  AutomationRunStatus,
+  type AutomationRunsResponse,
+} from "#/types/automation";
 
 export const AUTOMATION_DETAIL_QUERY_KEY = ["automation-detail"] as const;
 export const AUTOMATION_RUNS_QUERY_KEY = ["automation-runs"] as const;
@@ -47,5 +51,17 @@ export function useAutomationRuns(options: UseAutomationRunsOptions) {
     queryFn: () => AutomationService.getAutomationRuns(id, limit, offset),
     staleTime: 60 * 1000,
     enabled: !!id && enabled,
+    // Poll while any run is non-terminal so status and conversation_id
+    // transitions appear without a manual refresh.
+    refetchInterval: (query) => {
+      const data = query.state.data as AutomationRunsResponse | undefined;
+      if (!data) return false;
+      const hasInFlightRun = data.runs.some(
+        (run) =>
+          run.status === AutomationRunStatus.PENDING ||
+          run.status === AutomationRunStatus.RUNNING,
+      );
+      return hasInFlightRun ? 3000 : false;
+    },
   });
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

<img width="1440" height="795" alt="issue" src="https://github.com/user-attachments/assets/32367ca8-1c32-4e77-85cc-fbf162054473" />

On the automation details page (`/automations/[id]`), the Activity Log row for a freshly-dispatched run displays the label **"(Conversation not created)"** while the run is `Pending` or `Running`, even when the conversation has already been created and is visible in the left-hand conversation panel. The misleading label only disappears once the run reaches a terminal status — and only after the user manually refreshes the page, because the status badge never updates on its own either.

### Steps to reproduce

1. `npm run dev` and open `http://localhost:3001/automations`.
2. Open an automation's detail page.
3. Click **Run Now**.
4. Observe the new row in the Activity Log.

### Current behavior

- The new row shows the label **"(Conversation not created)"** while the status badge reads `Pending` or `Running`.
- The conversation panel on the left already shows the created conversation, so the two surfaces disagree.
- The status badge never transitions to `Successful` / `Failed` until the user manually refreshes the page; after refresh the label disappears.

### Expected behavior

- The Activity Log and the conversation panel stay consistent — no "Conversation not created" while a conversation actually exists.
- The status badge transitions `Pending → Running → Successful/Failed` automatically, without a manual refresh.
- The "Conversation not created" label is still useful (and shown) for runs that genuinely never created a conversation, e.g. sandbox provisioning failed before the conversation was opened.

### Root cause

Two compounding issues in the same surface:

1. **`useAutomationRuns` never polls.** It has `staleTime: 60 * 1000` but no `refetchInterval`, so after `useDispatchAutomation` invalidates the query once on Run Now, the response captures the run's earliest in-flight state (`status: PENDING`, `conversation_id: null`) and the UI freezes there. Backend updates to `status` and `conversation_id` never reach the page until another invalidation or a full refresh.
2. **Label is gated only on `!conversation_id`.** In `ActivityLogItem`, the "(Conversation not created)" label is shown whenever `conversation_id` is null — including the transient window between dispatch and conversation creation. The wording reads as a terminal failure, which is wrong for `PENDING`/`RUNNING`.

### Fix

1. Add a function-form `refetchInterval` to `useAutomationRuns` that polls every 3 s while any run is `PENDING`/`RUNNING`, and stops once all runs are terminal. Matches the pattern in `useSubConversationTaskPolling` / `useTaskPolling`. React Query v5's default behavior pauses interval refetches while the tab is hidden, so polling won't run in the background.
2. Gate the "(Conversation not created)" label on a terminal run status. While the run is `PENDING`/`RUNNING`, the `RunStatusBadge` already conveys the in-progress state; we no longer flash a misleading parenthetical. The label still appears for `COMPLETED`/`FAILED` runs with no conversation — the only state in which it is true and useful.

### Acceptance criteria

- [ ] After clicking Run Now, the new Activity Log row does **not** show "(Conversation not created)" at any point while it is `Pending` or `Running`.
- [ ] The status badge updates `Pending → Running → Successful/Failed` without any page refresh.
- [ ] A run that ends in `Failed` without a conversation **still** shows the "(Conversation not created)" label.
- [ ] Polling stops once all runs are terminal (verifiable in DevTools → Network — no repeating calls to `/api/automation/v1/{id}/runs`).
- [ ] Polling is paused while the tab is hidden.

### Out of scope (follow-up)

- Polling `useAutomationDetail` so the "Last run" relative-time label freshens on its own for scheduled (cron-triggered) runs.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The Activity Log row for a freshly-dispatched run no longer shows "(Conversation not created)" while the run is `Pending`/`Running`; the label is now gated on a terminal status (`COMPLETED`/`FAILED`).
- `useAutomationRuns` now polls every 3s while any run is non-terminal and stops once all runs are terminal — the status badge transitions `Pending → Running → Successful/Failed` without a manual refresh.
- Polling pauses automatically while the tab is hidden (React Query v5 default), so this doesn't generate background traffic.

## Why

Before this change, the Activity Log and the left-hand conversation panel could disagree for several minutes after clicking Run Now:

| Surface                   | What it showed                                                         |
| ------------------------- | ---------------------------------------------------------------------- |
| Conversation panel (left) | The created conversation, immediately                                  |
| Activity Log (right)      | "(Conversation not created)" + stuck on Pending until a manual refresh |

Root cause: `useAutomationRuns` had no `refetchInterval`, so after the single invalidation triggered by `useDispatchAutomation`, the UI froze on the earliest in-flight snapshot (`status: PENDING`, `conversation_id: null`). The label condition `!conversation_id` then reinforced the misleading "not created" wording during that window.

## Approach

Smallest possible change in two files:

- `src/hooks/query/use-automation-detail.ts`: add a function-form `refetchInterval` to `useAutomationRuns` that returns `3000` while any run is `PENDING`/`RUNNING`, `false` otherwise. Mirrors `useSubConversationTaskPolling` and `useTaskPolling`.
- `src/components/features/automations/detail/activity-log-item.tsx`: derive `isTerminal` and only render the "(Conversation not created)" label when `!hasConversation && isTerminal`. The `<a>` vs `<div>` branch (link vs non-link row) keeps its existing condition.

No new translation keys, no API or schema changes.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev` and open `http://localhost:3001/automations`.
2. Open an automation's detail page.
3. Click **Run Now**.
4. Observe the new row in the Activity Log.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/a472ecf5-c699-4dbd-acd8-dd12a4b87803

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- Polling `useAutomationDetail` so the "Last run" relative-time freshens on its own for scheduled (cron-triggered) runs — separate, less acute issue.
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `afe98f83d5dd0a0ee7ac18cf33f0398823e808d3` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-afe98f8
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-afe98f8
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-afe98f8-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1938-amd64
ghcr.io/openhands/agent-canvas:pr-824-amd64
ghcr.io/openhands/agent-canvas:sha-afe98f8-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1938-arm64
ghcr.io/openhands/agent-canvas:pr-824-arm64
ghcr.io/openhands/agent-canvas:sha-afe98f8
ghcr.io/openhands/agent-canvas:hieptl-app-1938
ghcr.io/openhands/agent-canvas:pr-824
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-afe98f8`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-afe98f8-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->