### PR TITLE
fix(snapshot-tests): mock POST /api/mcp/test and fix skills query key

### DIFF
--- a/src/mocks/settings-handlers.ts
+++ b/src/mocks/settings-handlers.ts
@@ -499,9 +499,7 @@ export const SETTINGS_HANDLERS = [
   // Mock MCP server connectivity test — always reports success so snapshot
   // tests that install/add MCP servers can complete the full flow without a
   // real agent-server running on port 8000.
-  http.post("*/api/mcp/test", async () =>
-    HttpResponse.json({ ok: true }),
-  ),
+  http.post("*/api/mcp/test", async () => HttpResponse.json({ ok: true })),
 
   http.get("*/server_info", async () =>
     HttpResponse.json({

--- a/src/mocks/settings-handlers.ts
+++ b/src/mocks/settings-handlers.ts
@@ -496,6 +496,13 @@ const MOCK_AGENT_SERVER_VERSION = "1.24.0";
 // when VITE_BACKEND_BASE_URL is configured.
 
 export const SETTINGS_HANDLERS = [
+  // Mock MCP server connectivity test — always reports success so snapshot
+  // tests that install/add MCP servers can complete the full flow without a
+  // real agent-server running on port 8000.
+  http.post("*/api/mcp/test", async () =>
+    HttpResponse.json({ ok: true }),
+  ),
+
   http.get("*/server_info", async () =>
     HttpResponse.json({
       uptime: 0,

--- a/tests/e2e/snapshots/skills-page.snapshot.spec.ts
+++ b/tests/e2e/snapshots/skills-page.snapshot.spec.ts
@@ -99,7 +99,7 @@ async function seedSkills(page: Page, skills = MOCK_SKILLS) {
           setQueryData: (key: unknown[], data: unknown) => void;
         };
       }
-    ).__OH_QUERY_CLIENT__.setQueryData(["skills"], skillsData);
+    ).__OH_QUERY_CLIENT__.setQueryData(["skills", null], skillsData);
   }, skills);
   await page.waitForTimeout(200);
 }


### PR DESCRIPTION
## Problem

Visual snapshot tests have been failing on all branches since [#833](https://github.com/OpenHands/agent-canvas/pull/833) landed on May 28. Two root causes were identified from CI log analysis:

---

### Root cause 1: `POST /api/mcp/test` not mocked in MSW

**Introduced by**: [9c86652](https://github.com/OpenHands/agent-canvas/commit/9c86652) — "feat: validate MCP server connectivity before saving (#785) (#816)"

That commit added `useTestMcpServer` which calls `McpService.testServer()` → `MCPClient.testServer()` → `POST /api/mcp/test` on the local agent-server **before** saving an MCP server config.

In snapshot tests there is no real agent-server on port 8000, so this request fails with `ECONNREFUSED`. The `onError` handler fires and the install/add modal stays open. Two iterative snapshot tests then crash in step 4:
- `install Slack from marketplace` — `mcp-install-modal` never closes
- `add custom SSE server via editor` — `mcp-custom-editor` never closes

**Fix**: Add an MSW handler for `POST */api/mcp/test` that always returns `{ ok: true }`. This lets the full flow complete: test → add → `PATCH /api/settings` → modal closes → installed server card appears.

---

### Root cause 2: skills query key mismatch in `### Root cause 2: skills query key mismatch in `### Root cause 2: skills query key mismatch in `### Root cause 2: skills query key mismatch in `### Root cauions (#707)"

That commit changed `useSkills()`'s `queryKey` from `["skills"]` to `["skills", projectDir ?? null]`. The global Skills page calls `useSkills()` with no argument, so the effective key is `["skills", null]`.

The `seedSkills()` helper in the snapshot test still seeded data at `["skills"]`, which no longer matched the key the component reads — so skill cards never appeared and four tests crasThe `seedSkills()` helper in the snapshot test still seeded data at `[\llThe `seedSkills()` helper in the snapshot test still seeded data at `["s| CThe `seedSkills()` helper in the snapshot test still seeded data at `["skills"]`, which no longer matched the key the component reads — so skill cards never appeared and four tests crasThe `seedSkills()` help.ts\Th| Change `setQueryData(["skills"], ...)` → `setQueryData(["skills", null], ...)` |

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `a7c5b8b6cc515abfee73ec8fd1c125e3f9f2b9a4` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-a7c5b8b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-a7c5b8b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-a7c5b8b-amd64
ghcr.io/openhands/agent-canvas:fix-snapshot-tests-mcp-and-skills-amd64
ghcr.io/openhands/agent-canvas:pr-952-amd64
ghcr.io/openhands/agent-canvas:sha-a7c5b8b-arm64
ghcr.io/openhands/agent-canvas:fix-snapshot-tests-mcp-and-skills-arm64
ghcr.io/openhands/agent-canvas:pr-952-arm64
ghcr.io/openhands/agent-canvas:sha-a7c5b8b
ghcr.io/openhands/agent-canvas:fix-snapshot-tests-mcp-and-skills
ghcr.io/openhands/agent-canvas:pr-952
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-a7c5b8b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-a7c5b8b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->