### PR TITLE
fix(frontend): hide Start from a proven workflow on cloud backends

### DIFF
--- a/__tests__/components/automations/recommended-automations.test.tsx
+++ b/__tests__/components/automations/recommended-automations.test.tsx
@@ -3,10 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsService from "#/api/settings-service/settings-service.api";
 import McpService from "#/api/mcp-service/mcp-service.api";
-import {
-  consumePendingTaskDraft,
-  getConversationState,
-} from "#/utils/conversation-local-storage";
+import { getConversationState } from "#/utils/conversation-local-storage";
 import {
   __resetActiveStoreForTests,
   setActiveSelection,
@@ -376,34 +373,15 @@ describe("recommended automations", () => {
     expect(mockCreateConversationMutate).toHaveBeenCalledTimes(1);
   });
 
-  it("stores cloud start-task drafts until the real conversation is ready", () => {
+  it("hides the recommended automations section on cloud backends", () => {
     setRegisteredBackends([cloudBackend]);
     setActiveSelection({ backendId: cloudBackend.id });
-    mockUseSettings.mockReturnValue({
-      data: settingsWithGithubMcp(),
-    });
 
     renderLauncher({ withBackendProvider: true });
 
-    fireEvent.click(
-      screen.getByTestId("recommended-automation-card-github-pr-reviewer"),
-    );
-
-    const [, options] = mockCreateConversationMutate.mock.calls[0];
-    options.onSuccess({
-      conversation_id: "task-cloud-start-task",
-      task_id: "cloud-start-task",
-    });
-
     expect(
-      getConversationState("task-cloud-start-task").draftMessage,
-    ).toBeNull();
-    const pendingDraft = consumePendingTaskDraft("cloud-start-task");
-    expect(pendingDraft).toContain(
-      "https://staging.all-hands.dev/api/automation/v1/preset/prompt",
-    );
-    expect(pendingDraft).not.toContain("https://staging.all-hands.dev//api");
-    expect(pendingDraft).toContain("$OPENHANDS_API_KEY");
+      screen.queryByTestId("recommended-automations-section"),
+    ).not.toBeInTheDocument();
   });
 
   it("launches the recommendation after the missing MCP is installed", async () => {

--- a/src/components/features/automations/recommended-automations-launcher.tsx
+++ b/src/components/features/automations/recommended-automations-launcher.tsx
@@ -208,6 +208,10 @@ export function RecommendedAutomationsLauncher({
 
   const installEntry = installQueue[0] ?? null;
 
+  // Recommended automations are a local-backend-only feature; cloud
+  // automations are managed elsewhere.
+  if (activeBackend.backend.kind === "cloud") return null;
+
   return (
     <>
       <RecommendedAutomationsSection


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

On the `/automations` page, the **"Start from a proven workflow"** section (recommended-automations cards) renders for **both** local and cloud backends. This section is a local-backend-only feature — cloud automations are managed elsewhere — so it must not appear when the active backend is a cloud environment.

### Steps to Reproduce

1. Run the dev server: `npm run dev`.
2. Open the `<BackendSelector />` dropdown and click **Add Backend**.
3. In the **Add a Backend** modal, add a Cloud backend tied to your Personal Workspace:
   - Host Name: `Production`
   - Host: `https://app.all-hands.dev`
   - Type: `Cloud`
   - API Key: `<api_key>` for Personal Workspace
4. Confirm the cloud backend is added, then select **Production — Personal Workspace**.
5. Navigate to `http://localhost:3001/automations`.

### Current Behavior

The "Start from a proven workflow" section is displayed while connected to the cloud backend.

### Expected Behavior

The "Start from a proven workflow" section is displayed **only** when connected to a local backend, and never for cloud backends.

### Root Cause

The section is `RecommendedAutomationsSection`, rendered by `RecommendedAutomationsLauncher`. Its visibility was gated only by (1) MCP availability via `isMarketplaceEntryAvailable(entry, backendKind)` and (2) the search query. Every required MCP in the catalog is marked `availability: "all"`, so the availability check passes for cloud just as it does for local, and there was **no guard restricting the feature to local backends** — even though sibling automation features (e.g. editing) are already local-only.

### Acceptance Criteria

- [ ] The recommended-automations section is hidden on the `/automations` page when the active backend is a cloud backend.
- [ ] The section still renders on local backends.
- [ ] The section is also hidden for cloud backends in the onboarding "say hello" step (both render sites go through the launcher).
- [ ] Automated test coverage verifies the cloud-hidden behavior.

## Summary

<!-- 1-3 bullets describing what changed. -->
- The "Start from a proven workflow" (recommended automations) section appeared on **cloud** backends, but it is a local-backend-only feature.
- Added a cloud guard in `RecommendedAutomationsLauncher` so the section renders only for local backends — covering both the `/automations` page and the onboarding "say hello" step in one place.
- Mirrors the established `task-suggestions.tsx` pattern (`if (!isCloud) return null;`).

### Root Cause

`RecommendedAutomationsSection` (rendered by `RecommendedAutomationsLauncher`) was gated only by MCP availability (`isMarketplaceEntryAvailable`) and the search query. Since every catalog MCP is marked `availability: "all"`, the availability check passed for cloud as well, and nothing restricted the feature to local backends.

### Changes

- **`src/components/features/automations/recommended-automations-launcher.tsx`** — return `null` when `activeBackend.backend.kind === "cloud"` (placed after all hooks to respect the Rules of Hooks).
- **`__tests__/components/automations/recommended-automations.test.tsx`** — removed the obsolete "stores cloud start-task drafts…" test (it clicked a card that no longer renders for cloud; `buildAutomationPrompt`'s cloud output stays covered by its dedicated unit tests) and added a test asserting the section is hidden for cloud backends. Dropped the now-unused `consumePendingTaskDraft` import.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #851 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Run the dev server: `npm run dev`.
2. Open the `<BackendSelector />` dropdown and click **Add Backend**.
3. In the **Add a Backend** modal, add a Cloud backend tied to your Personal Workspace:
   - Host Name: `Production`
   - Host: `https://app.all-hands.dev`
   - Type: `Cloud`
   - API Key: `<api_key>` for Personal Workspace
4. Confirm the cloud backend is added, then select **Production — Personal Workspace**.
5. Navigate to `http://localhost:3001/automations`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/2394b950-625d-4471-93cb-005f00448bf6

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `09bde2e8cbb5d852ba607100f860f50ab3d5cc71` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-09bde2e
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-09bde2e
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-09bde2e-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2002-amd64
ghcr.io/openhands/agent-canvas:pr-852-amd64
ghcr.io/openhands/agent-canvas:sha-09bde2e-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2002-arm64
ghcr.io/openhands/agent-canvas:pr-852-arm64
ghcr.io/openhands/agent-canvas:sha-09bde2e
ghcr.io/openhands/agent-canvas:hieptl-app-2002
ghcr.io/openhands/agent-canvas:pr-852
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-09bde2e`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-09bde2e-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->