### PR TITLE
fix(mocks): stub /api/mcp/test so MCP install flow completes in mock …

### DIFF
--- a/__tests__/api/mock-workspaces-handlers.test.ts
+++ b/__tests__/api/mock-workspaces-handlers.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import WorkspacesService from "#/api/workspaces-service/workspaces-service.api";
+import { resetMockWorkspaces } from "#/mocks/handlers";
+
+describe("mock workspaces handlers", () => {
+  afterEach(() => {
+    resetMockWorkspaces();
+  });
+
+  it("starts with an empty workspaces list", async () => {
+    const response = await WorkspacesService.listWorkspaces();
+    expect(response.workspaces).toEqual([]);
+    expect(response.workspaceParents).toEqual([]);
+  });
+
+  it("persists added workspaces across list calls", async () => {
+    await WorkspacesService.addWorkspaces([
+      { id: "w1", name: "Project", path: "/workspace/project" },
+    ]);
+
+    const response = await WorkspacesService.listWorkspaces();
+    expect(response.workspaces).toEqual([
+      { id: "w1", name: "Project", path: "/workspace/project" },
+    ]);
+  });
+
+  it("removes a workspace by path", async () => {
+    await WorkspacesService.addWorkspaces([
+      { id: "w1", name: "Project", path: "/workspace/project" },
+      { id: "w2", name: "Other", path: "/workspace/other" },
+    ]);
+
+    await WorkspacesService.removeWorkspace("/workspace/project");
+
+    const response = await WorkspacesService.listWorkspaces();
+    expect(response.workspaces.map((w) => w.path)).toEqual([
+      "/workspace/other",
+    ]);
+  });
+
+  it("persists workspace parents and removes them by path", async () => {
+    await WorkspacesService.addWorkspaceParents([
+      { id: "p1", name: "Repos", path: "/workspace/repos" },
+    ]);
+
+    const afterAdd = await WorkspacesService.listWorkspaces();
+    expect(afterAdd.workspaceParents).toEqual([
+      { id: "p1", name: "Repos", path: "/workspace/repos" },
+    ]);
+
+    await WorkspacesService.removeWorkspaceParent("/workspace/repos");
+
+    const afterRemove = await WorkspacesService.listWorkspaces();
+    expect(afterRemove.workspaceParents).toEqual([]);
+  });
+});

--- a/__tests__/api/mock-workspaces-handlers.test.ts
+++ b/__tests__/api/mock-workspaces-handlers.test.ts
@@ -25,6 +25,18 @@ describe("mock workspaces handlers", () => {
     ]);
   });
 
+  it("upserts a workspace when path already exists", async () => {
+    await WorkspacesService.addWorkspaces([
+      { id: "w1", name: "Old", path: "/workspace/project" },
+    ]);
+    await WorkspacesService.addWorkspaces([
+      { id: "w2", name: "New", path: "/workspace/project" },
+    ]);
+    const response = await WorkspacesService.listWorkspaces();
+    expect(response.workspaces).toHaveLength(1);
+    expect(response.workspaces[0].name).toBe("New");
+  });
+
   it("removes a workspace by path", async () => {
     await WorkspacesService.addWorkspaces([
       { id: "w1", name: "Project", path: "/workspace/project" },

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -19,6 +19,10 @@ import {
   resetAutomationMockData,
 } from "./automation-handlers";
 import { MCP_HANDLERS } from "./mcp-handlers";
+import {
+  WORKSPACES_HANDLERS,
+  resetMockWorkspaces,
+} from "./workspaces-handlers";
 
 export const handlers = [
   ...FILE_SERVICE_HANDLERS,
@@ -32,11 +36,13 @@ export const handlers = [
   ...ANALYTICS_HANDLERS,
   ...AUTOMATION_HANDLERS,
   ...MCP_HANDLERS,
+  ...WORKSPACES_HANDLERS,
 ];
 
 export {
   MOCK_DEFAULT_USER_SETTINGS,
   resetTestHandlersMockSettings,
   resetAutomationMockData,
+  resetMockWorkspaces,
   setMockGitChanges,
 };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -18,6 +18,7 @@ import {
   AUTOMATION_HANDLERS,
   resetAutomationMockData,
 } from "./automation-handlers";
+import { MCP_HANDLERS } from "./mcp-handlers";
 
 export const handlers = [
   ...FILE_SERVICE_HANDLERS,
@@ -30,6 +31,7 @@ export const handlers = [
   ...FEEDBACK_HANDLERS,
   ...ANALYTICS_HANDLERS,
   ...AUTOMATION_HANDLERS,
+  ...MCP_HANDLERS,
 ];
 
 export {

--- a/src/mocks/mcp-handlers.ts
+++ b/src/mocks/mcp-handlers.ts
@@ -1,0 +1,24 @@
+import { http, HttpResponse } from "msw";
+import type { MCPTestResponse } from "@openhands/typescript-client";
+
+/**
+ * MSW handlers for the MCP API.
+ *
+ * Currently only the pre-flight connectivity check (`POST /api/mcp/test`)
+ * needs a mock — the install/save flow in `InstallServerModal` and
+ * `CustomServerEditor` calls it before persisting the new server via the
+ * existing settings PATCH. In mock mode there is no real MCP server to
+ * connect to, so we return a deterministic success response so the install
+ * flow can complete in both `npm run dev:mock` and the Playwright snapshot
+ * tests.
+ */
+const MOCK_MCP_TEST_SUCCESS: MCPTestResponse = {
+  ok: true,
+  tools: [],
+};
+
+export const MCP_HANDLERS = [
+  http.post("*/api/mcp/test", async () =>
+    HttpResponse.json(MOCK_MCP_TEST_SUCCESS),
+  ),
+];

--- a/src/mocks/workspaces-handlers.ts
+++ b/src/mocks/workspaces-handlers.ts
@@ -1,0 +1,98 @@
+import { http, HttpResponse } from "msw";
+import type {
+  WorkspaceItem,
+  WorkspaceParentItem,
+  WorkspacesListResponse,
+} from "@openhands/typescript-client/clients";
+
+/**
+ * MSW handlers for the agent-server's `/api/workspaces` and
+ * `/api/auth/workspace-session` endpoints used by `useLocalWorkspaces`,
+ * `WorkspacesService`, and `useWorkspaceSession`.
+ *
+ * Without these handlers, mock-mode renders of the home / sidebar /
+ * conversation pages let those requests fall through to the Vite proxy
+ * (`127.0.0.1:8000` ECONNREFUSED), which spams the snapshot-test logs and
+ * surfaces global error toasts in the captured screenshots.
+ *
+ * The mock keeps an in-memory list so the install / remove flow round-trips
+ * cleanly within a single page load. State resets on every test reload.
+ */
+
+let workspaces: WorkspaceItem[] = [];
+let workspaceParents: WorkspaceParentItem[] = [];
+
+function snapshot(): WorkspacesListResponse {
+  return {
+    workspaces: workspaces.map((w) => ({ ...w })),
+    workspaceParents: workspaceParents.map((p) => ({ ...p })),
+  };
+}
+
+export function resetMockWorkspaces(): void {
+  workspaces = [];
+  workspaceParents = [];
+}
+
+export const WORKSPACES_HANDLERS = [
+  http.get("*/api/workspaces", async () => HttpResponse.json(snapshot())),
+
+  http.post("*/api/workspaces", async ({ request }) => {
+    const body = (await request.json()) as { workspaces?: WorkspaceItem[] };
+    for (const incoming of body.workspaces ?? []) {
+      const existingIndex = workspaces.findIndex(
+        (w) => w.path === incoming.path,
+      );
+      if (existingIndex >= 0) {
+        workspaces[existingIndex] = { ...incoming };
+      } else {
+        workspaces.push({ ...incoming });
+      }
+    }
+    return HttpResponse.json(snapshot());
+  }),
+
+  http.delete("*/api/workspaces", async ({ request }) => {
+    const url = new URL(request.url);
+    const path = url.searchParams.get("path");
+    const before = workspaces.length;
+    workspaces = workspaces.filter((w) => w.path !== path);
+    return HttpResponse.json({ deleted: workspaces.length !== before });
+  }),
+
+  http.post("*/api/workspaces/parents", async ({ request }) => {
+    const body = (await request.json()) as { parents?: WorkspaceParentItem[] };
+    for (const incoming of body.parents ?? []) {
+      const existingIndex = workspaceParents.findIndex(
+        (p) => p.path === incoming.path,
+      );
+      if (existingIndex >= 0) {
+        workspaceParents[existingIndex] = { ...incoming };
+      } else {
+        workspaceParents.push({ ...incoming });
+      }
+    }
+    return HttpResponse.json(snapshot());
+  }),
+
+  http.delete("*/api/workspaces/parents", async ({ request }) => {
+    const url = new URL(request.url);
+    const path = url.searchParams.get("path");
+    const before = workspaceParents.length;
+    workspaceParents = workspaceParents.filter((p) => p.path !== path);
+    return HttpResponse.json({ deleted: workspaceParents.length !== before });
+  }),
+
+  // Workspace static-asset session: minted on conversation pages by
+  // `useWorkspaceSession`. The real endpoint sets an HttpOnly cookie; in
+  // mock mode we just acknowledge the POST/DELETE so the call doesn't fall
+  // through to the Vite proxy.
+  http.post("*/api/auth/workspace-session", async () =>
+    HttpResponse.json({ ok: true }),
+  ),
+
+  http.delete(
+    "*/api/auth/workspace-session",
+    async () => new HttpResponse(null, { status: 204 }),
+  ),
+];

--- a/src/mocks/workspaces-handlers.ts
+++ b/src/mocks/workspaces-handlers.ts
@@ -38,6 +38,8 @@ export const WORKSPACES_HANDLERS = [
   http.get("*/api/workspaces", async () => HttpResponse.json(snapshot())),
 
   http.post("*/api/workspaces", async ({ request }) => {
+    // `workspaces` is the top-level key used by WorkspacesClient.addWorkspaces()
+    // in @openhands/typescript-client — aligns with the agent-server SDK contract.
     const body = (await request.json()) as { workspaces?: WorkspaceItem[] };
     for (const incoming of body.workspaces ?? []) {
       const existingIndex = workspaces.findIndex(
@@ -57,6 +59,8 @@ export const WORKSPACES_HANDLERS = [
     const path = url.searchParams.get("path");
     const before = workspaces.length;
     workspaces = workspaces.filter((w) => w.path !== path);
+    // WorkspacesService.removeWorkspace() discards the response body (returns
+    // void), so the shape here is mock-only and not coupled to the real contract.
     return HttpResponse.json({ deleted: workspaces.length !== before });
   }),
 
@@ -80,6 +84,9 @@ export const WORKSPACES_HANDLERS = [
     const path = url.searchParams.get("path");
     const before = workspaceParents.length;
     workspaceParents = workspaceParents.filter((p) => p.path !== path);
+    // WorkspacesService.removeWorkspaceParent() discards the response body
+    // (returns void), so the shape here is mock-only and not coupled to the
+    // real contract.
     return HttpResponse.json({ deleted: workspaceParents.length !== before });
   }),
 

--- a/tests/e2e/snapshots/skills-page.snapshot.spec.ts
+++ b/tests/e2e/snapshots/skills-page.snapshot.spec.ts
@@ -89,17 +89,23 @@ async function setupMocks(page: Page) {
 async function seedSkills(page: Page, skills = MOCK_SKILLS) {
   await page.waitForFunction(
     () =>
-      !!(window as unknown as { __OH_QUERY_CLIENT__?: unknown }).__OH_QUERY_CLIENT__,
+      !!(window as unknown as { __OH_QUERY_CLIENT__?: unknown })
+        .__OH_QUERY_CLIENT__,
     { timeout: 10_000 },
   );
   await page.evaluate((skillsData) => {
+    // Matches the `useSkills` queryKey: `["skills", projectDir ?? null]`.
+    // The global Skills page calls `useSkills()` with no projectDir, so the
+    // key resolves to `["skills", null]`. Seeding with the bare `["skills"]`
+    // tuple (as the test originally did) misses the cache entry and the
+    // skill cards never render.
     (
       window as unknown as {
         __OH_QUERY_CLIENT__: {
           setQueryData: (key: unknown[], data: unknown) => void;
         };
       }
-    ).__OH_QUERY_CLIENT__.setQueryData(["skills"], skillsData);
+    ).__OH_QUERY_CLIENT__.setQueryData(["skills", null], skillsData);
   }, skills);
   await page.waitForTimeout(200);
 }


### PR DESCRIPTION
Stub POST /api/mcp/test in MSW so the MCP install flow completes in mock mode
The MCP install flow (InstallServerModal and CustomServerEditor) added in https://github.com/OpenHands/agent-canvas/pull/816 calls POST /api/mcp/test to validate connectivity before persisting the new server. There was no MSW handler for that endpoint, so in mock mode the request fell through to the Vite proxy, hit ECONNREFUSED on localhost:8000, and the install modal stayed open with a connection error.

This broke:

npm run dev:mock install/save UX — you could not actually install an MCP server in the mock dev environment.

Two iterative Playwright snapshot tests in tests/e2e/snapshots/mcp-page.snapshot.spec.ts:

install Slack from marketplace (iterative snapshots)
add custom SSE server via editor (iterative snapshots)
Both call expect(page.getByTestId("mcp-custom-editor" | "mcp-install-modal")).not.toBeVisible({ timeout: 10_000 }) after submit. Because the modal stayed open, the assertion failed on every run.

Why this matters for the snapshot pipeline
snapshot-tests.yml on main runs test:e2e:snapshots:update and uploads tests/e2e/__snapshots__/ as the snapshot-baselines artifact — but only if the Generate baseline snapshots step succeeds. Because those two tests failed, the step exited non-zero, the upload step was skipped, and no new baseline artifact had been published since SHA 2c2c803 on 2026-05-27.

That stale baseline was what every subsequent PR's snapshot job downloaded. PRs opened or rebased after 2026-05-27 (e.g. https://github.com/OpenHands/agent-canvas/pull/605) got compared against a baseline that was ~36 commits and a day's worth of real UI changes behind. The PR comment surfaced those as "🔴 Changed", but they were really just baseline drift — the PRs weren't actually changing those pixels.

Once this PR lands, the next push to main will re-upload a fresh snapshot-baselines artifact and PR comparisons should return to reflecting real diffs only.

Files
New: src/mocks/mcp-handlers.ts — minimal MSW handler returning { ok: true, tools: [] }.
Modified: src/mocks/handlers.ts — registers MCP_HANDLERS alongside the existing handler arrays.
Verification
# Both previously-broken tests now run end-to-end and emit all 4 step screenshots:
npx playwright test tests/e2e/snapshots/mcp-page.snapshot.spec.ts \
  --project=chromium --update-snapshots -g "iterative snapshots"
# 2 passed (22.4s)



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `b289aaa7201cbe77a21bc9fdbfa360542a870979` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-b289aaa
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-b289aaa
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-b289aaa-amd64
ghcr.io/openhands/agent-canvas:fix-snapshot-build-amd64
ghcr.io/openhands/agent-canvas:pr-949-amd64
ghcr.io/openhands/agent-canvas:sha-b289aaa-arm64
ghcr.io/openhands/agent-canvas:fix-snapshot-build-arm64
ghcr.io/openhands/agent-canvas:pr-949-arm64
ghcr.io/openhands/agent-canvas:sha-b289aaa
ghcr.io/openhands/agent-canvas:fix-snapshot-build
ghcr.io/openhands/agent-canvas:pr-949
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-b289aaa`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-b289aaa-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->