### PR TITLE
docs: update README version to alpha.8 and add README step to release skill

### DIFF
--- a/.agents/skills/release.md
+++ b/.agents/skills/release.md
@@ -59,22 +59,31 @@ npm version <version> --no-git-tag-version
 
 This updates both files without creating a git tag (the tag is created automatically on merge).
 
+### 2c. Update version references in README.md
+
+The `README.md` contains Docker image tags that reference a specific version (e.g., `ghcr.io/openhands/agent-canvas:<version>`). Update **all** version references in `README.md` to match the new release version:
+
+```bash
+# Find and replace the old version tag with the new one
+sed -i 's/ghcr.io\/openhands\/agent-canvas:[0-9]*\.[0-9]*\.[0-9]*[^ ]*/ghcr.io\/openhands\/agent-canvas:<version>/g' README.md
+```
+
 Verify the change:
 
 ```bash
 git diff --stat
-# Should show: package.json and package-lock.json changed
+# Should show: package.json, package-lock.json, and README.md changed
 ```
 
-### 2c. Commit and push
+### 2d. Commit and push
 
 ```bash
-git add package.json package-lock.json
+git add package.json package-lock.json README.md
 git commit -m "chore: bump version to <version>"
 git push -u origin rel-<version>
 ```
 
-### 2d. Create the PR
+### 2e. Create the PR
 
 Create the PR targeting `main` with the `e2e-tests` label:
 
@@ -87,6 +96,7 @@ This PR bumps the version to **<version>** for release.
 
 ### Release Checklist
 - [x] Version bumped in package.json and package-lock.json
+- [x] Version references updated in README.md
 - [ ] CI passes (lint, test, build)
 - [ ] Visual snapshot tests pass
 - [ ] Mock-LLM E2E tests pass (triggered by \`e2e-tests\` label)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ agent-canvas
 ### Option 2: With a Docker Sandbox
 
 ```sh
-docker pull ghcr.io/openhands/agent-canvas:1.0.0-alpha.6
+docker pull ghcr.io/openhands/agent-canvas:1.0.0-alpha.8
 
 export PROJECTS_PATH=~/projects  # directory containing your project folders
 
@@ -61,7 +61,7 @@ docker run -it --rm \
   -p 8000:8000 \
   -v ~/.openhands:/home/openhands/.openhands \
   -v ${PROJECTS_PATH}:/projects \
-  ghcr.io/openhands/agent-canvas:1.0.0-alpha.6
+  ghcr.io/openhands/agent-canvas:1.0.0-alpha.8
 ```
 
 The agent will be able to access any project under `PROJECTS_PATH`.


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The README Docker image tags were stuck at `1.0.0-alpha.6` while the project is on `1.0.0-alpha.8`. Additionally, the release skill had no step to update the README, so this version drift will keep recurring on future releases.

## Summary

- Update Docker image tags in `README.md` from `1.0.0-alpha.6` to `1.0.0-alpha.8`
- Add step 2c to `.agents/skills/release.md` for updating version references in README during releases
- Add "Version references updated in README.md" to the release PR checklist template

## How to Test

Verify the README references match the current `package.json` version:

```bash
node -p "require('./package.json').version"
grep 'ghcr.io/openhands/agent-canvas:' README.md
```

Both should show `1.0.0-alpha.8`.

Review `.agents/skills/release.md` to confirm the new step 2c is correctly placed and the subsequent steps are renumbered properly.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/977e1923-eb8f-41eb-a4dd-adf7ceac764b)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `066d57f735feee83345628eb34adc643112b999e` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-066d57f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-066d57f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-066d57f-amd64
ghcr.io/openhands/agent-canvas:docs-update-readme-version-and-release-skill-amd64
ghcr.io/openhands/agent-canvas:pr-931-amd64
ghcr.io/openhands/agent-canvas:sha-066d57f-arm64
ghcr.io/openhands/agent-canvas:docs-update-readme-version-and-release-skill-arm64
ghcr.io/openhands/agent-canvas:pr-931-arm64
ghcr.io/openhands/agent-canvas:sha-066d57f
ghcr.io/openhands/agent-canvas:docs-update-readme-version-and-release-skill
ghcr.io/openhands/agent-canvas:pr-931
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-066d57f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-066d57f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->