### PR TITLE
chore: bump version to 1.0.0-alpha.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,7 @@ jobs:
       - name: Build test matrix
         id: matrix
         run: |
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo 'matrix={"include":[{"name":"ubuntu","os":"ubuntu-24.04","full_checks":true},{"name":"windows","os":"windows-latest","full_checks":false}]}' >> "$GITHUB_OUTPUT"
-          else
-            echo 'matrix={"include":[{"name":"ubuntu","os":"ubuntu-24.04","full_checks":true}]}' >> "$GITHUB_OUTPUT"
-          fi
+          echo 'matrix={"include":[{"name":"ubuntu","os":"ubuntu-24.04","full_checks":true},{"name":"windows","os":"windows-latest","full_checks":false}]}' >> "$GITHUB_OUTPUT"
 
   test-and-build:
     needs: prepare-test-matrix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openhands/agent-canvas",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openhands/agent-canvas",
-      "version": "1.0.0-alpha.7",
+      "version": "1.0.0-alpha.8",
       "license": "MIT",
       "dependencies": {
         "@heroui/react": "2.8.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhands/agent-canvas",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Agent Canvas UI for OpenHands - run AI coding agents with a visual interface",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Release v1.0.0-alpha.8

This PR bumps the version to **1.0.0-alpha.8** for release.

### Release Checklist
- [x] Version bumped in package.json and package-lock.json
- [ ] CI passes (lint, test, build)
- [ ] Visual snapshot tests pass
- [ ] Mock-LLM E2E tests pass (triggered by `e2e-tests` label)
- [ ] Review and approve

### What happens on merge
When this PR is merged, the `create-release.yml` workflow will automatically:
1. Create a GitHub release with tag `v1.0.0-alpha.8` and auto-generated notes
2. The tag push triggers `npm-publish.yml` to publish to npm
3. The tag push triggers `docker.yml` to build and push Docker images to GHCR

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `4d95459f4482f453f040e93b1df29da4cb164ec3` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-4d95459
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-4d95459
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-4d95459-amd64
ghcr.io/openhands/agent-canvas:rel-1.0.0-alpha.8-amd64
ghcr.io/openhands/agent-canvas:pr-920-amd64
ghcr.io/openhands/agent-canvas:sha-4d95459-arm64
ghcr.io/openhands/agent-canvas:rel-1.0.0-alpha.8-arm64
ghcr.io/openhands/agent-canvas:pr-920-arm64
ghcr.io/openhands/agent-canvas:sha-4d95459
ghcr.io/openhands/agent-canvas:rel-1.0.0-alpha.8
ghcr.io/openhands/agent-canvas:pr-920
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-4d95459`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-4d95459-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->