### PR TITLE
fix: make load_public_skills default to true (opt-out)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,7 +9,7 @@ VITE_BACKEND_BASE_URL="http://127.0.0.1:8000" # Base URL used by browser-side di
 # VITE_WORKING_DIR="/workspace/project/agent-canvas" # Base dir for per-conversation working_dirs. Each conversation's working_dir is <VITE_WORKING_DIR>/<id_hex>. Defaults to <OH_CANVAS_SAFE_STATE_DIR>/workspaces, which is the sibling of the agent server's <state_dir>/conversations/ persistence dir — both share the same <id_hex> per conversation.
 # VITE_WORKER_URLS="" # Optional comma-separated worker URLs for the Browser tab
 # VITE_ENABLE_BROWSER_TOOLS="true" # Set to false to omit BrowserToolSet from new conversations
-# VITE_LOAD_PUBLIC_SKILLS="true" # Set to true to enable loading public skills from https://github.com/OpenHands/extensions (off by default)
+# VITE_LOAD_PUBLIC_SKILLS="false" # Set to false to disable loading public skills from https://github.com/OpenHands/extensions (on by default)
 
 # Frontend dev server
 VITE_FRONTEND_PORT="3001" # Port to run the frontend application

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
   - `VITE_WORKING_DIR` for the default workspace path sent when starting conversations.
   - `VITE_WORKER_URLS` as a comma-separated list of browser worker URLs if you want the Browser tab to probe exposed app hosts.
   - `VITE_ENABLE_BROWSER_TOOLS=false` to omit `BrowserToolSet` from new conversation payloads.
-  - `VITE_LOAD_PUBLIC_SKILLS=false` to disable loading public skills from the OpenHands extensions marketplace (https://github.com/OpenHands/extensions). Defaults to true.
+  - `VITE_LOAD_PUBLIC_SKILLS=false` to disable loading public skills from the OpenHands extensions marketplace (https://github.com/OpenHands/extensions). Defaults to true (opt-out).
 - Default working-dir fallback is now the relative path `workspace/project` (exported as `DEFAULT_WORKING_DIR` from `src/api/agent-server-config.ts`); git-path heuristics and the default PLAN preview path should reuse that constant instead of hardcoding `/workspace/project`.
 - The UI keeps most OpenHands routes/layout intact, but hosted-only behavior (org, account management, integrations) has been removed via the fabricated OSS config because there is no separate app backend.
 - Verification command: `npm run typecheck && npm run build`.

--- a/__tests__/api/agent-server-config.test.ts
+++ b/__tests__/api/agent-server-config.test.ts
@@ -90,19 +90,19 @@ describe("agent server config", () => {
     expect(getAgentServerSessionApiKey()).toBe("saved-session-key");
   });
 
-  it("does not load public skills by default when VITE_LOAD_PUBLIC_SKILLS is unset", () => {
+  it("loads public skills by default when VITE_LOAD_PUBLIC_SKILLS is unset", () => {
     vi.stubEnv("VITE_LOAD_PUBLIC_SKILLS", "");
 
-    expect(shouldLoadPublicSkills()).toBe(false);
+    expect(shouldLoadPublicSkills()).toBe(true);
   });
 
-  it("loads public skills only when VITE_LOAD_PUBLIC_SKILLS is explicitly 'true'", () => {
+  it("loads public skills when VITE_LOAD_PUBLIC_SKILLS is explicitly 'true'", () => {
     vi.stubEnv("VITE_LOAD_PUBLIC_SKILLS", "true");
 
     expect(shouldLoadPublicSkills()).toBe(true);
   });
 
-  it("does not load public skills for any non-'true' value of VITE_LOAD_PUBLIC_SKILLS", () => {
+  it("does not load public skills only when VITE_LOAD_PUBLIC_SKILLS is explicitly 'false'", () => {
     vi.stubEnv("VITE_LOAD_PUBLIC_SKILLS", "false");
 
     expect(shouldLoadPublicSkills()).toBe(false);

--- a/src/api/agent-server-config.ts
+++ b/src/api/agent-server-config.ts
@@ -182,8 +182,8 @@ export function getAgentServerHeaders(): Record<string, string> {
  * Returns whether public skills from the OpenHands extensions marketplace
  * (https://github.com/OpenHands/extensions) should be loaded.
  *
- * Defaults to false. Set VITE_LOAD_PUBLIC_SKILLS=true to enable.
+ * Defaults to true. Set VITE_LOAD_PUBLIC_SKILLS=false to disable.
  */
 export function shouldLoadPublicSkills(): boolean {
-  return import.meta.env.VITE_LOAD_PUBLIC_SKILLS === "true";
+  return import.meta.env.VITE_LOAD_PUBLIC_SKILLS !== "false";
 }


### PR DESCRIPTION
## Problem

Public skills (including `github-repo-monitor` and `slack-channel-monitor` published in `OpenHands/extensions`) are not being loaded into new conversations, so slash commands like `/github-repo-monitor` have no skill context to guide them.

### Root cause — a three-PR chain

| PR | Date | Change |
|---|---|---|
| #229 | 2026-05-09 | Flipped `shouldLoadPublicSkills()` from opt-out (`!== "false"`, default **true**) to opt-in (`=== "true"`, default **false**) — public skills stopped loading |
| #362 | 2026-05-15 | Patched `createAgentFromSettings` by hardcoding `load_public_skills: true` — fixed |
| #457 | 2026-05-23 | Large adapter refactor replaced `createAgentFromSettings` with `buildAgentContext`, reintroducing `shouldLoadPublicSkills()` — silently broke it again |

## Fix

Restore the original opt-out semantics in `shouldLoadPublicSkills()`:

```diff
-// Defaults to false. Set VITE_LOAD_PUBLIC_SKILLS=true to enable.
-return import.meta.env.VITE_LOAD_PUBLIC_SKILLS === "true";
+// Defaults to true. Set VITE_LOAD_PUBLIC_SKILLS=false to disable.
+return import.meta.env.VITE_LOAD_PUBLIC_SKILLS !== "false";
```

This means `buildAgentContext()` (and therefore every new conversation) will carry `load_public_skills: true` unless the operator explicitly sets `VITE_LOAD_PUBLIC_SKILLS=false` (e.g. to save startup latency in CI or restricted envs).

## Files changed

- `src/api/agent-server-config.ts` — flip the predicate and update JSDoc
- `.env.sample` — document the opt-out form of the flag
- `__tests__/api/agent-server-config.test.ts` — update three tests to match new default
- `AGENTS.md` — add "(opt-out)" clarifier (the doc already said "defaults to true" but the code disagreed)

_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `68ad11dcafd4743da9078e88aea763c2c970dc80` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-68ad11d
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-68ad11d
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-68ad11d-amd64
ghcr.io/openhands/agent-canvas:fix-load-public-skills-default-true-amd64
ghcr.io/openhands/agent-canvas:pr-901-amd64
ghcr.io/openhands/agent-canvas:sha-68ad11d-arm64
ghcr.io/openhands/agent-canvas:fix-load-public-skills-default-true-arm64
ghcr.io/openhands/agent-canvas:pr-901-arm64
ghcr.io/openhands/agent-canvas:sha-68ad11d
ghcr.io/openhands/agent-canvas:fix-load-public-skills-default-true
ghcr.io/openhands/agent-canvas:pr-901
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-68ad11d`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-68ad11d-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->