### PR TITLE
fix: use PAT in create-release.yml so downstream workflows trigger

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check release does not already exist
         id: check
         env:
-          GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           if gh release view "v${VERSION}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
@@ -58,7 +58,7 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         id: prev_tag
         env:
-          GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PREV_TAG=$(gh release list --repo "${{ github.repository }}" \
             --exclude-drafts --limit 1 \

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check release does not already exist
         id: check
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           if gh release view "v${VERSION}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
@@ -58,7 +58,7 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         id: prev_tag
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || secrets.GITHUB_TOKEN }}
         run: |
           PREV_TAG=$(gh release list --repo "${{ github.repository }}" \
             --exclude-drafts --limit 1 \
@@ -69,7 +69,11 @@ jobs:
       - name: Create GitHub Release
         if: steps.check.outputs.exists == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT (not GITHUB_TOKEN) so the resulting tag-push event
+          # propagates to downstream workflows (npm-publish.yml, docker.yml).
+          # Tags created via GITHUB_TOKEN are silently suppressed by GitHub
+          # and will not trigger other workflow runs.
+          GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
           PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 concurrency:
-  group: npm-publish-${{ github.ref }}
+  group: npm-publish-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -69,11 +69,15 @@ jobs:
         run: npm pack --dry-run
 
       - name: Validate package version matches release tag
+        env:
+          # Pass inputs.tag via env var to prevent script injection from
+          # GitHub Actions expression interpolation inside run blocks.
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           # Resolve tag: prefer workflow_dispatch input, fall back to push-event GITHUB_REF
-          if [ -n "${{ inputs.tag }}" ]; then
-            RAW_TAG="${{ inputs.tag }}"
+          if [ -n "$INPUT_TAG" ]; then
+            RAW_TAG="$INPUT_TAG"
           else
             RAW_TAG="${GITHUB_REF#refs/tags/}"
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v1.0.0-alpha.8)'
+        required: true
+        type: string
 
 concurrency:
   group: npm-publish-${{ github.ref }}
@@ -22,6 +28,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       # Trusted publishing requires Node 22.14.0+ and npm 11.5.1+
       # See: https://docs.npmjs.com/trusted-publishers/
@@ -63,7 +71,13 @@ jobs:
       - name: Validate package version matches release tag
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          # Resolve tag: prefer workflow_dispatch input, fall back to push-event GITHUB_REF
+          if [ -n "${{ inputs.tag }}" ]; then
+            RAW_TAG="${{ inputs.tag }}"
+          else
+            RAW_TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          TAG_VERSION="${RAW_TAG#v}"
           echo "Package version: $PACKAGE_VERSION"
           echo "Release tag version: $TAG_VERSION"
           if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then


### PR DESCRIPTION
## Problem

When `create-release.yml` runs and creates the GitHub release/tag using `GITHUB_TOKEN`, GitHub **silently suppresses** any workflow runs that would be triggered by that tag push. This is a known GitHub limitation: events created by `GITHUB_TOKEN` do not trigger other workflows.

This meant that for `v1.0.0-alpha.8`, neither `npm-publish.yml` nor `docker.yml` (tag-triggered variant) were fired after the release was created.

## Fix

### `create-release.yml`
Use `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` (falling back to `GITHUB_TOKEN` if unset) for all `gh` CLI calls. Tags created via a PAT are treated as regular user pushes by GitHub, so downstream `push: tags: v*` workflows fire correctly.

### `npm-publish.yml`
Add a `workflow_dispatch` trigger with a `tag` input so the publish job can be manually re-triggered for `v1.0.0-alpha.8` (and any future missed publishes). Also:
- Pass `ref: ${{ inputs.tag || github.ref }}` to checkout so the dispatch checks out the right tag commit
- Update the version validation step to resolve the tag from either the input or `GITHUB_REF`

## After merging

Manually trigger the missed `v1.0.0-alpha.8` npm publish:
1. Go to **Actions → Publish to npm → Run workflow**
2. Enter `v1.0.0-alpha.8` as the tag input and run

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `50f0410c226e353869f8e7e12cdd4c1f39353b97` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-50f0410
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-50f0410
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-50f0410-amd64
ghcr.io/openhands/agent-canvas:fix-release-workflow-downstream-trigger-amd64
ghcr.io/openhands/agent-canvas:pr-921-amd64
ghcr.io/openhands/agent-canvas:sha-50f0410-arm64
ghcr.io/openhands/agent-canvas:fix-release-workflow-downstream-trigger-arm64
ghcr.io/openhands/agent-canvas:pr-921-arm64
ghcr.io/openhands/agent-canvas:sha-50f0410
ghcr.io/openhands/agent-canvas:fix-release-workflow-downstream-trigger
ghcr.io/openhands/agent-canvas:pr-921
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-50f0410`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-50f0410-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->