### PR TITLE
test(onboarding): extract shared saved-secret fixture in ACP secrets step tests

### DIFF
--- a/__tests__/components/onboarding/setup-acp-secrets-step.test.tsx
+++ b/__tests__/components/onboarding/setup-acp-secrets-step.test.tsx
@@ -13,6 +13,7 @@ import { SecretsService } from "#/api/secrets-service";
 function renderStep(providerKey: OnboardingAgentId = "claude-code") {
   const onBack = vi.fn();
   const onNext = vi.fn();
+  const user = userEvent.setup();
   render(
     <QueryClientProvider
       client={
@@ -28,7 +29,25 @@ function renderStep(providerKey: OnboardingAgentId = "claude-code") {
       </ActiveBackendProvider>
     </QueryClientProvider>,
   );
-  return { onBack, onNext };
+  return { onBack, onNext, user };
+}
+
+/**
+ * Render the Claude Code step with ANTHROPIC_API_KEY already saved, and wait
+ * until that state has loaded (its "already saved" placeholder appears once
+ * `useSearchSecrets` resolves). Shared by every test that exercises the
+ * existing-secret paths so the fixture lives in one place.
+ */
+async function renderWithSavedApiKey() {
+  vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
+    { name: "ANTHROPIC_API_KEY" },
+  ]);
+  const handles = renderStep("claude-code");
+  const apiKey = screen.getByTestId(
+    "onboarding-acp-secret-ANTHROPIC_API_KEY",
+  ) as HTMLInputElement;
+  await waitFor(() => expect(apiKey.placeholder.length).toBeGreaterThan(0));
+  return { ...handles, apiKey };
 }
 
 beforeEach(() => {
@@ -61,36 +80,19 @@ describe("SetupAcpSecretsStep", () => {
   });
 
   it("flags a credential that already exists as a saved secret", async () => {
-    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
-      { name: "ANTHROPIC_API_KEY" },
-    ]);
-    renderStep("claude-code");
+    const { apiKey } = await renderWithSavedApiKey();
 
     // The already-saved field carries a non-empty placeholder hint; a
     // not-yet-saved field (base URL) does not.
-    const apiKey = screen.getByTestId(
-      "onboarding-acp-secret-ANTHROPIC_API_KEY",
-    ) as HTMLInputElement;
     const baseUrl = screen.getByTestId(
       "onboarding-acp-secret-ANTHROPIC_BASE_URL",
     ) as HTMLInputElement;
-    await waitFor(() => expect(apiKey.placeholder.length).toBeGreaterThan(0));
+    expect(apiKey.placeholder.length).toBeGreaterThan(0);
     expect(baseUrl.placeholder).toBe("");
   });
 
   it("does not write an existing secret when its field is left blank", async () => {
-    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
-      { name: "ANTHROPIC_API_KEY" },
-    ]);
-    const { onNext } = renderStep("claude-code");
-    const user = userEvent.setup();
-
-    // Wait for the existing secret to register (its "already saved" placeholder
-    // appears) so we know the step has loaded before we advance.
-    const apiKey = screen.getByTestId(
-      "onboarding-acp-secret-ANTHROPIC_API_KEY",
-    ) as HTMLInputElement;
-    await waitFor(() => expect(apiKey.placeholder.length).toBeGreaterThan(0));
+    const { onNext, user } = await renderWithSavedApiKey();
 
     // Advance without typing: a blank field is a deliberate skip, so the
     // already-saved secret must be left untouched (no overwrite).
@@ -104,16 +106,7 @@ describe("SetupAcpSecretsStep", () => {
     // Key rotation: a credential is already saved, the user types a new value
     // over it. The blank-skip guard must not suppress this — the new value has
     // to be written even though the secret already exists.
-    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
-      { name: "ANTHROPIC_API_KEY" },
-    ]);
-    const { onNext } = renderStep("claude-code");
-    const user = userEvent.setup();
-
-    const apiKey = screen.getByTestId(
-      "onboarding-acp-secret-ANTHROPIC_API_KEY",
-    ) as HTMLInputElement;
-    await waitFor(() => expect(apiKey.placeholder.length).toBeGreaterThan(0));
+    const { onNext, user, apiKey } = await renderWithSavedApiKey();
 
     await user.type(apiKey, "sk-ant-new-key");
     await user.click(screen.getByTestId("onboarding-acp-secrets-next"));
@@ -129,8 +122,7 @@ describe("SetupAcpSecretsStep", () => {
   });
 
   it("upserts every filled field as a secret and then advances", async () => {
-    const { onNext } = renderStep("claude-code");
-    const user = userEvent.setup();
+    const { onNext, user } = renderStep("claude-code");
 
     await user.type(
       screen.getByTestId("onboarding-acp-secret-ANTHROPIC_API_KEY"),
@@ -161,8 +153,7 @@ describe("SetupAcpSecretsStep", () => {
     vi.spyOn(SecretsService, "createSecret").mockRejectedValue(
       new Error("boom"),
     );
-    const { onNext } = renderStep("claude-code");
-    const user = userEvent.setup();
+    const { onNext, user } = renderStep("claude-code");
 
     await user.type(
       screen.getByTestId("onboarding-acp-secret-ANTHROPIC_API_KEY"),


### PR DESCRIPTION
## Summary

Follow-up test-only cleanup on top of #967 (now merged). No production code or behavior change.

- Adds a `renderWithSavedApiKey()` helper that centralizes the "`ANTHROPIC_API_KEY` already saved + wait for the *already-saved* placeholder" fixture, collapsing the duplicated 4-line prologue in the three existing-secret tests (`flags…`, `does not write…blank`, `overwrites…replacement`) to a single line each.
- Moves `userEvent.setup()` into `renderStep` (called before `render`, the recommended order) and returns `user`, so individual tests no longer repeat the setup.

Net: **+26 / −35** in one test file.

## Verification

- `tsc --noEmit`: clean
- `eslint` + `prettier --check`: clean
- `vitest run` (the step's suite): 6/6 pass — same cases as before (render, already-saved placeholder, blank-skip, key-rotation, write-failure), just de-duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `bef9d1293eea21c00e5700cd98b8534cb20a1626` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-bef9d12
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-bef9d12
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-bef9d12-amd64
ghcr.io/openhands/agent-canvas:refactor-acp-secrets-test-fixture-amd64
ghcr.io/openhands/agent-canvas:pr-969-amd64
ghcr.io/openhands/agent-canvas:sha-bef9d12-arm64
ghcr.io/openhands/agent-canvas:refactor-acp-secrets-test-fixture-arm64
ghcr.io/openhands/agent-canvas:pr-969-arm64
ghcr.io/openhands/agent-canvas:sha-bef9d12
ghcr.io/openhands/agent-canvas:refactor-acp-secrets-test-fixture
ghcr.io/openhands/agent-canvas:pr-969
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-bef9d12`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-bef9d12-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->