### PR TITLE
chore: bump version to 1.0.0-alpha.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ agent-canvas
 ### Option 2: With a Docker Sandbox
 
 ```sh
-docker pull ghcr.io/openhands/agent-canvas:1.0.0-alpha.9
+docker pull ghcr.io/openhands/agent-canvas:1.0.0-alpha.10
 
 export PROJECTS_PATH=~/projects  # directory containing your project folders
 
@@ -69,7 +69,7 @@ docker run -it --rm \
   -p 8000:8000 \
   -v ~/.openhands:/home/openhands/.openhands \
   -v ${PROJECTS_PATH}:/projects \
-  ghcr.io/openhands/agent-canvas:1.0.0-alpha.9
+  ghcr.io/openhands/agent-canvas:1.0.0-alpha.10
 ```
 
 The agent will be able to access any project under `PROJECTS_PATH`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openhands/agent-canvas",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.0-alpha.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openhands/agent-canvas",
-      "version": "1.0.0-alpha.9",
+      "version": "1.0.0-alpha.10",
       "license": "MIT",
       "dependencies": {
         "@heroui/react": "2.8.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhands/agent-canvas",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.0-alpha.10",
   "description": "Agent Canvas UI for OpenHands - run AI coding agents with a visual interface",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Release v1.0.0-alpha.10

This PR bumps the version to **1.0.0-alpha.10** for release.

### Release Checklist
- [x] Version bumped in package.json and package-lock.json
- [x] Version references updated in README.md
- [ ] CI passes (lint, test, build)
- [ ] Visual snapshot tests pass
- [ ] Mock-LLM E2E tests pass (triggered by `e2e-tests` label)
- [ ] Review and approve

### What happens on merge
When this PR is merged, the `create-release.yml` workflow will automatically:
1. Create a GitHub release with tag `v1.0.0-alpha.10` and auto-generated notes
2. The tag push triggers `npm-publish.yml` to publish to npm
3. The tag push triggers `docker.yml` to build and push Docker images to GHCR

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `e0e171273d39049abc936ddfc5a5a22ba3ac9e20` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-e0e1712
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-e0e1712
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-e0e1712-amd64
ghcr.io/openhands/agent-canvas:rel-1.0.0-alpha.10-amd64
ghcr.io/openhands/agent-canvas:pr-990-amd64
ghcr.io/openhands/agent-canvas:sha-e0e1712-arm64
ghcr.io/openhands/agent-canvas:rel-1.0.0-alpha.10-arm64
ghcr.io/openhands/agent-canvas:pr-990-arm64
ghcr.io/openhands/agent-canvas:sha-e0e1712
ghcr.io/openhands/agent-canvas:rel-1.0.0-alpha.10
ghcr.io/openhands/agent-canvas:pr-990
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-e0e1712`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-e0e1712-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->