### PR TITLE
fix(frontend): scroll chat to bottom when a new prompt is submitted

### DIFF
--- a/__tests__/components/chat/chat-interface.test.tsx
+++ b/__tests__/components/chat/chat-interface.test.tsx
@@ -699,6 +699,107 @@ describe("ChatInterface - Pending message queue", () => {
   });
 });
 
+describe("ChatInterface - Auto-scroll on submit (issue #817)", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    mockSend.mockReset();
+    mockSend.mockResolvedValue({ queued: false });
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    useOptimisticUserMessageStore.setState({ pendingMessages: [] });
+    useErrorMessageStore.setState({ errorMessage: null });
+    (useConfig as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {},
+    });
+    (
+      useUnifiedUploadFiles as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({
+      mutateAsync: vi
+        .fn()
+        .mockResolvedValue({ skipped_files: [], uploaded_files: [] }),
+      isLoading: false,
+    });
+    useEventStore.setState({
+      events: [],
+      eventIds: new Set(),
+      uiEvents: [],
+    });
+  });
+
+  afterEach(() => {
+    useOptimisticUserMessageStore.setState({ pendingMessages: [] });
+  });
+
+  it("scrolls to bottom when a new prompt is submitted while the user is scrolled up", async () => {
+    // Arrange: render and grab the chat scroll container.
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/test-conversation-id"]}>
+          <Routes>
+            <Route path=":conversationId" element={<ChatInterface />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const scrollContainer = document.querySelector(
+      ".custom-scrollbar-always",
+    ) as HTMLElement | null;
+    expect(scrollContainer).not.toBeNull();
+
+    // Let the mount-time auto-scroll rAF (which re-arms autoScroll=true)
+    // run and settle BEFORE the scroll-up sim. Otherwise that rAF would
+    // fire later and undo the autoScroll=false precondition for the bug.
+    await new Promise((r) => {
+      setTimeout(r, 0);
+    });
+
+    // Capture every scrollTop write so we can detect the rAF inside
+    // scrollDomToBottom landing `dom.scrollTop = dom.scrollHeight`.
+    const scrollWrites: number[] = [];
+    let scrollTopRead = 200;
+    Object.defineProperty(scrollContainer!, "scrollTop", {
+      configurable: true,
+      get: () => scrollTopRead,
+      set: (value: number) => {
+        scrollWrites.push(value);
+      },
+    });
+    Object.defineProperty(scrollContainer!, "scrollHeight", {
+      configurable: true,
+      writable: true,
+      value: 10000,
+    });
+    Object.defineProperty(scrollContainer!, "clientHeight", {
+      configurable: true,
+      writable: true,
+      value: 800,
+    });
+
+    // Simulate the user scrolling up: first event seeds prev=200, the
+    // second event at scrollTop=50 is detected as scrolling up and flips
+    // the hook's `autoScroll` to false (the precondition for the bug).
+    fireEvent.scroll(scrollContainer!);
+    scrollTopRead = 50;
+    fireEvent.scroll(scrollContainer!);
+    scrollWrites.length = 0;
+
+    // Act: submit a new prompt (same path InteractiveChatBox uses).
+    act(() => {
+      useConversationStore.setState({ submittedMessage: "hello" });
+    });
+
+    // Assert: scrollDomToBottom landed scrollHeight onto scrollTop even
+    // though autoScroll was off. Without the fix the auto-scroll effect
+    // would skip the call and `scrollWrites` would stay empty.
+    await waitFor(() => {
+      expect(scrollWrites).toContain(10000);
+    });
+  });
+});
+
 describe("ChatInterface - Status Indicator", () => {
   it("should render ChatStatusIndicator when agent is not awaiting user input / conversation is NOT ready", () => {
     vi.mocked(useAgentState).mockReturnValue({

--- a/__tests__/components/chat/chat-interface.test.tsx
+++ b/__tests__/components/chat/chat-interface.test.tsx
@@ -388,7 +388,7 @@ describe("ChatInterface - Scroll-up loads older events", () => {
     renderWithQueryClient(<ChatInterface />, queryClient);
 
     const scrollContainer = document.querySelector(
-      ".custom-scrollbar-always",
+      "[data-testid='chat-scroll-container']",
     ) as HTMLElement | null;
     expect(scrollContainer).not.toBeNull();
 
@@ -434,7 +434,7 @@ describe("ChatInterface - Scroll-up loads older events", () => {
     renderWithQueryClient(<ChatInterface />, queryClient);
 
     const scrollContainer = document.querySelector(
-      ".custom-scrollbar-always",
+      "[data-testid='chat-scroll-container']",
     ) as HTMLElement | null;
     expect(scrollContainer).not.toBeNull();
 
@@ -518,7 +518,7 @@ describe("ChatInterface - Scroll-up loads older events", () => {
     renderWithQueryClient(<ChatInterface />, queryClient);
 
     const scrollContainer = document.querySelector(
-      ".custom-scrollbar-always",
+      "[data-testid='chat-scroll-container']",
     ) as HTMLElement | null;
     expect(scrollContainer).not.toBeNull();
 
@@ -577,7 +577,7 @@ describe("ChatInterface - Scroll-up loads older events", () => {
 
     // The scroll container exists (so the user can scroll up to load older).
     const scrollContainer = document.querySelector(
-      ".custom-scrollbar-always",
+      "[data-testid='chat-scroll-container']",
     ) as HTMLElement | null;
     expect(scrollContainer).not.toBeNull();
 
@@ -745,7 +745,7 @@ describe("ChatInterface - Auto-scroll on submit (issue #817)", () => {
     );
 
     const scrollContainer = document.querySelector(
-      ".custom-scrollbar-always",
+      "[data-testid='chat-scroll-container']",
     ) as HTMLElement | null;
     expect(scrollContainer).not.toBeNull();
 

--- a/__tests__/components/features/chat/git-control-bar.test.tsx
+++ b/__tests__/components/features/chat/git-control-bar.test.tsx
@@ -13,6 +13,16 @@ import { useHomeStore } from "#/stores/home-store";
 import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
 import { getStoredConversationMetadata } from "#/api/conversation-metadata-store";
 import { GitControlBar } from "#/components/features/chat/git-control-bar";
+import { ScrollProvider } from "#/context/scroll-context";
+
+// Holder so the OpenRepositoryModal mock can hand its `onLaunch` prop back
+// to the test — the modal renders null but the parent's launch flow is the
+// only way to drive handleLaunchRepository.
+const mocks = vi.hoisted(() => ({
+  modalLaunchHandler: {
+    current: null as ((repo: unknown, branch: unknown) => void) | null,
+  },
+}));
 
 vi.mock("#/hooks/use-conversation-id", () => ({
   useOptionalConversationId: () => ({ conversationId: "test-conversation-id" }),
@@ -55,7 +65,12 @@ vi.mock("#/components/features/chat/git-control-bar-tooltip-wrapper", () => ({
     children,
 }));
 vi.mock("#/components/features/chat/open-repository-modal", () => ({
-  OpenRepositoryModal: () => null,
+  OpenRepositoryModal: (props: {
+    onLaunch?: (repo: unknown, branch: unknown) => void;
+  }) => {
+    mocks.modalLaunchHandler.current = props.onLaunch ?? null;
+    return null;
+  },
 }));
 
 const makeBackend = (kind: "local" | "cloud") => ({
@@ -176,5 +191,76 @@ describe("GitControlBar repo button visibility", () => {
 
     const button = screen.getByTestId("git-control-bar-repo-button");
     expect(button).toHaveAttribute("data-disabled", "true");
+  });
+});
+
+describe("GitControlBar - Auto-scroll on clone (issue #817)", () => {
+  beforeEach(() => {
+    mocks.modalLaunchHandler.current = null;
+    vi.mocked(useActiveBackend).mockReturnValue(makeBackend("cloud"));
+    vi.mocked(useActiveConversation).mockReturnValue({
+      data: { id: "test-conversation-id" },
+    } as ReturnType<typeof useActiveConversation>);
+    vi.mocked(useTaskPolling).mockReturnValue({
+      repositoryInfo: null,
+    } as unknown as ReturnType<typeof useTaskPolling>);
+    vi.mocked(useLocalGitInfo).mockReturnValue({
+      data: null,
+    } as unknown as ReturnType<typeof useLocalGitInfo>);
+    vi.mocked(useUnifiedWebSocketStatus).mockReturnValue("OPEN");
+    vi.mocked(useSendMessage).mockReturnValue({
+      send: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<typeof useSendMessage>);
+    // updateRepository mocked to invoke onSuccess synchronously so the
+    // post-update branch (where the scroll now lives) runs deterministically.
+    vi.mocked(useUpdateConversationRepository).mockReturnValue({
+      mutate: (_args: unknown, options: { onSuccess?: () => void }) => {
+        options?.onSuccess?.();
+      },
+    } as unknown as ReturnType<typeof useUpdateConversationRepository>);
+    vi.mocked(useHomeStore).mockReturnValue({
+      addRecentRepository: vi.fn(),
+    } as unknown as ReturnType<typeof useHomeStore>);
+    vi.mocked(useOptimisticUserMessageStore).mockImplementation(((
+      selector: (s: unknown) => unknown,
+    ) =>
+      selector({
+        enqueuePendingMessage: vi.fn().mockReturnValue("pending-id"),
+        markPendingMessageError: vi.fn(),
+      })) as unknown as typeof useOptimisticUserMessageStore);
+    vi.mocked(getStoredConversationMetadata).mockReturnValue(null);
+  });
+
+  it("scrolls the chat to bottom after a successful clone is enqueued", () => {
+    // Arrange: provide a spy via ScrollProvider so we can observe the
+    // scroll callback the bar pulls out of useOptionalScrollContext.
+    const scrollDomToBottom = vi.fn();
+    const scrollValue = {
+      scrollRef: { current: null },
+      autoScroll: true,
+      setAutoScroll: vi.fn(),
+      scrollDomToBottom,
+      hitBottom: true,
+      setHitBottom: vi.fn(),
+      onChatBodyScroll: vi.fn(),
+    };
+
+    renderWithProviders(
+      <ScrollProvider value={scrollValue}>
+        <GitControlBar onSuggestionsClick={vi.fn()} />
+      </ScrollProvider>,
+    );
+
+    expect(typeof mocks.modalLaunchHandler.current).toBe("function");
+
+    // Act: drive handleLaunchRepository the same way the modal does.
+    mocks.modalLaunchHandler.current?.(
+      { full_name: "user/repo", git_provider: "github" },
+      { name: "main" },
+    );
+
+    // Assert: the optimistic clone bubble must pull the chat back to the
+    // bottom even if the user had scrolled up.
+    expect(scrollDomToBottom).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -459,6 +459,7 @@ export function ChatInterface() {
 
         <div
           ref={scrollRef}
+          data-testid="chat-scroll-container"
           onScroll={(e) => {
             onChatBodyScroll(e.currentTarget);
             maybeLoadOlder(e.currentTarget);

--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -336,6 +336,10 @@ export function ChatInterface() {
       fileUrls: uploadedFiles,
       timestamp,
     });
+    // Submitting a new prompt should always pull the chat back to the
+    // latest message even if the user had scrolled up. This also re-arms
+    // autoScroll so the streamed agent reply auto-follows.
+    scrollDomToBottom();
     setMessageToSend("");
 
     try {

--- a/src/components/features/chat/git-control-bar.tsx
+++ b/src/components/features/chat/git-control-bar.tsx
@@ -24,6 +24,7 @@ import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-
 import { getStoredConversationMetadata } from "#/api/conversation-metadata-store";
 import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useUserProviders } from "#/hooks/use-user-providers";
+import { useOptionalScrollContext } from "#/context/scroll-context";
 
 interface GitControlBarProps {
   onSuggestionsClick: (value: string) => void;
@@ -60,6 +61,7 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
   useEffect(() => {
     sendRef.current = send;
   }, [send]);
+  const scrollContext = useOptionalScrollContext();
   const { mutate: updateRepository } = useUpdateConversationRepository();
   const { mutate: _createConversation, isPending: _isCreatingConversation } =
     useCreateConversation();
@@ -169,6 +171,9 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
           const pendingId = conversationId
             ? enqueuePendingMessage({ conversationId, text: clonePrompt })
             : null;
+          // Pull chat back to the bottom so the optimistic "Clone …" bubble
+          // is visible even if the user had scrolled up.
+          scrollContext?.scrollDomToBottom();
           // `send` returns a Promise; surface a failed send by flipping the
           // matching pending entry to "error" so the user gets the retry link
           // rather than a perpetual "Sending…" bubble.

--- a/src/context/scroll-context.tsx
+++ b/src/context/scroll-context.tsx
@@ -40,3 +40,11 @@ export function useScrollContext() {
   }
   return context;
 }
+
+// Same as useScrollContext but returns undefined when no provider is mounted.
+// Use this in components that have valid render paths both inside and outside
+// the chat's ScrollProvider (e.g. GitControlBar in production vs. isolated
+// test mounts).
+export function useOptionalScrollContext() {
+  return useContext(ScrollContext);
+}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

When a user has scrolled up in the chat panel to review older messages, submitting a new prompt does **not** auto-scroll the chat back to the bottom. The new optimistic user-message bubble — and any streamed agent response that follows it — renders off-screen, forcing the user to scroll down manually (or hit the scroll-to-bottom button) to see what is happening.

### Affected entry points

| Entry point | Code path |
|---|---|
| Regular chat input | `InteractiveChatBox` → `handleSendMessage` (`chat-interface.tsx`) |
| Chat suggestion chips | `ChatSuggestions` → `onSuggestionsClick` → `handleSendMessage` |
| Git bar **Push / Pull / Create PR** buttons | `GitControlBar*Button` → `onSuggestionsClick` → `handleSendMessage` |
| **Connect Repo / Clone** dialog | `handleLaunchRepository` in `git-control-bar.tsx` (bypasses `handleSendMessage`) |

### Root cause

The auto-scroll `useEffect` in `chat-interface.tsx` only calls `scrollDomToBottom()` when its `autoScroll` flag is `true`. `autoScroll` is flipped to `false` by `onChatBodyScroll` whenever the user scrolls up, and is only re-armed when the user scrolls back to the bottom **or** an explicit `scrollDomToBottom()` call happens. Submitting a prompt while scrolled up triggers a re-render but the effect skips the scroll.

### Acceptance criteria

- [x] Submitting a prompt through the regular chat input scrolls the chat to the bottom even when the user was scrolled up.
- [x] Push / Pull / Create-PR buttons in the git control bar scroll the chat to the bottom on click.
- [x] Connect Repo → Launch (clone) scrolls the chat to the bottom when the clone prompt is enqueued.
- [x] Streamed agent responses after the prompt continue to auto-follow (auto-scroll is re-armed).
- [x] No regression for the `/new` command, file-validation failures, or already-pinned-to-bottom sends.
- [x] TDD tests cover at least the regular-send path and the clone path.

### Out of scope

- The Planner-tab Build button in `ConversationTabs` lives outside `ScrollProvider` (sibling of `ChatInterfaceWrapper`) and the user is not viewing the chat when they click it. Fixing it would require lifting `ScrollProvider` higher in the tree — tracked separately if/when the planner-tab UX is reworked.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `chat-interface.tsx:340` — call `scrollDomToBottom()` after `enqueuePendingMessage(...)` in `handleSendMessage`. Covers the chat input, the empty-state suggestion chips, and the git Push / Pull / Create-PR buttons (all three buttons funnel through `InteractiveChatBox` → `handleSubmit` → `onSubmit` → `handleSendMessage`).
- `git-control-bar.tsx:174` — call `scrollDomToBottom()` after `enqueuePendingMessage(...)` inside `handleLaunchRepository`'s `onSuccess`. Covers the Connect Repo → Launch (clone) path that bypasses `handleSendMessage`.
- `scroll-context.tsx` — add `useOptionalScrollContext()` so `GitControlBar` fails soft (no throw) when mounted outside a `ScrollProvider` (existing tests mount it standalone).

`scrollDomToBottom` already sets `autoscroll = true` and `hitBottom = true` inside its rAF, so the same call both scrolls and re-arms streaming-follow — no separate `setAutoScroll(true)` is needed.

### Why this approach

- Surgical per-callsite fix. `ScrollProvider` is **not** lifted and `useHandleBuildPlanClick` is **not** changed (its two in-scope callers — the Cmd+Enter shortcut and the `PlanPreview` Build button — already wrap with `scrollDomToBottom`).
- The Planner-tab Build button in `ConversationTabs` is the only remaining unfixed path. It lives outside `ScrollProvider`, and the user is not viewing the chat when they click it; fixing it requires a `ScrollProvider` lift that is out of scope for this bug. Tracked separately.

### Files changed

- `src/components/features/chat/chat-interface.tsx`
- `src/components/features/chat/git-control-bar.tsx`
- `src/context/scroll-context.tsx`
- `__tests__/components/chat/chat-interface.test.tsx`
- `__tests__/components/features/chat/git-control-bar.test.tsx`

### TDD evidence

Both new tests were validated by temporarily reverting the production change — both FAIL without the fix and PASS with it.

- `ChatInterface - Auto-scroll on submit (issue #817)` → drives the chat through a scroll-up sequence so `autoScroll = false`, submits a prompt, and asserts that `scrollTop` is set to `scrollHeight`.
- `GitControlBar - Auto-scroll on clone (issue #817)` → mounts `<GitControlBar>` inside a `<ScrollProvider value={…}>` with a spy `scrollDomToBottom`, captures `OpenRepositoryModal`'s `onLaunch` prop, drives a launch, and asserts the spy was called once.

### Edge cases

- `/new` command runs before the new scroll call (early-return at the top of `handleSendMessage`).
- File-validation failures return early before the scroll call.
- Send-error path: the optimistic bubble is already in view when it flips to "error"; no extra scroll needed.
- Clone with WebSocket disconnected or `updateRepository` mutation failure: scroll is inside `onSuccess` after the WS guard, so failed paths don't emit a spurious scroll.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #817 

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/7c802402-93a5-4782-851c-0a383a3ea865

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `2b5d78f6937a200b0e514bb024143daa4951fcfb` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-2b5d78f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-2b5d78f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-2b5d78f-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1977-amd64
ghcr.io/openhands/agent-canvas:pr-831-amd64
ghcr.io/openhands/agent-canvas:sha-2b5d78f-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1977-arm64
ghcr.io/openhands/agent-canvas:pr-831-arm64
ghcr.io/openhands/agent-canvas:sha-2b5d78f
ghcr.io/openhands/agent-canvas:hieptl-app-1977
ghcr.io/openhands/agent-canvas:pr-831
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-2b5d78f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-2b5d78f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->