### PR TITLE
fix: use backend registry apiKey for automation auth instead of build-time env var

### DIFF
--- a/__tests__/api/automation-service.test.ts
+++ b/__tests__/api/automation-service.test.ts
@@ -7,6 +7,7 @@ import type {
   AutomationRunsResponse,
 } from "#/types/automation";
 import type { Backend } from "#/api/backend-registry/types";
+import type { InternalAxiosRequestConfig } from "axios";
 
 // Use vi.hoisted to define mocks that will be available during vi.mock hoisting
 const {
@@ -16,14 +17,21 @@ const {
   mockDelete,
   mockCallCloudProxy,
   mockGetActive,
-} = vi.hoisted(() => ({
-  mockGet: vi.fn(),
-  mockPatch: vi.fn(),
-  mockPost: vi.fn(),
-  mockDelete: vi.fn(),
-  mockCallCloudProxy: vi.fn(),
-  mockGetActive: vi.fn(),
-}));
+  mockGetEffectiveLocal,
+  capturedInterceptors,
+} = vi.hoisted(() => {
+  const interceptors: Array<(config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig> = [];
+  return {
+    mockGet: vi.fn(),
+    mockPatch: vi.fn(),
+    mockPost: vi.fn(),
+    mockDelete: vi.fn(),
+    mockCallCloudProxy: vi.fn(),
+    mockGetActive: vi.fn(),
+    mockGetEffectiveLocal: vi.fn(),
+    capturedInterceptors: interceptors,
+  };
+});
 
 vi.mock("axios", () => ({
   default: {
@@ -35,7 +43,9 @@ vi.mock("axios", () => ({
       delete: mockDelete,
       interceptors: {
         request: {
-          use: vi.fn(),
+          use: (fn: (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig) => {
+            capturedInterceptors.push(fn);
+          },
         },
       },
     }),
@@ -48,6 +58,7 @@ vi.mock("#/api/cloud/proxy", () => ({
 
 vi.mock("#/api/backend-registry/active-store", () => ({
   getActiveBackend: mockGetActive,
+  getEffectiveLocalBackend: mockGetEffectiveLocal,
 }));
 
 // Import after mocking
@@ -68,6 +79,20 @@ const cloudBackend: Backend = {
   apiKey: "bearer-key",
   kind: "cloud",
 };
+
+/** Build a minimal InternalAxiosRequestConfig for interceptor tests. */
+function makeAxiosConfig(
+  overrides: Partial<InternalAxiosRequestConfig> = {},
+): InternalAxiosRequestConfig {
+  const headers = {
+    set: vi.fn(),
+    get: vi.fn(),
+  } as unknown as InternalAxiosRequestConfig["headers"];
+  return {
+    headers,
+    ...overrides,
+  } as unknown as InternalAxiosRequestConfig;
+}
 
 const mockAutomation: Automation = {
   id: "1",
@@ -106,6 +131,8 @@ describe("AutomationService", () => {
     // Default: active backend is local. Cloud-routing tests override this.
     mockGetActive.mockReset();
     mockGetActive.mockReturnValue({ backend: localBackend, orgId: null });
+    mockGetEffectiveLocal.mockReset();
+    mockGetEffectiveLocal.mockReturnValue(localBackend);
   });
 
   describe("listAutomations", () => {
@@ -416,6 +443,77 @@ describe("AutomationService", () => {
       });
       expect(mockPost).not.toHaveBeenCalled();
       expect(result).toEqual(run);
+    });
+  });
+
+  // The interceptor must read the session API key from the active backend
+  // registry rather than the build-time VITE_SESSION_API_KEY env var so that
+  // the published npm package picks up the runtime-injected key (issue #829).
+  describe("localAutomationAxios interceptor", () => {
+    it("sets X-Session-API-Key from the effective local backend apiKey", () => {
+      const interceptor = capturedInterceptors[0];
+      expect(interceptor).toBeDefined();
+
+      const backendWithKey: Backend = {
+        ...localBackend,
+        apiKey: "runtime-injected-key",
+      };
+      mockGetEffectiveLocal.mockReturnValue(backendWithKey);
+
+      const config = makeAxiosConfig();
+      interceptor(config);
+
+      expect(config.headers.set).toHaveBeenCalledWith(
+        "X-Session-API-Key",
+        "runtime-injected-key",
+      );
+    });
+
+    it("does not set X-Session-API-Key when backend apiKey is empty", () => {
+      const interceptor = capturedInterceptors[0];
+      expect(interceptor).toBeDefined();
+
+      mockGetEffectiveLocal.mockReturnValue({
+        ...localBackend,
+        apiKey: "",
+      });
+
+      const config = makeAxiosConfig();
+      interceptor(config);
+
+      expect(config.headers.set).not.toHaveBeenCalled();
+    });
+
+    it("sets baseURL from effective local backend host when not already set", () => {
+      const interceptor = capturedInterceptors[0];
+      expect(interceptor).toBeDefined();
+
+      mockGetEffectiveLocal.mockReturnValue({
+        ...localBackend,
+        host: "http://custom-host:9000",
+        apiKey: "key",
+      });
+
+      const config = makeAxiosConfig();
+      interceptor(config);
+
+      expect(config.baseURL).toBe("http://custom-host:9000");
+    });
+
+    it("does not overwrite an already-set baseURL", () => {
+      const interceptor = capturedInterceptors[0];
+      expect(interceptor).toBeDefined();
+
+      mockGetEffectiveLocal.mockReturnValue({
+        ...localBackend,
+        host: "http://should-not-use:9000",
+        apiKey: "key",
+      });
+
+      const config = makeAxiosConfig({ baseURL: "http://already-set:8000" });
+      interceptor(config);
+
+      expect(config.baseURL).toBe("http://already-set:8000");
     });
   });
 });

--- a/src/api/automation-service/automation-service.api.ts
+++ b/src/api/automation-service/automation-service.api.ts
@@ -20,19 +20,24 @@ export interface AutomationHealthResponse {
 
 // Local automation calls go to the automation sidecar that
 // `scripts/dev-with-automation.mjs` mounts behind the local agent-server.
-// Both backends use the same session API key (`VITE_SESSION_API_KEY`)
-// and the same `X-Session-API-Key` header for consistency.
+// Both backends use the same session API key and the same `X-Session-API-Key`
+// header for consistency.
 const localAutomationAxios = axios.create();
 
 localAutomationAxios.interceptors.request.use((config) => {
-  // Resolve the local backend host on every call so it tracks the
-  // currently-active local backend (and any host edits made via the
+  // Resolve the local backend on every call so it tracks the
+  // currently-active local backend (and any host/key edits made via the
   // manage-backends UI), rather than freezing whatever value the
   // agent-server-config produced at module load time.
+  // Using the backend registry (rather than the build-time VITE_SESSION_API_KEY
+  // env var) ensures the published npm package picks up the runtime-injected
+  // session key that scripts/static-server.mjs seeds into localStorage, fixing
+  // the 401 errors reported in issue #829.
+  const backend = getEffectiveLocalBackend();
   // eslint-disable-next-line no-param-reassign
-  if (!config.baseURL) config.baseURL = getEffectiveLocalBackend().host;
+  if (!config.baseURL) config.baseURL = backend.host;
 
-  const apiKey = import.meta.env.VITE_SESSION_API_KEY?.trim();
+  const apiKey = backend.apiKey?.trim();
   if (apiKey) {
     config.headers.set("X-Session-API-Key", apiKey);
   }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The automations list page was returning 401 errors when used with the published npm package (`@openhands/agent-canvas`). The root cause: the `localAutomationAxios` interceptor was reading the session API key from `import.meta.env.VITE_SESSION_API_KEY` (a compile-time value baked in at publish time), but users running the npm package have their session key injected at runtime into `localStorage` by `scripts/static-server.mjs`. Since the baked-in key doesn't match the runtime key, requests had no valid auth header and the automation backend fell back to a Keycloak cookie check — which always fails with "Invalid or expired session cookie" (401).

## Summary

- Changed `localAutomationAxios` interceptor to read the API key from `getEffectiveLocalBackend().apiKey` (the active backend registry) instead of `import.meta.env.VITE_SESSION_API_KEY`.
- This is consistent with how the interceptor already resolves `baseURL` — using `getEffectiveLocalBackend().host` on every call.
- Added tests that verify the interceptor correctly sets/omits `X-Session-API-Key` based on the backend's runtime `apiKey`, and that it handles host resolution correctly.

## Issue Number

Fixes #829

## How to Test

1. Install the alpha package: `npm install -g @openhands/agent-canvas`
2. Run `agent-canvas`
3. Navigate to the Automations page
4. The list should load without 401 errors, using `X-Session-API-Key` header with the runtime key

Or run the unit tests: `npm test -- --run __tests__/api/automation-service.test.ts`

## Type

- [x] Bug fix

## Notes

This was raised in issue #829. The keycloak cookie in the bug report's curl command was the browser sending an old/unrelated cookie — the real issue was the missing `X-Session-API-Key` header. The automation backend uses `AUTOMATION_LOCAL_API_KEY` which equals the session API key, so using `X-Session-API-Key` with the correct runtime value is the right fix.

_This PR was created by an AI agent (OpenHands) on behalf of a user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2f078ad1-a168-4576-97e7-028de1d40af1)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `f9d93110951699daeaa38b23a18cb4072c2d2344` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f9d9311
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f9d9311
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f9d9311-amd64
ghcr.io/openhands/agent-canvas:openhands-fix-automation-auth-session-key-amd64
ghcr.io/openhands/agent-canvas:pr-830-amd64
ghcr.io/openhands/agent-canvas:sha-f9d9311-arm64
ghcr.io/openhands/agent-canvas:openhands-fix-automation-auth-session-key-arm64
ghcr.io/openhands/agent-canvas:pr-830-arm64
ghcr.io/openhands/agent-canvas:sha-f9d9311
ghcr.io/openhands/agent-canvas:openhands-fix-automation-auth-session-key
ghcr.io/openhands/agent-canvas:pr-830
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f9d9311`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f9d9311-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->