### PR TITLE
feat(cli): add --info flag to show default stack versions and ports

### DIFF
--- a/bin/agent-canvas.mjs
+++ b/bin/agent-canvas.mjs
@@ -20,11 +20,33 @@ const PKG_JSON = join(__dirname, "..", "package.json");
 // Build output is in build/ (not build/client/) - see react-router.config.ts unpackClientDirectory
 const BUILD_DIR = join(__dirname, "..", "build");
 
-// Check for version/help flags first
+const DEFAULTS_JSON = join(__dirname, "..", "config", "defaults.json");
+
+// Check for version/help/info flags first
 const args = process.argv.slice(2);
 if (args.includes("-v") || args.includes("--version")) {
   const { version } = JSON.parse(readFileSync(PKG_JSON, "utf-8"));
   console.log(version);
+  process.exit(0);
+}
+if (args.includes("--info")) {
+  const { version } = JSON.parse(readFileSync(PKG_JSON, "utf-8"));
+  const defaults = JSON.parse(readFileSync(DEFAULTS_JSON, "utf-8"));
+  console.log(`@openhands/agent-canvas ${version}
+
+Default stack versions:
+  agent-server:    ${defaults.versions.agentServer}
+  automation:      ${defaults.versions.automation}
+  automation-sdk:  ${defaults.versions.automationSdk}
+
+Default ports:
+  ingress:         ${defaults.ports.proxy}
+  agent-server:    ${defaults.ports.agentServer}
+  automation:      ${defaults.ports.automation}
+
+Override versions via environment variables:
+  OH_AGENT_SERVER_VERSION, OH_AGENT_SERVER_GIT_REF, OH_AGENT_SERVER_LOCAL_PATH
+  OH_AUTOMATION_VERSION, OH_AUTOMATION_GIT_REF`);
   process.exit(0);
 }
 if (args.includes("-h") || args.includes("--help")) {
@@ -40,6 +62,7 @@ USAGE:
 OPTIONS:
   -p, --port <port>     Ingress port (default: 8000)
   -v, --version         Show version number
+  --info                Show version and default stack configuration
   -h, --help            Show this help message
 
 ENVIRONMENT VARIABLES:
@@ -57,6 +80,9 @@ EXAMPLES:
 
   # Use a specific port
   npx @openhands/agent-canvas --port 3000
+
+  # Show default stack versions and ports
+  npx @openhands/agent-canvas --info
 
   # Use local SDK checkout for development
   OH_AGENT_SERVER_LOCAL_PATH=/path/to/sdk npx @openhands/agent-canvas


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

`agent-canvas --version` only prints the npm package version (e.g. `1.0.0-alpha.7`). There's no CLI way to see which agent-server, automation, or SDK versions are bundled by default — users have to dig into `config/defaults.json` manually.

## Summary

- Add `--info` flag to `bin/agent-canvas.mjs` that reads `config/defaults.json` and prints the canvas version, default stack versions (agent-server, automation, automation-sdk), default ports, and the env vars available to override them.
- Add `--info` to the `--help` output and examples.

## How to Test

```bash
node bin/agent-canvas.mjs --info
# Should print:
# @openhands/agent-canvas 1.0.0-alpha.7
#
# Default stack versions:
#   agent-server:    1.24.0
#   automation:      1.0.0a5
#   automation-sdk:  1.22.1
#
# Default ports:
#   ingress:         8000
#   agent-server:    18000
#   automation:      18001
#
# Override versions via environment variables:
#   OH_AGENT_SERVER_VERSION, OH_AGENT_SERVER_GIT_REF, OH_AGENT_SERVER_LOCAL_PATH
#   OH_AUTOMATION_VERSION, OH_AUTOMATION_GIT_REF

# Verify existing flags still work:
node bin/agent-canvas.mjs --version
node bin/agent-canvas.mjs --help
```

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

_This PR was created by an AI agent (OpenHands) on behalf of the user._


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/03448009-4b90-44e2-9557-9eb9e79ed170)

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `b4ad82a8028a3cd59e021f3c13978a1dbc66314f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-b4ad82a
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-b4ad82a
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-b4ad82a-amd64
ghcr.io/openhands/agent-canvas:feat-cli-info-flag-amd64
ghcr.io/openhands/agent-canvas:pr-902-amd64
ghcr.io/openhands/agent-canvas:sha-b4ad82a-arm64
ghcr.io/openhands/agent-canvas:feat-cli-info-flag-arm64
ghcr.io/openhands/agent-canvas:pr-902-arm64
ghcr.io/openhands/agent-canvas:sha-b4ad82a
ghcr.io/openhands/agent-canvas:feat-cli-info-flag
ghcr.io/openhands/agent-canvas:pr-902
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-b4ad82a`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-b4ad82a-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->