### PR TITLE
fix: set OH_PERSISTENCE_DIR in dev stack to prevent .openhands double-nesting

### DIFF
--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -655,11 +655,7 @@ export function buildAgentServerEnv(config) {
     // This is a no-op on Linux/macOS where the locale is already UTF-8.
     PYTHONUTF8: "1",
     TMUX_TMPDIR: config.tmuxTmpDir,
-    // Explicitly set OH_PERSISTENCE_DIR so the agent-server stores settings
-    // and secrets directly in stateDir (e.g. ~/.openhands/agent-canvas/).
-    // Without this, the agent-server falls back to deriving the persistence
-    // dir as conversations_path.parent / ".openhands", which produces an
-    // unwanted double-nesting: ~/.openhands/agent-canvas/.openhands/
+    // Prevents deriving a nested .openhands dir from OH_CONVERSATIONS_PATH.
     OH_PERSISTENCE_DIR: config.stateDir,
     OH_CONVERSATIONS_PATH: config.conversationsPath,
     OH_BASH_EVENTS_DIR: config.bashEventsDir,

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -655,6 +655,12 @@ export function buildAgentServerEnv(config) {
     // This is a no-op on Linux/macOS where the locale is already UTF-8.
     PYTHONUTF8: "1",
     TMUX_TMPDIR: config.tmuxTmpDir,
+    // Explicitly set OH_PERSISTENCE_DIR so the agent-server stores settings
+    // and secrets directly in stateDir (e.g. ~/.openhands/agent-canvas/).
+    // Without this, the agent-server falls back to deriving the persistence
+    // dir as conversations_path.parent / ".openhands", which produces an
+    // unwanted double-nesting: ~/.openhands/agent-canvas/.openhands/
+    OH_PERSISTENCE_DIR: config.stateDir,
     OH_CONVERSATIONS_PATH: config.conversationsPath,
     OH_BASH_EVENTS_DIR: config.bashEventsDir,
     OH_VSCODE_PORT: String(config.vscodePort),


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

When running `npm run dev`, the agent-server derives the persistence directory from `conversations_path.parent / ".openhands"`. Because `OH_CONVERSATIONS_PATH` points to `~/.openhands/agent-canvas/conversations`, this produces `~/.openhands/agent-canvas/.openhands/` — an unwanted extra level of nesting. Docker's `entrypoint.sh` avoids this by setting `OH_PERSISTENCE_DIR` explicitly; `buildAgentServerEnv()` should do the same.

## Summary

- Set `OH_PERSISTENCE_DIR: config.stateDir` in `buildAgentServerEnv()` (`scripts/dev-safe.mjs`) so settings and secrets are stored directly in `~/.openhands/agent-canvas/` rather than the nested `~/.openhands/agent-canvas/.openhands/`

## Issue Number

## How to Test

1. Run `npm run dev` and configure an LLM provider
2. Confirm settings/secrets are written to `~/.openhands/agent-canvas/` directly, with no `.openhands/` subdirectory created inside it

## Video/Screenshots

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `1b8819014dfefacae6b931384568b5331a19d62d` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-1b88190
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-1b88190
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-1b88190-amd64
ghcr.io/openhands/agent-canvas:fix-oh-persistence-dir-dev-stack-amd64
ghcr.io/openhands/agent-canvas:pr-959-amd64
ghcr.io/openhands/agent-canvas:sha-1b88190-arm64
ghcr.io/openhands/agent-canvas:fix-oh-persistence-dir-dev-stack-arm64
ghcr.io/openhands/agent-canvas:pr-959-arm64
ghcr.io/openhands/agent-canvas:sha-1b88190
ghcr.io/openhands/agent-canvas:fix-oh-persistence-dir-dev-stack
ghcr.io/openhands/agent-canvas:pr-959
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-1b88190`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-1b88190-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->