### PR TITLE
Add openhands CLI alias for local install

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ code review and dependency updates, then have your personal agents running on yo
 
 ```sh
 npm install -g @openhands/agent-canvas
-agent-canvas
+openhands
 ```
+
+The package also exposes `agent-canvas` as a backwards-compatible command name.
 
 ### Option 2: With a Docker Sandbox
 

--- a/__tests__/package-library.test.ts
+++ b/__tests__/package-library.test.ts
@@ -11,6 +11,7 @@ const packageJson = JSON.parse(
   module: string;
   types: string;
   exports: Record<string, unknown>;
+  bin: Record<string, string>;
   scripts: Record<string, string>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
@@ -22,6 +23,10 @@ describe("package library metadata", () => {
     expect(packageJson.main).toBe("./dist/index.cjs");
     expect(packageJson.module).toBe("./dist/index.js");
     expect(packageJson.types).toBe("./dist/index.d.ts");
+    expect(packageJson.bin).toEqual({
+      "agent-canvas": "bin/agent-canvas.mjs",
+      openhands: "bin/agent-canvas.mjs",
+    });
     expect(packageJson.exports).toMatchObject({
       ".": {
         types: "./dist/index.d.ts",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,8 @@ Agent Canvas supports several modes:
 
 The npm package is `@openhands/agent-canvas`. The package exposes:
 
-- The `agent-canvas` binary for launching a local stack.
+- The `openhands` binary for launching a local stack, matching the primary quickstart command.
+- The `agent-canvas` binary as a backwards-compatible command alias.
 - A standalone app build.
 - Library entrypoints for browser, conversation, files, settings, sidebar, terminal, and i18n modules.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,8 @@
         "zustand": "5.0.12"
       },
       "bin": {
-        "agent-canvas": "bin/agent-canvas.mjs"
+        "agent-canvas": "bin/agent-canvas.mjs",
+        "openhands": "bin/agent-canvas.mjs"
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "url": "https://github.com/OpenHands/agent-canvas/issues"
   },
   "bin": {
-    "agent-canvas": "bin/agent-canvas.mjs"
+    "agent-canvas": "bin/agent-canvas.mjs",
+    "openhands": "bin/agent-canvas.mjs"
   },
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

Closes #451.

The MVP local install discussion asked for an install flow that feels like `npm install -g @openhands/agent-canvas` followed by `openhands`. The npm package currently only exposes `agent-canvas`, so the README quickstart could not use the expected OpenHands-style command.

## Summary

- Add `openhands` as an npm binary alias for the existing `bin/agent-canvas.mjs` launcher.
- Update the README npm quickstart to use `openhands` while documenting `agent-canvas` as a backwards-compatible command name.
- Add package metadata regression coverage for both CLI names and update architecture docs.

## Issue Number

#451

## How to Test

- `npm ci`
- `npm test -- --run __tests__/package-library.test.ts __tests__/bin/agent-canvas.test.ts`
- `npm pack --dry-run --json`

## Video/Screenshots

N/A — package metadata and documentation change.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This keeps `agent-canvas` available to avoid breaking existing installs/scripts while making `openhands` the primary user-facing command.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a0d16c07-a8b7-47ae-89df-203e17f39866)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `65cfa54d7aa15ac7e23f09d61b968b9c12318216` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-65cfa54
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-65cfa54
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-65cfa54-amd64
ghcr.io/openhands/agent-canvas:openhands-add-openhands-cli-alias-amd64
ghcr.io/openhands/agent-canvas:pr-1042-amd64
ghcr.io/openhands/agent-canvas:sha-65cfa54-arm64
ghcr.io/openhands/agent-canvas:openhands-add-openhands-cli-alias-arm64
ghcr.io/openhands/agent-canvas:pr-1042-arm64
ghcr.io/openhands/agent-canvas:sha-65cfa54
ghcr.io/openhands/agent-canvas:openhands-add-openhands-cli-alias
ghcr.io/openhands/agent-canvas:pr-1042
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-65cfa54`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-65cfa54-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->