### PR TITLE
fix: persist LLM profile changes from all tabs and fix OpenHands round-trip

### DIFF
--- a/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
+++ b/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
@@ -6,7 +6,10 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import SettingsService from "#/api/settings-service/settings-service.api";
-import { SdkSectionPage } from "#/components/features/settings/sdk-settings/sdk-section-page";
+import {
+  SdkSectionPage,
+  type SdkSectionSaveControl,
+} from "#/components/features/settings/sdk-settings/sdk-section-page";
 import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import { Settings } from "#/types/settings";
 import * as ToastHandlers from "#/utils/custom-toast-handlers";
@@ -663,6 +666,36 @@ describe("SdkSectionPage", () => {
       expect(saveSettingsSpy).toHaveBeenCalledWith(
         expect.objectContaining({ search_api_key: "external-search-key" }),
       );
+    });
+  });
+
+  it("exposes the active view and a coerced, dirty-only payload on the save control", async () => {
+    // Arrange — a basic-tier schema with a single editable field.
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSavableSettings(),
+    );
+    let latestControl: SdkSectionSaveControl | null = null;
+
+    renderSdkSectionPage({
+      sectionKeys: ["llm"],
+      onSaveControlChange: (control) => {
+        latestControl = control;
+      },
+    });
+
+    // Act — change one field so it becomes dirty.
+    const endpointInput = await screen.findByTestId("sdk-settings-llm.endpoint");
+    await userEvent.clear(endpointInput);
+    await userEvent.type(endpointInput, "https://new.example.com");
+
+    // Assert — the control reports the basic view and returns only the dirty
+    // field, nested under its section. Consumers (e.g. the local profile
+    // editor) rely on both to drive a custom save.
+    await waitFor(() => {
+      expect(latestControl?.view).toBe("basic");
+      expect(latestControl?.getDirtyPayload()).toEqual({
+        llm: { endpoint: "https://new.example.com" },
+      });
     });
   });
 });

--- a/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
+++ b/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
@@ -537,4 +537,97 @@ describe("LlmSettingsLocalView", () => {
       expect(true).toBe(true);
     });
   });
+
+  describe("Basic tab save", () => {
+    it("omits base_url so an OpenHands model round-trips on reload", async () => {
+      // Arrange — a profile whose stored config pairs an OpenHands model with a
+      // stale, non-proxy base_url. Persisting that base_url is exactly what
+      // makes the provider reload as "litellm_proxy" with an empty model; the
+      // Basic tab must drop it so the backend re-derives the All-Hands proxy.
+      const user = userEvent.setup();
+      vi.mocked(ProfilesService.getProfile).mockResolvedValue({
+        name: "gpt-4-profile",
+        api_key_set: true,
+        config: {
+          model: "openhands/claude-opus-4-5-20251101",
+          api_key: "gAAAA_encrypted_key",
+          base_url: "https://stale.example.com/v1",
+        },
+      });
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      renderWithProviders(<LlmSettingsLocalView />);
+
+      // Act — open the profile in edit mode, force the Basic tab, and save.
+      await user.click(screen.getAllByTestId("profile-menu-trigger")[0]);
+      await user.click(screen.getByTestId("profile-edit"));
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-name-input")).toHaveValue(
+          "gpt-4-profile",
+        );
+      });
+      await user.click(await screen.findByTestId("sdk-section-basic-toggle"));
+      await waitFor(() => {
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled();
+      });
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      // Assert — the saved LLM config keeps the OpenHands model but no longer
+      // carries the stale base_url.
+      await waitFor(() => expect(mockSaveMutateAsync).toHaveBeenCalled());
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.model).toBe("openhands/claude-opus-4-5-20251101");
+      expect(savedLlm).not.toHaveProperty("base_url");
+    });
+  });
+
+  describe("All tab save", () => {
+    it("persists a changed minor field without wiping untouched fields", async () => {
+      // Arrange — a profile with a minor field (temperature) plus fields the
+      // user will not touch. Saving the All tab must persist the edited minor
+      // field (typed → coerced to a number) while preserving the rest, instead
+      // of resetting everything to LLM defaults via the full-replace save.
+      const user = userEvent.setup();
+      vi.mocked(ProfilesService.getProfile).mockResolvedValue({
+        name: "gpt-4-profile",
+        api_key_set: true,
+        config: {
+          model: "anthropic/claude-opus-4-5-20251101",
+          api_key: "gAAAA_encrypted_key",
+          base_url: null,
+          temperature: 0.2,
+        },
+      });
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      renderWithProviders(<LlmSettingsLocalView />);
+
+      // Act — open the profile, switch to the All tab, edit temperature, save.
+      await user.click(screen.getAllByTestId("profile-menu-trigger")[0]);
+      await user.click(screen.getByTestId("profile-edit"));
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-name-input")).toHaveValue(
+          "gpt-4-profile",
+        );
+      });
+      await user.click(await screen.findByTestId("sdk-section-all-toggle"));
+      const temperatureInput = await screen.findByTestId(
+        "sdk-settings-llm.temperature",
+      );
+      await user.clear(temperatureInput);
+      await user.type(temperatureInput, "0.7");
+      await waitFor(() => {
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled();
+      });
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      // Assert — the edited minor field is persisted as a number, and the
+      // untouched model and API key survive.
+      await waitFor(() => expect(mockSaveMutateAsync).toHaveBeenCalled());
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.temperature).toBe(0.7);
+      expect(savedLlm.model).toBe("anthropic/claude-opus-4-5-20251101");
+      expect(savedLlm.api_key).toBe("gAAAA_encrypted_key");
+    });
+  });
 });

--- a/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
+++ b/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
@@ -6,6 +6,8 @@ import { BrandButton } from "#/components/features/settings/brand-button";
 import { LlmSettingsScreen } from "#/routes/llm-settings";
 import { useSaveLlmProfile } from "#/hooks/mutation/use-save-llm-profile";
 import { useLlmProfiles } from "#/hooks/query/use-llm-profiles";
+import { useSettings } from "#/hooks/query/use-settings";
+import { useAgentSettingsSchema } from "#/hooks/query/use-agent-settings-schema";
 import ProfilesService, {
   ProfileInfo,
 } from "#/api/profiles-service/profiles-service.api";
@@ -19,7 +21,10 @@ import {
   isProfileNameValid,
 } from "#/utils/derive-profile-name";
 import { SdkSectionSaveControl } from "../sdk-settings/sdk-section-page";
-import { SettingsFormValues } from "#/utils/sdk-settings-schema";
+import {
+  normalizeFieldValue,
+  SettingsFormValues,
+} from "#/utils/sdk-settings-schema";
 import { ArrowLeft } from "lucide-react";
 import { Typography } from "#/ui/typography";
 import { useSettingsSectionHeader } from "#/contexts/settings-section-header-context";
@@ -29,6 +34,13 @@ type ViewMode = "list" | "create" | "edit";
 interface EditingProfile {
   profile: ProfileInfo;
   initialValues: SettingsFormValues;
+  /**
+   * The profile's full LLM config (flat keys; `api_key` is the encrypted
+   * token). Used as the merge base on save so fields the user did not touch —
+   * including ones hidden in the current tab or absent from the schema — are
+   * preserved instead of being reset to LLM defaults by the full-replace save.
+   */
+  baseConfig: Record<string, unknown>;
 }
 
 /**
@@ -46,6 +58,10 @@ export function LlmSettingsLocalView() {
   const { setHideSectionHeader } = useSettingsSectionHeader();
   const saveProfile = useSaveLlmProfile();
   const { data: profilesData } = useLlmProfiles();
+  const { data: settings } = useSettings();
+  const { data: agentSchema } = useAgentSettingsSchema(
+    settings?.agent_settings_schema,
+  );
 
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [profileName, setProfileName] = useState("");
@@ -105,13 +121,33 @@ export function LlmSettingsLocalView() {
         // (NOT nested under a "llm" key)
         const config = (detail.config ?? {}) as Record<string, unknown>;
 
-        const initialValues: SettingsFormValues = {
-          "llm.model": (config.model as string) ?? "",
-          "llm.api_key": (config.api_key as string) ?? "",
-          "llm.base_url": (config.base_url as string) ?? "",
-        };
+        // Seed every llm.* form field from the profile config so all tabs —
+        // including "All" — reflect the profile's real values rather than the
+        // active settings. Fields absent from the schema are still preserved
+        // on save via `baseConfig`.
+        const llmFields =
+          agentSchema?.sections.find((section) => section.key === "llm")
+            ?.fields ?? [];
+        const initialValues: SettingsFormValues = {};
+        for (const field of llmFields) {
+          const flatKey = field.key.startsWith("llm.")
+            ? field.key.slice("llm.".length)
+            : field.key;
+          initialValues[field.key] = normalizeFieldValue(
+            field,
+            config[flatKey],
+          );
+        }
 
-        setEditingProfile({ profile, initialValues });
+        // Safety net for the specially-rendered keys when the schema is
+        // unavailable, so editing still works without it.
+        if (llmFields.length === 0) {
+          initialValues["llm.model"] = (config.model as string) ?? "";
+          initialValues["llm.api_key"] = (config.api_key as string) ?? "";
+          initialValues["llm.base_url"] = (config.base_url as string) ?? "";
+        }
+
+        setEditingProfile({ profile, initialValues, baseConfig: config });
         setProfileName(profile.name);
         setViewMode("edit");
       } catch (error) {
@@ -119,7 +155,7 @@ export function LlmSettingsLocalView() {
         displayErrorToast(t(I18nKey.ERROR$GENERIC));
       }
     },
-    [t],
+    [agentSchema, t],
   );
 
   const handleBackToList = useCallback(() => {
@@ -156,14 +192,57 @@ export function LlmSettingsLocalView() {
   const handleSave = useCallback(async () => {
     if (!saveControl || !isNameValid) return;
 
-    const values = saveControl.values;
-    const model =
-      typeof values["llm.model"] === "string" ? values["llm.model"] : "";
-    const apiKey =
-      typeof values["llm.api_key"] === "string" ? values["llm.api_key"] : "";
-    const baseUrl =
-      typeof values["llm.base_url"] === "string" ? values["llm.base_url"] : "";
+    // Coerced, dirty-only changes from the embedded form. Merging these over
+    // the profile's existing full config preserves fields the user did not
+    // touch (incl. ones hidden in the current tab or absent from the schema);
+    // the backend replaces the whole LLM object, so a partial payload would
+    // otherwise reset everything else to defaults.
+    let dirtyLlm: Record<string, unknown>;
+    try {
+      dirtyLlm = (saveControl.getDirtyPayload().llm ?? {}) as Record<
+        string,
+        unknown
+      >;
+    } catch (error) {
+      displayErrorToast(
+        error instanceof Error ? error.message : t(I18nKey.ERROR$GENERIC),
+      );
+      return;
+    }
 
+    const baseConfig =
+      viewMode === "edit" && editingProfile?.baseConfig
+        ? { ...editingProfile.baseConfig }
+        : {};
+    const llmConfig: Record<string, unknown> = { ...baseConfig, ...dirtyLlm };
+
+    // The Basic tab has no base_url field; the provider implies it. Drop any
+    // (possibly stale, non-proxy) base_url so the backend derives the correct
+    // one — e.g. the All-Hands proxy for openhands/* models, which is required
+    // for the provider to round-trip back to "OpenHands" on reload. Mirrors
+    // LlmSettingsScreen.buildPayload's Basic-view reset.
+    if (saveControl.view === "basic") {
+      delete llmConfig.base_url;
+    }
+
+    // API key handling: an empty value means "no change" (the UX doesn't
+    // support clearing a key). In edit mode preserve the existing encrypted
+    // key from the profile; in create mode omit api_key entirely. A newly
+    // typed key arrives in `dirtyLlm` and wins.
+    if (
+      typeof llmConfig.api_key !== "string" ||
+      llmConfig.api_key.trim() === ""
+    ) {
+      const existingKey =
+        typeof baseConfig.api_key === "string" ? baseConfig.api_key : "";
+      if (existingKey) {
+        llmConfig.api_key = existingKey;
+      } else {
+        delete llmConfig.api_key;
+      }
+    }
+
+    const model = typeof llmConfig.model === "string" ? llmConfig.model : "";
     if (!model) {
       displayErrorToast(t(I18nKey.SETTINGS$MODEL_REQUIRED));
       return;
@@ -180,32 +259,6 @@ export function LlmSettingsLocalView() {
       // If editing and name changed, rename the profile first
       if (isRename) {
         await ProfilesService.renameProfile(originalName, trimmedName);
-      }
-
-      // Build the LLM config object
-      const llmConfig: Record<string, unknown> = { model };
-
-      // API key handling:
-      // - If user entered a new key, use it
-      // - In edit mode with no new key, preserve the existing encrypted key
-      //   (fetched with exposeSecrets='encrypted' and passed back to server)
-      // - In create mode with no key, omit api_key entirely
-      //
-      // Note: The current UX doesn't support explicitly clearing an API key.
-      // If needed, a future enhancement could add a "Clear API Key" option.
-      // The encrypted key format is stable and can be round-tripped to the server.
-      if (apiKey) {
-        llmConfig.api_key = apiKey;
-      } else if (
-        viewMode === "edit" &&
-        editingProfile?.initialValues["llm.api_key"]
-      ) {
-        llmConfig.api_key = editingProfile.initialValues["llm.api_key"];
-      }
-
-      // Only include base_url if set
-      if (baseUrl) {
-        llmConfig.base_url = baseUrl;
       }
 
       await saveProfile.mutateAsync({

--- a/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
+++ b/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useCallback, useMemo, useEffect } from "react";
+import React, {
+  useState,
+  useCallback,
+  useMemo,
+  useEffect,
+  useRef,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { LlmProfilesManager } from "./llm-profiles-manager";
 import { ProfileNameInput } from "./profile-name-input";
@@ -63,6 +69,15 @@ export function LlmSettingsLocalView() {
     settings?.agent_settings_schema,
   );
 
+  // Always hold the freshest schema. `handleEditProfile` awaits a network
+  // round-trip before seeding the form, so reading the schema from a ref
+  // (rather than the value captured in the callback's closure) picks up a
+  // schema that finished loading during that await. This closes the brief
+  // first-load window where the schema is still pending when Edit is clicked
+  // and would otherwise seed only the three hard-coded keys.
+  const agentSchemaRef = useRef(agentSchema);
+  agentSchemaRef.current = agentSchema;
+
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [profileName, setProfileName] = useState("");
   const [editingProfile, setEditingProfile] = useState<EditingProfile | null>(
@@ -124,10 +139,12 @@ export function LlmSettingsLocalView() {
         // Seed every llm.* form field from the profile config so all tabs —
         // including "All" — reflect the profile's real values rather than the
         // active settings. Fields absent from the schema are still preserved
-        // on save via `baseConfig`.
+        // on save via `baseConfig`. Read the schema from the ref so a schema
+        // that loaded during the `getProfile` await above is used.
+        const schema = agentSchemaRef.current;
         const llmFields =
-          agentSchema?.sections.find((section) => section.key === "llm")
-            ?.fields ?? [];
+          schema?.sections.find((section) => section.key === "llm")?.fields ??
+          [];
         const initialValues: SettingsFormValues = {};
         for (const field of llmFields) {
           const flatKey = field.key.startsWith("llm.")
@@ -155,7 +172,7 @@ export function LlmSettingsLocalView() {
         displayErrorToast(t(I18nKey.ERROR$GENERIC));
       }
     },
-    [agentSchema, t],
+    [t],
   );
 
   const handleBackToList = useCallback(() => {

--- a/src/components/features/settings/sdk-settings/sdk-section-page.tsx
+++ b/src/components/features/settings/sdk-settings/sdk-section-page.tsx
@@ -19,6 +19,7 @@ import {
 import { retrieveAxiosErrorMessage } from "#/utils/retrieve-axios-error-message";
 import {
   buildInitialSettingsFormValues,
+  buildSdkSettingsPayload,
   buildSdkSettingsPayloadForView,
   getVisibleSettingsSections,
   hasAdvancedSettings,
@@ -117,6 +118,15 @@ export interface SdkSectionSaveControl {
   isDirty: boolean;
   /** Current form values (for custom save flows). */
   values: SettingsFormValues;
+  /** The active view tier (basic/advanced/all) the form is rendering. */
+  view: SettingsView;
+  /**
+   * Returns the coerced, dirty-only payload as a nested object
+   * (e.g. `{ llm: { temperature: 0.7 } }`). Lets a custom save flow persist
+   * exactly the fields the user changed, with proper types, without
+   * re-implementing schema-driven coercion. Throws if a field fails coercion.
+   */
+  getDirtyPayload: () => Record<string, unknown>;
 }
 
 /**
@@ -360,6 +370,17 @@ export function SdkSectionPage({
     handleSaveRef.current();
   }, []);
 
+  // Stable accessor for the coerced, dirty-only payload. Mirrors the
+  // `handleSaveRef` pattern so the exposed function reference stays stable
+  // across renders while always reading the latest closure at call time.
+  const buildDirtyPayloadRef = React.useRef<() => Record<string, unknown>>(
+    () => ({}),
+  );
+  const stableGetDirtyPayload = React.useCallback(
+    () => buildDirtyPayloadRef.current(),
+    [],
+  );
+
   const handleSave = () => {
     if (!filteredSchema || isReadOnly) return;
 
@@ -400,6 +421,14 @@ export function SdkSectionPage({
   };
 
   handleSaveRef.current = handleSave;
+  // Dirty-only (NOT view-filtered): we must never inject defaults for
+  // non-visible fields here, or a custom save flow would reset fields the
+  // user never touched. `buildSdkSettingsPayloadForView` is reserved for the
+  // built-in full-replace save above.
+  buildDirtyPayloadRef.current = () =>
+    filteredSchema
+      ? buildSdkSettingsPayload(filteredSchema, values, dirty)
+      : {};
 
   // Surface save state to the parent. Hooks must run before any
   // conditional early-returns below, so this lives here rather than
@@ -415,8 +444,10 @@ export function SdkSectionPage({
       isSaving: isPending,
       isDirty: saveControlIsDirty,
       values,
+      view,
+      getDirtyPayload: stableGetDirtyPayload,
     });
-  }, [isPending, saveControlIsDirty, values]);
+  }, [isPending, saveControlIsDirty, values, view]);
 
   if (isLoading || isFetching || isSchemaLoading) {
     return <LlmSettingsInputsSkeleton />;

--- a/src/utils/sdk-settings-schema.ts
+++ b/src/utils/sdk-settings-schema.ts
@@ -125,7 +125,7 @@ function isMinorField(field: SettingsFieldSchema): boolean {
   return field.prominence === "minor";
 }
 
-function normalizeFieldValue(
+export function normalizeFieldValue(
   field: SettingsFieldSchema,
   rawValue: unknown,
 ): string | boolean {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary
On `/settings/llm` connected to a local `agent-server`, saving an LLM profile from the **Basic** or **All** tab does not persist the changes (a success toast still appears), while the **Advanced** tab works. Separately, after selecting **LLM Provider = OpenHands** + a model and saving from the **Basic** tab, the profile re‑renders with the provider reverted to `litellm_proxy` and an empty model dropdown.

### Steps to Reproduce
1. Run the GUI against a local agent‑server (`http://127.0.0.1:8000`) and open `/settings/llm`.
2. Edit (or create) an LLM profile.
3. **All tab:** change a non‑critical field (e.g. *Temperature*) → **Save** → reopen the profile. The change is gone.
4. **Basic tab:** select **OpenHands** + a model → **Save** → reopen the profile. Provider shows `litellm_proxy`, model is empty.
5. **Advanced tab:** change *Model / Base URL / API Key* → **Save** → reopen. Persists correctly.

### Expected Behavior
All three tabs persist their changes, untouched fields are never wiped, and an OpenHands selection re‑renders as **OpenHands** with the chosen model.

### Actual Behavior
- **All tab:** non‑critical (minor) fields are silently dropped; on every save the backend resets all non‑sent fields to LLM defaults.
- **Basic tab + OpenHands:** the profile is stored with a stale, non‑proxy `base_url`, so it can no longer be recognized as OpenHands on reload.
- **Advanced tab:** works (coincidentally — see root cause).

### Root Cause
The local profile editor (`LlmSettingsLocalView`) drives its own save from the embedded settings form's `SdkSectionSaveControl`, but `handleSave` rebuilt the saved `LLM` object from only three hard‑coded keys: `llm.model`, `llm.api_key`, `llm.base_url`.

- The backend profile save (`SaveProfileRequest.llm: LLM`) is a **full object replace** — any field not sent is reset to its default. The Advanced tab edits exactly those three keys (`model`/`api_key` are *critical*, `base_url` is *major*), so it round‑trips losslessly. The All tab also exposes *minor* fields (e.g. `temperature`) that were dropped.
- In the Basic tab there is no `base_url` field, so a **stale, non‑proxy `base_url`** carried over from the profile's prior config was persisted. The backend's `openhands/* → litellm_proxy/*` rewrite only injects the All‑Hands proxy `base_url` when `base_url` is falsy (`d.get("base_url") or proxy`), so the stale value survived. On reload, `normalizeDisplayModel` requires the proxy `base_url` to map `litellm_proxy/<m>` back to `openhands/<m>` — with a non‑proxy URL it cannot, so the provider falls back to `litellm_proxy` and the model dropdown (which has no `litellm_proxy` entries) renders empty. This was self‑reinforcing: every Basic re‑save re‑sent the stale URL.

The cloud settings path was unaffected because its `buildPayload` already resets `base_url` to the schema default in the Basic view; the local profile path had no equivalent.

### Fix
1. Expose a coerced, dirty‑only payload and the active view tier on the shared save control (`SdkSectionSaveControl.getDirtyPayload()` and `.view`).
2. On edit, hydrate **all** `llm.*` fields from the profile config (not just three) and keep the full config as a merge base.
3. On save, merge the coerced dirty changes over the profile's existing full config (preserving untouched fields), and — in the Basic view only — drop `base_url` so the backend re‑derives the correct one (the proxy for `openhands/*`).

### Acceptance Criteria
- [x] Changing a minor field in the **All** tab persists it (typed value coerced to the correct type) without wiping untouched fields.
- [x] Saving from the **Basic** tab does not persist a stale `base_url`; an OpenHands selection round‑trips to **OpenHands** + the chosen model on reload.
- [x] The **Advanced** tab continues to persist `model` / `base_url` / `API key`.
- [x] The existing API‑key round‑trip (encrypted key preserved when not changed) is unchanged.
- [x] The cloud (non‑local) settings flow is unaffected.
- [x] Automated tests cover the above; full suite green.

### Out of Scope
- Reworking the OpenHands display heuristic (`normalizeDisplayModel`) — it is correct; the defect was that the wrong `base_url` was persisted.

## Summary

<!-- 1-3 bullets describing what changed. -->
On a local `agent-server`, the LLM profile editor only persisted changes made from the **Advanced** tab. The **Basic** and **All** tabs showed a success toast but silently dropped changes, and selecting **OpenHands** in the Basic tab re‑rendered the profile as `litellm_proxy` with an empty model. This PR makes all three tabs persist correctly and repairs the OpenHands round‑trip.

### Why it happened
`LlmSettingsLocalView.handleSave` reconstructed the profile's `LLM` object from only three hard‑coded keys (`llm.model`, `llm.api_key`, `llm.base_url`). Since the profile save (`SaveProfileRequest.llm: LLM`) is a **full‑object replace**, every other field was reset to its default:

- **Advanced** edits exactly those three keys (`model`/`api_key` = *critical*, `base_url` = *major*) → round‑trips losslessly.
- **All** also exposes *minor* fields (e.g. `temperature`) → dropped on save.
- **Basic** has no `base_url` input, so a stale, non‑proxy `base_url` from the profile's prior config was persisted. The backend only injects the proxy `base_url` for `openhands/*` models when `base_url` is falsy (`d.get("base_url") or proxy`), so the stale value survived and `normalizeDisplayModel` could no longer map `litellm_proxy/<m>` back to `openhands/<m>` → provider reverted to `litellm_proxy`, model dropdown empty. Self‑reinforcing: every Basic re‑save re‑sent the stale URL.

The cloud settings path was unaffected because its `buildPayload` already resets `base_url` to the schema default in Basic view.

### What changed
**Production**
- `src/components/features/settings/sdk-settings/sdk-section-page.tsx`
  - `SdkSectionSaveControl` now exposes `view` (active tier) and `getDirtyPayload()` — the coerced, **dirty‑only** payload nested by section (built with `buildSdkSettingsPayload`, deliberately **not** the view‑filtered variant, so non‑visible fields are never reset to defaults). Wired via a stable ref so the control reference stays stable.
- `src/components/features/settings/llm-profiles/llm-settings-local-view.tsx`
  - `EditingProfile` gains `baseConfig`; `handleEditProfile` hydrates **all** `llm.*` fields from the profile config and keeps the full config as a merge base.
  - `handleSave` merges the coerced dirty changes over the full config (preserving untouched fields, incl. ones not in the form), preserves the existing encrypted API key when unchanged, and — in the **Basic** view — drops `base_url` so the backend re‑derives it (mirrors the cloud path).
- `src/utils/sdk-settings-schema.ts`
  - Export `normalizeFieldValue` for profile hydration.

**Tests**
- `__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx` — the save control exposes `view` and a coerced, dirty‑only `getDirtyPayload()`.
- `__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx`
  - Basic‑tab save omits `base_url` so an OpenHands model round‑trips.
  - All‑tab change to a minor field (`temperature`) is persisted (coerced to a number) without wiping the untouched `model`/`api_key`.

`normalizeDisplayModel` is intentionally unchanged — it is correct; the defect was the persisted `base_url`.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #842 , #942 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

- **Automated:** `npm run lint` and `npm test` — full suite green (2693 passing).
- **Manual** (local agent‑server at `127.0.0.1:8000`):
  - All tab → change *Temperature* → Save → reopen: value persists, other fields intact.
  - Basic tab → select **OpenHands** + a model → Save → reopen: renders **OpenHands** + the model (repairs an already‑broken profile on the next Basic save).
  - Advanced tab → change *Model / Base URL / API Key* → Save → reopen: persists.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `9dd8f7acb4f1db85720b1c6153320fe2b95cc370` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-9dd8f7a
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-9dd8f7a
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-9dd8f7a-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1995-amd64
ghcr.io/openhands/agent-canvas:pr-970-amd64
ghcr.io/openhands/agent-canvas:sha-9dd8f7a-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1995-arm64
ghcr.io/openhands/agent-canvas:pr-970-arm64
ghcr.io/openhands/agent-canvas:sha-9dd8f7a
ghcr.io/openhands/agent-canvas:hieptl-app-1995
ghcr.io/openhands/agent-canvas:pr-970
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-9dd8f7a`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-9dd8f7a-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->