### PR TITLE
fix(frontend): stop sending agent_context: null in cloud settings saves

### DIFF
--- a/__tests__/api/cloud/settings-service.test.ts
+++ b/__tests__/api/cloud/settings-service.test.ts
@@ -153,3 +153,57 @@ describe("cloud settings via local proxy", () => {
     });
   });
 });
+
+describe("saveCloudSettings drops agent_context: null (agent-canvas#981)", () => {
+  it("strips a null agent_context while preserving sibling agent settings", async () => {
+    // Arrange: the cloud rejects agent_context: null against OpenHandsAgentSettings.
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
+
+    // Act
+    await saveCloudSettings({
+      agent_settings_diff: {
+        llm: { model: "anthropic/claude-sonnet-4-20250514" },
+        agent_context: null,
+      },
+    });
+
+    // Assert: agent_context never reaches the wire, but the real llm change does.
+    const [, body] = vi.mocked(axios.post).mock.calls[0]!;
+    const proxiedBody = (body as { body: Record<string, unknown> }).body;
+    expect(proxiedBody).toEqual({
+      agent_settings_diff: {
+        llm: { model: "anthropic/claude-sonnet-4-20250514" },
+      },
+    });
+  });
+
+  it("preserves a null mcp_config so clearing MCP config still round-trips", async () => {
+    // Arrange: mcp_config: null is an intentional "clear" signal, not an error.
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
+
+    // Act
+    await saveCloudSettings({
+      agent_settings_diff: { mcp_config: null },
+    });
+
+    // Assert: the null mcp_config must survive (don't over-strip nulls).
+    const [, body] = vi.mocked(axios.post).mock.calls[0]!;
+    const proxiedBody = (body as { body: Record<string, unknown> }).body;
+    expect(proxiedBody).toEqual({ agent_settings_diff: { mcp_config: null } });
+  });
+
+  it("omits agent_settings_diff when agent_context: null is its only key", async () => {
+    // Arrange
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
+
+    // Act
+    await saveCloudSettings({
+      agent_settings_diff: { agent_context: null },
+    });
+
+    // Assert: nothing is left to send, so no agent_settings_diff goes on the wire.
+    const [, body] = vi.mocked(axios.post).mock.calls[0]!;
+    const proxiedBody = (body as { body: Record<string, unknown> }).body;
+    expect(proxiedBody).toEqual({});
+  });
+});

--- a/src/api/cloud/settings-service.api.ts
+++ b/src/api/cloud/settings-service.api.ts
@@ -154,11 +154,21 @@ export async function saveCloudSettings(diff: {
 }): Promise<void> {
   const backend = getActiveCloudBackend();
   const body: Record<string, unknown> = {};
-  if (
-    diff.agent_settings_diff &&
-    Object.keys(diff.agent_settings_diff).length > 0
-  ) {
-    body.agent_settings_diff = diff.agent_settings_diff;
+  if (diff.agent_settings_diff) {
+    const agentDiff: Record<string, SettingsValue> = {
+      ...diff.agent_settings_diff,
+    };
+    // The cloud validates agent settings against the SDK's
+    // OpenHandsAgentSettings, whose `agent_context` is a required
+    // AgentContext (not Optional). A literal `agent_context: null` fails
+    // backend validation, so drop it and let the backend keep/default it.
+    // See OpenHands/agent-canvas#981.
+    if (agentDiff.agent_context === null) {
+      delete agentDiff.agent_context;
+    }
+    if (Object.keys(agentDiff).length > 0) {
+      body.agent_settings_diff = agentDiff;
+    }
   }
   if (
     diff.conversation_settings_diff &&


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Problem
Saving an LLM configuration from Agent Canvas against an **OpenHands Cloud** backend can break the user's Cloud settings with a backend validation error:

```
1 validation error for OpenHandsAgentSettings
agent_context
  Input should be a valid dictionary or instance of AgentContext [input_value=None, input_type=NoneType]
```

### Root cause
- The cloud validates `agent_settings` against the SDK model `OpenHandsAgentSettings`, whose `agent_context: AgentContext = Field(default_factory=AgentContext)` is **required / non-optional**. A literal `agent_context: null` in the POSTed `agent_settings_diff` therefore fails validation. (`ACPAgentSettings.agent_context` is `AgentContext | None`, which is why only the OpenHands variant rejects `null`.)
- Agent Canvas had no guard preventing a `null` `agent_context` from being included in a Cloud settings save.

### Why it wasn't reproducible locally
- `agent_context` is **not** part of the settings schema the UI renders, and no save path emits it — the standard flows never produce it.
- The local agent-server's deep-merge maps a `null` value to "remove key", so even a hand-crafted `null` is stripped before validation. **The failure is cloud-only.**

### Scope / solution (frontend, cloud-only)
Normalize the cloud save payload in `saveCloudSettings()` so `agent_context` is removed from `agent_settings_diff` before the POST — a `null` can never reach the backend, which then keeps/defaults it. Targeted so `mcp_config: null` (an intentional "clear MCP config" signal) still round-trips; if dropping `agent_context` empties the diff, `agent_settings_diff` is omitted entirely.

### Acceptance criteria
- [ ] Saving an LLM config against Cloud no longer produces the `agent_context` validation error.
- [ ] Agent Canvas never sends `agent_context: null` in a Cloud settings save request.
- [ ] `mcp_config: null` (clear MCP config) is preserved.
- [ ] Regression tests assert the above.

## Summary

<!-- 1-3 bullets describing what changed. -->
Agent Canvas could break a user's **Cloud** settings when saving an LLM configuration: a `agent_context: null` reached the cloud backend and failed `OpenHandsAgentSettings` validation. This adds a defensive normalization so the cloud save payload can never carry `agent_context: null`.

### Problem
```
1 validation error for OpenHandsAgentSettings
agent_context
  Input should be a valid dictionary or instance of AgentContext [input_value=None, input_type=NoneType]
```

### Root cause
The cloud validates `agent_settings` against the SDK model `OpenHandsAgentSettings`, whose `agent_context` is a **required** `AgentContext` (not `Optional`). A literal `agent_context: null` in the POSTed `agent_settings_diff` fails. (`ACPAgentSettings.agent_context` is `AgentContext | None`, so only the OpenHands variant rejects `null`.) Agent Canvas had no guard against including a `null` `agent_context` in a cloud save.

### What changed
- **`src/api/cloud/settings-service.api.ts`** — `saveCloudSettings()` removes `agent_context` from `agent_settings_diff` before POSTing to `/api/v1/settings`; if that empties the diff, `agent_settings_diff` is omitted.
- **`__tests__/api/cloud/settings-service.test.ts`** — 3 regression tests (4 existing tests unchanged → 7 total).

### Why this scope
- **Cloud-only:** the local agent-server's deep-merge already treats a `null` value as "remove key", so the local path needs no change.
- **Targeted, not a blanket null-strip:** `mcp_config: null` is an intentional "clear MCP config" signal and must round-trip — a wholesale null-strip would break it.
- **Why it never reproduced locally:** `agent_context` isn't a rendered settings field and no UI path emits it, so the failure is cloud-side only.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #981 

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

### Risk / out of scope
Low risk — one cloud function plus tests. The underlying backend contract (cloud accepting/normalizing `null`) is unchanged and can be hardened in a separate change.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `5a75b99aeaa3cd0e16475b643c4997693a93539d` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-5a75b99
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-5a75b99
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-5a75b99-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2083-amd64
ghcr.io/openhands/agent-canvas:pr-1021-amd64
ghcr.io/openhands/agent-canvas:sha-5a75b99-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2083-arm64
ghcr.io/openhands/agent-canvas:pr-1021-arm64
ghcr.io/openhands/agent-canvas:sha-5a75b99
ghcr.io/openhands/agent-canvas:hieptl-app-2083
ghcr.io/openhands/agent-canvas:pr-1021
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-5a75b99`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-5a75b99-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->