### PR TITLE
fix(frontend): redirect to section list after adding a backend (automations)

### DIFF
--- a/__tests__/components/backends/add-backend-modal.test.tsx
+++ b/__tests__/components/backends/add-backend-modal.test.tsx
@@ -5,15 +5,28 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __resetActiveStoreForTests } from "#/api/backend-registry/active-store";
 import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import {
+  NavigationProvider,
+  type NavigationContextValue,
+} from "#/context/navigation-context";
 import { AddBackendModal } from "#/components/features/backends/add-backend-modal";
 
-function renderWithProviders(ui: React.ReactElement) {
+function renderWithProviders(
+  ui: React.ReactElement,
+  navigation?: NavigationContextValue,
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <ActiveBackendProvider>{ui}</ActiveBackendProvider>
+      <ActiveBackendProvider>
+        {navigation ? (
+          <NavigationProvider value={navigation}>{ui}</NavigationProvider>
+        ) : (
+          ui
+        )}
+      </ActiveBackendProvider>
     </QueryClientProvider>,
   );
 }
@@ -180,5 +193,60 @@ describe("AddBackendModal – two-column layout", () => {
     const loginButton = screen.getByTestId("add-backend-login-button");
     expect(loginButton.textContent?.trim()).not.toMatch(/^🔑/);
     expect(loginButton.textContent).not.toContain("🔑");
+  });
+});
+
+// @spec BM-002 — adding a backend auto-switches the active selection, so a
+// backend-scoped detail page is now stale; the user must land on the section
+// list rather than the previous backend's detail page.
+describe("AddBackendModal – redirect after adding a backend", () => {
+  function renderOnPath(currentPath: string) {
+    const navigate = vi.fn();
+    const navigation: NavigationContextValue = {
+      currentPath,
+      conversationId: null,
+      isNavigating: false,
+      navigate,
+    };
+    renderWithProviders(<AddBackendModal onClose={vi.fn()} />, navigation);
+    return { navigate };
+  }
+
+  async function addLocalBackend() {
+    const user = userEvent.setup();
+    await user.type(screen.getByTestId("add-backend-name"), "Local Extra");
+    await user.type(
+      screen.getByTestId("add-backend-host"),
+      "http://127.0.0.1:18002",
+    );
+    await user.click(screen.getByTestId("add-backend-submit"));
+  }
+
+  it.each([
+    { path: "/automations/auto-1", expected: "/automations" },
+    { path: "/conversations/abc", expected: "/conversations" },
+  ])(
+    "redirects to the section list when adding from $path",
+    async ({ path, expected }) => {
+      // Arrange
+      const { navigate } = renderOnPath(path);
+
+      // Act
+      await addLocalBackend();
+
+      // Assert
+      expect(navigate).toHaveBeenCalledWith(expected);
+    },
+  );
+
+  it("does not redirect when adding from a section list page", async () => {
+    // Arrange
+    const { navigate } = renderOnPath("/automations");
+
+    // Act
+    await addLocalBackend();
+
+    // Assert
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -12,6 +12,7 @@ import { ModalCloseButton } from "#/components/shared/modals/modal-close-button"
 import { BrandButton } from "#/components/features/settings/brand-button";
 import { SettingsInput } from "#/components/features/settings/settings-input";
 import { useActiveBackendContext } from "#/contexts/active-backend-context";
+import { useNavigation } from "#/context/navigation-context";
 import { useBackendsHealth } from "#/hooks/query/use-backends-health";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
 import ChevronDownSmallIcon from "#/icons/chevron-down-small.svg?react";
@@ -393,6 +394,21 @@ export function BackendForm({
 // ── Add-mode two-column layout ──────────────────────────────────────
 
 /**
+ * @spec BM-002 — Adding a backend auto-switches the active selection to it
+ * (BM-001), so a backend-scoped detail page the user is viewing now belongs
+ * to the previous backend. Redirect to that section's list so they never see
+ * stale data, mirroring the switch-backend redirect in BackendSelector.
+ */
+function useRedirectAfterAddBackend() {
+  const { currentPath, navigate } = useNavigation();
+  return React.useCallback(() => {
+    if (/^\/automations\/[^/]+/.test(currentPath)) navigate("/automations");
+    else if (/^\/conversations\/[^/]+/.test(currentPath))
+      navigate("/conversations");
+  }, [currentPath, navigate]);
+}
+
+/**
  * Left column of the "Add a Backend" modal: manual connection via
  * Host + API Key. Designed for self-hosted agent servers and
  * self-hosted OpenHands Cloud with API key auth.
@@ -400,6 +416,7 @@ export function BackendForm({
 function ManualConnectionColumn({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation("openhands");
   const { addBackend } = useActiveBackendContext();
+  const redirectAfterAdd = useRedirectAfterAddBackend();
 
   const [name, setName] = React.useState("");
   const [host, setHost] = React.useState("");
@@ -420,6 +437,7 @@ function ManualConnectionColumn({ onClose }: { onClose: () => void }) {
       apiKey: apiKey.trim(),
       kind,
     });
+    redirectAfterAdd();
     onClose();
   };
 
@@ -496,6 +514,7 @@ function ManualConnectionColumn({ onClose }: { onClose: () => void }) {
 function CloudLoginColumn({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation("openhands");
   const { addBackend } = useActiveBackendContext();
+  const redirectAfterAdd = useRedirectAfterAddBackend();
 
   const [advancedOpen, setAdvancedOpen] = React.useState(false);
   const [customHost, setCustomHost] = React.useState("");
@@ -509,6 +528,7 @@ function CloudLoginColumn({ onClose }: { onClose: () => void }) {
       apiKey,
       kind: "cloud",
     });
+    redirectAfterAdd();
     onClose();
   };
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

When a user adds a new backend from the sidebar while viewing an automation detail page, they remain on that detail page. They should be redirected to the Automations list page, because adding a backend auto-switches the active backend and the detail page now belongs to the previous backend (stale data).

### Steps to Reproduce
1. Start the dev server: `npm run dev`.
2. Open the app and navigate to `http://localhost:3001/automations`.
3. Open an existing automation (`/automations/:automationId`).
4. From the sidebar, add a new backend.

### Current Behavior
The user stays on the current automation detail page, which has silently disabled its data query (because the active backend changed), leaving a stale/blank view.

### Expected Behavior
After adding a backend, the user is redirected to the Automations list page (`/automations`). The same applies to a conversation detail page (`/conversations/:id` → `/conversations`).

### Root Cause
Adding a backend auto-switches the active selection — `addBackend()` in `src/contexts/active-backend-context.tsx` calls `setActiveSelection({ backendId: next.id })` (spec **BM-001**). Spec **BM-002** requires that switching backends redirect the user off any backend-scoped detail page to that section's list so they never see stale data.

The *switch* action implements BM-002 (`backend-selector.tsx` `handleSelectBackend`), but the *add* action does not: both add-modal columns in `backend-form-modal.tsx` (`ManualConnectionColumn`, `CloudLoginColumn`) called `addBackend(...)` followed only by `onClose()` — never applying the redirect. `automation-detail.tsx` already disables its query on backend change "so we don't fire a request that the backend selector's redirect will immediately navigate away from anyway" — but that redirect never fired on the add path.

### Acceptance Criteria
- [x] Adding a backend from an automation detail page redirects to `/automations`.
- [x] Adding a backend from a conversation detail page redirects to `/conversations`.
- [x] Adding a backend from a list/settings page does **not** redirect.
- [x] Both add-modal entry points (sidebar and backend selector) are covered.
- [x] Automated tests cover the redirect behavior.

## Summary

<!-- 1-3 bullets describing what changed. -->
After adding a new backend from an automation (or conversation) detail page, the user now lands on that section's list page instead of being stranded on a stale detail page.

### Problem
Adding a backend auto-switches the active backend (`addBackend()` → `setActiveSelection(...)`, spec **BM-001**). Spec **BM-002** requires redirecting the user off any backend-scoped detail page to that section's list so they never see stale data from the previous backend.

The *switch* action (`BackendSelector.handleSelectBackend`) implemented BM-002, but the *add* action did not — both columns of the "Add a Backend" modal (`ManualConnectionColumn`, `CloudLoginColumn` in `backend-form-modal.tsx`) called `addBackend(...)` then only `onClose()`. As a result, adding a backend on `/automations/:id` left the user on a detail page whose data query had been disabled (see the explanatory comment in `automation-detail.tsx`), showing stale/empty content.

### Fix
All changes are confined to `src/components/features/backends/backend-form-modal.tsx`:
- Added a module-private `useRedirectAfterAddBackend()` hook that reads `currentPath`/`navigate` from the existing `useNavigation()` context and redirects to the section list when on a detail page:
  - `/automations/:id` → `/automations`
  - `/conversations/:id` → `/conversations`
- Call it after `addBackend(...)` in both `ManualConnectionColumn` and `CloudLoginColumn`.

Because both modal entry points (the sidebar at `sidebar.tsx` and the backend selector at `backend-selector.tsx`) render through `BackendFormModal mode="add"` → these two columns, a single change fixes both.

**Why `useNavigation()` (not react-router `useNavigate`/`useMatch`):** the custom navigation context has a safe default (noop `navigate`, `currentPath: "/"`), so it does not throw when the modal is rendered outside a router — keeping the existing router-less modal tests green. It is also the same navigation API the detail page itself uses.

### Scope notes
- A list/settings page (e.g. `/automations`) does **not** match the detail predicate, so adding a backend there does not redirect.
- `BackendForm` (used by onboarding via `edit` mode), `backend-selector.tsx`, `add-backend-modal.tsx`, and `sidebar.tsx` are untouched. No other `addBackend` call sites need the redirect.

### Testing
Extended `__tests__/components/backends/add-backend-modal.test.tsx` (real `ActiveBackendProvider`; navigation context provided with a `navigate` spy — the underlying service/context is supplied, the hook is not mocked):
- Parametrized: adding from `/automations/auto-1` → `navigate("/automations")`; from `/conversations/abc` → `navigate("/conversations")`.
- Negative: adding from `/automations` (list) → `navigate` not called.

```
npx vitest run __tests__/components/backends/add-backend-modal.test.tsx
# Test Files  1 passed (1)   Tests  12 passed (12)
```
`backend-selector` and `sidebar` suites remain green; `tsc --noEmit` reports no errors in the changed files.

### Manual verification
`npm run dev` → open an automation → add a backend from the sidebar → lands on `/automations`. Repeat from a conversation detail page → lands on `/conversations`. Adding from the `/automations` list page does not redirect.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #870 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Start the dev server: `npm run dev`.
2. Open the app and navigate to `http://localhost:3001/automations`.
3. Open an existing automation (`/automations/:automationId`).
4. From the sidebar, add a new backend.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/34f14a0f-dc9b-4b0c-9d92-0ca1df4e17ae

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `e3812969baad2f2b3c1c080b6e6b19794db62ad8` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-e381296
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-e381296
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-e381296-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2014-amd64
ghcr.io/openhands/agent-canvas:pr-927-amd64
ghcr.io/openhands/agent-canvas:sha-e381296-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2014-arm64
ghcr.io/openhands/agent-canvas:pr-927-arm64
ghcr.io/openhands/agent-canvas:sha-e381296
ghcr.io/openhands/agent-canvas:hieptl-app-2014
ghcr.io/openhands/agent-canvas:pr-927
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-e381296`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-e381296-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->