### PR TITLE
fix(frontend): stop duplicating the first user message on cloud backends

### DIFF
--- a/__tests__/contexts/conversation-websocket-context.test.tsx
+++ b/__tests__/contexts/conversation-websocket-context.test.tsx
@@ -89,7 +89,10 @@ describe("ConversationWebSocketProvider — conversation-scoped event store", ()
     // Act: switch to conversation B.
     rerender(
       <QueryClientProvider client={queryClient}>
-        <ConversationWebSocketProvider conversationId="conv-b" conversationUrl={null}>
+        <ConversationWebSocketProvider
+          conversationId="conv-b"
+          conversationUrl={null}
+        >
           <div />
         </ConversationWebSocketProvider>
       </QueryClientProvider>,
@@ -119,5 +122,36 @@ describe("ConversationWebSocketProvider — conversation-scoped event store", ()
     // ...and the re-seed deduped against the existing user message rather than
     // appending a second copy — exactly two events, no double-insertion.
     expect(eventIds()).toHaveLength(2);
+  });
+
+  it("consumes the optimistic pending bubble when the echoed user message arrives via REST preload", async () => {
+    // Arrange: a cloud start-task conversation left a "Sending…" bubble whose
+    // content matches the first message the server has already persisted. With
+    // the WebSocket stubbed, the only path that delivers the echo is the REST
+    // history preload — the path that previously left this bubble orphaned.
+    useOptimisticUserMessageStore.setState({
+      pendingMessages: [
+        {
+          id: "pending-1",
+          conversationId: "conv-a",
+          text: "User message",
+          content: "User message",
+          status: "sending",
+          imageUrls: [],
+          fileUrls: [],
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    });
+
+    // Act: open the conversation; preload returns the echoed user message.
+    renderProvider("conv-a");
+
+    // Assert: the preloaded echo cleared the bubble, so it isn't shown twice.
+    await waitFor(() =>
+      expect(useOptimisticUserMessageStore.getState().pendingMessages).toEqual(
+        [],
+      ),
+    );
   });
 });

--- a/src/contexts/conversation-websocket-context.tsx
+++ b/src/contexts/conversation-websocket-context.tsx
@@ -248,7 +248,28 @@ export function ConversationWebSocketProvider({
       return;
     }
     addEvents(preloadedHistory.events);
-  }, [preloadedHistory, addEvents]);
+
+    // The first user message of a cloud start-task conversation is persisted
+    // server-side and reaches us via this REST preload, not over the WebSocket
+    // (which subscribes with resend_mode='since' after the latest preloaded
+    // timestamp). Consume any matching optimistic "Sending…" bubble here too —
+    // mirroring the WS handler — so it doesn't linger as a duplicate of the echo.
+    if (conversationId) {
+      for (const event of preloadedHistory.events) {
+        if (isUserMessageEvent(event)) {
+          consumeMatchingPendingMessage(
+            conversationId,
+            extractMessageEventText(event),
+          );
+        }
+      }
+    }
+  }, [
+    preloadedHistory,
+    addEvents,
+    conversationId,
+    consumeMatchingPendingMessage,
+  ]);
 
   /**
    * Timestamp of the latest event we already have from REST. Used as


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

When the first message is sent from the home page against a **Cloud** backend, the message renders **twice** in the newly created conversation — once as a normal message and once as a faded **"Sending…"** bubble pinned at the bottom — even though it was sent only once. Local backends are unaffected.

### Steps to reproduce

1. Run the GUI (`npm run dev`).
2. Open the **`<BackendSelector />`** dropdown → **Add Backend**, and add the OpenHands Cloud production backend (Host: `https://app.all-hands.dev`, Type: **Cloud**, with an API key for the Personal Workspace organization).
3. Select the **Production – Personal Workspace** cloud environment.
4. On the home page chat input, send `Hello`.
5. Observe the newly created conversation.

### Expected behavior

The initial user message appears **once**.

### Actual behavior

The message appears **twice**: the real message at the top (followed by the agent's greeting), plus a duplicate `Hello` with a *"Sending…"* state at the bottom.

### Root cause

The cloud first-message flow creates two representations of the same message that are supposed to reconcile but don't:

* The home launcher sends the message server-side as the conversation's `initial_message` (`query`) **and**, because cloud returns a provisional `task-{uuid}` id, enqueues an optimistic *"Sending…"* bubble so the user sees their message while the sandbox provisions. This bubble is a genuine UX need during the `task-` polling phase.
* That optimistic bubble is only ever removed by `consumeMatchingPendingMessage`, which was called **exclusively in the WebSocket message handlers**.
* By the time the user lands on the real conversation, the server has already persisted the first message, so it arrives through the **REST history preload** (`addEvents`), not the WebSocket — which subscribes with `resend_mode:"since"` past that message's timestamp and therefore never re-delivers it.
* The REST preload path lacked the pending-message reconciliation the WebSocket path has, so the bubble was never consumed and lingered as a duplicate (until the 150 s watchdog flipped it to an error state).

Local backends never return a `task-` id, so they never enqueue the optimistic bubble — which is why the bug is cloud-only.

### Proposed fix

Make the REST preload path symmetric with the WebSocket path: when seeding preloaded history, consume any matching optimistic pending bubble for each echoed `UserMessageEvent` (reusing the existing `consumeMatchingPendingMessage`).

### Acceptance criteria

* [ ] Sending the first message from home on a cloud backend shows the message exactly once.
* [ ] No lingering *"Sending…"* bubble after the conversation loads.
* [ ] Local-backend behavior is unchanged.
* [ ] Regression test covers the REST-preload reconciliation path.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Make the REST history preload reconcile the optimistic queue the same way the WebSocket handler does: for each preloaded `UserMessageEvent`, call `consumeMatchingPendingMessage` so the _"Sending…"_ bubble is cleared instead of rendering as a duplicate.
- Reuses existing helpers (`consumeMatchingPendingMessage`, `isUserMessageEvent`, `extractMessageEventText`) — no new imports, no change to the still-needed optimistic bubble.
- Add a regression test in `conversation-websocket-context.test.tsx`.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #826 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

**Automated**

```bash
npm install
npx vitest run __tests__/contexts/conversation-websocket-context.test.tsx
npm run typecheck
```

The new test fails on `main` (the orphaned bubble lingers) and passes with this change. The suite stubs the WebSocket, so the REST preload is the only path delivering the echo — exactly the cloud scenario.

**Manual**

1. Add and select an OpenHands **Cloud** backend (Production – Personal Workspace).
2. From the home page, send `Hello`.
3. Confirm the message appears **once** with no trailing _"Sending…"_ bubble.
4. Repeat on a **local** backend and confirm behavior is unchanged.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="798" alt="image" src="https://github.com/user-attachments/assets/8a7953a9-0e2e-4477-af0e-f47de64e1a03" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

The fix relies on the cloud REST history resolving **after** mount, by which point `useTaskPolling` has already reassigned the pending bubble from `task-{uuid}` to the real conversation id — so the strict content/conversation match in `consumeMatchingPendingMessage` succeeds. Files touched:

- `src/contexts/conversation-websocket-context.tsx` — consume matching pending messages in the REST preload effect.
- `__tests__/contexts/conversation-websocket-context.test.tsx` — regression test.
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `38708d9273db1ae3490adad8ef54d02f8430c5b5` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-38708d9
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-38708d9
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-38708d9-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1982-amd64
ghcr.io/openhands/agent-canvas:pr-924-amd64
ghcr.io/openhands/agent-canvas:sha-38708d9-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1982-arm64
ghcr.io/openhands/agent-canvas:pr-924-arm64
ghcr.io/openhands/agent-canvas:sha-38708d9
ghcr.io/openhands/agent-canvas:hieptl-app-1982
ghcr.io/openhands/agent-canvas:pr-924
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-38708d9`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-38708d9-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->