### PR TITLE
fix(sidebar): scroll conversation filter menu on short viewports

### DIFF
--- a/src/components/features/conversation-panel/conversation-panel-filter-menu.tsx
+++ b/src/components/features/conversation-panel/conversation-panel-filter-menu.tsx
@@ -24,6 +24,7 @@ import {
   dropdownMenuRowIconClassName,
   dropdownInstantColorClassName,
   dropdownMenuListClassName,
+  dropdownMenuViewportScrollClassName,
 } from "#/utils/dropdown-classes";
 import type {
   ConversationSortField,
@@ -272,6 +273,7 @@ export function ConversationPanelFilterMenu({
           className={cn(
             "absolute right-0 top-full z-50 mt-0 w-64 rounded-md border border-[var(--oh-border-subtle)] bg-tertiary px-1 py-1 text-[var(--oh-foreground)] shadow-lg",
             dropdownMenuListClassName,
+            dropdownMenuViewportScrollClassName,
           )}
         >
           <MenuHeading>{t(I18nKey.CONVERSATION_PANEL$ORGANIZE)}</MenuHeading>

--- a/src/utils/dropdown-classes.ts
+++ b/src/utils/dropdown-classes.ts
@@ -72,6 +72,15 @@ export const switchProfileMenuListScrollClassName = cn(
   "max-h-[13.875rem]",
 );
 
+/**
+ * Tall sidebar/context menus: cap height to the viewport and scroll with the
+ * custom scrollbar when content overflows (no scrollbar when everything fits).
+ */
+export const dropdownMenuViewportScrollClassName = cn(
+  "overflow-y-auto custom-scrollbar",
+  "max-h-[min(60vh,calc(100dvh-5rem))]",
+);
+
 /** Footer action row inside a dropdown panel. */
 export const dropdownFooterActionClassName = cn(
   "group flex w-full items-center rounded-md px-2 py-2 text-sm font-normal text-white",


### PR DESCRIPTION
## Problem

The sidebar **Filter conversations** dropdown (`older-conversations-filter-menu`) renders a tall panel with Organize, Sort by, Show, Metadata, Older conversations, and Delete all sections. It had no height constraint, so on short viewports the menu extended below the visible window. Users could not scroll to reach options at the bottom (e.g. toggles and **Delete all**).

## Fix

- Add a shared `dropdownMenuViewportScrollClassName` utility that caps menu height to `min(60vh, calc(100dvh - 5rem))` so the panel stays within the viewport.
- Apply `overflow-y-auto` with the existing `custom-scrollbar` styling on the filter menu.
- Scrollbar appears **only when content overflows** — if the full menu fits, no scrollbar is shown.

## Test plan

- [ ] Open the app with the sidebar visible and click the filter (list-filter) icon next to **Conversations**.
- [ ] At normal window height, confirm the full menu is visible with no scrollbar.
- [ ] Shrink the window height until the menu would exceed the viewport; confirm a scrollbar appears and all sections remain reachable.
- [ ] Verify keyboard navigation (Arrow Up/Down, Escape) still works while scrolling.


Made with [Cursor](https://cursor.com)