### PR TITLE
fix(frontend): restore disabled Change Agent button on home page chat input

### DIFF
--- a/__tests__/components/features/chat/change-agent-button.test.tsx
+++ b/__tests__/components/features/chat/change-agent-button.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { QueryClient } from "@tanstack/react-query";
@@ -5,9 +6,29 @@ import { ChangeAgentButton } from "#/components/features/chat/change-agent-butto
 import { renderWithProviders } from "../../../../test-utils";
 import { useConversationStore } from "#/stores/conversation-store";
 
-// Mock WebSocket status
+// Stub StyledTooltip so its content renders eagerly. HeroUI's Tooltip (the
+// real engine) only mounts content on real-DOM hover, which jsdom doesn't
+// fire reliably, so we surface the content as a marker element instead.
+vi.mock("#/components/shared/buttons/styled-tooltip", () => ({
+  StyledTooltip: ({
+    content,
+    children,
+  }: {
+    content: ReactNode;
+    children: ReactNode;
+  }) => (
+    <>
+      {children}
+      <span data-testid="styled-tooltip-content">{content}</span>
+    </>
+  ),
+}));
+
+// Mock WebSocket status. Controllable so a test can simulate a ready
+// connection and isolate the home-page disable from the no-connection one.
+const wsState = vi.hoisted(() => ({ status: "CONNECTED" }));
 vi.mock("#/hooks/use-unified-websocket-status", () => ({
-  useUnifiedWebSocketStatus: () => "CONNECTED",
+  useUnifiedWebSocketStatus: () => wsState.status,
 }));
 
 // Mock agent state
@@ -76,6 +97,7 @@ describe("ChangeAgentButton - Cache Invalidation", () => {
     // Reset mock task polling result
     mockTaskPollingResult.taskStatus = undefined;
     mockTaskPollingResult.subConversationId = undefined;
+    wsState.status = "CONNECTED";
   });
 
   afterEach(() => {
@@ -150,5 +172,45 @@ describe("ChangeAgentButton - Cache Invalidation", () => {
     // Assert
     const button = screen.getByRole("button");
     expect(button).toBeInTheDocument();
+  });
+});
+
+describe("ChangeAgentButton - Home page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useConversationStore.setState({
+      conversationMode: "code",
+      subConversationTaskId: null,
+    });
+    mockTaskPollingResult.taskStatus = undefined;
+    mockTaskPollingResult.subConversationId = undefined;
+    // A ready websocket isolates the home-page disable: the only reason the
+    // button is disabled here is the absence of a started conversation.
+    wsState.status = "OPEN";
+  });
+
+  it("disables the button and explains why via a tooltip on the home page", () => {
+    // Arrange & Act - render with no active conversation (the home page)
+    renderWithProviders(<ChangeAgentButton />, {
+      navigation: { conversationId: null },
+    });
+
+    // Assert - button stays disabled and the explanatory tooltip is wired up
+    expect(screen.getByRole("button")).toBeDisabled();
+    expect(screen.getByTestId("styled-tooltip-content")).toHaveTextContent(
+      "CHANGE_AGENT$SWITCH_AFTER_CONVERSATION",
+    );
+  });
+
+  it("drops the explanatory tooltip once a conversation has begun", () => {
+    // Arrange & Act - render inside an active conversation
+    renderWithProviders(<ChangeAgentButton />, {
+      navigation: { conversationId: "conversation-1" },
+    });
+
+    // Assert - no home-page tooltip wrapper is rendered
+    expect(
+      screen.queryByTestId("styled-tooltip-content"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/features/chat/components/chat-input-actions.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-actions.test.tsx
@@ -160,7 +160,7 @@ describe("ChatInputActions", () => {
     expect(screen.getByTestId("change-agent-button-stub")).toBeInTheDocument();
   });
 
-  it("hides the Change Agent button on the home page on a cloud backend", () => {
+  it("shows the Change Agent button on the home page on a cloud backend", () => {
     setRegisteredBackends([cloudBackend]);
     setActiveSelection({ backendId: cloudBackend.id });
 
@@ -172,7 +172,7 @@ describe("ChatInputActions", () => {
     );
 
     expect(
-      screen.queryByTestId("change-agent-button-stub"),
-    ).not.toBeInTheDocument();
+      screen.getByTestId("change-agent-button-stub"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/features/chat/change-agent-button.tsx
+++ b/src/components/features/chat/change-agent-button.tsx
@@ -15,12 +15,18 @@ import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useUnifiedWebSocketStatus } from "#/hooks/use-unified-websocket-status";
 import { useSubConversationTaskPolling } from "#/hooks/query/use-sub-conversation-task-polling";
 import { useHandlePlanClick } from "#/hooks/use-handle-plan-click";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
+import { StyledTooltip } from "#/components/shared/buttons/styled-tooltip";
 
 export function ChangeAgentButton() {
   const [contextMenuOpen, setContextMenuOpen] = useState<boolean>(false);
 
   const { conversationMode, setConversationMode, subConversationTaskId } =
     useConversationStore();
+
+  const { conversationId } = useOptionalConversationId();
+
+  const isHomePage = !conversationId;
 
   const webSocketStatus = useUnifiedWebSocketStatus();
 
@@ -80,7 +86,10 @@ export function ChangeAgentButton() {
   }, [isAgentRunning, contextMenuOpen, isWebSocketConnected]);
 
   const isButtonDisabled =
-    isAgentRunning || isCreatingConversation || !isWebSocketConnected;
+    isHomePage ||
+    isAgentRunning ||
+    isCreatingConversation ||
+    !isWebSocketConnected;
 
   // Handle Shift + Tab keyboard shortcut to cycle through modes
   useEffect(() => {
@@ -145,7 +154,7 @@ export function ChangeAgentButton() {
     return <LessonPlanIcon width={18} height={18} color="currentColor" />;
   }, [isExecutionAgent]);
 
-  return (
+  const button = (
     <div className="relative">
       <button
         type="button"
@@ -186,4 +195,17 @@ export function ChangeAgentButton() {
       )}
     </div>
   );
+
+  if (isHomePage) {
+    return (
+      <StyledTooltip
+        content={t(I18nKey.CHANGE_AGENT$SWITCH_AFTER_CONVERSATION)}
+        placement="top"
+      >
+        {button}
+      </StyledTooltip>
+    );
+  }
+
+  return button;
 }

--- a/src/components/features/chat/components/chat-input-actions.tsx
+++ b/src/components/features/chat/components/chat-input-actions.tsx
@@ -74,10 +74,10 @@ export function ChatInputActions({
     ? (labelForAcpModel(conversation?.acp_server, conversation?.llm_model) ??
       conversation?.llm_model)
     : conversation?.llm_model;
-  // The change-agent button can never be enabled on the home page (no
-  // conversation → no WebSocket → permanently disabled), so hide it there
-  // entirely. It is still shown inside a conversation on cloud backends.
-  const showChangeAgentButton = isCloud && Boolean(conversationId);
+  // Shown on cloud backends. On the home page it renders disabled with an
+  // explanatory tooltip (ChangeAgentButton handles that), since agent mode can
+  // only be switched once a conversation has begun.
+  const showChangeAgentButton = isCloud;
   const webSocketStatus = useUnifiedWebSocketStatus();
   const { curAgentState } = useAgentState();
   const { conversationMode, setConversationMode } = useConversationStore();

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -23306,6 +23306,23 @@
     "uk": "Окресліть цілі, структуруйте завдання та сплануйте наступні кроки.",
     "ca": "Defineix objectius, estructura tasques i planifica els propers passos."
   },
+  "CHANGE_AGENT$SWITCH_AFTER_CONVERSATION": {
+    "en": "Agent mode can be switched after a conversation begins",
+    "ja": "会話が始まると、エージェントモードを切り替えられます",
+    "zh-CN": "对话开始后即可切换智能体模式",
+    "zh-TW": "對話開始後即可切換代理模式",
+    "ko-KR": "대화가 시작된 후에 에이전트 모드를 전환할 수 있습니다",
+    "no": "Agentmodus kan byttes etter at en samtale har startet",
+    "it": "La modalità agente può essere cambiata dopo l'inizio di una conversazione",
+    "pt": "O modo do agente pode ser alterado após o início de uma conversa",
+    "es": "El modo de agente se puede cambiar después de que comience una conversación",
+    "ar": "يمكن تبديل وضع الوكيل بعد بدء المحادثة",
+    "fr": "Le mode agent peut être changé une fois la conversation commencée",
+    "tr": "Aracı modu, bir konuşma başladıktan sonra değiştirilebilir",
+    "de": "Der Agentenmodus kann gewechselt werden, nachdem ein Gespräch begonnen hat",
+    "uk": "Режим агента можна змінити після початку розмови",
+    "ca": "El mode d'agent es pot canviar després que comenci una conversa"
+  },
   "PLANNING_AGENTT$PLANNING_AGENT_INITIALIZED": {
     "en": "Planning agent initialized",
     "ja": "プランニングエージェントが初期化されました",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description**

PR #798 ("fix: hide Change Agent button on home page chat input") removed the Change Agent button from the home page chat input entirely. The reasoning was that the button can never be *enabled* on the home page (no conversation → no WebSocket → permanently disabled), so it was hidden rather than shown disabled.

We want the button back on the home page for cloud backends, but **disabled**, with a tooltip that tells the user when it becomes usable. This keeps the agent-mode affordance discoverable and explains the gating instead of silently hiding it.

**Current behavior**

* On a cloud backend, the home page chat input shows **no** Change Agent button.

**Expected behavior**

* On a cloud backend, the home page chat input shows the Change Agent button.
* The button is **disabled**.
* Hovering the button shows the tooltip: `Agent mode can be switched after a conversation begins`.
* Inside a conversation, behavior is unchanged (button enabled/disabled per agent + WebSocket state, no home-page tooltip).
* On a local backend, behavior is unchanged (button not shown).

**Acceptance criteria**

* [ ] Change Agent button is visible on the home page when connected to a cloud backend.
* [ ] The button is disabled on the home page.
* [ ] Hover tooltip reads exactly: `Agent mode can be switched after a conversation begins`.
* [ ] No regression inside a conversation or on local backends.
* [ ] Tooltip string is localized across all supported locales.
* [ ] Covered by tests.

**Technical notes**

* Regression introduced in PR #798 at `src/components/features/chat/components/chat-input-actions.tsx` where `showChangeAgentButton` was changed from `isCloud` to `isCloud && Boolean(conversationId)`.
* Reuse the existing `StyledTooltip` primitive and the `useOptionalConversationId` hook rather than introducing new utilities.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Restores the Change Agent button on the **home page** chat input for **cloud backends**, reverting the visibility gate that PR #798 introduced.
- The button is shown **disabled** on the home page and, on hover, displays the tooltip `Agent mode can be switched after a conversation begins` (new localized i18n key `CHANGE_AGENT$SWITCH_AFTER_CONVERSATION`).
- Behavior inside a conversation and on local backends is unchanged.

## Why

PR #798 hid the button entirely on the home page since it cannot be enabled without an active conversation. Hiding it removed a discoverable affordance and gave users no explanation. Showing it disabled with a tooltip communicates _when_ agent mode can be switched.

## Changes

- `src/components/features/chat/components/chat-input-actions.tsx` — `showChangeAgentButton` gates on `isCloud` only again (drops `&& Boolean(conversationId)`).
- `src/components/features/chat/change-agent-button.tsx` — derives `isHomePage` from `useOptionalConversationId`, folds it into the disabled state, and wraps the button in `StyledTooltip` with the explanatory message on the home page only.
- `src/i18n/translation.json` — adds `CHANGE_AGENT$SWITCH_AFTER_CONVERSATION` for all locales (`src/i18n/declaration.ts` is regenerated from this by `make-i18n`).
- Tests:

  - `__tests__/components/features/chat/components/chat-input-actions.test.tsx` — the home-page case now asserts the button **is** shown on a cloud backend (was: hidden).
  - `__tests__/components/features/chat/change-agent-button.test.tsx` — adds a home-page case (disabled + tooltip wired up) and an in-conversation case (no home-page tooltip).

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #857 

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="798" alt="app-2005" src="https://github.com/user-attachments/assets/d261299d-60a0-42cc-a19b-fa4f5e1a6e70" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `1621381ac08da02ab14b96d71132fe0266924ebe` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-1621381
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-1621381
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-1621381-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2005-amd64
ghcr.io/openhands/agent-canvas:pr-858-amd64
ghcr.io/openhands/agent-canvas:sha-1621381-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2005-arm64
ghcr.io/openhands/agent-canvas:pr-858-arm64
ghcr.io/openhands/agent-canvas:sha-1621381
ghcr.io/openhands/agent-canvas:hieptl-app-2005
ghcr.io/openhands/agent-canvas:pr-858
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-1621381`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-1621381-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->