### PR TITLE
fix(frontend): hide Planner tab on local backends

### DIFF
--- a/__tests__/components/features/conversation/conversation-tabs-context-menu.test.tsx
+++ b/__tests__/components/features/conversation/conversation-tabs-context-menu.test.tsx
@@ -58,15 +58,13 @@ describe("ConversationTabsContextMenu", () => {
   it("should render all default tabs when open", () => {
     render(<ConversationTabsContextMenu isOpen={true} onClose={vi.fn()} />);
 
-    const expectedTabs = [
-      "COMMON$PLANNER",
-      "COMMON$FILES",
-      "COMMON$TERMINAL",
-      "COMMON$BROWSER",
-    ];
+    const expectedTabs = ["COMMON$FILES", "COMMON$TERMINAL", "COMMON$BROWSER"];
     for (const tab of expectedTabs) {
       expect(screen.getByText(tab)).toBeInTheDocument();
     }
+
+    // Planner is cloud-only; on the default (local) backend it is hidden.
+    expect(screen.queryByText("COMMON$PLANNER")).not.toBeInTheDocument();
   });
 
   it("should show the Code entry when the active backend is cloud", () => {
@@ -85,6 +83,24 @@ describe("ConversationTabsContextMenu", () => {
     );
 
     expect(screen.getByText("COMMON$CODE")).toBeInTheDocument();
+  });
+
+  it("should show the Planner entry when the active backend is cloud", () => {
+    seedActiveBackend({
+      id: "cloud-test",
+      name: "Cloud Test",
+      host: "https://app.example.com",
+      apiKey: "secret",
+      kind: "cloud",
+    });
+
+    render(
+      <ActiveBackendProvider>
+        <ConversationTabsContextMenu isOpen={true} onClose={vi.fn()} />
+      </ActiveBackendProvider>,
+    );
+
+    expect(screen.getByText("COMMON$PLANNER")).toBeInTheDocument();
   });
 
   it("should open a tab from the label button without changing pin state", async () => {
@@ -130,13 +146,13 @@ describe("ConversationTabsContextMenu", () => {
 
     const storeState = useConversationStore.getState();
     expect(storeState.hasRightPanelToggled).toBe(true);
-    expect(storeState.selectedTab).toBe("planner");
+    expect(storeState.selectedTab).toBe("terminal");
 
     const storedState = JSON.parse(
       localStorage.getItem(`conversation-state-${CONVERSATION_ID}`)!,
     );
     expect(storedState.unpinnedTabs).toContain("files");
-    expect(storedState.selectedTab).toBe("planner");
+    expect(storedState.selectedTab).toBe("terminal");
   });
 
   it("should not close the right panel when unpinning a non-active tab", async () => {

--- a/__tests__/components/features/conversation/conversation-tabs.test.tsx
+++ b/__tests__/components/features/conversation/conversation-tabs.test.tsx
@@ -315,6 +315,15 @@ describe("ConversationTabs localStorage behavior", () => {
 
     it("shows an unpinned tab in the bar while it is selected", () => {
       mockConversationId = REAL_CONVERSATION_ID;
+      // Planner is cloud-only, so a cloud backend is required to exercise
+      // the unpinned-while-selected logic against the planner tab.
+      seedActiveBackend({
+        id: "cloud-test",
+        name: "Cloud Test",
+        host: "https://app.example.com",
+        apiKey: "secret",
+        kind: "cloud",
+      });
       seedConversationState(REAL_CONVERSATION_ID, {
         selectedTab: "planner",
         unpinnedTabs: ["planner"],
@@ -336,6 +345,15 @@ describe("ConversationTabs localStorage behavior", () => {
 
     it("hides an unpinned tab from the bar once another tab is selected", () => {
       mockConversationId = REAL_CONVERSATION_ID;
+      // Cloud backend so the planner tab would be eligible — it stays
+      // hidden here because it is unpinned and not the selected tab.
+      seedActiveBackend({
+        id: "cloud-test",
+        name: "Cloud Test",
+        host: "https://app.example.com",
+        apiKey: "secret",
+        kind: "cloud",
+      });
       seedConversationState(REAL_CONVERSATION_ID, {
         selectedTab: "files",
         unpinnedTabs: ["planner"],
@@ -474,6 +492,54 @@ describe("ConversationTabs localStorage behavior", () => {
 
       // Assert
       expect(screen.getByTestId("conversation-tab-vscode")).toBeInTheDocument();
+    });
+  });
+
+  describe("planner tab visibility by backend kind", () => {
+    beforeEach(() => {
+      mockConversationId = REAL_CONVERSATION_ID;
+    });
+
+    it("should hide the planner tab when the active backend is local", () => {
+      // Arrange
+      seedActiveBackend({
+        id: "local-test",
+        name: "Local Test",
+        host: "http://localhost:8000",
+        apiKey: "",
+        kind: "local",
+      });
+
+      // Act
+      render(<ConversationTabs />, {
+        wrapper: createWrapper(REAL_CONVERSATION_ID),
+      });
+
+      // Assert
+      expect(
+        screen.queryByTestId("conversation-tab-planner"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show the planner tab when the active backend is cloud", () => {
+      // Arrange
+      seedActiveBackend({
+        id: "cloud-test",
+        name: "Cloud Test",
+        host: "https://app.example.com",
+        apiKey: "secret",
+        kind: "cloud",
+      });
+
+      // Act
+      render(<ConversationTabs />, {
+        wrapper: createWrapper(REAL_CONVERSATION_ID),
+      });
+
+      // Assert
+      expect(
+        screen.getByTestId("conversation-tab-planner"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
@@ -73,7 +73,8 @@ export function ConversationTabsContextMenu({
   }
 
   const visibleTabConfig = tabConfig.filter(
-    ({ tab }) => tab !== "vscode" || backend.kind === "cloud",
+    ({ tab }) =>
+      (tab !== "vscode" && tab !== "planner") || backend.kind === "cloud",
   );
 
   if (!isOpen) return null;

--- a/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
+++ b/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
@@ -144,9 +144,11 @@ export function ConversationTabs({
 
   // Pinned tabs always show in the bar. Unpinned tabs stay hidden unless the
   // user has that tab selected — then it appears while active so the bar
-  // matches the open panel. Hide VS Code on local backends (cloud-only URL).
+  // matches the open panel. Hide VS Code and Planner on local backends —
+  // both are cloud-only (the planning agent isn't supported locally).
   const visibleTabs = tabs.filter((tab) => {
     if (tab.tabValue === "vscode" && backend.kind !== "cloud") return false;
+    if (tab.tabValue === "planner" && backend.kind !== "cloud") return false;
     if (!persistedState.unpinnedTabs.includes(tab.tabValue)) return true;
     return selectedTab === tab.tabValue;
   });


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

The planning agent is only supported on **cloud** backends, not on **local** ones. However, the **Planner** tab is currently rendered on the conversation page regardless of which backend is active, so local-backend users see a tab for a feature that isn't available to them.

**Steps to reproduce**
1. Clone `agent-server-gui` and run `npm run dev`.
2. Open the home page (default local backend).
3. Create a new conversation and open the conversation page.

**Current behavior**
- The Planner tab is visible in the tab bar (and in the ellipsis "more tabs" context menu) when connected to a local backend.

**Expected behavior**
- The Planner tab is hidden whenever the active backend is local, and visible only on cloud — matching how the VS Code tab is already gated.

### Acceptance Criteria
- [ ] On a local backend, the Planner tab does not appear in the conversation tab bar.
- [ ] On a local backend, the Planner entry does not appear in the tab-overflow context menu.
- [ ] On a cloud backend, the Planner tab and context-menu entry remain visible and functional.
- [ ] Behavior follows the existing VS Code gating pattern (`backend.kind !== "cloud"`).
- [ ] Automated tests cover both the local-hidden and cloud-visible cases for the tab bar and the context menu.

### Notes / Scope
- The "Build plan" button row is gated by the planner tab being *active*; since the tab can no longer be selected on local backends and the default tab is `files`, that row is unreachable locally and is intentionally left untouched (mirrors the VS Code precedent, which doesn't guard its content either).

## Summary

<!-- 1-3 bullets describing what changed. -->
- The planning agent is cloud-only, yet the **Planner** tab was always shown on the conversation page (tab bar + overflow context menu), even on local backends.
- Gate the Planner tab on the active backend kind so it appears only on **cloud** backends, mirroring the existing VS Code gating (`backend.kind !== "cloud"`).

### Root cause
The Planner tab was added to the tab list unconditionally, and only the VS Code tab was filtered out for non-cloud backends:
- `conversation-tabs.tsx` — `visibleTabs` filter excluded only `vscode`.
- `conversation-tabs-context-menu.tsx` — `visibleTabConfig` filter dropped only `vscode`.

### Changes
- **`src/components/features/conversation/conversation-tabs/conversation-tabs.tsx`** — add a `planner` exclusion to the `visibleTabs` filter alongside the existing `vscode` one; update the adjacent comment.
- **`src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx`** — extend the `visibleTabConfig` filter so `planner` (like `vscode`) is shown only when `backend.kind === "cloud"`.
- **Tests** (`__tests__/components/features/conversation/`):
  - New `conversation-tabs.test.tsx` suite "planner tab visibility by backend kind": hidden on local, visible on cloud.
  - New `conversation-tabs-context-menu.test.tsx` case: Planner entry shown on cloud.
  - Updated existing tests that assumed Planner was visible on the default (local) backend: the two "unpinned tab" cases now seed a cloud backend so they exercise the unpinned logic; the "render all default tabs" case now asserts Planner is hidden on local; the "switch to another pinned tab when unpinning" case now expects `terminal` (the next visible tab on local) instead of `planner`.

### Out of scope
The "Build plan" button row is gated by the planner tab being *active*. On local backends the tab can no longer be selected and the default tab is `files`, so the row is unreachable; it is intentionally left unchanged, consistent with the VS Code precedent.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #841 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository.
2. Start the development server:

```bash
npm run dev
```

3. Open the application home page.
4. Create a new conversation.
5. Navigate to the conversation page.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="798" alt="image" src="https://github.com/user-attachments/assets/0594565e-4d26-47b8-8070-63dd1973018b" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.23.1-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `069743fb073cc9551a0c2396c2f4f6e5429b8522` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-069743f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-069743f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-069743f-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1994-amd64
ghcr.io/openhands/agent-canvas:pr-861-amd64
ghcr.io/openhands/agent-canvas:sha-069743f-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1994-arm64
ghcr.io/openhands/agent-canvas:pr-861-arm64
ghcr.io/openhands/agent-canvas:sha-069743f
ghcr.io/openhands/agent-canvas:hieptl-app-1994
ghcr.io/openhands/agent-canvas:pr-861
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-069743f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-069743f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->