### PR TITLE
chore: bump version to 1.0.0-alpha.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ agent-canvas
 ### Option 2: With a Docker Sandbox
 
 ```sh
-docker pull ghcr.io/openhands/agent-canvas:1.0.0-alpha.8
+docker pull ghcr.io/openhands/agent-canvas:1.0.0-alpha.9
 
 export PROJECTS_PATH=~/projects  # directory containing your project folders
 
@@ -69,7 +69,7 @@ docker run -it --rm \
   -p 8000:8000 \
   -v ~/.openhands:/home/openhands/.openhands \
   -v ${PROJECTS_PATH}:/projects \
-  ghcr.io/openhands/agent-canvas:1.0.0-alpha.8
+  ghcr.io/openhands/agent-canvas:1.0.0-alpha.9
 ```
 
 The agent will be able to access any project under `PROJECTS_PATH`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openhands/agent-canvas",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openhands/agent-canvas",
-      "version": "1.0.0-alpha.8",
+      "version": "1.0.0-alpha.9",
       "license": "MIT",
       "dependencies": {
         "@heroui/react": "2.8.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhands/agent-canvas",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "description": "Agent Canvas UI for OpenHands - run AI coding agents with a visual interface",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Release v1.0.0-alpha.9

This PR bumps the version to **1.0.0-alpha.9** for release.

### Release Checklist
- [x] Version bumped in package.json and package-lock.json
- [x] Version references updated in README.md
- [ ] CI passes (lint, test, build)
- [ ] Visual snapshot tests pass
- [ ] Mock-LLM E2E tests pass (triggered by `e2e-tests` label)
- [ ] Review and approve

### What happens on merge
When this PR is merged, the `create-release.yml` workflow will automatically:
1. Create a GitHub release with tag `v1.0.0-alpha.9` and auto-generated notes
2. The tag push triggers `npm-publish.yml` to publish to npm
3. The tag push triggers `docker.yml` to build and push Docker images to GHCR

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `d9c6759cb159c4279303163165498cb562be8e5e` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-d9c6759
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-d9c6759
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-d9c6759-amd64
ghcr.io/openhands/agent-canvas:rel-1.0.0-alpha.9-amd64
ghcr.io/openhands/agent-canvas:pr-948-amd64
ghcr.io/openhands/agent-canvas:sha-d9c6759-arm64
ghcr.io/openhands/agent-canvas:rel-1.0.0-alpha.9-arm64
ghcr.io/openhands/agent-canvas:pr-948-arm64
ghcr.io/openhands/agent-canvas:sha-d9c6759
ghcr.io/openhands/agent-canvas:rel-1.0.0-alpha.9
ghcr.io/openhands/agent-canvas:pr-948
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-d9c6759`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-d9c6759-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->