### PR TITLE
ci: cache Playwright browsers and pin Node 24.15 across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Set up Node.js with npm cache
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          # Pin to 24.15.x — Node 24.16.0 has a zip-extraction regression
+          # (nodejs/node#63487) that hangs `playwright install` for Playwright
+          # < 1.60.0. Remove this pin after upgrading to Playwright >= 1.60.0.
+          node-version: "24.15"
           cache: npm
 
       - name: Install dependencies
@@ -200,7 +203,10 @@ jobs:
         if: steps.pr_context.outputs.is_fork != 'true' && steps.latest_commit.outputs.pr_artifact_only != 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: 22.12.0
+          # Pin to 24.15.x — Node 24.16.0 has a zip-extraction regression
+          # (nodejs/node#63487) that hangs `playwright install` for Playwright
+          # < 1.60.0. Remove this pin after upgrading to Playwright >= 1.60.0.
+          node-version: "24.15"
           cache: npm
 
       - name: Create live E2E PR comment
@@ -230,9 +236,26 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Install Playwright Chromium
+      - name: Get Playwright version
         if: steps.live_credential.outputs.has_key == 'true' && steps.pr_context.outputs.is_fork != 'true' && steps.latest_commit.outputs.pr_artifact_only != 'true'
-        run: npx playwright install --with-deps chromium
+        id: pw_version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        if: steps.live_credential.outputs.has_key == 'true' && steps.pr_context.outputs.is_fork != 'true' && steps.latest_commit.outputs.pr_artifact_only != 'true'
+        id: pw_cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw_version.outputs.version }}
+
+      - name: Install Playwright Chromium
+        if: steps.live_credential.outputs.has_key == 'true' && steps.pr_context.outputs.is_fork != 'true' && steps.latest_commit.outputs.pr_artifact_only != 'true' && steps.pw_cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
+
+      - name: Install Playwright system deps
+        if: steps.live_credential.outputs.has_key == 'true' && steps.pr_context.outputs.is_fork != 'true' && steps.latest_commit.outputs.pr_artifact_only != 'true'
+        run: npx playwright install-deps chromium
 
       - name: Run live Agent Server E2E
         id: live_test

--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -51,14 +51,32 @@ jobs:
       - name: Set up Node.js with npm cache
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          # Pin to 24.15.x — Node 24.16.0 has a zip-extraction regression
+          # (nodejs/node#63487) that hangs `playwright install` for Playwright
+          # < 1.60.0. Remove this pin after upgrading to Playwright >= 1.60.0.
+          node-version: "24.15"
           cache: npm
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Get Playwright version
+        id: pw_version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw_cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw_version.outputs.version }}
+
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        if: steps.pw_cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
+
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium
 
       # ── MAIN BRANCH: generate fresh baselines and store as artifact ──────
 


### PR DESCRIPTION
## Summary

Applies the same Playwright caching and Node version pin from #833 to all other CI workflows that install Playwright browsers.

## Changes

### 1. Cache Playwright browsers (`actions/cache`)

Playwright browser downloads (~150 MB for Chromium) are cached via `actions/cache` keyed by `playwright-{OS}-{version}`. On cache hit, the `npx playwright install chromium` step is skipped entirely. System deps (`npx playwright install-deps chromium`) always run since OS packages can't be cached across runners.

**Workflows updated:**
- `ci.yml` — live E2E job
- `snapshot-tests.yml`

### 2. Pin Node to 24.15.x

Node 24.16.0 introduced a zip-extraction regression ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)) that causes `playwright install` to hang indefinitely for Playwright < 1.60.0. All jobs that could resolve `node-version: "24"` to 24.16.0 are now pinned to `"24.15"`.

**Workflows updated:**
- `ci.yml` — build job (`'24'` → `"24.15"`), live E2E job (`22.12.0` → `"24.15"`)
- `snapshot-tests.yml` (`"24"` → `"24.15"`)

### Pattern applied (same as #833)

```yaml
- name: Get Playwright version
  id: pw_version
  run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"

- name: Cache Playwright browsers
  id: pw_cache
  uses: actions/cache@v4
  with:
    path: ~/.cache/ms-playwright
    key: playwright-${{ runner.os }}-${{ steps.pw_version.outputs.version }}

- name: Install Playwright Chromium
  if: steps.pw_cache.outputs.cache-hit != 'true'
  run: npx playwright install chromium

- name: Install Playwright system deps
  run: npx playwright install-deps chromium
```

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/54487e14-03ef-46d3-804e-d028a865a8bd)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `c9f4ad4b7a532139ff0b6e9f260dbdc2363c4c3d` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-c9f4ad4
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-c9f4ad4
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-c9f4ad4-amd64
ghcr.io/openhands/agent-canvas:ci-cache-playwright-browsers-amd64
ghcr.io/openhands/agent-canvas:pr-893-amd64
ghcr.io/openhands/agent-canvas:sha-c9f4ad4-arm64
ghcr.io/openhands/agent-canvas:ci-cache-playwright-browsers-arm64
ghcr.io/openhands/agent-canvas:pr-893-arm64
ghcr.io/openhands/agent-canvas:sha-c9f4ad4
ghcr.io/openhands/agent-canvas:ci-cache-playwright-browsers
ghcr.io/openhands/agent-canvas:pr-893
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-c9f4ad4`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-c9f4ad4-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->