### PR TITLE
refactor: update @openhands/extensions from MCP to integrations

### DIFF
--- a/__tests__/components/features/mcp-page/install-server-modal.test.tsx
+++ b/__tests__/components/features/mcp-page/install-server-modal.test.tsx
@@ -7,9 +7,9 @@ import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import { ActiveBackendProvider } from "#/contexts/active-backend-context";
 import { InstallServerModal } from "#/components/features/mcp-page/install-server-modal";
 import {
-  MCP_CATALOG as MCP_MARKETPLACE,
-  type McpCatalogEntry as MarketplaceEntry,
-} from "@openhands/extensions/mcps";
+  INTEGRATION_CATALOG as INTEGRATION_MARKETPLACE,
+  type IntegrationCatalogEntry as MarketplaceEntry,
+} from "@openhands/extensions/integrations";
 
 function renderWith(ui: React.ReactNode) {
   return render(ui, {
@@ -38,14 +38,18 @@ describe("InstallServerModal", () => {
     });
   });
 
-  it("requires Slack token + team id and posts a stdio mcp_config diff", async () => {
-    const slack = MCP_MARKETPLACE.find((e) => e.id === "slack")!;
+  it("requires Tavily API key and posts a stdio mcp_config diff", async () => {
+    // Tavily is a stdio-only integration with a single envField.
+    // Slack now defaults to OAuth/shttp, so we test stdio installs with Tavily.
+    const tavily = INTEGRATION_MARKETPLACE.find(
+      (e: MarketplaceEntry) => e.id === "tavily",
+    )!;
     const saveSpy = vi
       .spyOn(SettingsService, "saveSettings")
       .mockResolvedValue(true);
 
     const onClose = vi.fn();
-    renderWith(<InstallServerModal entry={slack} onClose={onClose} />);
+    renderWith(<InstallServerModal entry={tavily} onClose={onClose} />);
 
     await screen.findByTestId("mcp-install-modal");
 
@@ -55,11 +59,8 @@ describe("InstallServerModal", () => {
       expect(saveSpy).not.toHaveBeenCalled();
     });
 
-    fireEvent.change(screen.getByTestId("mcp-install-field-SLACK_BOT_TOKEN"), {
-      target: { value: "xoxb-abc" },
-    });
-    fireEvent.change(screen.getByTestId("mcp-install-field-SLACK_TEAM_ID"), {
-      target: { value: "T01" },
+    fireEvent.change(screen.getByTestId("mcp-install-field-TAVILY_API_KEY"), {
+      target: { value: "tvly-test-key" },
     });
     fireEvent.click(screen.getByTestId("mcp-install-submit"));
 
@@ -70,51 +71,10 @@ describe("InstallServerModal", () => {
       mcp_config: { mcpServers: Record<string, unknown> };
     };
     expect(sentMcpConfig.mcp_config.mcpServers).toMatchObject({
-      slack: {
-        command: "npx",
-        args: ["-y", "@zencoderai/slack-mcp-server"],
-        env: { SLACK_BOT_TOKEN: "xoxb-abc", SLACK_TEAM_ID: "T01" },
-      },
-    });
-    expect(onClose).toHaveBeenCalled();
-  });
-
-  it("installs Tavily as a stdio MCP server with TAVILY_API_KEY env", async () => {
-    // Tavily was previously a fake `kind: "tavily-builtin"` template
-    // that called saveSettings({ search_api_key }) — but that field
-    // was dropped on the floor in both local and cloud save paths, so
-    // installing Tavily silently did nothing. It's now a regular
-    // stdio MCP entry (`npx -y tavily-mcp` + TAVILY_API_KEY) that
-    // goes through the same mcp_config write as every other entry.
-    const tavily = MCP_MARKETPLACE.find((e) => e.id === "tavily")!;
-    const saveSpy = vi
-      .spyOn(SettingsService, "saveSettings")
-      .mockResolvedValue(true);
-
-    const onClose = vi.fn();
-    renderWith(<InstallServerModal entry={tavily} onClose={onClose} />);
-
-    await screen.findByTestId("mcp-install-modal");
-
-    // Submit with no key fails the required-field check.
-    fireEvent.click(screen.getByTestId("mcp-install-submit"));
-    await waitFor(() => expect(saveSpy).not.toHaveBeenCalled());
-
-    fireEvent.change(screen.getByTestId("mcp-install-field-TAVILY_API_KEY"), {
-      target: { value: "tvly-secret" },
-    });
-    fireEvent.click(screen.getByTestId("mcp-install-submit"));
-
-    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
-    const sent = (saveSpy.mock.calls[0][0] as Record<string, unknown>)
-      .agent_settings_diff as {
-      mcp_config: { mcpServers: Record<string, unknown> };
-    };
-    expect(sent.mcp_config.mcpServers).toMatchObject({
       tavily: {
         command: "npx",
         args: ["-y", "tavily-mcp"],
-        env: { TAVILY_API_KEY: "tvly-secret" },
+        env: { TAVILY_API_KEY: "tvly-test-key" },
       },
     });
     expect(onClose).toHaveBeenCalled();
@@ -126,14 +86,22 @@ describe("InstallServerModal", () => {
     // without relying on the catalog choosing to mark one this way.
     const entry: MarketplaceEntry = {
       id: "synthetic-required",
+      kind: "mcp",
       name: "Synthetic",
       description: "Synthetic catalog entry used in tests.",
       iconBg: "#000000",
-      template: {
-        kind: "shttp",
-        url: "https://example.com/mcp",
-        apiKeyOptional: false,
-      },
+      connectionOptions: [
+        {
+          id: "api",
+          provider: "mcp",
+          transport: {
+            kind: "shttp",
+            url: "https://example.com/mcp",
+            apiKeyOptional: false,
+          },
+          auth: { strategy: "api_key" },
+        },
+      ],
     };
     const saveSpy = vi
       .spyOn(SettingsService, "saveSettings")
@@ -160,14 +128,22 @@ describe("InstallServerModal", () => {
   it("allows submitting an shttp template with no key when apiKeyOptional is true", async () => {
     const entry: MarketplaceEntry = {
       id: "synthetic-optional",
+      kind: "mcp",
       name: "Synthetic Optional",
       description: "Synthetic entry that allows empty api_key.",
       iconBg: "#000000",
-      template: {
-        kind: "shttp",
-        url: "https://example.com/mcp",
-        apiKeyOptional: true,
-      },
+      connectionOptions: [
+        {
+          id: "api",
+          provider: "mcp",
+          transport: {
+            kind: "shttp",
+            url: "https://example.com/mcp",
+            apiKeyOptional: true,
+          },
+          auth: { strategy: "api_key" },
+        },
+      ],
     };
     const getSpy = vi
       .spyOn(SettingsService, "getSettings")
@@ -190,8 +166,10 @@ describe("InstallServerModal", () => {
 
   it("closes from the top-right close button", async () => {
     const onClose = vi.fn();
-    const slack = MCP_MARKETPLACE.find((e) => e.id === "slack")!;
-    renderWith(<InstallServerModal entry={slack} onClose={onClose} />);
+    const tavily = INTEGRATION_MARKETPLACE.find(
+      (e: MarketplaceEntry) => e.id === "tavily",
+    )!;
+    renderWith(<InstallServerModal entry={tavily} onClose={onClose} />);
     await screen.findByTestId("mcp-install-modal");
 
     fireEvent.click(screen.getByTestId("mcp-install-modal-close"));
@@ -200,8 +178,10 @@ describe("InstallServerModal", () => {
 
   it("places Cancel before Install in the footer so the dominant action is the last focusable button", async () => {
     // Arrange: render with any marketplace entry so the footer is mounted.
-    const slack = MCP_MARKETPLACE.find((e) => e.id === "slack")!;
-    renderWith(<InstallServerModal entry={slack} onClose={vi.fn()} />);
+    const tavily = INTEGRATION_MARKETPLACE.find(
+      (e: MarketplaceEntry) => e.id === "tavily",
+    )!;
+    renderWith(<InstallServerModal entry={tavily} onClose={vi.fn()} />);
     await screen.findByTestId("mcp-install-modal");
 
     // Act: locate both footer buttons.
@@ -228,14 +208,22 @@ describe("InstallServerModal", () => {
 
     const entry: MarketplaceEntry = {
       id: "synthetic-test-fail",
+      kind: "mcp",
       name: "Failing Server",
       description: "Always fails the connection test.",
       iconBg: "#000000",
-      template: {
-        kind: "shttp",
-        url: "https://example.com/mcp",
-        apiKeyOptional: true,
-      },
+      connectionOptions: [
+        {
+          id: "api",
+          provider: "mcp",
+          transport: {
+            kind: "shttp",
+            url: "https://example.com/mcp",
+            apiKeyOptional: true,
+          },
+          auth: { strategy: "api_key" },
+        },
+      ],
     };
 
     renderWith(<InstallServerModal entry={entry} onClose={onClose} />);
@@ -273,14 +261,22 @@ describe("InstallServerModal", () => {
 
     const entry: MarketplaceEntry = {
       id: "synthetic-test-pass",
+      kind: "mcp",
       name: "Passing Server",
       description: "Always passes the connection test.",
       iconBg: "#000000",
-      template: {
-        kind: "shttp",
-        url: "https://example.com/mcp",
-        apiKeyOptional: true,
-      },
+      connectionOptions: [
+        {
+          id: "api",
+          provider: "mcp",
+          transport: {
+            kind: "shttp",
+            url: "https://example.com/mcp",
+            apiKeyOptional: true,
+          },
+          auth: { strategy: "api_key" },
+        },
+      ],
     };
 
     renderWith(<InstallServerModal entry={entry} onClose={onClose} />);
@@ -307,14 +303,22 @@ describe("InstallServerModal", () => {
 
     const entry: MarketplaceEntry = {
       id: "synthetic-pending",
+      kind: "mcp",
       name: "Pending Server",
       description: "Connection test never resolves.",
       iconBg: "#000000",
-      template: {
-        kind: "shttp",
-        url: "https://example.com/mcp",
-        apiKeyOptional: true,
-      },
+      connectionOptions: [
+        {
+          id: "api",
+          provider: "mcp",
+          transport: {
+            kind: "shttp",
+            url: "https://example.com/mcp",
+            apiKeyOptional: true,
+          },
+          auth: { strategy: "api_key" },
+        },
+      ],
     };
 
     renderWith(<InstallServerModal entry={entry} onClose={vi.fn()} />);

--- a/__tests__/components/features/mcp-page/mcp-logo-stack-badge.test.tsx
+++ b/__tests__/components/features/mcp-page/mcp-logo-stack-badge.test.tsx
@@ -1,12 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { MCP_CATALOG } from "@openhands/extensions/mcps";
+import {
+  INTEGRATION_CATALOG,
+  type IntegrationCatalogEntry,
+} from "@openhands/extensions/integrations";
 import { McpLogoStackBadge } from "#/components/features/mcp-page/mcp-logo-stack-badge";
 
 function entry(id: string) {
-  const match = MCP_CATALOG.find((item) => item.id === id);
+  const match = INTEGRATION_CATALOG.find(
+    (item: IntegrationCatalogEntry) => item.id === id,
+  );
   if (!match) {
-    throw new Error(`Missing MCP catalog entry: ${id}`);
+    throw new Error(`Missing integration catalog entry: ${id}`);
   }
   return match;
 }

--- a/__tests__/constants/extensions-catalogs.test.ts
+++ b/__tests__/constants/extensions-catalogs.test.ts
@@ -1,55 +1,77 @@
 import { describe, expect, it } from "vitest";
 import { AUTOMATION_CATALOG } from "@openhands/extensions/automations";
-import { MCP_LOGO_IDS, MCP_LOGOS } from "@openhands/extensions/mcps/logos";
-import { MCP_CATALOG } from "@openhands/extensions/mcps";
+import {
+  INTEGRATION_LOGO_IDS,
+  INTEGRATION_LOGOS,
+} from "@openhands/extensions/integrations/logos";
+import {
+  INTEGRATION_CATALOG,
+  type IntegrationCatalogEntry,
+} from "@openhands/extensions/integrations";
+import { getDefaultTemplate } from "#/utils/mcp-marketplace-utils";
 
 describe("OpenHands extensions catalogs", () => {
-  it("hydrates the MCP marketplace from @openhands/extensions", () => {
-    expect(MCP_CATALOG.length).toBeGreaterThan(0);
+  it("hydrates the integration marketplace from @openhands/extensions", () => {
+    expect(INTEGRATION_CATALOG.length).toBeGreaterThan(0);
 
-    const github = MCP_CATALOG.find((entry) => entry.id === "github");
-    expect(github?.template.kind).toBe("stdio");
-    expect(MCP_LOGOS.github).toBeTruthy();
+    // Tavily has stdio as its default MCP transport
+    const tavily = INTEGRATION_CATALOG.find(
+      (entry: IntegrationCatalogEntry) => entry.id === "tavily",
+    );
+    const tavilyTemplate = tavily ? getDefaultTemplate(tavily) : undefined;
+    expect(tavilyTemplate?.kind).toBe("stdio");
+    expect(INTEGRATION_LOGOS.tavily).toBeTruthy();
 
-    for (const entry of MCP_CATALOG) {
-      expect(MCP_LOGO_IDS.has(entry.id)).toBe(true);
+    // Not all integrations have logos (some may be HTTP-only), so we just
+    // check that the logo collection is populated
+    expect(INTEGRATION_LOGO_IDS.size).toBeGreaterThan(0);
+  });
+
+  it("includes Slack with OAuth as default and stdio fallback", () => {
+    const slack = INTEGRATION_CATALOG.find(
+      (entry: IntegrationCatalogEntry) => entry.id === "slack",
+    );
+    expect(slack).toBeDefined();
+    // Slack's default is now OAuth/shttp
+    const defaultTemplate = slack ? getDefaultTemplate(slack) : undefined;
+    expect(defaultTemplate?.kind).toBe("shttp");
+
+    // But the stdio option with the maintained npm package is still available
+    const stdioOption = slack?.connectionOptions.find((o) => o.id === "api");
+    expect(stdioOption?.transport?.kind).toBe("stdio");
+    if (stdioOption?.transport?.kind === "stdio") {
+      expect(stdioOption.transport.args).toContain(
+        "@zencoderai/slack-mcp-server",
+      );
     }
   });
 
-  it("patches Slack to the maintained docs and npm package", () => {
-    const slack = MCP_CATALOG.find((entry) => entry.id === "slack");
-    expect(slack?.docsUrl).toBe(
-      "https://github.com/zencoderai/slack-mcp-server",
+  it("includes common integrations in the catalog", () => {
+    const catalogIds = new Set(
+      INTEGRATION_CATALOG.map((entry: IntegrationCatalogEntry) => entry.id),
     );
-    expect(slack?.template.kind).toBe("stdio");
-    if (slack?.template.kind !== "stdio") {
-      throw new Error("Slack template should be stdio");
-    }
-    expect(slack.template.args).toContain("@zencoderai/slack-mcp-server");
-    expect(slack.template.args).not.toContain(
-      "@modelcontextprotocol/server-slack",
-    );
-  });
 
-  it("drops deprecated MCP entries that no longer have maintained replacements", () => {
-    const catalogIds = new Set(MCP_CATALOG.map((entry) => entry.id));
-
-    expect(catalogIds.has("gitlab")).toBe(false);
-    expect(catalogIds.has("google-maps")).toBe(false);
-    expect(catalogIds.has("postgres")).toBe(false);
-    expect(catalogIds.has("puppeteer")).toBe(false);
-    expect(catalogIds.has("sqlite")).toBe(false);
+    // These should all be present
+    expect(catalogIds.has("github")).toBe(true);
+    expect(catalogIds.has("slack")).toBe(true);
+    expect(catalogIds.has("tavily")).toBe(true);
+    expect(catalogIds.has("linear")).toBe(true);
+    expect(catalogIds.has("notion")).toBe(true);
   });
 
   it("loads recommended automations from @openhands/extensions", () => {
     expect(AUTOMATION_CATALOG.length).toBeGreaterThan(0);
 
-    const knownMcpIds = new Set(MCP_CATALOG.map((entry) => entry.id));
+    const knownIntegrationIds = new Set(
+      INTEGRATION_CATALOG.map((entry: IntegrationCatalogEntry) => entry.id),
+    );
     for (const automation of AUTOMATION_CATALOG) {
-      expect(automation.requiredMcpIds.length).toBeGreaterThan(0);
-      expect(automation.requiredMcpIds.every((id) => knownMcpIds.has(id))).toBe(
-        true,
-      );
+      expect(automation.requiredIntegrationIds.length).toBeGreaterThan(0);
+      expect(
+        automation.requiredIntegrationIds.every((id: string) =>
+          knownIntegrationIds.has(id),
+        ),
+      ).toBe(true);
     }
   });
 });

--- a/__tests__/utils/mcp-marketplace-utils.test.ts
+++ b/__tests__/utils/mcp-marketplace-utils.test.ts
@@ -2,33 +2,46 @@ import { describe, expect, it } from "vitest";
 import {
   findCatalogEntryForServer,
   findInstalledMatch,
+  getDefaultTemplate,
   installedServerMatchesQuery,
   isMarketplaceEntryAvailable,
   marketplaceEntryMatchesQuery,
 } from "#/utils/mcp-marketplace-utils";
-import { MCP_CATALOG as MCP_MARKETPLACE } from "@openhands/extensions/mcps";
+import {
+  INTEGRATION_CATALOG as INTEGRATION_MARKETPLACE,
+  type IntegrationCatalogEntry,
+} from "@openhands/extensions/integrations";
 
-const slackEntry = MCP_MARKETPLACE.find((e) => e.id === "slack")!;
-const tavilyEntry = MCP_MARKETPLACE.find((e) => e.id === "tavily")!;
-const linearEntry = MCP_MARKETPLACE.find((e) => e.id === "linear")!;
-const filesystemEntry = MCP_MARKETPLACE.find((e) => e.id === "filesystem")!;
+const tavilyEntry = INTEGRATION_MARKETPLACE.find(
+  (e: IntegrationCatalogEntry) => e.id === "tavily",
+)!;
+const filesystemEntry = INTEGRATION_MARKETPLACE.find(
+  (e: IntegrationCatalogEntry) => e.id === "filesystem",
+)!;
+// Atlassian has an SSE server as the default MCP option
+const atlassianEntry = INTEGRATION_MARKETPLACE.find(
+  (e: IntegrationCatalogEntry) => e.id === "atlassian",
+)!;
+
+const tavilyTemplate = getDefaultTemplate(tavilyEntry)!;
+const atlassianTemplate = getDefaultTemplate(atlassianEntry)!;
 
 describe("findInstalledMatch", () => {
   it("matches stdio servers by name", () => {
-    const result = findInstalledMatch(slackEntry.template, [
+    const result = findInstalledMatch(tavilyTemplate, [
       {
         id: "stdio-0",
         type: "stdio",
-        name: "slack",
+        name: "tavily",
         command: "npx",
-        args: ["-y", "@zencoderai/slack-mcp-server"],
+        args: ["-y", "tavily-mcp"],
       },
     ]);
     expect(result).toEqual(expect.objectContaining({ id: "stdio-0" }));
   });
 
   it("does not match a different stdio name", () => {
-    const result = findInstalledMatch(slackEntry.template, [
+    const result = findInstalledMatch(tavilyTemplate, [
       {
         id: "stdio-0",
         type: "stdio",
@@ -44,7 +57,7 @@ describe("findInstalledMatch", () => {
     // Tavily lives in the catalog as a stdio MCP entry (the previous
     // tavily-builtin / search_api_key flow never persisted anywhere
     // and silently dropped the key); confirm the now-uniform match.
-    const result = findInstalledMatch(tavilyEntry.template, [
+    const result = findInstalledMatch(tavilyTemplate, [
       {
         id: "stdio-0",
         type: "stdio",
@@ -58,18 +71,19 @@ describe("findInstalledMatch", () => {
   });
 
   it("matches SSE servers loosely on URL", () => {
-    const result = findInstalledMatch(linearEntry.template, [
+    // Atlassian has SSE as its default MCP transport
+    const result = findInstalledMatch(atlassianTemplate, [
       {
         id: "sse-0",
         type: "sse",
-        url: "https://mcp.linear.app/sse/",
+        url: "https://mcp.atlassian.com/v1/sse/",
       },
     ]);
     expect(result).toEqual(expect.objectContaining({ id: "sse-0" }));
   });
 
   it("returns null when servers carry malformed urls (defensive)", () => {
-    const result = findInstalledMatch(linearEntry.template, [
+    const result = findInstalledMatch(atlassianTemplate, [
       // Cast to any to simulate runtime data slipping past the type.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       { id: "sse-0", type: "sse", url: undefined as any },
@@ -80,8 +94,8 @@ describe("findInstalledMatch", () => {
 
 describe("isMarketplaceEntryAvailable", () => {
   it("treats unset availability as 'all'", () => {
-    expect(isMarketplaceEntryAvailable(slackEntry, "local")).toBe(true);
-    expect(isMarketplaceEntryAvailable(slackEntry, "cloud")).toBe(true);
+    expect(isMarketplaceEntryAvailable(tavilyEntry, "local")).toBe(true);
+    expect(isMarketplaceEntryAvailable(tavilyEntry, "cloud")).toBe(true);
   });
 
   it("hides local-only entries on cloud", () => {
@@ -92,12 +106,12 @@ describe("isMarketplaceEntryAvailable", () => {
 
 describe("marketplaceEntryMatchesQuery", () => {
   it("matches by name (case-insensitive)", () => {
-    expect(marketplaceEntryMatchesQuery(slackEntry, "slack")).toBe(true);
-    expect(marketplaceEntryMatchesQuery(slackEntry, "SLACK")).toBe(true);
+    expect(marketplaceEntryMatchesQuery(tavilyEntry, "tavily")).toBe(true);
+    expect(marketplaceEntryMatchesQuery(tavilyEntry, "TAVILY")).toBe(true);
   });
 
   it("matches by keyword", () => {
-    expect(marketplaceEntryMatchesQuery(slackEntry, "messaging")).toBe(true);
+    expect(marketplaceEntryMatchesQuery(tavilyEntry, "search")).toBe(true);
   });
 
   it("matches by substring of description", () => {
@@ -105,35 +119,35 @@ describe("marketplaceEntryMatchesQuery", () => {
   });
 
   it("returns true for empty/whitespace queries", () => {
-    expect(marketplaceEntryMatchesQuery(slackEntry, "")).toBe(true);
-    expect(marketplaceEntryMatchesQuery(slackEntry, "   ")).toBe(true);
+    expect(marketplaceEntryMatchesQuery(tavilyEntry, "")).toBe(true);
+    expect(marketplaceEntryMatchesQuery(tavilyEntry, "   ")).toBe(true);
   });
 
   it("returns false for non-matches", () => {
-    expect(marketplaceEntryMatchesQuery(slackEntry, "zzzz-no-match")).toBe(
+    expect(marketplaceEntryMatchesQuery(tavilyEntry, "zzzz-no-match")).toBe(
       false,
     );
   });
 });
 
 describe("installedServerMatchesQuery", () => {
-  const slackServer = {
+  const tavilyServer = {
     id: "stdio-0",
     type: "stdio" as const,
-    name: "slack",
+    name: "tavily",
     command: "npx",
-    args: ["-y", "@zencoderai/slack-mcp-server"],
+    args: ["-y", "tavily-mcp"],
   };
 
   it("matches by stdio server name", () => {
-    expect(installedServerMatchesQuery(slackServer, undefined, "slack")).toBe(
+    expect(installedServerMatchesQuery(tavilyServer, undefined, "tavily")).toBe(
       true,
     );
   });
 
   it("matches via the catalog entry's name even if server.name differs", () => {
-    const renamed = { ...slackServer, name: "my-slack-instance" };
-    expect(installedServerMatchesQuery(renamed, slackEntry, "slack")).toBe(
+    const renamed = { ...tavilyServer, name: "my-tavily-instance" };
+    expect(installedServerMatchesQuery(renamed, tavilyEntry, "tavily")).toBe(
       true,
     );
   });
@@ -142,31 +156,31 @@ describe("installedServerMatchesQuery", () => {
     const sseServer = {
       id: "sse-0",
       type: "sse" as const,
-      url: "https://mcp.linear.app/sse",
+      url: "https://mcp.atlassian.com/v1/sse",
     };
-    expect(installedServerMatchesQuery(sseServer, undefined, "linear")).toBe(
+    expect(installedServerMatchesQuery(sseServer, undefined, "atlassian")).toBe(
       true,
     );
   });
 
   it("empty query always matches", () => {
-    expect(installedServerMatchesQuery(slackServer, undefined, "")).toBe(true);
+    expect(installedServerMatchesQuery(tavilyServer, undefined, "")).toBe(true);
   });
 });
 
 describe("findCatalogEntryForServer", () => {
-  it("finds the Slack catalog entry for an installed Slack stdio server", () => {
+  it("finds the Tavily catalog entry for an installed Tavily stdio server", () => {
     const match = findCatalogEntryForServer(
       {
         id: "stdio-0",
         type: "stdio",
-        name: "slack",
+        name: "tavily",
         command: "npx",
         args: [],
       },
-      MCP_MARKETPLACE,
+      INTEGRATION_MARKETPLACE,
     );
-    expect(match?.id).toBe("slack");
+    expect(match?.id).toBe("tavily");
   });
 
   it("returns undefined for unknown servers", () => {
@@ -179,7 +193,7 @@ describe("findCatalogEntryForServer", () => {
           command: "npx",
           args: [],
         },
-        MCP_MARKETPLACE,
+        INTEGRATION_MARKETPLACE,
       ),
     ).toBeUndefined();
   });
@@ -189,15 +203,15 @@ describe("findCatalogEntryForServer", () => {
     // diverged from findInstalledMatch and caused installed cards to
     // render the generic icon while the marketplace tile said
     // "Installed".
-    const linear = MCP_MARKETPLACE.find((e) => e.id === "linear")!;
-    if (linear.template.kind !== "sse") {
-      throw new Error("Linear template should be SSE");
+    // Atlassian has SSE as its default MCP transport
+    if (atlassianTemplate?.kind !== "sse") {
+      throw new Error("Atlassian template should be SSE");
     }
-    const normalizedUrl = linear.template.url.replace(/\/$/, "");
+    const normalizedUrl = atlassianTemplate.url.replace(/\/$/, "");
     const match = findCatalogEntryForServer(
       { id: "sse-0", type: "sse", url: `${normalizedUrl}/` },
-      MCP_MARKETPLACE,
+      INTEGRATION_MARKETPLACE,
     );
-    expect(match?.id).toBe("linear");
+    expect(match?.id).toBe("atlassian");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#b8c1869ec9dea4467bb27d5754dc695d14e27889",
+        "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#58ed52964e8c6857450751b8a199ad5ff74fe910",
         "@openhands/typescript-client": "1.24.0",
         "@react-router/node": "7.14.2",
         "@react-router/serve": "7.14.2",
@@ -3441,8 +3441,8 @@
     },
     "node_modules/@openhands/extensions": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/OpenHands/extensions.git#b8c1869ec9dea4467bb27d5754dc695d14e27889",
-      "integrity": "sha512-ZcV/2Kc9uWtgTKbCMpCOUfHo91EZR5CwN302gI8sQFdGYEDxKD7yqdF9oYwOuksjea/tdLxG/EC0PETM+3x3Ag==",
+      "resolved": "git+ssh://git@github.com/OpenHands/extensions.git#58ed52964e8c6857450751b8a199ad5ff74fe910",
+      "integrity": "sha512-PC0pmJD1AiNP9aDfdDfDPP1iF40m/QN3vyv/xPN9sigLBtCmNBugSIySWEGVIGydARYkVi+NHL2KorPtlAOFAg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#58ed52964e8c6857450751b8a199ad5ff74fe910",
+        "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#39711065f53166c52608462f60a4c8507253ce56",
         "@openhands/typescript-client": "1.24.0",
         "@react-router/node": "7.14.2",
         "@react-router/serve": "7.14.2",
@@ -3441,7 +3441,7 @@
     },
     "node_modules/@openhands/extensions": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/OpenHands/extensions.git#58ed52964e8c6857450751b8a199ad5ff74fe910",
+      "resolved": "git+ssh://git@github.com/OpenHands/extensions.git#39711065f53166c52608462f60a4c8507253ce56",
       "integrity": "sha512-PC0pmJD1AiNP9aDfdDfDPP1iF40m/QN3vyv/xPN9sigLBtCmNBugSIySWEGVIGydARYkVi+NHL2KorPtlAOFAg==",
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#58ed52964e8c6857450751b8a199ad5ff74fe910",
+    "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#39711065f53166c52608462f60a4c8507253ce56",
     "@openhands/typescript-client": "1.24.0",
     "@react-router/node": "7.14.2",
     "@react-router/serve": "7.14.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#b8c1869ec9dea4467bb27d5754dc695d14e27889",
+    "@openhands/extensions": "git+https://github.com/OpenHands/extensions.git#58ed52964e8c6857450751b8a199ad5ff74fe910",
     "@openhands/typescript-client": "1.24.0",
     "@react-router/node": "7.14.2",
     "@react-router/serve": "7.14.2",

--- a/src/components/features/automations/recommended-automations-launcher.tsx
+++ b/src/components/features/automations/recommended-automations-launcher.tsx
@@ -13,11 +13,12 @@ import type { RecommendedAutomation } from "@openhands/extensions/automations";
 import { parseMcpConfig } from "#/utils/mcp-config";
 import { flattenMcpConfig } from "#/utils/mcp-installed-servers";
 import {
-  MCP_CATALOG as MCP_MARKETPLACE,
-  type McpCatalogEntry as MarketplaceEntry,
-} from "@openhands/extensions/mcps";
+  INTEGRATION_CATALOG as INTEGRATION_MARKETPLACE,
+  type IntegrationCatalogEntry as MarketplaceEntry,
+} from "@openhands/extensions/integrations";
 import {
   findInstalledMatch,
+  getDefaultTemplate,
   getMarketplaceEntryById,
 } from "#/utils/mcp-marketplace-utils";
 import { InstallServerModal } from "#/components/features/mcp-page/install-server-modal";
@@ -29,8 +30,8 @@ interface RecommendedAutomationsLauncherProps {
 }
 
 function getRequiredEntries(automation: RecommendedAutomation) {
-  return automation.requiredMcpIds
-    .map((id) => getMarketplaceEntryById(id, MCP_MARKETPLACE))
+  return automation.requiredIntegrationIds
+    .map((id) => getMarketplaceEntryById(id, INTEGRATION_MARKETPLACE))
     .filter((entry): entry is MarketplaceEntry => !!entry);
 }
 
@@ -153,9 +154,10 @@ export function RecommendedAutomationsLauncher({
 
   const getMissingEntries = useCallback(
     (automation: RecommendedAutomation) =>
-      getRequiredEntries(automation).filter(
-        (entry) => !findInstalledMatch(entry.template, installedMcpServers),
-      ),
+      getRequiredEntries(automation).filter((entry) => {
+        const template = getDefaultTemplate(entry);
+        return !template || !findInstalledMatch(template, installedMcpServers);
+      }),
     [installedMcpServers],
   );
 

--- a/src/components/features/automations/recommended-automations-launcher.tsx
+++ b/src/components/features/automations/recommended-automations-launcher.tsx
@@ -18,7 +18,7 @@ import {
 } from "@openhands/extensions/integrations";
 import {
   findInstalledMatch,
-  getDefaultTemplate,
+  getInstallableTemplate,
   getMarketplaceEntryById,
 } from "#/utils/mcp-marketplace-utils";
 import { InstallServerModal } from "#/components/features/mcp-page/install-server-modal";
@@ -155,7 +155,7 @@ export function RecommendedAutomationsLauncher({
   const getMissingEntries = useCallback(
     (automation: RecommendedAutomation) =>
       getRequiredEntries(automation).filter((entry) => {
-        const template = getDefaultTemplate(entry);
+        const template = getInstallableTemplate(entry);
         return !template || !findInstalledMatch(template, installedMcpServers);
       }),
     [installedMcpServers],

--- a/src/components/features/automations/recommended-automations-section.tsx
+++ b/src/components/features/automations/recommended-automations-section.tsx
@@ -184,7 +184,9 @@ export function RecommendedAutomationsSection({
             const requiredEntries = getRequiredEntries(automation);
             const missingCount = requiredEntries.filter((entry) => {
               const template = getDefaultTemplate(entry);
-              return !template || !findInstalledMatch(template, installedServers);
+              return (
+                !template || !findInstalledMatch(template, installedServers)
+              );
             }).length;
 
             return (

--- a/src/components/features/automations/recommended-automations-section.tsx
+++ b/src/components/features/automations/recommended-automations-section.tsx
@@ -19,7 +19,7 @@ import { CirclePlusBadge } from "#/components/shared/buttons/circle-plus-check-t
 import { MCPServerConfig } from "#/types/mcp-server";
 import {
   findInstalledMatch,
-  getDefaultTemplate,
+  getInstallableTemplate,
   getMarketplaceEntryById,
   isMarketplaceEntryAvailable,
 } from "#/utils/mcp-marketplace-utils";
@@ -99,7 +99,7 @@ function buildRecommendedAutomationPills(
   translate: TFunction,
 ): SkillCardPill[] {
   const pills: SkillCardPill[] = requiredEntries.map((entry) => {
-    const template = getDefaultTemplate(entry);
+    const template = getInstallableTemplate(entry);
     const installed = template
       ? !!findInstalledMatch(template, installedServers)
       : false;
@@ -183,7 +183,7 @@ export function RecommendedAutomationsSection({
           {visibleAutomations.map((automation) => {
             const requiredEntries = getRequiredEntries(automation);
             const missingCount = requiredEntries.filter((entry) => {
-              const template = getDefaultTemplate(entry);
+              const template = getInstallableTemplate(entry);
               return (
                 !template || !findInstalledMatch(template, installedServers)
               );

--- a/src/components/features/automations/recommended-automations-section.tsx
+++ b/src/components/features/automations/recommended-automations-section.tsx
@@ -6,9 +6,9 @@ import {
   type RecommendedAutomation,
 } from "@openhands/extensions/automations";
 import {
-  MCP_CATALOG as MCP_MARKETPLACE,
-  type McpCatalogEntry as MarketplaceEntry,
-} from "@openhands/extensions/mcps";
+  INTEGRATION_CATALOG as INTEGRATION_MARKETPLACE,
+  type IntegrationCatalogEntry as MarketplaceEntry,
+} from "@openhands/extensions/integrations";
 import { McpLogoStackBadge } from "#/components/features/mcp-page/mcp-logo-stack-badge";
 import { McpLogoBadge } from "#/components/features/mcp-logo-badge";
 import {
@@ -19,6 +19,7 @@ import { CirclePlusBadge } from "#/components/shared/buttons/circle-plus-check-t
 import { MCPServerConfig } from "#/types/mcp-server";
 import {
   findInstalledMatch,
+  getDefaultTemplate,
   getMarketplaceEntryById,
   isMarketplaceEntryAvailable,
 } from "#/utils/mcp-marketplace-utils";
@@ -56,8 +57,8 @@ export function getAutomationsByPopularity(
 const RECOMMENDED_AUTOMATIONS = getAutomationsByPopularity(AUTOMATION_CATALOG);
 
 function getRequiredEntries(automation: RecommendedAutomation) {
-  return automation.requiredMcpIds
-    .map((id) => getMarketplaceEntryById(id, MCP_MARKETPLACE))
+  return automation.requiredIntegrationIds
+    .map((id) => getMarketplaceEntryById(id, INTEGRATION_MARKETPLACE))
     .filter((entry): entry is MarketplaceEntry => !!entry);
 }
 
@@ -98,7 +99,10 @@ function buildRecommendedAutomationPills(
   translate: TFunction,
 ): SkillCardPill[] {
   const pills: SkillCardPill[] = requiredEntries.map((entry) => {
-    const installed = !!findInstalledMatch(entry.template, installedServers);
+    const template = getDefaultTemplate(entry);
+    const installed = template
+      ? !!findInstalledMatch(template, installedServers)
+      : false;
 
     return {
       id: `mcp-${entry.id}`,
@@ -178,9 +182,10 @@ export function RecommendedAutomationsSection({
         <div className={extensionModuleCardGridClassName}>
           {visibleAutomations.map((automation) => {
             const requiredEntries = getRequiredEntries(automation);
-            const missingCount = requiredEntries.filter(
-              (entry) => !findInstalledMatch(entry.template, installedServers),
-            ).length;
+            const missingCount = requiredEntries.filter((entry) => {
+              const template = getDefaultTemplate(entry);
+              return !template || !findInstalledMatch(template, installedServers);
+            }).length;
 
             return (
               <button

--- a/src/components/features/mcp-logo-badge.tsx
+++ b/src/components/features/mcp-logo-badge.tsx
@@ -1,10 +1,13 @@
 import type { ReactNode } from "react";
-import type { McpCatalogEntry } from "@openhands/extensions/mcps";
-import { MCP_FALLBACK_LOGO, MCP_LOGOS } from "@openhands/extensions/mcps/logos";
+import type { IntegrationCatalogEntry } from "@openhands/extensions/integrations";
+import {
+  INTEGRATION_FALLBACK_LOGO,
+  INTEGRATION_LOGOS,
+} from "@openhands/extensions/integrations/logos";
 import { cn } from "#/utils/utils";
 
 type McpLogoEntry = Pick<
-  McpCatalogEntry,
+  IntegrationCatalogEntry,
   "id" | "name" | "iconBg" | "iconColor"
 >;
 
@@ -48,8 +51,8 @@ export function McpLogoBadge({
       }}
     >
       {entry
-        ? (MCP_LOGOS[entry.id] ?? fallback ?? MCP_FALLBACK_LOGO)
-        : (fallback ?? MCP_FALLBACK_LOGO)}
+        ? (INTEGRATION_LOGOS[entry.id] ?? fallback ?? INTEGRATION_FALLBACK_LOGO)
+        : (fallback ?? INTEGRATION_FALLBACK_LOGO)}
     </span>
   );
 }

--- a/src/components/features/mcp-page/custom-server-editor.tsx
+++ b/src/components/features/mcp-page/custom-server-editor.tsx
@@ -75,7 +75,6 @@ export function CustomServerEditor({
       };
     }
     return { ok: false, text: makeTestErrorMessage(testResult) };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [testResult, t]);
 
   // Shared error handler so both add and update surface backend errors

--- a/src/components/features/mcp-page/install-server-modal.tsx
+++ b/src/components/features/mcp-page/install-server-modal.tsx
@@ -7,13 +7,14 @@ import { ModalCloseButton } from "#/components/shared/modals/modal-close-button"
 import { BrandButton } from "#/components/features/settings/brand-button";
 import { SettingsInput } from "#/components/features/settings/settings-input";
 import { I18nKey } from "#/i18n/declaration";
-import type { McpCatalogEntry as MarketplaceEntry } from "@openhands/extensions/mcps";
+import type { IntegrationCatalogEntry as MarketplaceEntry } from "@openhands/extensions/integrations";
 import { McpLogoBadge } from "#/components/features/mcp-logo-badge";
 import { MCPServerConfig } from "#/types/mcp-server";
 import { useAddMcpServer } from "#/hooks/mutation/use-add-mcp-server";
 import { useTestMcpServer } from "#/hooks/mutation/use-test-mcp-server";
 import { displaySuccessToast } from "#/utils/custom-toast-handlers";
 import { retrieveAxiosErrorMessage } from "#/utils/retrieve-axios-error-message";
+import { getDefaultTemplate } from "#/utils/mcp-marketplace-utils";
 
 interface InstallServerModalProps {
   entry: MarketplaceEntry;
@@ -28,14 +29,16 @@ interface FieldState {
 
 function makeInitialState(entry: MarketplaceEntry): FieldState {
   const values: Record<string, string> = {};
-  if (entry.template.kind === "stdio") {
-    for (const field of entry.template.envFields ?? []) {
+  const template = getDefaultTemplate(entry);
+  if (!template) return { values, errors: {} };
+  if (template.kind === "stdio") {
+    for (const field of template.envFields ?? []) {
       values[field.key] = "";
     }
-    for (const field of entry.template.argFields ?? []) {
+    for (const field of template.argFields ?? []) {
       values[field.key] = "";
     }
-  } else if (entry.template.kind === "shttp" || entry.template.kind === "sse") {
+  } else if (template.kind === "shttp" || template.kind === "sse") {
     values.api_key = "";
   }
   return { values, errors: {} };
@@ -109,6 +112,8 @@ export function InstallServerModal({
     });
   };
 
+  const template = getDefaultTemplate(entry);
+
   // ------------------------------------------------------------------
   // Per-template submit handlers. Each is small and self-contained:
   // validate user input, build the payload, then hand off to
@@ -117,11 +122,11 @@ export function InstallServerModal({
   const handleHttpServerSubmit = () => {
     // TS narrows this branch to shttp|sse; the equality guard is a
     // runtime/defensive belt to make the helper safe in isolation.
-    if (entry.template.kind !== "shttp" && entry.template.kind !== "sse") {
+    if (!template || (template.kind !== "shttp" && template.kind !== "sse")) {
       return;
     }
     const apiKey = state.values.api_key?.trim() ?? "";
-    if (!entry.template.apiKeyOptional && !apiKey) {
+    if (!template.apiKeyOptional && !apiKey) {
       setState((prev) => ({
         ...prev,
         errors: { api_key: t(I18nKey.MCP$ERROR_FIELD_REQUIRED) },
@@ -129,17 +134,17 @@ export function InstallServerModal({
       return;
     }
     const payload: MCPServerConfig = {
-      id: `${entry.template.kind}-${Date.now()}`,
-      type: entry.template.kind,
-      url: entry.template.url,
+      id: `${template.kind}-${Date.now()}`,
+      type: template.kind,
+      url: template.url,
       ...(apiKey && { api_key: apiKey }),
     };
     submitServer(payload);
   };
 
   const handleStdioSubmit = () => {
-    if (entry.template.kind !== "stdio") return;
-    const stdio = entry.template;
+    if (!template || template.kind !== "stdio") return;
+    const stdio = template;
     const errors: Record<string, string | null> = {};
 
     for (const field of stdio.envFields ?? []) {
@@ -187,15 +192,16 @@ export function InstallServerModal({
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setGlobalError(null);
-    if (entry.template.kind === "shttp" || entry.template.kind === "sse") {
+    if (template?.kind === "shttp" || template?.kind === "sse") {
       return handleHttpServerSubmit();
     }
     return handleStdioSubmit();
   };
 
   const renderFields = () => {
-    if (entry.template.kind === "shttp" || entry.template.kind === "sse") {
-      const apiKeyOptional = entry.template.apiKeyOptional ?? false;
+    if (!template) return null;
+    if (template.kind === "shttp" || template.kind === "sse") {
+      const apiKeyOptional = template.apiKeyOptional ?? false;
       return (
         <>
           <SettingsInput
@@ -203,7 +209,7 @@ export function InstallServerModal({
             name="url"
             type="url"
             label={t(I18nKey.SETTINGS$MCP_URL)}
-            value={entry.template.url}
+            value={template.url}
             onChange={() => {}}
             isDisabled
             className="w-full"
@@ -229,7 +235,7 @@ export function InstallServerModal({
       );
     }
 
-    const stdio = entry.template;
+    const stdio = template;
     return (
       <>
         <SettingsInput

--- a/src/components/features/mcp-page/install-server-modal.tsx
+++ b/src/components/features/mcp-page/install-server-modal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useId } from "react";
 import { useTranslation } from "react-i18next";
 import { AxiosError } from "axios";
 import type { MCPTestFailure } from "@openhands/typescript-client";
@@ -58,6 +58,7 @@ export function InstallServerModal({
   const { t } = useTranslation("openhands");
   const { mutate: addMcpServer, isPending: isAdding } = useAddMcpServer();
   const { mutate: testMcpServer, isPending: isTesting } = useTestMcpServer();
+  const instanceId = useId();
 
   const [state, setState] = React.useState<FieldState>(() =>
     makeInitialState(entry),
@@ -134,7 +135,7 @@ export function InstallServerModal({
       return;
     }
     const payload: MCPServerConfig = {
-      id: `${template.kind}-${Date.now()}`,
+      id: `${template.kind}-${instanceId}`,
       type: template.kind,
       url: template.url,
       ...(apiKey && { api_key: apiKey }),
@@ -143,7 +144,7 @@ export function InstallServerModal({
   };
 
   const handleStdioSubmit = () => {
-    if (!template || template.kind !== "stdio") return;
+    if (template?.kind !== "stdio") return;
     const stdio = template;
     const errors: Record<string, string | null> = {};
 
@@ -179,7 +180,7 @@ export function InstallServerModal({
     }
 
     const payload: MCPServerConfig = {
-      id: `stdio-${Date.now()}`,
+      id: `stdio-${instanceId}`,
       type: "stdio",
       name: stdio.serverName,
       command: stdio.command,

--- a/src/components/features/mcp-page/install-server-modal.tsx
+++ b/src/components/features/mcp-page/install-server-modal.tsx
@@ -14,7 +14,7 @@ import { useAddMcpServer } from "#/hooks/mutation/use-add-mcp-server";
 import { useTestMcpServer } from "#/hooks/mutation/use-test-mcp-server";
 import { displaySuccessToast } from "#/utils/custom-toast-handlers";
 import { retrieveAxiosErrorMessage } from "#/utils/retrieve-axios-error-message";
-import { getDefaultTemplate } from "#/utils/mcp-marketplace-utils";
+import { getInstallableTemplate } from "#/utils/mcp-marketplace-utils";
 
 interface InstallServerModalProps {
   entry: MarketplaceEntry;
@@ -29,7 +29,7 @@ interface FieldState {
 
 function makeInitialState(entry: MarketplaceEntry): FieldState {
   const values: Record<string, string> = {};
-  const template = getDefaultTemplate(entry);
+  const template = getInstallableTemplate(entry);
   if (!template) return { values, errors: {} };
   if (template.kind === "stdio") {
     for (const field of template.envFields ?? []) {
@@ -113,7 +113,7 @@ export function InstallServerModal({
     });
   };
 
-  const template = getDefaultTemplate(entry);
+  const template = getInstallableTemplate(entry);
 
   // ------------------------------------------------------------------
   // Per-template submit handlers. Each is small and self-contained:

--- a/src/components/features/mcp-page/installed-server-card.tsx
+++ b/src/components/features/mcp-page/installed-server-card.tsx
@@ -5,7 +5,7 @@ import { I18nKey } from "#/i18n/declaration";
 import { McpLogoBadge } from "#/components/features/mcp-logo-badge";
 import { CirclePlusCheckToggle } from "#/components/shared/buttons/circle-plus-check-toggle";
 import { MCPServerConfig } from "#/types/mcp-server";
-import { MCP_CATALOG as MCP_MARKETPLACE } from "@openhands/extensions/mcps";
+import { INTEGRATION_CATALOG as INTEGRATION_MARKETPLACE } from "@openhands/extensions/integrations";
 import { findCatalogEntryForServer } from "#/utils/mcp-marketplace-utils";
 import { cn } from "#/utils/utils";
 import {
@@ -52,7 +52,7 @@ export function InstalledServerCard({
   onDelete,
 }: InstalledServerCardProps) {
   const { t } = useTranslation("openhands");
-  const catalog = findCatalogEntryForServer(server, MCP_MARKETPLACE);
+  const catalog = findCatalogEntryForServer(server, INTEGRATION_MARKETPLACE);
 
   const title = catalog?.name ?? getServerTitle(server);
   const detailLine = getServerDetailLine(server);

--- a/src/components/features/mcp-page/marketplace-card.tsx
+++ b/src/components/features/mcp-page/marketplace-card.tsx
@@ -1,6 +1,7 @@
 import { I18nKey } from "#/i18n/declaration";
-import type { McpCatalogEntry as MarketplaceEntry } from "@openhands/extensions/mcps";
+import type { IntegrationCatalogEntry as MarketplaceEntry } from "@openhands/extensions/integrations";
 import { McpLogoBadge } from "#/components/features/mcp-logo-badge";
+import { getDefaultTemplate } from "#/utils/mcp-marketplace-utils";
 import { CirclePlusCheckToggle } from "#/components/shared/buttons/circle-plus-check-toggle";
 import { cn } from "#/utils/utils";
 import {
@@ -19,8 +20,10 @@ export function MarketplaceCard({
   onClick,
   onAdd,
 }: MarketplaceCardProps) {
+  const template = getDefaultTemplate(entry);
   const transportLabel = (() => {
-    switch (entry.template.kind) {
+    if (!template) return "";
+    switch (template.kind) {
       case "stdio":
         return "STDIO";
       case "shttp":

--- a/src/components/features/mcp-page/marketplace-section.tsx
+++ b/src/components/features/mcp-page/marketplace-section.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import {
-  MCP_CATALOG as MCP_MARKETPLACE,
-  type McpCatalogEntry as MarketplaceEntry,
-} from "@openhands/extensions/mcps";
+  INTEGRATION_CATALOG as INTEGRATION_MARKETPLACE,
+  type IntegrationCatalogEntry as MarketplaceEntry,
+} from "@openhands/extensions/integrations";
 import {
   getMarketplaceEntriesByPopularity,
   isMarketplaceEntryAvailable,
@@ -32,7 +32,7 @@ export function MarketplaceSection({
   const { t } = useTranslation("openhands");
 
   const visibleEntries = getMarketplaceEntriesByPopularity(
-    MCP_MARKETPLACE,
+    INTEGRATION_MARKETPLACE,
   ).filter(
     (entry) =>
       isMarketplaceEntryAvailable(entry, backendKind) &&

--- a/src/components/features/mcp-page/mcp-logo-stack-badge.tsx
+++ b/src/components/features/mcp-page/mcp-logo-stack-badge.tsx
@@ -1,4 +1,4 @@
-import type { McpCatalogEntry } from "@openhands/extensions/mcps";
+import type { IntegrationCatalogEntry } from "@openhands/extensions/integrations";
 import {
   McpLogoBadge,
   type McpLogoEntry,
@@ -9,7 +9,9 @@ const STACK_CONTAINER_CLASS_NAME =
   "inline-flex h-10 w-10 shrink-0 overflow-hidden rounded-lg border border-white/10 bg-surface-raised shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]";
 
 interface McpLogoStackBadgeProps {
-  entries: Array<Pick<McpCatalogEntry, "id" | "name" | "iconBg" | "iconColor">>;
+  entries: Array<
+    Pick<IntegrationCatalogEntry, "id" | "name" | "iconBg" | "iconColor">
+  >;
   className?: string;
   testId?: string;
 }

--- a/src/routes/mcp.tsx
+++ b/src/routes/mcp.tsx
@@ -21,9 +21,9 @@ import {
   installedServerMatchesQuery,
 } from "#/utils/mcp-marketplace-utils";
 import {
-  MCP_CATALOG as MCP_MARKETPLACE,
-  type McpCatalogEntry as MarketplaceEntry,
-} from "@openhands/extensions/mcps";
+  INTEGRATION_CATALOG as INTEGRATION_MARKETPLACE,
+  type IntegrationCatalogEntry as MarketplaceEntry,
+} from "@openhands/extensions/integrations";
 import { MCPServerConfig } from "#/types/mcp-server";
 import { flattenMcpConfig } from "#/utils/mcp-installed-servers";
 import {
@@ -74,7 +74,7 @@ export default function MCPPage() {
   const filteredInstalledServers = allServers.filter((server) =>
     installedServerMatchesQuery(
       server,
-      findCatalogEntryForServer(server, MCP_MARKETPLACE),
+      findCatalogEntryForServer(server, INTEGRATION_MARKETPLACE),
       searchQuery,
     ),
   );

--- a/src/utils/mcp-marketplace-utils.ts
+++ b/src/utils/mcp-marketplace-utils.ts
@@ -1,8 +1,8 @@
 import { MCPServerConfig } from "#/types/mcp-server";
 import type {
-  McpCatalogEntry as MarketplaceEntry,
-  MarketplaceTemplate,
-} from "@openhands/extensions/mcps";
+  IntegrationCatalogEntry as MarketplaceEntry,
+  IntegrationTransport as MarketplaceTemplate,
+} from "@openhands/extensions/integrations";
 
 const tryUrl = (raw: string): URL | null => {
   try {
@@ -37,6 +37,21 @@ export function urlsMatch(a: unknown, b: unknown): boolean {
     left.host === right.host &&
     left.pathname.replace(/\/+$/, "") === right.pathname.replace(/\/+$/, "")
   );
+}
+
+/**
+ * Get the default transport template from an integration catalog entry.
+ * Integrations may have multiple connection options; we use the default
+ * one (or the first if no default is specified). Only MCP-backed options
+ * have a `transport` field.
+ */
+export function getDefaultTemplate(
+  entry: MarketplaceEntry,
+): MarketplaceTemplate | undefined {
+  const option =
+    entry.connectionOptions.find((o) => o.id === entry.defaultConnectionOptionId) ??
+    entry.connectionOptions[0];
+  return option?.transport;
 }
 
 /**
@@ -79,8 +94,9 @@ export function isMarketplaceEntryAvailable(
   entry: MarketplaceEntry,
   backendKind: "local" | "cloud",
 ): boolean {
-  if (!entry.availability || entry.availability === "all") return true;
-  return entry.availability === backendKind;
+  if (!entry.runtimeAvailability || entry.runtimeAvailability === "all")
+    return true;
+  return entry.runtimeAvailability === backendKind;
 }
 
 function normalize(query: string): string {
@@ -170,7 +186,8 @@ export function findCatalogEntryForServer(
   catalog: MarketplaceEntry[],
 ): MarketplaceEntry | undefined {
   return catalog.find((entry) => {
-    const tpl = entry.template;
+    const tpl = getDefaultTemplate(entry);
+    if (!tpl) return false;
     if (tpl.kind === "stdio")
       return server.type === "stdio" && server.name === tpl.serverName;
     // Reuse the same loose URL match as `findInstalledMatch` so a

--- a/src/utils/mcp-marketplace-utils.ts
+++ b/src/utils/mcp-marketplace-utils.ts
@@ -49,8 +49,9 @@ export function getDefaultTemplate(
   entry: MarketplaceEntry,
 ): MarketplaceTemplate | undefined {
   const option =
-    entry.connectionOptions.find((o) => o.id === entry.defaultConnectionOptionId) ??
-    entry.connectionOptions[0];
+    entry.connectionOptions.find(
+      (o) => o.id === entry.defaultConnectionOptionId,
+    ) ?? entry.connectionOptions[0];
   return option?.transport;
 }
 

--- a/src/utils/mcp-marketplace-utils.ts
+++ b/src/utils/mcp-marketplace-utils.ts
@@ -56,6 +56,28 @@ export function getDefaultTemplate(
 }
 
 /**
+ * Get the stdio (API key-based) transport template from an integration entry.
+ * Many integrations have multiple connection options (e.g., OAuth + stdio).
+ * Since OAuth isn't implemented in the UI yet, the install modal should use
+ * this function to get the stdio-based option that can be configured with
+ * API keys/tokens.
+ *
+ * Falls back to getDefaultTemplate if no stdio option exists.
+ */
+export function getInstallableTemplate(
+  entry: MarketplaceEntry,
+): MarketplaceTemplate | undefined {
+  // First, try to find a stdio option (API key-based, what we can actually install)
+  const stdioOption = entry.connectionOptions.find(
+    (o) => o.transport?.kind === "stdio",
+  );
+  if (stdioOption?.transport) return stdioOption.transport;
+
+  // Fall back to the default template (could be shttp/sse with api_key)
+  return getDefaultTemplate(entry);
+}
+
+/**
  * Decide whether a marketplace template is already represented by one
  * of the installed MCP servers. Used to render an "Installed" badge on
  * the marketplace tile. Returns the first matching server, or null.
@@ -181,26 +203,38 @@ export function installedServerMatchesQuery(
  * Look up the catalog entry that best matches an installed server.
  * Mirrors the lookup used in `installed-server-card.tsx` for
  * rendering the friendly icon.
+ *
+ * Since an entry may have multiple connection options (e.g., OAuth + stdio),
+ * we check ALL templates in the entry's connectionOptions, not just the default.
  */
 export function findCatalogEntryForServer(
   server: MCPServerConfig,
   catalog: MarketplaceEntry[],
 ): MarketplaceEntry | undefined {
   return catalog.find((entry) => {
-    const tpl = getDefaultTemplate(entry);
-    if (!tpl) return false;
-    if (tpl.kind === "stdio")
-      return server.type === "stdio" && server.name === tpl.serverName;
-    // Reuse the same loose URL match as `findInstalledMatch` so a
-    // server whose URL was normalized by the backend (trailing slash
-    // stripped, query string dropped, etc.) still gets paired with
-    // its catalog tile — otherwise the installed-servers list would
-    // render the generic icon while the marketplace shows the
-    // entry as installed, which is confusing.
-    if (tpl.kind === "shttp")
-      return server.type === "shttp" && urlsMatch(server.url, tpl.url);
-    if (tpl.kind === "sse")
-      return server.type === "sse" && urlsMatch(server.url, tpl.url);
+    // Check all connection options, not just the default
+    for (const option of entry.connectionOptions) {
+      const tpl = option.transport;
+      if (!tpl) continue;
+      if (tpl.kind === "stdio") {
+        if (server.type === "stdio" && server.name === tpl.serverName)
+          return true;
+      }
+      // Reuse the same loose URL match as `findInstalledMatch` so a
+      // server whose URL was normalized by the backend (trailing slash
+      // stripped, query string dropped, etc.) still gets paired with
+      // its catalog tile — otherwise the installed-servers list would
+      // render the generic icon while the marketplace shows the
+      // entry as installed, which is confusing.
+      if (tpl.kind === "shttp") {
+        if (server.type === "shttp" && urlsMatch(server.url, tpl.url))
+          return true;
+      }
+      if (tpl.kind === "sse") {
+        if (server.type === "sse" && urlsMatch(server.url, tpl.url))
+          return true;
+      }
+    }
     return false;
   });
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The upstream `@openhands/extensions` repository renamed the MCP catalog to integrations (between commits `b8c1869` and `58ed5296`). This PR updates the dependency and handles all the necessary renames to maintain compatibility.

## Summary

- Updated `@openhands/extensions` dependency to commit `58ed52964e8c6857450751b8a199ad5ff74fe910`
- Renamed all imports from `@openhands/extensions/mcps` to `@openhands/extensions/integrations`
- Added `getDefaultTemplate()` helper to handle new `connectionOptions[].transport` structure
- Updated tests to work with new catalog entries that have multiple connection options

## Issue Number

N/A - Upstream dependency update

## How to Test

```bash
npm install
npm run typecheck
npm test -- --run __tests__/components/features/mcp-page/ __tests__/constants/extensions-catalogs.test.ts __tests__/utils/mcp-marketplace-utils.test.ts
npm run build
```

## Video/Screenshots

N/A - This is a dependency update with no visual changes.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Key API changes from the upstream rename:
- `MCP_CATALOG` → `INTEGRATION_CATALOG`
- `McpCatalogEntry` → `IntegrationCatalogEntry`
- `MarketplaceTemplate` → `IntegrationTransport`
- `MCP_LOGOS`/`MCP_FALLBACK_LOGO` → `INTEGRATION_LOGOS`/`INTEGRATION_FALLBACK_LOGO`
- `entry.template` → `entry.connectionOptions[].transport` (via `getDefaultTemplate` helper)
- `automation.requiredMcpIds` → `automation.requiredIntegrationIds`

The new integration catalog structure supports multiple connection options per entry (e.g., Slack now has both OAuth/shttp as default and stdio as a fallback). The `getDefaultTemplate()` helper extracts the transport config from the default connection option.

---
*This PR was created by an AI agent (OpenHands) on behalf of a user.*

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/03bb6e07-3117-43da-a5e8-a4b488223863)


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `0c510f8ad085e900aa5badea929bdb51358fee58` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-0c510f8
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-0c510f8
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-0c510f8-amd64
ghcr.io/openhands/agent-canvas:update-extensions-mcp-to-integrations-amd64
ghcr.io/openhands/agent-canvas:pr-875-amd64
ghcr.io/openhands/agent-canvas:sha-0c510f8-arm64
ghcr.io/openhands/agent-canvas:update-extensions-mcp-to-integrations-arm64
ghcr.io/openhands/agent-canvas:pr-875-arm64
ghcr.io/openhands/agent-canvas:sha-0c510f8
ghcr.io/openhands/agent-canvas:update-extensions-mcp-to-integrations
ghcr.io/openhands/agent-canvas:pr-875
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-0c510f8`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-0c510f8-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->