### PR TITLE
feat(acp): inline live model picker for ACP conversations (#769)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,10 +389,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.23.1")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.24.0")
   - `OH_SECRET_KEY` — secret key for settings encryption; uses a static default for local dev since it's needed for reading persisted encrypted values across restarts
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.23.1` for agent-server SDK libraries
+  - Default: released PyPI version `1.24.0` for agent-server SDK libraries
 
 - Security: `scripts/dev-safe.mjs` and `scripts/dev-with-automation.mjs` auto-generate random API keys when needed and persist the defaults so static builds, localStorage, and restarted services stay in sync:
   - `SESSION_API_KEY` — 64-character hex (256-bit) for agent-server API authentication; persisted at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden via env var

--- a/__tests__/components/features/chat/components/chat-input-model.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-model.test.tsx
@@ -5,6 +5,8 @@ import { renderWithProviders } from "test-utils";
 
 const useActiveConversationMock = vi.fn();
 const useSettingsMock = vi.fn();
+const useActiveBackendMock = vi.fn();
+const switchAcpModelMutate = vi.fn();
 
 vi.mock("#/hooks/query/use-active-conversation", () => ({
   useActiveConversation: () => useActiveConversationMock(),
@@ -14,6 +16,20 @@ vi.mock("#/hooks/query/use-settings", () => ({
   useSettings: () => useSettingsMock(),
 }));
 
+vi.mock("#/contexts/active-backend-context", async () => {
+  const actual = await vi.importActual<
+    typeof import("#/contexts/active-backend-context")
+  >("#/contexts/active-backend-context");
+  return {
+    ...actual,
+    useActiveBackend: () => useActiveBackendMock(),
+  };
+});
+
+vi.mock("#/hooks/mutation/use-switch-acp-model", () => ({
+  useSwitchAcpModel: () => ({ mutate: switchAcpModelMutate }),
+}));
+
 import { ChatInputModel } from "#/components/features/chat/components/chat-input-model";
 
 describe("ChatInputModel", () => {
@@ -21,6 +37,11 @@ describe("ChatInputModel", () => {
     useActiveConversationMock.mockReset();
     useSettingsMock.mockReset();
     useSettingsMock.mockReturnValue({ data: undefined });
+    useActiveBackendMock.mockReset();
+    // Default to a local backend (mirrors useActiveBackend's standalone
+    // fallback): live ACP model switching is local-only.
+    useActiveBackendMock.mockReturnValue({ backend: { kind: "local" } });
+    switchAcpModelMutate.mockReset();
   });
 
   it("renders the active conversation's llm_model when present", () => {
@@ -200,6 +221,109 @@ describe("ChatInputModel", () => {
     // acp-providers.ts.
     expect(model).toHaveAttribute("title", "Claude Opus 4.7");
     fireEvent.click(model);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/settings/agent");
+  });
+
+  it("renders the provider's available models as selectable rows for an ACP conversation", () => {
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        conversation_id: "test-conversation-id",
+        agent_kind: "acp",
+        acp_server: "claude-code",
+        llm_model: "claude-sonnet-4-6",
+      },
+    });
+
+    renderWithProviders(<ChatInputModel />);
+
+    fireEvent.click(screen.getByTestId("chat-input-llm-model"));
+
+    // Every registered Claude Code model is offered as a row, and the running
+    // one (claude-sonnet-4-6) is marked selected.
+    const selectedRow = screen.getByTestId(
+      "chat-input-acp-model-option-claude-sonnet-4-6",
+    );
+    expect(selectedRow).toBeInTheDocument();
+    expect(selectedRow).toHaveTextContent("Claude Sonnet 4.6");
+    expect(
+      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-7"),
+    ).toBeInTheDocument();
+  });
+
+  it("live-switches the model when a row is selected in an active ACP conversation", () => {
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        conversation_id: "test-conversation-id",
+        agent_kind: "acp",
+        acp_server: "claude-code",
+        llm_model: "claude-sonnet-4-6",
+      },
+    });
+
+    renderWithProviders(<ChatInputModel />);
+
+    fireEvent.click(screen.getByTestId("chat-input-llm-model"));
+    fireEvent.click(
+      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-7"),
+    );
+
+    // Active conversation → live switch keyed by the conversation id from the
+    // navigation context (test-conversation-id), default-write NOT used.
+    expect(switchAcpModelMutate).toHaveBeenCalledWith({
+      conversationId: "test-conversation-id",
+      model: "claude-opus-4-7",
+    });
+    // Popover closes after a selection.
+    expect(
+      screen.queryByTestId("chat-input-llm-model-popover"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("persists the choice as the default (conversationId null) in the home ACP case", () => {
+    useActiveConversationMock.mockReturnValue({ data: undefined });
+    useSettingsMock.mockReturnValue({
+      data: {
+        agent_settings: { agent_kind: "acp", acp_server: "claude-code" },
+        llm_model: "anthropic/claude-sonnet-4-20250514",
+      },
+    });
+
+    renderWithProviders(<ChatInputModel />);
+
+    fireEvent.click(screen.getByTestId("chat-input-llm-model"));
+    fireEvent.click(
+      screen.getByTestId("chat-input-acp-model-option-claude-sonnet-4-6"),
+    );
+
+    // Home / no session → null conversationId routes the hook to the
+    // settings-default write path.
+    expect(switchAcpModelMutate).toHaveBeenCalledWith({
+      conversationId: null,
+      model: "claude-sonnet-4-6",
+    });
+  });
+
+  it("does not offer selectable rows on a cloud backend (display + Settings link only)", () => {
+    useActiveBackendMock.mockReturnValue({ backend: { kind: "cloud" } });
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        conversation_id: "test-conversation-id",
+        agent_kind: "acp",
+        acp_server: "claude-code",
+        llm_model: "claude-sonnet-4-6",
+      },
+    });
+
+    renderWithProviders(<ChatInputModel />);
+
+    fireEvent.click(screen.getByTestId("chat-input-llm-model"));
+
+    // No selectable model rows; the popover keeps the display value + Settings.
+    expect(
+      screen.queryByTestId("chat-input-acp-model-option-claude-sonnet-4-6"),
+    ).not.toBeInTheDocument();
+    const popover = screen.getByTestId("chat-input-llm-model-popover");
+    expect(popover).toHaveTextContent("Claude Sonnet 4.6");
     expect(screen.getByRole("link")).toHaveAttribute("href", "/settings/agent");
   });
 });

--- a/__tests__/hooks/mutation/use-switch-acp-model.test.tsx
+++ b/__tests__/hooks/mutation/use-switch-acp-model.test.tsx
@@ -45,7 +45,7 @@ describe("useSwitchAcpModel", () => {
 
   it("live-switches the ACP model for an active conversation and invalidates conversation queries", async () => {
     vi.mocked(AgentServerConversationService.switchAcpModel).mockResolvedValue(
-      undefined as never,
+      undefined,
     );
 
     const { result, invalidateQueriesSpy } = renderSwitchHook();
@@ -76,7 +76,7 @@ describe("useSwitchAcpModel", () => {
   });
 
   it("persists the model as the agent-settings default on the home page (conversationId === null)", async () => {
-    vi.mocked(SettingsService.saveSettings).mockResolvedValue(true as never);
+    vi.mocked(SettingsService.saveSettings).mockResolvedValue(true);
 
     const { result, invalidateQueriesSpy } = renderSwitchHook();
 

--- a/__tests__/hooks/mutation/use-switch-acp-model.test.tsx
+++ b/__tests__/hooks/mutation/use-switch-acp-model.test.tsx
@@ -1,0 +1,122 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useSwitchAcpModel } from "#/hooks/mutation/use-switch-acp-model";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import SettingsService from "#/api/settings-service/settings-service.api";
+import { SETTINGS_QUERY_KEYS } from "#/hooks/query/query-keys";
+
+vi.mock(
+  "#/api/conversation-service/agent-server-conversation-service.api",
+  () => ({
+    default: {
+      switchAcpModel: vi.fn(),
+    },
+  }),
+);
+
+vi.mock("#/api/settings-service/settings-service.api", () => ({
+  default: {
+    saveSettings: vi.fn(),
+    invalidateCache: vi.fn(),
+  },
+}));
+
+const renderSwitchHook = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const { result } = renderHook(() => useSwitchAcpModel(), {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+  return { result, invalidateQueriesSpy };
+};
+
+describe("useSwitchAcpModel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("live-switches the ACP model for an active conversation and invalidates conversation queries", async () => {
+    vi.mocked(AgentServerConversationService.switchAcpModel).mockResolvedValue(
+      undefined as never,
+    );
+
+    const { result, invalidateQueriesSpy } = renderSwitchHook();
+
+    result.current.mutate({
+      conversationId: "conv-1",
+      model: "claude-sonnet-4-6",
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(AgentServerConversationService.switchAcpModel).toHaveBeenCalledWith(
+      "conv-1",
+      "claude-sonnet-4-6",
+    );
+    // Does NOT write to settings on the per-conversation path.
+    expect(SettingsService.saveSettings).not.toHaveBeenCalled();
+    expect(SettingsService.invalidateCache).not.toHaveBeenCalled();
+    // Refreshes the conversation caches so the model chip updates.
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["user", "conversation", "conv-1"],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["user", "conversations"],
+    });
+  });
+
+  it("persists the model as the agent-settings default on the home page (conversationId === null)", async () => {
+    vi.mocked(SettingsService.saveSettings).mockResolvedValue(true as never);
+
+    const { result, invalidateQueriesSpy } = renderSwitchHook();
+
+    result.current.mutate({ conversationId: null, model: "gemini-2.5-pro" });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // The home-page default is written via a scalar acp_model diff (deep-merged
+    // into agent_settings so the provider + command are preserved).
+    expect(SettingsService.saveSettings).toHaveBeenCalledWith({
+      agent_settings_diff: { acp_model: "gemini-2.5-pro" },
+    });
+    expect(
+      AgentServerConversationService.switchAcpModel,
+    ).not.toHaveBeenCalled();
+    // Clears the stale settings cache + refetches so the next conversation and
+    // the home chip read the new default.
+    expect(SettingsService.invalidateCache).toHaveBeenCalled();
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: SETTINGS_QUERY_KEYS.personal(),
+    });
+  });
+
+  it("does not invalidate caches when the live switch fails", async () => {
+    vi.mocked(AgentServerConversationService.switchAcpModel).mockRejectedValue(
+      new Error("boom"),
+    );
+
+    const { result, invalidateQueriesSpy } = renderSwitchHook();
+
+    result.current.mutate({ conversationId: "conv-1", model: "x" });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(invalidateQueriesSpy).not.toHaveBeenCalledWith({
+      queryKey: ["user", "conversation", "conv-1"],
+    });
+  });
+});

--- a/__tests__/hooks/use-chat-input-model-state.test.tsx
+++ b/__tests__/hooks/use-chat-input-model-state.test.tsx
@@ -1,0 +1,226 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AcpModelContext } from "#/hooks/use-acp-model-context";
+import { getAcpProvider } from "#/constants/acp-providers";
+
+const useActiveConversationMock = vi.fn();
+const useSettingsMock = vi.fn();
+const useActiveBackendMock = vi.fn();
+const useAcpModelContextMock = vi.fn();
+const useOptionalConversationIdMock = vi.fn();
+
+vi.mock("#/hooks/query/use-active-conversation", () => ({
+  useActiveConversation: () => useActiveConversationMock(),
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => useSettingsMock(),
+}));
+
+vi.mock("#/contexts/active-backend-context", async () => {
+  const actual = await vi.importActual<
+    typeof import("#/contexts/active-backend-context")
+  >("#/contexts/active-backend-context");
+  return {
+    ...actual,
+    useActiveBackend: () => useActiveBackendMock(),
+  };
+});
+
+vi.mock("#/hooks/use-acp-model-context", () => ({
+  useAcpModelContext: () => useAcpModelContextMock(),
+}));
+
+vi.mock("#/hooks/use-conversation-id", () => ({
+  useOptionalConversationId: () => useOptionalConversationIdMock(),
+}));
+
+// `getAcpProvider`/`labelForAcpModel`/`resolveEffectiveAcpModel` are exercised
+// for real (not mocked) so the test pins the actual registry-sourced model
+// list the picker shows.
+import { useChatInputModelState } from "#/hooks/use-chat-input-model-state";
+
+// `useAcpModelContext` derives these booleans; here we drive them directly so
+// each branch of `useChatInputModelState` is documented in isolation.
+const acpContext = (
+  overrides: Partial<AcpModelContext> = {},
+): AcpModelContext => ({
+  isActiveAcpConversation: false,
+  isHomeAcp: false,
+  isAcpContext: false,
+  destinationPath: "/settings",
+  destinationLabel: "LLM Profiles",
+  ...overrides,
+});
+
+describe("useChatInputModelState", () => {
+  beforeEach(() => {
+    useActiveConversationMock.mockReset();
+    useActiveConversationMock.mockReturnValue({ data: undefined });
+    useSettingsMock.mockReset();
+    useSettingsMock.mockReturnValue({ data: undefined });
+    useActiveBackendMock.mockReset();
+    // Default to a local backend — live ACP switching is local-only.
+    useActiveBackendMock.mockReturnValue({ backend: { kind: "local" } });
+    useAcpModelContextMock.mockReset();
+    useAcpModelContextMock.mockReturnValue(acpContext());
+    useOptionalConversationIdMock.mockReset();
+    useOptionalConversationIdMock.mockReturnValue({ conversationId: null });
+  });
+
+  it("non-ACP: shows the conversation/settings llm_model with no picker", () => {
+    useActiveConversationMock.mockReturnValue({
+      data: { conversation_id: "c1", llm_model: "openai/gpt-4o" },
+    });
+    useOptionalConversationIdMock.mockReturnValue({ conversationId: "c1" });
+
+    const { result } = renderHook(() => useChatInputModelState());
+
+    expect(result.current.isAcpContext).toBe(false);
+    expect(result.current.currentModelId).toBe("openai/gpt-4o");
+    expect(result.current.displayModel).toBe("openai/gpt-4o");
+    expect(result.current.availableAcpModels).toEqual([]);
+    expect(result.current.showAcpPicker).toBe(false);
+    // switchConversationId is ACP-only — null for native conversations.
+    expect(result.current.switchConversationId).toBeNull();
+    expect(result.current.destinationPath).toBe("/settings");
+  });
+
+  it("non-ACP: falls back to settings.llm_model when the conversation has none", () => {
+    useActiveConversationMock.mockReturnValue({ data: undefined });
+    useSettingsMock.mockReturnValue({ data: { llm_model: "openai/gpt-4o" } });
+
+    const { result } = renderHook(() => useChatInputModelState());
+
+    expect(result.current.currentModelId).toBe("openai/gpt-4o");
+  });
+
+  it("active ACP: resolves the provider's available models (getAcpProvider called for active contexts, not just home)", () => {
+    // Regression guard: in the old ChatInputModel `getAcpProvider` ran only on
+    // the home branch. The shared hook calls it for ANY ACP context so the
+    // picker has a model list on active conversations too. Pin that contract.
+    const provider = getAcpProvider("claude-code");
+    expect(provider?.available_models?.length).toBeGreaterThan(0);
+
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        conversation_id: "c1",
+        agent_kind: "acp",
+        acp_server: "claude-code",
+        llm_model: "claude-sonnet-4-6",
+      },
+    });
+    useOptionalConversationIdMock.mockReturnValue({ conversationId: "c1" });
+    useAcpModelContextMock.mockReturnValue(
+      acpContext({
+        isActiveAcpConversation: true,
+        isAcpContext: true,
+        destinationPath: "/settings/agent",
+        destinationLabel: "Agent",
+      }),
+    );
+
+    const { result } = renderHook(() => useChatInputModelState());
+
+    expect(result.current.isAcpContext).toBe(true);
+    expect(result.current.currentModelId).toBe("claude-sonnet-4-6");
+    // Human label resolved from the registry (matches the conversation chip).
+    expect(result.current.displayModel).toBe("Claude Sonnet 4.6");
+    expect(result.current.availableAcpModels).toEqual(
+      provider?.available_models,
+    );
+    // Local backend + ACP + a non-empty model list → picker is enabled.
+    expect(result.current.showAcpPicker).toBe(true);
+    // Live switch targets the navigation conversation id.
+    expect(result.current.switchConversationId).toBe("c1");
+    expect(result.current.destinationPath).toBe("/settings/agent");
+  });
+
+  it("home ACP: resolves the configured acp_model and exposes the picker, but no live-switch target", () => {
+    useActiveConversationMock.mockReturnValue({ data: undefined });
+    useSettingsMock.mockReturnValue({
+      data: {
+        agent_settings: {
+          agent_kind: "acp",
+          acp_server: "claude-code",
+          acp_model: "claude-sonnet-4-6",
+        },
+      },
+    });
+    useOptionalConversationIdMock.mockReturnValue({ conversationId: null });
+    useAcpModelContextMock.mockReturnValue(
+      acpContext({
+        isHomeAcp: true,
+        isAcpContext: true,
+        destinationPath: "/settings/agent",
+        destinationLabel: "Agent",
+      }),
+    );
+
+    const { result } = renderHook(() => useChatInputModelState());
+
+    expect(result.current.currentModelId).toBe("claude-sonnet-4-6");
+    expect(result.current.showAcpPicker).toBe(true);
+    // Home / no session → there is no conversation to switch in place.
+    expect(result.current.switchConversationId).toBeNull();
+  });
+
+  it("home ACP: falls back to the provider default when no acp_model is saved", () => {
+    const provider = getAcpProvider("claude-code");
+    useActiveConversationMock.mockReturnValue({ data: undefined });
+    useSettingsMock.mockReturnValue({
+      data: {
+        agent_settings: { agent_kind: "acp", acp_server: "claude-code" },
+      },
+    });
+    useAcpModelContextMock.mockReturnValue(
+      acpContext({ isHomeAcp: true, isAcpContext: true }),
+    );
+
+    const { result } = renderHook(() => useChatInputModelState());
+
+    expect(result.current.currentModelId).toBe(provider?.default_model);
+  });
+
+  it("showAcpPicker tri-condition: cloud backend suppresses the picker even with a model list", () => {
+    useActiveBackendMock.mockReturnValue({ backend: { kind: "cloud" } });
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        conversation_id: "c1",
+        agent_kind: "acp",
+        acp_server: "claude-code",
+        llm_model: "claude-sonnet-4-6",
+      },
+    });
+    useAcpModelContextMock.mockReturnValue(
+      acpContext({ isActiveAcpConversation: true, isAcpContext: true }),
+    );
+
+    const { result } = renderHook(() => useChatInputModelState());
+
+    expect(result.current.availableAcpModels.length).toBeGreaterThan(0);
+    // ACP + model list present, but cloud backend → display-only.
+    expect(result.current.showAcpPicker).toBe(false);
+  });
+
+  it("showAcpPicker tri-condition: an unknown ACP provider has no model list → no picker", () => {
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        conversation_id: "c1",
+        agent_kind: "acp",
+        acp_server: "some-custom-server",
+        llm_model: "custom-model",
+      },
+    });
+    useAcpModelContextMock.mockReturnValue(
+      acpContext({ isActiveAcpConversation: true, isAcpContext: true }),
+    );
+
+    const { result } = renderHook(() => useChatInputModelState());
+
+    expect(result.current.availableAcpModels).toEqual([]);
+    expect(result.current.showAcpPicker).toBe(false);
+    // Unknown model id has no registry label → falls back to the raw id.
+    expect(result.current.displayModel).toBe("custom-model");
+  });
+});

--- a/__tests__/routes/settings.test.tsx
+++ b/__tests__/routes/settings.test.tsx
@@ -36,10 +36,8 @@ describe("settings route", () => {
   });
 
   it("prefers /settings/agent when LLM settings are hidden", () => {
-    // /settings/agent is the ACP landing page and is always available.
-    // When ``hide_llm_settings`` flips on, the user is steered there
-    // rather than to ``/settings/app`` (which is a far less useful
-    // landing for first-time setup).
+    // /settings/agent is the unconditional first fallback — always
+    // available and the single place to switch agent kinds.
     expect(
       getFirstAvailablePath({
         hide_llm_settings: true,
@@ -48,15 +46,16 @@ describe("settings route", () => {
     ).toBe("/settings/agent");
   });
 
-  it("prefers /settings/llm when LLM settings are visible", () => {
-    // ``/settings/llm`` is the first non-hidden entry in the fallback
-    // order when ``hide_llm_settings`` is off.
+  it("prefers /settings/agent when LLM settings are visible", () => {
+    // /settings/agent wins unconditionally, so OpenHands users land
+    // there too and reach LLM via the left nav instead of bouncing
+    // through /settings/llm (which is disabled for ACP users).
     expect(
       getFirstAvailablePath({
         hide_llm_settings: false,
         hide_users_page: true,
       }),
-    ).toBe("/settings/llm");
+    ).toBe("/settings/agent");
   });
 
   it("redirects hidden OSS settings pages to the first available route", async () => {

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -319,16 +319,16 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.23.1",
+      "openhands-agent-server==1.24.0",
       "--with",
-      "openhands-sdk==1.23.1",
+      "openhands-sdk==1.24.0",
       "--with",
-      "openhands-tools==1.23.1",
+      "openhands-tools==1.24.0",
       "--with",
-      "openhands-workspace==1.23.1",
+      "openhands-workspace==1.24.0",
       "agent-server",
     ]);
-    expect(cmd.source).toBe("PyPI (1.23.1, default)");
+    expect(cmd.source).toBe("PyPI (1.24.0, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -2,7 +2,7 @@
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
 
   "versions": {
-    "agentServer": "1.23.1",
+    "agentServer": "1.24.0",
     "automation": "1.0.0a5",
     "automationSdk": "1.22.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
         "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#b8c1869ec9dea4467bb27d5754dc695d14e27889",
-        "@openhands/typescript-client": "1.23.3",
+        "@openhands/typescript-client": "1.24.0",
         "@react-router/node": "7.14.2",
         "@react-router/serve": "7.14.2",
         "@tailwindcss/vite": "4.2.4",
@@ -3454,9 +3454,9 @@
       }
     },
     "node_modules/@openhands/typescript-client": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.23.3.tgz",
-      "integrity": "sha512-tkUt1XeGUfmgnmf8BYQvbhYfiDp4eC/g7VAbLmHEmoRTCNvoKjACBs/gc8q9XxdgjyUM4RJwYiVOugP/bHAtrQ==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.24.0.tgz",
+      "integrity": "sha512-rFKBcJ9GqvDOYBhgfaW9LYF0Ma2ehMIvLz09oo8zcPn/nZt9I/XvtdKqDslVPShxrCxWDVmKqNLQ7TKL7l+MQw==",
       "license": "MIT",
       "dependencies": {
         "@openrouter/sdk": "^0.12.35",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
     "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#b8c1869ec9dea4467bb27d5754dc695d14e27889",
-    "@openhands/typescript-client": "1.23.3",
+    "@openhands/typescript-client": "1.24.0",
     "@react-router/node": "7.14.2",
     "@react-router/serve": "7.14.2",
     "@tailwindcss/vite": "4.2.4",

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.23.1 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.24.0 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -79,7 +79,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/agent-canvas/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.23.1"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.24.0"}}'
 `);
   process.exit(0);
 }
@@ -268,9 +268,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.23.1,<2.0.0"
- *   "openhands-tools==1.23.1"
- *   "openhands-workspace (>=1.23.1)"
+ *   "openhands-sdk>=1.24.0,<2.0.0"
+ *   "openhands-tools==1.24.0"
+ *   "openhands-workspace (>=1.24.0)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -284,7 +284,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.23.1", "==1.23.1", "(>=1.23.1)", "~=1.23.1"
+      // ">=1.24.0", "==1.24.0", "(>=1.24.0)", "~=1.24.0"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -337,7 +337,7 @@ export function validateFrontendDependencies(
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.23.1")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.24.0")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -702,6 +702,33 @@ class AgentServerConversationService {
       profile.config,
     );
   }
+
+  /**
+   * Switches the model of a running ACP conversation in place (POST
+   * /switch_acp_model — the ACP analog of {@link switchProfile}'s /switch_llm).
+   * The agent-server calls the ACP wrapper's ``session/set_model`` on the live
+   * session, preserving context. Mirrors {@link switchProfile}'s
+   * local-backend-only guard and per-conversation ConversationClient call.
+   *
+   * Only valid once an ACP session exists (after the first message); the
+   * agent-server returns 409 before then — the home/no-session default is
+   * persisted via Settings instead (see ``use-switch-acp-model``).
+   */
+  static async switchAcpModel(
+    conversationId: string,
+    model: string,
+  ): Promise<void> {
+    if (getActiveBackend().backend.kind === "cloud") {
+      throw new Error(
+        "ACP model switching is only supported for local agent-server backends.",
+      );
+    }
+
+    await new ConversationClient(getAgentServerClientOptions()).switchAcpModel(
+      conversationId,
+      model,
+    );
+  }
 }
 
 export default AgentServerConversationService;

--- a/src/components/features/chat/components/chat-input-actions.tsx
+++ b/src/components/features/chat/components/chat-input-actions.tsx
@@ -4,12 +4,10 @@ import { useTranslation } from "react-i18next";
 import { Cpu } from "lucide-react";
 import { AgentStatus } from "#/components/features/controls/agent-status";
 import { ChangeAgentButton } from "../change-agent-button";
-import { ChatInputModel } from "./chat-input-model";
+import { ChatInputModel, ChatInputModelMenuContent } from "./chat-input-model";
 import { SwitchProfileButton } from "../switch-profile-button";
 import { ChatAddFileButton } from "../chat-add-file-button";
 import { ChatSendButton } from "../chat-send-button";
-import { NavigationLink } from "#/components/shared/navigation-link";
-import SettingsGearIcon from "#/icons/settings-gear.svg?react";
 import CarretRightFillIcon from "#/icons/carret-right-fill.svg?react";
 import LessonPlanIcon from "#/icons/lesson-plan.svg?react";
 import ThreeDotsVerticalIcon from "#/icons/three-dots-vertical.svg?react";
@@ -19,9 +17,7 @@ import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { usePauseConversation } from "#/hooks/mutation/use-pause-conversation";
 import { useResumeConversation } from "#/hooks/mutation/use-resume-conversation";
 import { useActiveBackend } from "#/contexts/active-backend-context";
-import { useActiveConversation } from "#/hooks/query/use-active-conversation";
-import { useAcpModelContext } from "#/hooks/use-acp-model-context";
-import { labelForAcpModel } from "#/constants/acp-providers";
+import { useChatInputModelState } from "#/hooks/use-chat-input-model-state";
 import { useConversationStore } from "#/stores/conversation-store";
 import { useAgentState } from "#/hooks/use-agent-state";
 import { AgentState } from "#/types/agent-state";
@@ -31,7 +27,6 @@ import { I18nKey } from "#/i18n/declaration";
 import { ToolsContextMenuIconText } from "../../controls/tools-context-menu-icon-text";
 import { ContextMenuListItem } from "../../context-menu/context-menu-list-item";
 import { ContextMenu } from "#/ui/context-menu";
-import { Divider } from "#/ui/divider";
 import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
 import { cn } from "#/utils/utils";
 import { formControlTransitionClassName } from "#/utils/form-control-classes";
@@ -58,25 +53,9 @@ export function ChatInputActions({
   const pauseConversationMutation = usePauseConversation();
   const resumeConversationMutation = useResumeConversation();
   const { conversationId } = useOptionalConversationId();
-  const { data: conversation } = useActiveConversation();
   const { backend } = useActiveBackend();
   const isCloud = backend.kind === "cloud";
-  // Shared with ChatInputModel: routes the model affordance to ChatInputModel
-  // (which knows how to show the ACP model) instead of SwitchProfileButton for
-  // ACP conversations — and for the home screen when Settings → Agent already
-  // selects an ACP agent, since the next conversation will inherit it.
-  const { isAcpContext, destinationPath, destinationLabel } =
-    useAcpModelContext();
-  // Mirror ChatInputModel: ACP conversations show the provider's human label
-  // (e.g. "Claude Opus 4.7") in the overflow model submenu, not the raw
-  // ``acp_model`` id. OpenHands keeps the raw model string.
-  const overflowModelLabel = isAcpContext
-    ? (labelForAcpModel(conversation?.acp_server, conversation?.llm_model) ??
-      conversation?.llm_model)
-    : conversation?.llm_model;
-  // Shown on cloud backends. On the home page it renders disabled with an
-  // explanatory tooltip (ChangeAgentButton handles that), since agent mode can
-  // only be switched once a conversation has begun.
+  const modelState = useChatInputModelState();
   const showChangeAgentButton = isCloud;
   const webSocketStatus = useUnifiedWebSocketStatus();
   const { curAgentState } = useAgentState();
@@ -376,35 +355,21 @@ export function ChatInputActions({
           >
             <ContextMenu
               testId="overflow-model-submenu"
-              className="overflow-visible min-w-[220px] max-w-[320px] gap-0"
+              className="min-w-[220px] max-w-[320px] max-h-[60vh] overflow-y-auto gap-0"
             >
-              <li className="text-sm">
-                <div className="p-2 leading-5 text-[var(--oh-foreground)] break-all">
-                  {overflowModelLabel}
-                </div>
-              </li>
-              <Divider inset="menu" />
-              <li className="text-sm">
-                <NavigationLink
-                  to={destinationPath}
-                  onClick={closeOverflowMenus}
-                  className={cn(
-                    "group flex h-[30px] items-center gap-2 rounded p-2 leading-5 text-[var(--oh-foreground)] hover:bg-[var(--oh-interactive-hover)]",
-                    formControlTransitionClassName,
-                  )}
-                >
-                  <SettingsGearIcon
-                    width={16}
-                    height={16}
-                    className={cn(
-                      "shrink-0 text-[var(--oh-muted)] group-hover:text-[var(--oh-foreground)]",
-                      formControlTransitionClassName,
-                    )}
-                    aria-hidden
-                  />
-                  <span>{destinationLabel}</span>
-                </NavigationLink>
-              </li>
+              <ChatInputModelMenuContent
+                model={modelState}
+                onClose={closeOverflowMenus}
+                dividerInset="menu"
+                settingsLinkClassName={cn(
+                  "group",
+                  formControlTransitionClassName,
+                )}
+                settingsIconClassName={cn(
+                  "text-[var(--oh-muted)] group-hover:text-[var(--oh-foreground)]",
+                  formControlTransitionClassName,
+                )}
+              />
             </ContextMenu>
           </div>
         </div>
@@ -431,7 +396,7 @@ export function ChatInputActions({
             </div>
           )}
           <div ref={modelRef} className={cn(!showModelInline && "hidden")}>
-            {isCloud || isAcpContext ? (
+            {isCloud || modelState.isAcpContext ? (
               <ChatInputModel />
             ) : (
               <SwitchProfileButton />

--- a/src/components/features/chat/components/chat-input-actions.tsx
+++ b/src/components/features/chat/components/chat-input-actions.tsx
@@ -353,6 +353,11 @@ export function ChatInputActions({
                 "opacity-100 visible pointer-events-auto",
             )}
           >
+            {/* overflow-y-auto (not overflow-visible) so a long ACP model list
+                scrolls within the menu instead of overflowing the viewport.
+                Safe because this menu has no floating children (tooltips /
+                nested popovers) that would be clipped — only a flat model list
+                + Settings link. Revisit if floating children are added here. */}
             <ContextMenu
               testId="overflow-model-submenu"
               className="min-w-[220px] max-w-[320px] max-h-[60vh] overflow-y-auto gap-0"

--- a/src/components/features/chat/components/chat-input-model.tsx
+++ b/src/components/features/chat/components/chat-input-model.tsx
@@ -1,17 +1,25 @@
+import { useTranslation } from "react-i18next";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useSettings } from "#/hooks/query/use-settings";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useAcpModelContext } from "#/hooks/use-acp-model-context";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
+import { useSwitchAcpModel } from "#/hooks/mutation/use-switch-acp-model";
 import { ComboboxCaretInline } from "#/ui/combobox-caret";
 import SettingsGearIcon from "#/icons/settings-gear.svg?react";
+import CheckIcon from "#/icons/checkmark.svg?react";
 import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
 import { NavigationLink } from "#/components/shared/navigation-link";
 import { ContextMenu } from "#/ui/context-menu";
+import { ContextMenuListItem } from "#/components/features/context-menu/context-menu-list-item";
 import { Divider } from "#/ui/divider";
+import { Typography } from "#/ui/typography";
 import {
   getAcpProvider,
   labelForAcpModel,
   resolveEffectiveAcpModel,
 } from "#/constants/acp-providers";
+import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";
 import React from "react";
 
@@ -32,10 +40,18 @@ function truncateModelLabel(
 }
 
 export function ChatInputModel() {
+  const { t } = useTranslation("openhands");
   const { data: conversation } = useActiveConversation();
   // Home page has no active conversation; fall back to the user's default
   // model so the switcher renders consistently across both surfaces.
   const { data: settings } = useSettings();
+  const { backend } = useActiveBackend();
+  // Live model switching mirrors the native LLM-profile switcher: local
+  // agent-server backends only. On cloud the popover stays display + a
+  // Settings link, with no selectable rows (see SwitchProfileButton /
+  // AgentServerConversationService.switchProfile's same cloud guard).
+  const isCloud = backend.kind === "cloud";
+  const { conversationId } = useOptionalConversationId();
   const {
     isActiveAcpConversation,
     isHomeAcp,
@@ -43,6 +59,7 @@ export function ChatInputModel() {
     destinationPath,
     destinationLabel,
   } = useAcpModelContext();
+  const switchAcpModel = useSwitchAcpModel();
   // ACP conversations do not use the OpenHands LLM profile. Resolve the model
   // label through the shared helper so the displayed value matches what the
   // conversation-creation path will actually send to the agent-server (the
@@ -59,7 +76,10 @@ export function ChatInputModel() {
         ? settings.agent_settings.acp_server
         : null
       : null;
-  const acpProvider = isHomeAcp ? getAcpProvider(acpServerKey) : undefined;
+  // Resolve the provider for both ACP surfaces so the picker can list the
+  // provider's ``available_models``. (The home case also needs it for the
+  // default-model fallback below.)
+  const acpProvider = isAcpContext ? getAcpProvider(acpServerKey) : undefined;
   let llmModel: string | null | undefined;
   if (isActiveAcpConversation) {
     llmModel = conversation?.llm_model;
@@ -94,6 +114,29 @@ export function ChatInputModel() {
     isAcpContext ? ACP_MODEL_LABEL_MAX_CHARS : MODEL_LABEL_MAX_CHARS,
   );
 
+  // The inline picker is only offered for ACP contexts on a local backend
+  // where the provider exposes a known model list. Everything else (native
+  // OpenHands LLM-profile surface, cloud, custom/unknown ACP providers) keeps
+  // today's display-only popover + Settings link.
+  const availableModels = acpProvider?.available_models ?? [];
+  const showAcpPicker = isAcpContext && !isCloud && availableModels.length > 0;
+
+  const handleSelectAcpModel = (modelId: string) => {
+    // No-op when re-selecting the already-effective model — mirrors the
+    // native picker, which skips the switch when the profile is unchanged.
+    if (modelId !== llmModel) {
+      switchAcpModel.mutate({
+        // Live switch for a running ACP conversation; otherwise (home / no
+        // session) the hook persists the choice as the agent-settings default.
+        conversationId: isActiveAcpConversation
+          ? (conversationId ?? null)
+          : null,
+        model: modelId,
+      });
+    }
+    setIsPopoverOpen(false);
+  };
+
   return (
     <div className="relative min-w-0">
       <button
@@ -123,13 +166,56 @@ export function ChatInputModel() {
           position="top"
           alignment="left"
           spacing="none"
-          className="z-[60] mb-2 min-w-[200px] max-w-[320px]"
+          className="z-[60] mb-2 min-w-[200px] max-w-[320px] max-h-[60vh] overflow-y-auto"
         >
-          <li className="text-sm">
-            <div className="p-2 leading-5 text-white break-all">
-              {displayModel}
-            </div>
-          </li>
+          {showAcpPicker ? (
+            <>
+              <div className="px-2 pt-1 pb-0.5">
+                <Typography.Text className="text-[11px] font-medium text-[var(--oh-text-dim)] uppercase tracking-wide leading-4">
+                  {t(I18nKey.MODEL$AVAILABLE_MODELS)}
+                </Typography.Text>
+              </div>
+              {availableModels.map((option) => {
+                const isSelected = option.id === llmModel;
+                return (
+                  <ContextMenuListItem
+                    key={option.id}
+                    testId={`chat-input-acp-model-option-${option.id}`}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      handleSelectAcpModel(option.id);
+                    }}
+                    className={cn(
+                      "flex items-center gap-2",
+                      isSelected && "bg-[var(--oh-interactive-hover)]",
+                    )}
+                  >
+                    <span
+                      className="flex-1 truncate text-sm leading-5"
+                      title={option.label}
+                    >
+                      {option.label}
+                    </span>
+                    {isSelected && (
+                      <CheckIcon
+                        width={14}
+                        height={14}
+                        className="shrink-0"
+                        aria-hidden
+                      />
+                    )}
+                  </ContextMenuListItem>
+                );
+              })}
+            </>
+          ) : (
+            <li className="text-sm">
+              <div className="p-2 leading-5 text-white break-all">
+                {displayModel}
+              </div>
+            </li>
+          )}
           <Divider />
           <li className="text-sm">
             <NavigationLink

--- a/src/components/features/chat/components/chat-input-model.tsx
+++ b/src/components/features/chat/components/chat-input-model.tsx
@@ -95,10 +95,17 @@ export function ChatInputModel() {
     llmModel = conversation?.llm_model ?? settings?.llm_model;
   }
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
 
-  const popoverRef = useClickOutsideElement<HTMLUListElement>(() => {
-    setIsPopoverOpen(false);
-  });
+  // Pass the trigger as the ignore-ref: a click on the chip toggles the popover
+  // rather than the document click-outside handler treating it as an "outside"
+  // click and closing the popover in the same interaction. Without this the
+  // chip opened then instantly re-closed the popover — it looked like clicking
+  // did nothing.
+  const popoverRef = useClickOutsideElement<HTMLUListElement>(
+    () => setIsPopoverOpen(false),
+    triggerRef,
+  );
 
   if (!llmModel) {
     return null;
@@ -140,6 +147,7 @@ export function ChatInputModel() {
   return (
     <div className="relative min-w-0">
       <button
+        ref={triggerRef}
         type="button"
         className={cn(
           "inline-flex items-center gap-1 rounded-[100px] border border-transparent px-1.5 text-sm font-normal leading-5 text-[var(--oh-muted)] whitespace-nowrap min-w-0 transition-[border-color,background-color,box-shadow,opacity] duration-150 motion-reduce:transition-none",

--- a/src/components/features/chat/components/chat-input-model.tsx
+++ b/src/components/features/chat/components/chat-input-model.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from "react-i18next";
-import { useActiveConversation } from "#/hooks/query/use-active-conversation";
-import { useSettings } from "#/hooks/query/use-settings";
-import { useActiveBackend } from "#/contexts/active-backend-context";
-import { useAcpModelContext } from "#/hooks/use-acp-model-context";
-import { useOptionalConversationId } from "#/hooks/use-conversation-id";
+import {
+  useChatInputModelState,
+  type ChatInputModelState,
+} from "#/hooks/use-chat-input-model-state";
 import { useSwitchAcpModel } from "#/hooks/mutation/use-switch-acp-model";
 import { ComboboxCaretInline } from "#/ui/combobox-caret";
 import SettingsGearIcon from "#/icons/settings-gear.svg?react";
@@ -14,11 +13,6 @@ import { ContextMenu } from "#/ui/context-menu";
 import { ContextMenuListItem } from "#/components/features/context-menu/context-menu-list-item";
 import { Divider } from "#/ui/divider";
 import { Typography } from "#/ui/typography";
-import {
-  getAcpProvider,
-  labelForAcpModel,
-  resolveEffectiveAcpModel,
-} from "#/constants/acp-providers";
 import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";
 import React from "react";
@@ -39,110 +33,125 @@ function truncateModelLabel(
   return `${model.slice(0, maxChars)}…`;
 }
 
-export function ChatInputModel() {
+interface ChatInputModelMenuContentProps {
+  model: ChatInputModelState;
+  onClose: () => void;
+  dividerInset?: "menu";
+  settingsLinkClassName?: string;
+  settingsIconClassName?: string;
+}
+
+export function ChatInputModelMenuContent({
+  model,
+  onClose,
+  dividerInset,
+  settingsLinkClassName,
+  settingsIconClassName,
+}: ChatInputModelMenuContentProps) {
   const { t } = useTranslation("openhands");
-  const { data: conversation } = useActiveConversation();
-  // Home page has no active conversation; fall back to the user's default
-  // model so the switcher renders consistently across both surfaces.
-  const { data: settings } = useSettings();
-  const { backend } = useActiveBackend();
-  // Live model switching mirrors the native LLM-profile switcher: local
-  // agent-server backends only. On cloud the popover stays display + a
-  // Settings link, with no selectable rows (see SwitchProfileButton /
-  // AgentServerConversationService.switchProfile's same cloud guard).
-  const isCloud = backend.kind === "cloud";
-  const { conversationId } = useOptionalConversationId();
-  const {
-    isActiveAcpConversation,
-    isHomeAcp,
-    isAcpContext,
-    destinationPath,
-    destinationLabel,
-  } = useAcpModelContext();
   const switchAcpModel = useSwitchAcpModel();
-  // ACP conversations do not use the OpenHands LLM profile. Resolve the model
-  // label through the shared helper so the displayed value matches what the
-  // conversation-creation path will actually send to the agent-server (the
-  // helper applies provider defaults + filters out the SDK ``"default"``
-  // placeholders + the ``"acp-managed"`` sentinel).
-  //
-  // The ACP server key whose registry owns the model label comes off the
-  // active conversation when there is one, else the saved agent settings the
-  // next home-page conversation will inherit.
-  const acpServerKey = isActiveAcpConversation
-    ? conversation?.acp_server
-    : isHomeAcp
-      ? typeof settings?.agent_settings?.acp_server === "string"
-        ? settings.agent_settings.acp_server
-        : null
-      : null;
-  // Resolve the provider for both ACP surfaces so the picker can list the
-  // provider's ``available_models``. (The home case also needs it for the
-  // default-model fallback below.)
-  const acpProvider = isAcpContext ? getAcpProvider(acpServerKey) : undefined;
-  let llmModel: string | null | undefined;
-  if (isActiveAcpConversation) {
-    llmModel = conversation?.llm_model;
-  } else if (isHomeAcp) {
-    llmModel = resolveEffectiveAcpModel({
-      configured:
-        typeof settings?.agent_settings?.acp_model === "string"
-          ? settings.agent_settings.acp_model
-          : null,
-      providerDefault: acpProvider?.default_model,
-    });
-  } else {
-    llmModel = conversation?.llm_model ?? settings?.llm_model;
-  }
+  const hasModelRows = model.showAcpPicker || Boolean(model.displayModel);
+
+  const handleSelectAcpModel = (modelId: string) => {
+    if (modelId !== model.currentModelId) {
+      switchAcpModel.mutate({
+        conversationId: model.switchConversationId,
+        model: modelId,
+      });
+    }
+    onClose();
+  };
+
+  return (
+    <>
+      {model.showAcpPicker ? (
+        <>
+          <div className="px-2 pt-1 pb-0.5">
+            <Typography.Text className="text-[11px] font-medium text-[var(--oh-text-dim)] uppercase tracking-wide leading-4">
+              {t(I18nKey.MODEL$AVAILABLE_MODELS)}
+            </Typography.Text>
+          </div>
+          {model.availableAcpModels.map((option) => {
+            const isSelected = option.id === model.currentModelId;
+            return (
+              <ContextMenuListItem
+                key={option.id}
+                testId={`chat-input-acp-model-option-${option.id}`}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  handleSelectAcpModel(option.id);
+                }}
+                className={cn(
+                  "flex items-center gap-2",
+                  isSelected && "bg-[var(--oh-interactive-hover)]",
+                )}
+              >
+                <span
+                  className="flex-1 truncate text-sm leading-5"
+                  title={option.label}
+                >
+                  {option.label}
+                </span>
+                {isSelected && (
+                  <CheckIcon
+                    width={14}
+                    height={14}
+                    className="shrink-0"
+                    aria-hidden
+                  />
+                )}
+              </ContextMenuListItem>
+            );
+          })}
+        </>
+      ) : model.displayModel ? (
+        <li className="text-sm">
+          <div className="p-2 leading-5 text-[var(--oh-foreground)] break-all">
+            {model.displayModel}
+          </div>
+        </li>
+      ) : null}
+      {hasModelRows && <Divider inset={dividerInset} />}
+      <li className="text-sm">
+        <NavigationLink
+          to={model.destinationPath}
+          onClick={onClose}
+          className={cn(
+            "flex h-[30px] items-center gap-2 rounded p-2 leading-5 text-[var(--oh-foreground)] hover:bg-[var(--oh-interactive-hover)] transition-colors",
+            settingsLinkClassName,
+          )}
+        >
+          <SettingsGearIcon
+            width={16}
+            height={16}
+            className={cn("shrink-0", settingsIconClassName)}
+            aria-hidden
+          />
+          <span>{model.destinationLabel}</span>
+        </NavigationLink>
+      </li>
+    </>
+  );
+}
+
+export function ChatInputModel() {
+  const model = useChatInputModelState();
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
-
-  // Pass the trigger as the ignore-ref: a click on the chip toggles the popover
-  // rather than the document click-outside handler treating it as an "outside"
-  // click and closing the popover in the same interaction. Without this the
-  // chip opened then instantly re-closed the popover — it looked like clicking
-  // did nothing.
   const popoverRef = useClickOutsideElement<HTMLUListElement>(
     () => setIsPopoverOpen(false),
     triggerRef,
   );
 
-  if (!llmModel) {
+  if (!model.displayModel) {
     return null;
   }
-  // For ACP, surface the provider's human label (matching the conversation
-  // list chip) instead of the raw ``acp_model`` id; falls back to the raw
-  // value for custom / unknown ids. OpenHands keeps the raw model string.
-  const displayModel = isAcpContext
-    ? (labelForAcpModel(acpServerKey, llmModel) ?? llmModel)
-    : llmModel;
+
   const truncatedModelLabel = truncateModelLabel(
-    displayModel,
-    isAcpContext ? ACP_MODEL_LABEL_MAX_CHARS : MODEL_LABEL_MAX_CHARS,
+    model.displayModel,
+    model.isAcpContext ? ACP_MODEL_LABEL_MAX_CHARS : MODEL_LABEL_MAX_CHARS,
   );
-
-  // The inline picker is only offered for ACP contexts on a local backend
-  // where the provider exposes a known model list. Everything else (native
-  // OpenHands LLM-profile surface, cloud, custom/unknown ACP providers) keeps
-  // today's display-only popover + Settings link.
-  const availableModels = acpProvider?.available_models ?? [];
-  const showAcpPicker = isAcpContext && !isCloud && availableModels.length > 0;
-
-  const handleSelectAcpModel = (modelId: string) => {
-    // No-op when re-selecting the already-effective model — mirrors the
-    // native picker, which skips the switch when the profile is unchanged.
-    if (modelId !== llmModel) {
-      switchAcpModel.mutate({
-        // Live switch for a running ACP conversation; otherwise (home / no
-        // session) the hook persists the choice as the agent-settings default.
-        conversationId: isActiveAcpConversation
-          ? (conversationId ?? null)
-          : null,
-        model: modelId,
-      });
-    }
-    setIsPopoverOpen(false);
-  };
 
   return (
     <div className="relative min-w-0">
@@ -153,7 +162,7 @@ export function ChatInputModel() {
           "inline-flex items-center gap-1 rounded-[100px] border border-transparent px-1.5 text-sm font-normal leading-5 text-[var(--oh-muted)] whitespace-nowrap min-w-0 transition-[border-color,background-color,box-shadow,opacity] duration-150 motion-reduce:transition-none",
           "hover:text-white hover:bg-white/10 cursor-pointer",
         )}
-        title={displayModel}
+        title={model.displayModel}
         data-testid="chat-input-llm-model"
         aria-expanded={isPopoverOpen}
         aria-haspopup="dialog"
@@ -176,70 +185,10 @@ export function ChatInputModel() {
           spacing="none"
           className="z-[60] mb-2 min-w-[200px] max-w-[320px] max-h-[60vh] overflow-y-auto"
         >
-          {showAcpPicker ? (
-            <>
-              <div className="px-2 pt-1 pb-0.5">
-                <Typography.Text className="text-[11px] font-medium text-[var(--oh-text-dim)] uppercase tracking-wide leading-4">
-                  {t(I18nKey.MODEL$AVAILABLE_MODELS)}
-                </Typography.Text>
-              </div>
-              {availableModels.map((option) => {
-                const isSelected = option.id === llmModel;
-                return (
-                  <ContextMenuListItem
-                    key={option.id}
-                    testId={`chat-input-acp-model-option-${option.id}`}
-                    onClick={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      handleSelectAcpModel(option.id);
-                    }}
-                    className={cn(
-                      "flex items-center gap-2",
-                      isSelected && "bg-[var(--oh-interactive-hover)]",
-                    )}
-                  >
-                    <span
-                      className="flex-1 truncate text-sm leading-5"
-                      title={option.label}
-                    >
-                      {option.label}
-                    </span>
-                    {isSelected && (
-                      <CheckIcon
-                        width={14}
-                        height={14}
-                        className="shrink-0"
-                        aria-hidden
-                      />
-                    )}
-                  </ContextMenuListItem>
-                );
-              })}
-            </>
-          ) : (
-            <li className="text-sm">
-              <div className="p-2 leading-5 text-white break-all">
-                {displayModel}
-              </div>
-            </li>
-          )}
-          <Divider />
-          <li className="text-sm">
-            <NavigationLink
-              to={destinationPath}
-              onClick={() => setIsPopoverOpen(false)}
-              className="flex h-[30px] items-center gap-2 rounded p-2 leading-5 text-white hover:bg-[var(--oh-interactive-hover)] transition-colors"
-            >
-              <SettingsGearIcon
-                width={16}
-                height={16}
-                className="shrink-0"
-                aria-hidden
-              />
-              <span>{destinationLabel}</span>
-            </NavigationLink>
-          </li>
+          <ChatInputModelMenuContent
+            model={model}
+            onClose={() => setIsPopoverOpen(false)}
+          />
         </ContextMenu>
       )}
     </div>

--- a/src/components/features/chat/components/chat-input-model.tsx
+++ b/src/components/features/chat/components/chat-input-model.tsx
@@ -66,11 +66,14 @@ export function ChatInputModelMenuContent({
     <>
       {model.showAcpPicker ? (
         <>
-          <div className="px-2 pt-1 pb-0.5">
+          {/* role="presentation" keeps this a valid <li> child of the
+              ContextMenu <ul> without exposing the section label as a
+              selectable menu item (the label text is still announced). */}
+          <li role="presentation" className="px-2 pt-1 pb-0.5">
             <Typography.Text className="text-[11px] font-medium text-[var(--oh-text-dim)] uppercase tracking-wide leading-4">
               {t(I18nKey.MODEL$AVAILABLE_MODELS)}
             </Typography.Text>
-          </div>
+          </li>
           {model.availableAcpModels.map((option) => {
             const isSelected = option.id === model.currentModelId;
             return (

--- a/src/constants/settings-nav.tsx
+++ b/src/constants/settings-nav.tsx
@@ -45,6 +45,7 @@ export const OSS_NAV_ITEMS: SettingsNavItem[] = [
     to: "/settings/verification",
     text: "SETTINGS$NAV_VERIFICATION",
     subtitle: "SETTINGS$PAGE_VERIFICATION_SUBLINE",
+    disabledByAcp: true,
   },
   {
     icon: <AppWindow className="size-4" strokeWidth={2} aria-hidden />,

--- a/src/hooks/mutation/use-switch-acp-model.ts
+++ b/src/hooks/mutation/use-switch-acp-model.ts
@@ -59,7 +59,9 @@ export const useSwitchAcpModel = () => {
         });
       }
     },
-    // Caller surfaces errors via toast; keep parity with useSwitchLlmProfile.
-    meta: { disableToast: true },
+    // No meta.disableToast: unlike useSwitchLlmProfile (wrapped by
+    // useSwitchLlmProfileAndLog, which re-surfaces errors), this hook is called
+    // directly, so we let the global mutation error toast report a failed
+    // switch / settings write rather than swallowing it.
   });
 };

--- a/src/hooks/mutation/use-switch-acp-model.ts
+++ b/src/hooks/mutation/use-switch-acp-model.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import SettingsService from "#/api/settings-service/settings-service.api";
+import { SETTINGS_QUERY_KEYS } from "#/hooks/query/query-keys";
+import { invalidateConversationQueries } from "./conversation-mutation-utils";
+
+interface SwitchAcpModelVars {
+  /**
+   * When set, the ACP conversation's running model is swapped live via the
+   * wrapper's ``session/set_model`` (POST /switch_acp_model) and the user's
+   * saved default is untouched. When null (home page / no session), the model
+   * is persisted as the agent-settings default so the next conversation
+   * created here inherits it.
+   */
+  conversationId: string | null;
+  model: string;
+}
+
+/**
+ * ACP analog of {@link useSwitchLlmProfile}. Switches the ACP model
+ * per-conversation when called from inside a conversation (live in-place model
+ * switch); persists it as the agent-settings default when called from the home
+ * page (no live session to switch — the agent-server returns 409 before the
+ * first message, so we write the default the next conversation inherits).
+ *
+ * Invalidates the same conversation/settings query keys the profile hook does
+ * so the chat-input model chip + conversation chip refresh with the new model.
+ */
+export const useSwitchAcpModel = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ conversationId, model }: SwitchAcpModelVars) => {
+      if (conversationId) {
+        await AgentServerConversationService.switchAcpModel(
+          conversationId,
+          model,
+        );
+        return;
+      }
+      // Home page / no session: persist as the agent-settings default. The
+      // backend deep-merges ``agent_settings_diff`` into the existing
+      // ``agent_settings`` dict, so a scalar ``acp_model`` diff updates only
+      // the model and preserves the selected provider + command.
+      await SettingsService.saveSettings({
+        agent_settings_diff: { acp_model: model },
+      });
+    },
+    onSuccess: (_data, { conversationId }) => {
+      if (conversationId) {
+        invalidateConversationQueries(queryClient, conversationId);
+      } else {
+        // Mirror useSwitchLlmProfile's home-page path: clear the stale settings
+        // cache so the next conversation-start reads the newly saved default,
+        // and refetch the settings query so the home-page chip updates.
+        SettingsService.invalidateCache();
+        queryClient.invalidateQueries({
+          queryKey: SETTINGS_QUERY_KEYS.personal(),
+        });
+      }
+    },
+    // Caller surfaces errors via toast; keep parity with useSwitchLlmProfile.
+    meta: { disableToast: true },
+  });
+};

--- a/src/hooks/use-acp-model-context.ts
+++ b/src/hooks/use-acp-model-context.ts
@@ -23,10 +23,9 @@ export interface AcpModelContext {
 
 /**
  * Shared source of truth for "is this an ACP model context, and where does
- * the model affordance link?". Consumed by both {@link ChatInputActions}
- * (model render + overflow settings link) and {@link ChatInputModel} (model
- * label popover) so the two surfaces can't drift on the home-page-ACP rule or
- * on the destination path/label.
+ * the model affordance link?". The chat model affordance consumes this through
+ * ``useChatInputModelState`` so inline and overflow surfaces can't drift on the
+ * home-page-ACP rule or on the destination path/label.
  */
 export function useAcpModelContext(): AcpModelContext {
   const { t } = useTranslation("openhands");

--- a/src/hooks/use-chat-input-model-state.ts
+++ b/src/hooks/use-chat-input-model-state.ts
@@ -1,0 +1,82 @@
+import { useActiveBackend } from "#/contexts/active-backend-context";
+import { useActiveConversation } from "#/hooks/query/use-active-conversation";
+import { useSettings } from "#/hooks/query/use-settings";
+import { useAcpModelContext } from "#/hooks/use-acp-model-context";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
+import {
+  getAcpProvider,
+  labelForAcpModel,
+  resolveEffectiveAcpModel,
+  type ACPModelOption,
+} from "#/constants/acp-providers";
+
+export interface ChatInputModelState {
+  isAcpContext: boolean;
+  displayModel: string | null;
+  currentModelId: string | null;
+  availableAcpModels: ACPModelOption[];
+  showAcpPicker: boolean;
+  switchConversationId: string | null;
+  destinationPath: "/settings/agent" | "/settings";
+  destinationLabel: string;
+}
+
+export function useChatInputModelState(): ChatInputModelState {
+  const { data: conversation } = useActiveConversation();
+  const { data: settings } = useSettings();
+  const { backend } = useActiveBackend();
+  const { conversationId } = useOptionalConversationId();
+  const {
+    isActiveAcpConversation,
+    isHomeAcp,
+    isAcpContext,
+    destinationPath,
+    destinationLabel,
+  } = useAcpModelContext();
+
+  const acpServerKey = isActiveAcpConversation
+    ? conversation?.acp_server
+    : isHomeAcp
+      ? typeof settings?.agent_settings?.acp_server === "string"
+        ? settings.agent_settings.acp_server
+        : null
+      : null;
+  const acpProvider = isAcpContext ? getAcpProvider(acpServerKey) : undefined;
+
+  let currentModelId: string | null = null;
+  if (isActiveAcpConversation) {
+    currentModelId = conversation?.llm_model ?? null;
+  } else if (isHomeAcp) {
+    currentModelId = resolveEffectiveAcpModel({
+      configured:
+        typeof settings?.agent_settings?.acp_model === "string"
+          ? settings.agent_settings.acp_model
+          : null,
+      providerDefault: acpProvider?.default_model,
+    });
+  } else {
+    currentModelId = conversation?.llm_model ?? settings?.llm_model ?? null;
+  }
+
+  const displayModel =
+    currentModelId && isAcpContext
+      ? (labelForAcpModel(acpServerKey, currentModelId) ?? currentModelId)
+      : currentModelId;
+  const availableAcpModels = acpProvider?.available_models ?? [];
+  const showAcpPicker =
+    isAcpContext && backend.kind !== "cloud" && availableAcpModels.length > 0;
+  const switchConversationId = isActiveAcpConversation
+    ? (conversationId ?? null)
+    : null;
+
+  return {
+    isAcpContext,
+    displayModel,
+    currentModelId,
+    availableAcpModels,
+    showAcpPicker,
+    switchConversationId,
+    destinationPath,
+    destinationLabel,
+  };
+}

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -8737,6 +8737,23 @@
     "tr": "Kullanılabilir profiller ({{count}})",
     "uk": "Доступні профілі ({{count}})"
   },
+  "MODEL$AVAILABLE_MODELS": {
+    "en": "Available models",
+    "ja": "利用可能なモデル",
+    "zh-CN": "可用模型",
+    "zh-TW": "可用模型",
+    "ko-KR": "사용 가능한 모델",
+    "no": "Tilgjengelige modeller",
+    "ar": "النماذج المتاحة",
+    "de": "Verfügbare Modelle",
+    "fr": "Modèles disponibles",
+    "it": "Modelli disponibili",
+    "pt": "Modelos disponíveis",
+    "es": "Modelos disponibles",
+    "ca": "Models disponibles",
+    "tr": "Kullanılabilir modeller",
+    "uk": "Доступні моделі"
+  },
   "MODEL$NO_SAVED_PROFILES": {
     "en": "No saved profiles",
     "ja": "保存済みプロファイルはありません",

--- a/src/mocks/settings-handlers.ts
+++ b/src/mocks/settings-handlers.ts
@@ -488,7 +488,7 @@ const MOCK_VERIFIED_MODELS_BY_PROVIDER = MOCK_MODELS.reduce<
   return acc;
 }, {});
 
-const MOCK_AGENT_SERVER_VERSION = "1.23.1";
+const MOCK_AGENT_SERVER_VERSION = "1.24.0";
 
 // --- Handlers for options/config/settings ---
 // Uses wildcard "*" prefix to match both relative paths and absolute URLs

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -366,10 +366,13 @@ function AgentSettingsScreen() {
                 setAcpModel(provider.default_model ?? "");
                 setIsCustomAcpModel(false);
               } else if (preset === ACP_CUSTOM_PRESET_KEY) {
-                // Switching to Custom must clear any built-in default the
-                // user just left — otherwise saving the custom command
-                // silently leaks e.g. ``claude-opus-4-7`` into
-                // ``acp_model`` for an unrelated wrapper.
+                // Clear command + model: the previous provider's default
+                // command would otherwise make detectPreset(commandText)
+                // re-match it on the next render and snap the dropdown back
+                // off "Custom". Clearing model also prevents leaking e.g.
+                // ``claude-opus-4-7`` into ``acp_model`` for an unrelated
+                // wrapper.
+                setCommandText("");
                 setAcpModel("");
                 setIsCustomAcpModel(true);
               }

--- a/src/utils/settings-utils.ts
+++ b/src/utils/settings-utils.ts
@@ -60,15 +60,15 @@ export function isSettingsPageHidden(
 export function getFirstAvailablePath(
   featureFlags: WebClientFeatureFlags | undefined,
 ): string | null {
-  // ``/settings/agent`` precedes ``/settings`` because it is the ACP
-  // landing page and is always available (no feature flag hides it).
-  // When ``hide_llm_settings`` is on, the user is steered there rather
-  // than to ``/settings/app`` (an unrelated section that used to win the
-  // fallback). For OpenHands-agent users this is also a sensible landing
-  // — the Agent page is the single place to switch kinds.
+  // ``/settings/agent`` always wins: it is the single place to switch
+  // agent kinds (OpenHands / ACP) and the only sub-page that is always
+  // available regardless of feature flags. Landing here keeps the
+  // routing simple — ACP users no longer have to bounce through
+  // ``/settings/llm`` (which is disabled for them), and OpenHands users
+  // are one nav-click away from the LLM page.
   const fallbackOrder = [
-    { path: "/settings/llm", hidden: !!featureFlags?.hide_llm_settings },
     { path: "/settings/agent", hidden: false },
+    { path: "/settings/llm", hidden: !!featureFlags?.hide_llm_settings },
     { path: "/settings", hidden: !!featureFlags?.hide_llm_settings },
     { path: "/settings/app", hidden: false },
     { path: "/settings/secrets", hidden: false },


### PR DESCRIPTION
## What
Converges ACP model selection onto the **native LLM-profile inline picker UX** with **live mid-conversation switching**, replacing today's display-only popover (which only showed the model + a Settings link). Part of #769.

## Changes
- **Bump `@openhands/typescript-client` `1.23.3` → `1.24.0`** — adds `conversation.switchAcpModel(...)` (sdk #3390 / ts-client #189).
- **`AgentServerConversationService.switchAcpModel(conversationId, model)`** — `POST /switch_acp_model` via `ConversationClient`, mirroring `switchProfile` incl. the **local-backend-only guard**.
- **`useSwitchAcpModel` hook** — live in-place switch for a running ACP session; for the **home / no-session** case, persists the choice as the agent-settings default (`agent_settings_diff { acp_model }`) so the next conversation inherits it. Invalidates the same conversation/settings caches as the profile hook.
- **`ChatInputModel` popover → picker** over the provider's `available_models` (check on the effective model), keeping the Settings link. Shown only for **local-backend ACP with a known model list**; cloud / custom-or-unknown providers / native surfaces keep the prior display-only behavior.
- New i18n key `MODEL$AVAILABLE_MODELS` (source `translation.json`; `declaration.ts`/locales are generated by `make-i18n` in CI).

## Scope (per #769)
Local agent-server backend only (matches native LLM-profile switching). Custom/unknown ACP providers and any `OpenHands/OpenHands` app_server route are **out of scope**.

## Depends on (all released)
- software-agent-sdk **v1.24.0** (runtime `/switch_acp_model`) + `agent-server:1.24.0` image.
- `@openhands/typescript-client` **1.24.0** on npmjs (`switchAcpModel`).

## Test plan
- `npm run lint` (make-i18n + typecheck + eslint + prettier): clean.
- Vitest: new `use-switch-acp-model` hook tests (live-switch vs settings-default branches; cache invalidation) and `chat-input-model` picker tests (renders `available_models`, active-conv switch, home default-write, cloud display-only). 16 tests pass; broader chat suites show no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)










<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `cee6ebba4ba255a5c28d3af225e443fed45c5b6f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-cee6ebb
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-cee6ebb
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-cee6ebb-amd64
ghcr.io/openhands/agent-canvas:feat-acp-inline-model-picker-amd64
ghcr.io/openhands/agent-canvas:pr-832-amd64
ghcr.io/openhands/agent-canvas:sha-cee6ebb-arm64
ghcr.io/openhands/agent-canvas:feat-acp-inline-model-picker-arm64
ghcr.io/openhands/agent-canvas:pr-832-arm64
ghcr.io/openhands/agent-canvas:sha-cee6ebb
ghcr.io/openhands/agent-canvas:feat-acp-inline-model-picker
ghcr.io/openhands/agent-canvas:pr-832
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-cee6ebb`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-cee6ebb-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->