### PR TITLE
fix : skills disabled state persistence

### DIFF
--- a/__tests__/api/settings-service.test.ts
+++ b/__tests__/api/settings-service.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from "msw";
 
 import SettingsService from "#/api/settings-service/settings-service.api";
 import { APP_PREFERENCES_STORAGE_KEY } from "#/api/app-preferences-store";
+import { SKILLS_PREFERENCES_STORAGE_KEY } from "#/api/skills-preferences-store";
 import {
   __resetActiveStoreForTests,
   setActiveSelection,
@@ -140,10 +141,8 @@ describe("SettingsService", () => {
   });
 
   it("skips PATCH for a skills-only save against a local backend", async () => {
-    // Arrange: skills are a cloud-only feature. The local agent-server's
-    // PATCH /api/settings rejects payloads without agent/conversation diffs
-    // (the MSW handler returns 400 in that case), so a successful no-op here
-    // also confirms disabled_skills is not leaked to the local backend.
+    // Arrange: local backends persist disabled skills in localStorage since
+    // PATCH /api/settings rejects unknown top-level fields and requires a diff.
     const fetchSpy = vi.spyOn(SettingsService, "fetchSettingsFromApi");
 
     // Act
@@ -151,10 +150,14 @@ describe("SettingsService", () => {
       disabled_skills: ["SSH Microagent"],
     });
 
-    // Assert: returns true and never fires the PATCH (no fetch invalidation
-    // either, because the cache wasn't cleared).
+    // Assert: returns true and never fires the PATCH.
     expect(result).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(SKILLS_PREFERENCES_STORAGE_KEY) ?? "{}",
+      ),
+    ).toEqual({ disabled_skills: ["SSH Microagent"] });
 
     fetchSpy.mockRestore();
   });

--- a/__tests__/routes/skills-settings.test.tsx
+++ b/__tests__/routes/skills-settings.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, within, fireEvent } from "@testing-library/react";
+import { render, screen, within, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import SkillsSettingsScreen from "#/routes/skills-settings";
@@ -292,6 +292,30 @@ Full skill body.`,
       within(card).getByTestId(`skill-toggle-${skill.name}`),
     ).toHaveAttribute("aria-checked", "false");
     expect(screen.queryByTestId("skill-detail-modal")).not.toBeInTheDocument();
+  });
+
+  it("auto-saves disabled skills after hydrating an empty disabled_skills list", async () => {
+    const user = userEvent.setup();
+    const skill = buildSkill({ name: "hydration-test" });
+    vi.spyOn(SkillsService, "getSkills").mockResolvedValue([skill]);
+
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({ disabled_skills: [] }),
+    );
+    const saveSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+
+    renderSkillsSettingsScreen();
+    await screen.findByTestId(`skill-card-${skill.name}`);
+
+    await user.click(screen.getByTestId(`skill-toggle-${skill.name}`));
+
+    await waitFor(() => {
+      expect(saveSpy).toHaveBeenCalledWith({
+        disabled_skills: [skill.name],
+      });
+    });
   });
 
   it("shows an empty-state message when no skills match the current filters", async () => {

--- a/src/api/settings-service/settings-service.api.ts
+++ b/src/api/settings-service/settings-service.api.ts
@@ -6,6 +6,10 @@ import {
   readStoredAppPreferences,
   writeStoredAppPreferences,
 } from "../app-preferences-store";
+import {
+  readStoredSkillsPreferences,
+  writeStoredSkillsPreferences,
+} from "../skills-preferences-store";
 import { getActiveBackend } from "../backend-registry/active-store";
 import {
   fetchCloudConversationSettingsSchema,
@@ -136,10 +140,12 @@ const syncDerivedSettings = (settings: Partial<Settings>): Settings => {
   // analytics consent) live in localStorage in local mode. In cloud mode the
   // server response carries them and overrides the local cache.
   const storedAppPrefs = readStoredAppPreferences();
+  const storedSkillsPrefs = readStoredSkillsPreferences();
 
   const merged = {
     ...deepClone(DEFAULT_SETTINGS),
     ...storedAppPrefs,
+    ...storedSkillsPrefs,
     ...settings,
     provider_tokens_set: {
       ...(DEFAULT_SETTINGS.provider_tokens_set ?? {}),
@@ -313,6 +319,19 @@ class SettingsService {
   static async saveSettings(
     settings: Partial<Settings> & Record<string, unknown>,
   ): Promise<boolean> {
+    const isCloud = getActiveBackend().backend.kind === "cloud";
+
+    // Skills enable/disable is represented as a list of disabled skill names.
+    // Cloud backends persist this server-side. The local agent-server rejects
+    // unknown top-level fields on PATCH /api/settings, so persist this
+    // preference in localStorage for local mode.
+    if (!isCloud) {
+      const disabledSkills = settings.disabled_skills;
+      if (Array.isArray(disabledSkills)) {
+        writeStoredSkillsPreferences({ disabled_skills: disabledSkills });
+      }
+    }
+
     // Split app-level user-preference fields (language, git identity, sound
     // notifications, analytics consent) off before building the diff payload.
     // The local agent-server's PATCH /api/settings has no schema for these
@@ -352,8 +371,6 @@ class SettingsService {
     if (Array.isArray(disabledSkills)) {
       payload.disabled_skills = disabledSkills;
     }
-
-    const isCloud = getActiveBackend().backend.kind === "cloud";
 
     // The backend applies ``agent_settings_diff`` by deep-merging it into the
     // existing ``agent_settings`` dict (see SDK

--- a/src/api/skills-preferences-store.ts
+++ b/src/api/skills-preferences-store.ts
@@ -1,0 +1,64 @@
+import { DEFAULT_SETTINGS } from "#/services/settings";
+import type { Settings } from "#/types/settings";
+
+export const SKILLS_PREFERENCES_STORAGE_KEY =
+  "openhands-agent-server-skills-preferences";
+
+type StoredSkillsPreferences = Pick<Settings, "disabled_skills">;
+
+const sanitizeDisabledSkills = (value: unknown): string[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item === "string" && item.length > 0) {
+      out.push(item);
+    }
+  }
+  return out;
+};
+
+export const readStoredSkillsPreferences = (): StoredSkillsPreferences => {
+  if (typeof window === "undefined") {
+    return { disabled_skills: DEFAULT_SETTINGS.disabled_skills };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SKILLS_PREFERENCES_STORAGE_KEY);
+    if (!raw) {
+      return { disabled_skills: DEFAULT_SETTINGS.disabled_skills };
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { disabled_skills: DEFAULT_SETTINGS.disabled_skills };
+    }
+
+    const disabled = sanitizeDisabledSkills(
+      (parsed as Record<string, unknown>).disabled_skills,
+    );
+    return {
+      disabled_skills: disabled ?? DEFAULT_SETTINGS.disabled_skills,
+    };
+  } catch {
+    return { disabled_skills: DEFAULT_SETTINGS.disabled_skills };
+  }
+};
+
+export const writeStoredSkillsPreferences = (
+  partial: Partial<StoredSkillsPreferences>,
+): void => {
+  if (typeof window === "undefined") return;
+
+  const disabled = sanitizeDisabledSkills(partial.disabled_skills);
+  if (!disabled) return;
+
+  const merged: StoredSkillsPreferences = {
+    ...readStoredSkillsPreferences(),
+    disabled_skills: disabled,
+  };
+
+  window.localStorage.setItem(
+    SKILLS_PREFERENCES_STORAGE_KEY,
+    JSON.stringify(merged),
+  );
+};
+

--- a/src/routes/skills-settings.tsx
+++ b/src/routes/skills-settings.tsx
@@ -55,13 +55,15 @@ function SkillsSettingsScreen() {
   );
   const [showAddSkillModal, setShowAddSkillModal] = React.useState(false);
 
-  // Sync local state with server settings when data first arrives
+  // Sync local state with settings once, when data first arrives.
   React.useEffect(() => {
-    if (settings?.disabled_skills) {
-      setDisabledSet(new Set(settings.disabled_skills));
-      setHasHydratedInitialSettings(true);
-    }
-  }, [settings?.disabled_skills]);
+    if (!settings || hasHydratedInitialSettings) return;
+    const disabledSkills = Array.isArray(settings.disabled_skills)
+      ? settings.disabled_skills
+      : [];
+    setDisabledSet(new Set(disabledSkills));
+    setHasHydratedInitialSettings(true);
+  }, [settings, hasHydratedInitialSettings]);
 
   const handleToggle = (skillName: string, enabled: boolean) => {
     setDisabledSet((prev) => {


### PR DESCRIPTION
#### why
- Disabled skills weren’t saved, so refresh re-enabled them.

##### Summary

- Persist disabled_skills for local mode.
- Fix hydration when disabled_skills is empty.
- Add regression coverage.

#### Issue Number
 fix : #834

#### How to Test
- Go to /skills
- Disable a skill
- Refresh
- It stays disabled

#### Video/Screenshots
N/A

#### Type
- Bug fix

#### Notes
Local backend can’t store disabled_skills via /api/settings, so we store it client-side.

