### PR TITLE
Fix port 8000 startup error

### DIFF
--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -662,7 +662,7 @@ function startIngress(config) {
 
   const ingressScript = join(projectRoot, "scripts", "ingress.mjs");
 
-  spawnService(
+  return spawnService(
     "ingress",
     "node",
     [
@@ -979,7 +979,21 @@ async function main(options = {}) {
   // Start services phase
   logStep("2/2", "Starting services...");
 
-  // 1. Start agent-server first (other services depend on it)
+  // 1. Start ingress first so port conflicts fail before spawning
+  // the heavier backend/frontend services.
+  const ingressProcess = startIngress(config);
+
+  // Wait briefly for ingress to either start listening or fail fast.
+  await delay(1000);
+
+  if (!isProcessRunning(ingressProcess)) {
+    logError(
+      `Ingress failed to start on port ${config.ingressPort}. See the ingress logs above for details.`,
+    );
+    process.exit(1);
+  }
+
+  // 2. Start agent-server first (other services depend on it)
   const agentServerStarter = startAgentServerOverride ?? startAgentServer;
   agentServerStarter(config);
 
@@ -990,7 +1004,7 @@ async function main(options = {}) {
     60000, // 60 second timeout for initial startup
   );
 
-  // 2. Seed automation API key into agent-server secrets
+  // 3. Seed automation API key into agent-server secrets
   // This makes the key available to agents during conversations
   // Note: seedAutomationSecret has its own retry logic if server is still warming up
   if (agentServerReady) {
@@ -1003,24 +1017,18 @@ async function main(options = {}) {
     );
   }
 
-  // 3. Start automation backend
+  // 4. Start automation backend
   startAutomationBackend(config);
 
-  // 4. Start frontend server (Vite dev server OR static server)
+  // 5. Start frontend server (Vite dev server OR static server)
   if (useStaticMode) {
     startStaticFrontend(config, staticDir);
   } else {
     startVite(config);
   }
 
-  // 5. Wait for services to be ready
+  // 6. Wait for services to be ready
   await delay(2000);
-
-  // 6. Start ingress proxy (routes traffic to all backends)
-  startIngress(config);
-
-  // Wait for ingress to start
-  await delay(1000);
 
   printBanner(config);
 }

--- a/scripts/ingress.mjs
+++ b/scripts/ingress.mjs
@@ -128,16 +128,12 @@ function buildConfig(args, env = process.env) {
 function createRouter(routes, defaultBackend) {
   // Sort routes by path length (longest first) for most-specific matching
   const sortedRoutes = Object.entries(routes).sort(
-    ([a], [b]) => b.length - a.length,
+    ([a], [b]) => b.length - a.length
   );
 
   return function route(url) {
     for (const [prefix, backend] of sortedRoutes) {
-      if (
-        url === prefix ||
-        url.startsWith(prefix + "/") ||
-        url.startsWith(prefix + "?")
-      ) {
+      if (url === prefix || url.startsWith(prefix + "/") || url.startsWith(prefix + "?")) {
         return backend;
       }
     }
@@ -257,10 +253,7 @@ function proxyWebSocket(req, socket, head, backendUrl) {
   // TCP socket would crash the entire ingress process.
   socket.on("error", (err) => {
     if (!isBenignSocketError(err)) {
-      console.error(
-        `WebSocket client socket error for ${req.url}:`,
-        err.message,
-      );
+      console.error(`WebSocket client socket error for ${req.url}:`, err.message);
     }
     proxyReq.destroy();
   });
@@ -285,12 +278,10 @@ function proxyWebSocket(req, socket, head, backendUrl) {
     proxySocket.on("close", () => socket.destroy());
 
     socket.write(
-      `HTTP/${proxyRes.httpVersion} ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n`,
+      `HTTP/${proxyRes.httpVersion} ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n`
     );
     for (let i = 0; i < proxyRes.rawHeaders.length; i += 2) {
-      socket.write(
-        `${proxyRes.rawHeaders[i]}: ${proxyRes.rawHeaders[i + 1]}\r\n`,
-      );
+      socket.write(`${proxyRes.rawHeaders[i]}: ${proxyRes.rawHeaders[i + 1]}\r\n`);
     }
     socket.write("\r\n");
 
@@ -370,27 +361,15 @@ function startIngress(config) {
 
   server.listen(config.port, () => {
     console.log("");
-    console.log(
-      "╔═══════════════════════════════════════════════════════════════╗",
-    );
-    console.log(
-      "║  Ingress Proxy                                                ║",
-    );
-    console.log(
-      "╠═══════════════════════════════════════════════════════════════╣",
-    );
-    console.log(
-      `║  Listening on: http://localhost:${config.port}/`.padEnd(66) + "║",
-    );
-    console.log(
-      "╠═══════════════════════════════════════════════════════════════╣",
-    );
-    console.log(
-      "║  Routes:                                                      ║",
-    );
+    console.log("╔═══════════════════════════════════════════════════════════════╗");
+    console.log("║  Ingress Proxy                                                ║");
+    console.log("╠═══════════════════════════════════════════════════════════════╣");
+    console.log(`║  Listening on: http://localhost:${config.port}/`.padEnd(66) + "║");
+    console.log("╠═══════════════════════════════════════════════════════════════╣");
+    console.log("║  Routes:                                                      ║");
 
     const sortedRoutes = Object.entries(config.routes).sort(
-      ([a], [b]) => b.length - a.length,
+      ([a], [b]) => b.length - a.length
     );
     for (const [path, backend] of sortedRoutes) {
       const line = `    ${path} → ${backend}`;
@@ -402,12 +381,8 @@ function startIngress(config) {
       console.log(`║  ${line.padEnd(61)}║`);
     }
 
-    console.log(
-      "║                                                               ║",
-    );
-    console.log(
-      "╚═══════════════════════════════════════════════════════════════╝",
-    );
+    console.log("║                                                               ║");
+    console.log("╚═══════════════════════════════════════════════════════════════╝");
     console.log("");
   });
 
@@ -422,9 +397,7 @@ const args = parseArgs();
 const config = buildConfig(args);
 
 if (Object.keys(config.routes).length === 0 && !config.defaultBackend) {
-  console.error(
-    "Error: No routes configured. Use --route or --default options.",
-  );
+  console.error("Error: No routes configured. Use --route or --default options.");
   console.error("Run with --help for usage information.");
   process.exit(1);
 }

--- a/scripts/ingress.mjs
+++ b/scripts/ingress.mjs
@@ -128,12 +128,16 @@ function buildConfig(args, env = process.env) {
 function createRouter(routes, defaultBackend) {
   // Sort routes by path length (longest first) for most-specific matching
   const sortedRoutes = Object.entries(routes).sort(
-    ([a], [b]) => b.length - a.length
+    ([a], [b]) => b.length - a.length,
   );
 
   return function route(url) {
     for (const [prefix, backend] of sortedRoutes) {
-      if (url === prefix || url.startsWith(prefix + "/") || url.startsWith(prefix + "?")) {
+      if (
+        url === prefix ||
+        url.startsWith(prefix + "/") ||
+        url.startsWith(prefix + "?")
+      ) {
         return backend;
       }
     }
@@ -253,7 +257,10 @@ function proxyWebSocket(req, socket, head, backendUrl) {
   // TCP socket would crash the entire ingress process.
   socket.on("error", (err) => {
     if (!isBenignSocketError(err)) {
-      console.error(`WebSocket client socket error for ${req.url}:`, err.message);
+      console.error(
+        `WebSocket client socket error for ${req.url}:`,
+        err.message,
+      );
     }
     proxyReq.destroy();
   });
@@ -278,10 +285,12 @@ function proxyWebSocket(req, socket, head, backendUrl) {
     proxySocket.on("close", () => socket.destroy());
 
     socket.write(
-      `HTTP/${proxyRes.httpVersion} ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n`
+      `HTTP/${proxyRes.httpVersion} ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n`,
     );
     for (let i = 0; i < proxyRes.rawHeaders.length; i += 2) {
-      socket.write(`${proxyRes.rawHeaders[i]}: ${proxyRes.rawHeaders[i + 1]}\r\n`);
+      socket.write(
+        `${proxyRes.rawHeaders[i]}: ${proxyRes.rawHeaders[i + 1]}\r\n`,
+      );
     }
     socket.write("\r\n");
 
@@ -347,17 +356,41 @@ function startIngress(config) {
     }
   });
 
+  server.on("error", (err) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(
+        `Cannot start ingress: port ${config.port} is already in use.\n` +
+          "Stop the process using that port, or choose another port with --port.",
+      );
+      process.exit(1);
+    }
+
+    throw err;
+  });
+
   server.listen(config.port, () => {
     console.log("");
-    console.log("╔═══════════════════════════════════════════════════════════════╗");
-    console.log("║  Ingress Proxy                                                ║");
-    console.log("╠═══════════════════════════════════════════════════════════════╣");
-    console.log(`║  Listening on: http://localhost:${config.port}/`.padEnd(66) + "║");
-    console.log("╠═══════════════════════════════════════════════════════════════╣");
-    console.log("║  Routes:                                                      ║");
+    console.log(
+      "╔═══════════════════════════════════════════════════════════════╗",
+    );
+    console.log(
+      "║  Ingress Proxy                                                ║",
+    );
+    console.log(
+      "╠═══════════════════════════════════════════════════════════════╣",
+    );
+    console.log(
+      `║  Listening on: http://localhost:${config.port}/`.padEnd(66) + "║",
+    );
+    console.log(
+      "╠═══════════════════════════════════════════════════════════════╣",
+    );
+    console.log(
+      "║  Routes:                                                      ║",
+    );
 
     const sortedRoutes = Object.entries(config.routes).sort(
-      ([a], [b]) => b.length - a.length
+      ([a], [b]) => b.length - a.length,
     );
     for (const [path, backend] of sortedRoutes) {
       const line = `    ${path} → ${backend}`;
@@ -369,8 +402,12 @@ function startIngress(config) {
       console.log(`║  ${line.padEnd(61)}║`);
     }
 
-    console.log("║                                                               ║");
-    console.log("╚═══════════════════════════════════════════════════════════════╝");
+    console.log(
+      "║                                                               ║",
+    );
+    console.log(
+      "╚═══════════════════════════════════════════════════════════════╝",
+    );
     console.log("");
   });
 
@@ -385,7 +422,9 @@ const args = parseArgs();
 const config = buildConfig(args);
 
 if (Object.keys(config.routes).length === 0 && !config.defaultBackend) {
-  console.error("Error: No routes configured. Use --route or --default options.");
+  console.error(
+    "Error: No routes configured. Use --route or --default options.",
+  );
   console.error("Run with --help for usage information.");
   process.exit(1);
 }


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

When port 8000 is already in use, the ingress process fails, but the dev launcher can still report that the Agent Canvas stack started successfully. This is confusing because the main UI is served through the ingress port.

## Summary

- Handle `EADDRINUSE` in `scripts/ingress.mjs` with a clear error message.
- Start ingress before the heavier backend/frontend services in the automation dev stack.
- Fail fast when the ingress port is unavailable instead of printing the success banner.

## Issue Number

Fixes #899

## How to Test

1. Start a process on port 8000:

   ```sh
   python -m http.server 8000
   ```

2. In another terminal, run:

   ```sh
   npm run dev
   ```

3. Confirm the command fails fast with a clear ingress port error.
4. Confirm it fails before starting agent-server, automation, or vite.
5. Confirm it does not print the `Main UI: http://localhost:8000/` success banner.

I also tested the normal ingress startup path:

```sh
node scripts/ingress.mjs --port 8000 --default http://localhost:3001
```

with port 8000 free, and confirmed ingress starts normally.

## Video/Screenshots

Not included; this is a CLI startup/error-handling fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Ingress is started first so port conflicts fail before spawning heavier backend/frontend services. `ingress.mjs` only binds the listening port and configures proxy routes, so it does not require target backends to be ready at startup.
