### PR TITLE
fix(frontend): stop loading the cloud conversation after switching to a local backend

### DIFF
--- a/__tests__/hooks/query/use-user-conversation.test.tsx
+++ b/__tests__/hooks/query/use-user-conversation.test.tsx
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import { useUserConversation } from "#/hooks/query/use-user-conversation";
+import type { Backend } from "#/api/backend-registry/types";
+import type { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
+
+// Mock the underlying service the hook depends on (not the hook itself).
+vi.mock(
+  "#/api/conversation-service/agent-server-conversation-service.api",
+  () => ({
+    default: { batchGetAppConversations: vi.fn() },
+  }),
+);
+
+const localBackend: Backend = {
+  id: "local-1",
+  name: "Local 1",
+  host: "http://localhost:8000",
+  apiKey: "session-key",
+  kind: "local",
+};
+
+const cloudBackend: Backend = {
+  id: "cloud-1",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "bearer-key",
+  kind: "cloud",
+};
+
+const CLOUD_CONVERSATION_ID = "conv-cloud";
+
+function makeConversation(id: string): AppConversation {
+  return {
+    id,
+    created_by_user_id: null,
+    selected_repository: null,
+    selected_branch: null,
+    git_provider: null,
+    title: "Test",
+    trigger: null,
+    pr_number: [],
+    llm_model: null,
+    metrics: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    execution_status: null,
+    sandbox_status: null,
+    conversation_url: "https://sandbox.example.com/api",
+    session_api_key: null,
+    sandbox_id: null,
+    sub_conversation_ids: [],
+  };
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ActiveBackendProvider>{children}</ActiveBackendProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  vi.mocked(
+    AgentServerConversationService.batchGetAppConversations,
+  ).mockReset();
+  vi.mocked(
+    AgentServerConversationService.batchGetAppConversations,
+  ).mockResolvedValue([makeConversation(CLOUD_CONVERSATION_ID)]);
+  setRegisteredBackends([localBackend, cloudBackend]);
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+});
+
+describe("useUserConversation — backend switch", () => {
+  it("does not load the conversation id against a different backend after switching", async () => {
+    // Arrange — the conversation is opened while the cloud backend is active.
+    setActiveSelection({ backendId: cloudBackend.id });
+    const { result } = renderHook(
+      () => useUserConversation(CLOUD_CONVERSATION_ID),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(
+      AgentServerConversationService.batchGetAppConversations,
+    ).toHaveBeenCalledTimes(1);
+
+    // Act — switch to the local backend without leaving the conversation.
+    setActiveSelection({ backendId: localBackend.id });
+
+    // Assert — the cloud id is foreign to the local backend, so the query is
+    // disabled and never fetched against it (no second service call).
+    await waitFor(() => expect(result.current.data).toBeUndefined());
+    expect(
+      AgentServerConversationService.batchGetAppConversations,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("still loads the conversation when only the org changes on the same backend", async () => {
+    // Arrange — opened under a cloud backend scoped to one org.
+    setActiveSelection({ backendId: cloudBackend.id, orgId: "org-a" });
+    const { result } = renderHook(
+      () => useUserConversation(CLOUD_CONVERSATION_ID),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(
+      AgentServerConversationService.batchGetAppConversations,
+    ).toHaveBeenCalledTimes(1);
+
+    // Act — switch org within the same backend (e.g. the cloud personal-
+    // workspace self-heal), which keeps the same agent-server schema.
+    setActiveSelection({ backendId: cloudBackend.id, orgId: "org-b" });
+
+    // Assert — same backend, so the conversation is fetched again for the
+    // new org rather than being disabled.
+    await waitFor(() =>
+      expect(
+        AgentServerConversationService.batchGetAppConversations,
+      ).toHaveBeenCalledTimes(2),
+    );
+  });
+});

--- a/__tests__/routes/conversation-backend-switch.test.tsx
+++ b/__tests__/routes/conversation-backend-switch.test.tsx
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import { NavigationProvider } from "#/context/navigation-context";
+import ConversationView from "#/routes/conversation";
+import type { Backend } from "#/api/backend-registry/types";
+import type { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
+
+// Mock the underlying service the conversation queries depend on.
+vi.mock(
+  "#/api/conversation-service/agent-server-conversation-service.api",
+  () => ({
+    default: { batchGetAppConversations: vi.fn() },
+  }),
+);
+
+// Stub the heavy presentational subtree so the test focuses on the route's
+// teardown behaviour, not the conversation UI.
+vi.mock(
+  "#/components/features/conversation/conversation-main/conversation-main",
+  () => ({
+    ConversationMain: () => <div data-testid="conversation-main" />,
+    ConversationMobilePanelPage: () => <div data-testid="conversation-panel" />,
+  }),
+);
+vi.mock("#/wrapper/event-handler", () => ({
+  EventHandler: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+vi.mock("#/contexts/websocket-provider-wrapper", () => ({
+  WebSocketProviderWrapper: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+vi.mock("#/hooks/query/use-task-polling", () => ({
+  useTaskPolling: () => ({ isTask: false, taskStatus: null, taskDetail: null }),
+}));
+vi.mock("#/hooks/query/use-is-authed", () => ({
+  useIsAuthed: () => ({ data: true }),
+}));
+vi.mock("#/api/cloud/conversation-service.api", () => ({
+  resumeCloudSandbox: vi.fn(),
+}));
+
+const localBackend: Backend = {
+  id: "local-1",
+  name: "Local 1",
+  host: "http://localhost:8000",
+  apiKey: "session-key",
+  kind: "local",
+};
+
+const cloudBackend: Backend = {
+  id: "cloud-1",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "bearer-key",
+  kind: "cloud",
+};
+
+const CLOUD_CONVERSATION_ID = "conv-cloud";
+
+function makeConversation(id: string): AppConversation {
+  return {
+    id,
+    created_by_user_id: null,
+    selected_repository: null,
+    selected_branch: null,
+    git_provider: null,
+    title: "Test",
+    trigger: null,
+    pr_number: [],
+    llm_model: null,
+    metrics: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    execution_status: null,
+    sandbox_status: null,
+    conversation_url: "https://sandbox.example.com/api",
+    session_api_key: null,
+    sandbox_id: null,
+    sub_conversation_ids: [],
+  };
+}
+
+function renderConversation() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter initialEntries={[`/conversations/${CLOUD_CONVERSATION_ID}`]}>
+      <QueryClientProvider client={queryClient}>
+        <ActiveBackendProvider>
+          <NavigationProvider
+            value={{
+              currentPath: `/conversations/${CLOUD_CONVERSATION_ID}`,
+              conversationId: CLOUD_CONVERSATION_ID,
+              isNavigating: false,
+              navigate: vi.fn(),
+            }}
+          >
+            <ConversationView />
+          </NavigationProvider>
+        </ActiveBackendProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  vi.mocked(
+    AgentServerConversationService.batchGetAppConversations,
+  ).mockReset();
+  vi.mocked(
+    AgentServerConversationService.batchGetAppConversations,
+  ).mockResolvedValue([makeConversation(CLOUD_CONVERSATION_ID)]);
+  setRegisteredBackends([localBackend, cloudBackend]);
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+});
+
+describe("conversation route — backend switch", () => {
+  it("tears down the conversation view when the active backend changes mid-conversation", async () => {
+    // Arrange — the cloud conversation renders while the cloud backend is active.
+    setActiveSelection({ backendId: cloudBackend.id });
+    renderConversation();
+    expect(
+      await screen.findByTestId("conversation-main"),
+    ).toBeInTheDocument();
+
+    // Act — switch to the local backend without leaving the conversation.
+    setActiveSelection({ backendId: localBackend.id });
+
+    // Assert — the subtree unmounts instead of rendering the cloud
+    // conversation under the local backend, so its per-conversation queries
+    // cannot fire against a backend the id is foreign to.
+    await waitFor(() => {
+      expect(screen.queryByTestId("conversation-main")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/hooks/query/use-user-conversation.ts
+++ b/src/hooks/query/use-user-conversation.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { useRef } from "react";
 import { Query, useQuery } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
@@ -23,6 +24,22 @@ export const useUserConversation = (
 ) => {
   const active = useActiveBackend();
 
+  // The cid belongs to whichever backend was active when the user opened this
+  // conversation. If they switch to a *different* backend (e.g. cloud → local)
+  // without leaving the conversation view, the cid is foreign to the new
+  // backend; fetching it makes that backend parse a response for an id it
+  // doesn't own and surfaces a confusing "agent server returned data this UI
+  // does not understand" toast. Pin the cid to its origin backend and disable
+  // the query until the route navigates to a valid id. Compare backend id
+  // ONLY — org changes within the same backend (e.g. the cloud
+  // personal-workspace self-heal in BackendSelector) keep the same
+  // agent-server schema and must still refetch.
+  const origin = useRef({ cid, backendId: active.backend.id });
+  if (origin.current.cid !== cid) {
+    origin.current = { cid, backendId: active.backend.id };
+  }
+  const backendChanged = origin.current.backendId !== active.backend.id;
+
   return useQuery({
     // Include the active backend identity so each (backend, org) pair
     // maintains its own per-conversation cache entry. Without this, a
@@ -40,7 +57,7 @@ export const useUserConversation = (
         await AgentServerConversationService.batchGetAppConversations([cid]);
       return results[0] ?? null;
     },
-    enabled: !!cid && !cid.startsWith("task-"),
+    enabled: !!cid && !cid.startsWith("task-") && !backendChanged,
     retry: false,
     refetchInterval,
     staleTime: FIVE_MINUTES,

--- a/src/routes/conversation.tsx
+++ b/src/routes/conversation.tsx
@@ -178,6 +178,20 @@ function AppContent() {
     t,
   ]);
 
+  // A backend switch is in flight (BackendSelector flips the active backend
+  // and redirects to /conversations on the next tick). The conversationId in
+  // the URL belongs to the *previous* backend, so unmount the whole
+  // conversation subtree now — before any per-conversation query (history,
+  // metrics, sub-conversations, runtime info, …) re-fires against a backend
+  // the id is foreign to. Those foreign fetches fail response validation and
+  // surface "agent server returned data this UI does not understand". This is
+  // deterministic regardless of the navigate-vs-setActive render race: React
+  // re-renders this parent before its children, so returning null removes them
+  // before they can issue the request.
+  if (backendChanged) {
+    return null;
+  }
+
   const content = (
     <EventHandler>
       <div data-testid="app-route" className="flex h-full flex-col">


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

When a user is viewing a conversation on a **cloud** backend and switches the active backend to a **local** backend, the app shows an error toast:

> Unable to load conversations because the selected agent server returned data this UI does not understand. Check the backend URL/session key and update the agent server if needed.

### Steps to reproduce

1. Configure both a cloud backend and a local backend.
2. Open a conversation while connected to the cloud backend (`/conversations/:conversationId`).
3. Without leaving the conversation, switch the active backend to the local backend via the backend selector.

### Actual behavior

The error toast above is displayed.

### Expected behavior

After switching to the local backend, the app lands on a valid local state (the conversations list) and shows **no error** — it must not try to load the cloud conversation against the local backend.

### Root cause

The error message originates from `invalidConversationResponse()` in `agent-server-conversation-service.api.ts`, thrown when a conversation response fails schema validation. It is surfaced by the **global** React Query `QueryCache.onError` handler (`query-client-config.ts`).

When the backend is switched while a conversation is open:

- React Router v7's `navigate("/conversations")` (in `BackendSelector`) runs inside a **deferred** `startTransition`, while `setActive(...)` is an **urgent** external‑store update. The urgent re-render flips the active backend **before** the route navigates away.
- During that render, the conversation route subtree and the always‑mounted page‑title hook still hold the **cloud** `conversationId`. Several per‑conversation queries re-key to `(cloudConversationId + localBackend)` and fetch against the local backend:
  - `useUserConversation` / `useActiveConversation` → `batchGetAppConversations([cloudId])`
  - `useSubConversations` → `batchGetAppConversations(subIds)`
  - `useConversationMetrics` → `getRuntimeConversation(...)`
  - `useConversationHistory` → event fetch
- The local backend's response for an id it doesn't own fails validation → `invalidConversationResponse()` → global error toast.

The existing `backendChanged` guard in `conversation.tsx` only suppressed that component's *own* "conversation not available" toast; it did not stop the shared queries from firing.

### Fix

1. **Gate `useUserConversation`** — pin each `conversationId` to the backend it was first observed under and disable the query when the active **backend id** changes. Covers the always‑mounted page‑title hook (`useAppTitle`, in `root-layout`) and the route's own `useActiveConversation`. Compares backend id only, so an org switch on the same cloud backend (e.g. the personal‑workspace self‑heal) still refetches.
2. **Short‑circuit `conversation.tsx`** — when the active backend changes, return `null` so the entire conversation subtree unmounts before any per‑conversation query (sub‑conversations, metrics, history, websocket) can fire against the foreign backend. Deterministic via React's top‑down render order. The backend selector's existing redirect then lands the user on `/conversations`.

### Acceptance criteria

- [ ] Switching from a cloud conversation to a local backend shows no error toast.
- [ ] The user lands on a valid local state (the conversations list).
- [ ] No conversation request carrying the cloud `conversationId` is issued against the local backend.
- [ ] Switching org within the same cloud backend still loads the conversation.
- [ ] Automated tests cover the above and fail without the fix.

### Test plan

- `useUserConversation` does not refetch a stale conversation id after switching to a different backend.
- `useUserConversation` still refetches when only the org changes on the same backend.
- The conversation route unmounts its subtree when the active backend changes mid‑conversation.

## Summary

<!-- 1-3 bullets describing what changed. -->
Fixes the error toast shown when a user switches from a **cloud** backend to a **local** backend while viewing a conversation:

> Unable to load conversations because the selected agent server returned data this UI does not understand…

### Root cause

The toast comes from `invalidConversationResponse()` (response schema validation) surfaced by the global React Query `QueryCache.onError` handler.

On a backend switch, React Router v7's `navigate("/conversations")` is a **deferred** transition while `setActive()` is an **urgent** store update, so the active backend flips **before** the route navigates away. During that render the conversation subtree and the always‑mounted page‑title hook still carry the **cloud** `conversationId`, and several per‑conversation queries re-key to `(cloudConversationId + localBackend)` and fetch against the local backend. The local backend rejects the foreign id → error toast.

### Changes

- **`src/hooks/query/use-user-conversation.ts`** — Pin each `conversationId` to the backend it was first observed under; disable the query when the active **backend id** changes. This is the single shared source for conversation‑detail data, so it covers the always‑mounted `useAppTitle` and the route's `useActiveConversation`. Org‑only switches on the same backend still refetch.
- **`src/routes/conversation.tsx`** — When the active backend changes (`backendChanged`), return `null` so the whole conversation subtree unmounts before its per‑conversation queries (sub‑conversations, metrics, history, websocket) can fire against the foreign backend. Deterministic via React's parent‑before‑children render order. The backend selector's existing redirect then lands the user on `/conversations`.

No change to the backend selector's navigation or to the sidebar conversation list (which correctly refetches against the local backend).

### Tests

New, service‑mocked (not hook‑mocked) tests; both bug‑catching tests fail without the fix:

- `__tests__/hooks/query/use-user-conversation.test.tsx`
  - does not load the conversation id against a different backend after switching
  - still loads the conversation when only the org changes on the same backend
- `__tests__/routes/conversation-backend-switch.test.tsx`
  - tears down the conversation view when the active backend changes mid‑conversation

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #1044 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Configure both a cloud backend and a local backend.
2. Open a conversation while connected to the cloud backend (`/conversations/:conversationId`).
3. Without leaving the conversation, switch the active backend to the local backend via the backend selector.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/78777ab0-b41e-496d-8622-e2c2c700e22e

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

### Risk / scope

Low. Behavior changes only while a backend switch is in flight: per‑conversation queries are disabled and the conversation subtree is torn down for the dying route, exactly when the user is being redirected away. Same‑backend org switches and normal conversation loading are unaffected.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `2222e1b8f5239cbb75769b8ec36375f5542163d4` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-2222e1b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-2222e1b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-2222e1b-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2125-amd64
ghcr.io/openhands/agent-canvas:pr-1047-amd64
ghcr.io/openhands/agent-canvas:sha-2222e1b-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2125-arm64
ghcr.io/openhands/agent-canvas:pr-1047-arm64
ghcr.io/openhands/agent-canvas:sha-2222e1b
ghcr.io/openhands/agent-canvas:hieptl-app-2125
ghcr.io/openhands/agent-canvas:pr-1047
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-2222e1b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-2222e1b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->