### PR TITLE
fix(automations): replace runtime-instruction prompt with slash-command trigger

### DIFF
--- a/__tests__/components/automations/recommended-automations.test.tsx
+++ b/__tests__/components/automations/recommended-automations.test.tsx
@@ -3,7 +3,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsService from "#/api/settings-service/settings-service.api";
 import McpService from "#/api/mcp-service/mcp-service.api";
-import { getConversationState } from "#/utils/conversation-local-storage";
 import {
   __resetActiveStoreForTests,
   setActiveSelection,
@@ -371,14 +370,12 @@ describe("recommended automations", () => {
     expect(mockCreateConversationMutate).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId("mcp-install-modal")).not.toBeInTheDocument();
 
-    const [, options] = mockCreateConversationMutate.mock.calls[0];
-    options.onSuccess({ conversation_id: "conversation-1" });
-
-    const draft = getConversationState("conversation-1").draftMessage;
-    expect(draft).toBe("/create-automation github-pr-reviewer");
-    expect(draft).not.toContain("RUNTIME_SERVICES");
-    expect(draft).not.toContain("OPENHANDS_AUTOMATION_API_KEY");
-    expect(draft).not.toContain("app.all-hands.dev");
+    // The slash command is passed as the initial query — submitted immediately,
+    // not stored as a draft for the user to press Enter.
+    const [variables] = mockCreateConversationMutate.mock.calls[0];
+    expect(variables.query).toBe("/create-github-pr-reviewer");
+    expect(variables.query).not.toContain("RUNTIME_SERVICES");
+    expect(variables.query).not.toContain("OPENHANDS_AUTOMATION_API_KEY");
   });
 
   it("blocks launch and shows an error toast when the automation backend is unavailable", () => {
@@ -452,9 +449,12 @@ describe("recommended automations", () => {
 });
 
 describe("buildAutomationSlashCommand", () => {
-  it("returns a slash-command trigger using the automation id", () => {
+  it("returns /create-{id} for a given automation id", () => {
     expect(buildAutomationSlashCommand("github-pr-reviewer")).toBe(
-      "/create-automation github-pr-reviewer",
+      "/create-github-pr-reviewer",
+    );
+    expect(buildAutomationSlashCommand("slack-channel-monitor")).toBe(
+      "/create-slack-channel-monitor",
     );
   });
 
@@ -470,7 +470,7 @@ describe("buildAutomationSlashCommand", () => {
     const ids = ["github-pr-reviewer", "slack-channel-monitor", "linear-triage-assistant"];
     ids.forEach((id) => {
       const cmd = buildAutomationSlashCommand(id);
-      expect(cmd).toBe(`/create-automation ${id}`);
+      expect(cmd).toBe(`/create-${id}`);
       expect(cmd.split("\n")).toHaveLength(1);
     });
   });

--- a/__tests__/components/automations/recommended-automations.test.tsx
+++ b/__tests__/components/automations/recommended-automations.test.tsx
@@ -13,7 +13,7 @@ import { ActiveBackendProvider } from "#/contexts/active-backend-context";
 import type { Backend } from "#/api/backend-registry/types";
 import {
   RecommendedAutomationsLauncher,
-  buildAutomationPrompt,
+  buildAutomationSlashCommand,
 } from "#/components/features/automations/recommended-automations-launcher";
 import {
   RecommendedAutomationsSection,
@@ -24,9 +24,11 @@ import {
   type RecommendedAutomation,
 } from "@openhands/extensions/automations";
 
-const { mockCreateConversationMutate, mockUseSettings } = vi.hoisted(() => ({
+const { mockCreateConversationMutate, mockUseSettings, mockUseAutomationHealth, mockDisplayErrorToast } = vi.hoisted(() => ({
   mockCreateConversationMutate: vi.fn(),
   mockUseSettings: vi.fn(),
+  mockUseAutomationHealth: vi.fn(),
+  mockDisplayErrorToast: vi.fn(),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -49,6 +51,20 @@ vi.mock("#/hooks/mutation/use-create-conversation", () => ({
 vi.mock("#/hooks/query/use-settings", () => ({
   useSettings: () => mockUseSettings(),
 }));
+
+vi.mock("#/hooks/query/use-automation-health", () => ({
+  useAutomationHealth: () => mockUseAutomationHealth(),
+}));
+
+vi.mock(
+  "#/utils/custom-toast-handlers",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("#/utils/custom-toast-handlers")
+    >()),
+    displayErrorToast: mockDisplayErrorToast,
+  }),
+);
 
 const localBackend: Backend = {
   id: "local-backend",
@@ -114,6 +130,7 @@ describe("recommended automations", () => {
     mockUseSettings.mockReturnValue({
       data: settingsWithMcpConfig({ mcpServers: {} }),
     });
+    mockUseAutomationHealth.mockReturnValue({ data: { status: "ok" } });
     // Pre-flight connectivity test must pass so save mutations are reached.
     vi.spyOn(McpService, "testServer").mockResolvedValue({
       ok: true,
@@ -340,7 +357,7 @@ describe("recommended automations", () => {
     expect(mockCreateConversationMutate).not.toHaveBeenCalled();
   });
 
-  it("launches directly with local automation API instructions when the required MCP is already installed", () => {
+  it("launches with a concise slash-command payload when the required MCP is already installed", () => {
     mockUseSettings.mockReturnValue({
       data: settingsWithGithubMcp(),
     });
@@ -358,10 +375,28 @@ describe("recommended automations", () => {
     options.onSuccess({ conversation_id: "conversation-1" });
 
     const draft = getConversationState("conversation-1").draftMessage;
-    expect(draft).toContain("local");
-    expect(draft).toContain("$OPENHANDS_AUTOMATION_API_KEY");
+    expect(draft).toBe("/create-automation github-pr-reviewer");
+    expect(draft).not.toContain("RUNTIME_SERVICES");
+    expect(draft).not.toContain("OPENHANDS_AUTOMATION_API_KEY");
     expect(draft).not.toContain("app.all-hands.dev");
-    expect(draft).not.toContain("$OPENHANDS_API_KEY");
+  });
+
+  it("blocks launch and shows an error toast when the automation backend is unavailable", () => {
+    mockUseSettings.mockReturnValue({
+      data: settingsWithGithubMcp(),
+    });
+    mockUseAutomationHealth.mockReturnValue({ data: { status: "error" } });
+
+    renderLauncher();
+
+    fireEvent.click(
+      screen.getByTestId("recommended-automation-card-github-pr-reviewer"),
+    );
+
+    expect(mockCreateConversationMutate).not.toHaveBeenCalled();
+    expect(mockDisplayErrorToast).toHaveBeenCalledWith(
+      "RECOMMENDED_AUTOMATIONS$BACKEND_UNAVAILABLE",
+    );
   });
 
   it("ignores repeated card clicks while a recommendation launch is in flight", () => {
@@ -416,49 +451,27 @@ describe("recommended automations", () => {
   });
 });
 
-describe("buildAutomationPrompt", () => {
-  const basePrompt = "Create an automation that does something useful.";
-
-  it("appends local API instructions for local backends without cloud endpoints", () => {
-    const result = buildAutomationPrompt(basePrompt, "local");
-    expect(result).toContain(basePrompt);
-    expect(result).toContain("local");
-    expect(result).toContain("<RUNTIME_SERVICES>");
-    expect(result).toContain("$OPENHANDS_AUTOMATION_API_KEY");
-    expect(result).toContain("/api/automation/v1/preset/prompt");
-    expect(result).not.toContain("app.all-hands.dev");
-    expect(result).not.toContain("$OPENHANDS_API_KEY");
-    expect(result).toContain(
-      "instead of using any remote/cloud automation API",
+describe("buildAutomationSlashCommand", () => {
+  it("returns a slash-command trigger using the automation id", () => {
+    expect(buildAutomationSlashCommand("github-pr-reviewer")).toBe(
+      "/create-automation github-pr-reviewer",
     );
   });
 
-  it("appends cloud API instructions for the active cloud backend", () => {
-    const result = buildAutomationPrompt(
-      basePrompt,
-      "cloud",
-      "https://staging.all-hands.dev/",
-    );
-    expect(result).toContain(basePrompt);
-    expect(result).toContain(
-      "https://staging.all-hands.dev/api/automation/v1/preset/prompt",
-    );
-    expect(result).not.toContain("https://staging.all-hands.dev//api");
-    expect(result).not.toContain("app.all-hands.dev");
-    expect(result).toContain("$OPENHANDS_API_KEY");
-    expect(result).toContain("/api/automation/v1/preset/prompt");
-    expect(result).not.toContain("<RUNTIME_SERVICES>");
-    expect(result).not.toContain("$OPENHANDS_AUTOMATION_API_KEY");
+  it("does not include any runtime scaffolding or internal instructions", () => {
+    const result = buildAutomationSlashCommand("slack-standup-digest");
+    expect(result).not.toContain("RUNTIME_SERVICES");
+    expect(result).not.toContain("OPENHANDS_AUTOMATION_API_KEY");
+    expect(result).not.toContain("OPENHANDS_API_KEY");
+    expect(result).not.toContain("/api/automation/v1/preset/prompt");
   });
 
-  it("keeps the original prompt text verbatim at the start", () => {
-    const localResult = buildAutomationPrompt(basePrompt, "local");
-    const cloudResult = buildAutomationPrompt(
-      basePrompt,
-      "cloud",
-      "https://staging.all-hands.dev",
-    );
-    expect(localResult.startsWith(basePrompt)).toBe(true);
-    expect(cloudResult.startsWith(basePrompt)).toBe(true);
+  it("produces a deterministic single-line command regardless of id", () => {
+    const ids = ["github-pr-reviewer", "slack-channel-monitor", "linear-triage-assistant"];
+    ids.forEach((id) => {
+      const cmd = buildAutomationSlashCommand(id);
+      expect(cmd).toBe(`/create-automation ${id}`);
+      expect(cmd.split("\n")).toHaveLength(1);
+    });
   });
 });

--- a/src/components/features/automations/recommended-automations-launcher.tsx
+++ b/src/components/features/automations/recommended-automations-launcher.tsx
@@ -6,11 +6,6 @@ import { useCreateConversation } from "#/hooks/mutation/use-create-conversation"
 import { useSettings } from "#/hooks/query/use-settings";
 import { useAutomationHealth } from "#/hooks/query/use-automation-health";
 import { useIsCreatingConversation } from "#/hooks/use-is-creating-conversation";
-import { useConversationStore } from "#/stores/conversation-store";
-import {
-  setConversationState,
-  setPendingTaskDraft,
-} from "#/utils/conversation-local-storage";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { I18nKey } from "#/i18n/declaration";
 import type { RecommendedAutomation } from "@openhands/extensions/automations";
@@ -47,7 +42,7 @@ function getRequiredEntries(automation: RecommendedAutomation) {
  * is injected into the user-visible chat message.
  */
 export function buildAutomationSlashCommand(id: string): string {
-  return `/create-automation ${id}`;
+  return `/create-${id}`;
 }
 
 export function RecommendedAutomationsLauncher({
@@ -61,9 +56,6 @@ export function RecommendedAutomationsLauncher({
   const { data: healthData } = useAutomationHealth();
   const createConversation = useCreateConversation();
   const isCreatingConversation = useIsCreatingConversation();
-  const setMessageToSend = useConversationStore(
-    (state) => state.setMessageToSend,
-  );
   const [pendingAutomation, setPendingAutomation] =
     useState<RecommendedAutomation | null>(null);
   const [installQueue, setInstallQueue] = useState<MarketplaceEntry[]>([]);
@@ -95,25 +87,16 @@ export function RecommendedAutomationsLauncher({
 
       launchInFlightRef.current = true;
 
-      const message = buildAutomationSlashCommand(automation.id);
+      // Pass the slash command as the initial query so it is submitted to the
+      // agent immediately when the conversation opens — no draft pre-fill needed.
+      const query = buildAutomationSlashCommand(automation.id);
 
       createConversation.mutate(
-        {},
+        { query },
         {
           onSuccess: (conversation) => {
-            if (
-              conversation.conversation_id.startsWith("task-") &&
-              conversation.task_id
-            ) {
-              setPendingTaskDraft(conversation.task_id, message);
-            } else {
-              setConversationState(conversation.conversation_id, {
-                draftMessage: message,
-              });
-            }
             onLaunched?.();
             navigate?.(`/conversations/${conversation.conversation_id}`);
-            window.setTimeout(() => setMessageToSend(message), 0);
           },
           onError: () => {
             launchInFlightRef.current = false;
@@ -127,7 +110,6 @@ export function RecommendedAutomationsLauncher({
       isCreatingConversation,
       navigate,
       onLaunched,
-      setMessageToSend,
       t,
     ],
   );

--- a/src/components/features/automations/recommended-automations-launcher.tsx
+++ b/src/components/features/automations/recommended-automations-launcher.tsx
@@ -1,14 +1,18 @@
 import { useCallback, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useNavigation } from "#/context/navigation-context";
 import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
 import { useSettings } from "#/hooks/query/use-settings";
+import { useAutomationHealth } from "#/hooks/query/use-automation-health";
 import { useIsCreatingConversation } from "#/hooks/use-is-creating-conversation";
 import { useConversationStore } from "#/stores/conversation-store";
 import {
   setConversationState,
   setPendingTaskDraft,
 } from "#/utils/conversation-local-storage";
+import { displayErrorToast } from "#/utils/custom-toast-handlers";
+import { I18nKey } from "#/i18n/declaration";
 import type { RecommendedAutomation } from "@openhands/extensions/automations";
 import { parseMcpConfig } from "#/utils/mcp-config";
 import { flattenMcpConfig } from "#/utils/mcp-installed-servers";
@@ -37,45 +41,13 @@ function getRequiredEntries(automation: RecommendedAutomation) {
 }
 
 /**
- * Augment the catalog prompt with explicit API instructions so the agent
- * calls the correct automation endpoint instead of guessing (e.g. calling
- * the cloud API when running locally, or vice-versa).
+ * Returns a concise slash-command style trigger for launching a prebuilt
+ * automation. The agent receives routing details from the <RUNTIME_SERVICES>
+ * block already present in its system context — no implementation scaffolding
+ * is injected into the user-visible chat message.
  */
-function trimTrailingSlashes(value: string): string {
-  return value.replace(/\/+$/, "");
-}
-
-export function buildAutomationPrompt(
-  basePrompt: string,
-  backendKind: "local" | "cloud",
-  backendHost?: string,
-): string {
-  if (backendKind === "cloud") {
-    const endpoint = backendHost
-      ? `POST ${trimTrailingSlashes(backendHost)}/api/automation/v1/preset/prompt`
-      : "POST /api/automation/v1/preset/prompt on the active OpenHands Cloud backend";
-
-    return [
-      basePrompt,
-      "",
-      "---",
-      "**Which API to use:** Create this automation using the active OpenHands Cloud Automations API.",
-      `- Endpoint: \`${endpoint}\``,
-      "- Auth: `Authorization: Bearer $OPENHANDS_API_KEY`",
-    ].join("\n");
-  }
-
-  // Local backend — the automation sidecar URL is in <RUNTIME_SERVICES>.
-  return [
-    basePrompt,
-    "",
-    "---",
-    "**Which API to use:** Create this automation using the **local** OpenHands Automations API that is running alongside this agent.",
-    "- Read the Automation backend URL from the `<RUNTIME_SERVICES>` block in your system context.",
-    "- Endpoint path: `POST /api/automation/v1/preset/prompt`",
-    "- Auth: `X-Session-API-Key: $OPENHANDS_AUTOMATION_API_KEY`",
-    "- If no local Automation backend is listed in `<RUNTIME_SERVICES>`, stop and ask me to start the full local automation stack instead of using any remote/cloud automation API.",
-  ].join("\n");
+export function buildAutomationSlashCommand(id: string): string {
+  return `/create-automation ${id}`;
 }
 
 export function RecommendedAutomationsLauncher({
@@ -83,8 +55,10 @@ export function RecommendedAutomationsLauncher({
   onLaunched,
 }: RecommendedAutomationsLauncherProps) {
   const activeBackend = useActiveBackend();
+  const { t } = useTranslation("openhands");
   const { navigate } = useNavigation();
   const { data: settings } = useSettings();
+  const { data: healthData } = useAutomationHealth();
   const createConversation = useCreateConversation();
   const isCreatingConversation = useIsCreatingConversation();
   const setMessageToSend = useConversationStore(
@@ -111,13 +85,17 @@ export function RecommendedAutomationsLauncher({
       ) {
         return;
       }
+
+      if (healthData?.status === "error") {
+        displayErrorToast(
+          t(I18nKey.RECOMMENDED_AUTOMATIONS$BACKEND_UNAVAILABLE),
+        );
+        return;
+      }
+
       launchInFlightRef.current = true;
 
-      const prompt = buildAutomationPrompt(
-        automation.prompt,
-        activeBackend.backend.kind,
-        activeBackend.backend.host,
-      );
+      const message = buildAutomationSlashCommand(automation.id);
 
       createConversation.mutate(
         {},
@@ -127,15 +105,15 @@ export function RecommendedAutomationsLauncher({
               conversation.conversation_id.startsWith("task-") &&
               conversation.task_id
             ) {
-              setPendingTaskDraft(conversation.task_id, prompt);
+              setPendingTaskDraft(conversation.task_id, message);
             } else {
               setConversationState(conversation.conversation_id, {
-                draftMessage: prompt,
+                draftMessage: message,
               });
             }
             onLaunched?.();
             navigate?.(`/conversations/${conversation.conversation_id}`);
-            window.setTimeout(() => setMessageToSend(prompt), 0);
+            window.setTimeout(() => setMessageToSend(message), 0);
           },
           onError: () => {
             launchInFlightRef.current = false;
@@ -144,12 +122,13 @@ export function RecommendedAutomationsLauncher({
       );
     },
     [
-      activeBackend.backend.kind,
       createConversation,
+      healthData?.status,
       isCreatingConversation,
       navigate,
       onLaunched,
       setMessageToSend,
+      t,
     ],
   );
 

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -29375,6 +29375,23 @@
     "tr": "{{count}} gerekli MCP kaldı.",
     "uk": "Залишилося обов’язкових MCP: {{count}}."
   },
+  "RECOMMENDED_AUTOMATIONS$BACKEND_UNAVAILABLE": {
+    "en": "Automation backend unavailable. Start the full automation stack to use prebuilt automations.",
+    "ja": "自動化バックエンドが利用できません。プリビルド自動化を使用するには、完全な自動化スタックを起動してください。",
+    "zh-CN": "自动化后端不可用。启动完整的自动化堆栈以使用预建自动化。",
+    "zh-TW": "自動化後端不可用。啟動完整的自動化堆疊以使用預建自動化。",
+    "ko-KR": "자동화 백엔드를 사용할 수 없습니다. 사전 빌드된 자동화를 사용하려면 전체 자동화 스택을 시작하세요.",
+    "no": "Automatiseringsbakenden er ikke tilgjengelig. Start den fullstendige automatiseringsstakken for å bruke ferdigbygde automatiseringer.",
+    "ar": "الواجهة الخلفية للأتمتة غير متاحة. ابدأ مكدس الأتمتة الكامل لاستخدام الأتمتة المبنية مسبقًا.",
+    "de": "Automatisierungs-Backend nicht verfügbar. Starten Sie den vollständigen Automatisierungs-Stack, um vorgefertigte Automatisierungen zu verwenden.",
+    "fr": "Backend d'automatisation indisponible. Démarrez la pile d'automatisation complète pour utiliser les automatisations prédéfinies.",
+    "it": "Backend di automazione non disponibile. Avviare lo stack di automazione completo per utilizzare le automazioni predefinite.",
+    "pt": "Backend de automação indisponível. Inicie o stack de automação completo para usar automações pré-criadas.",
+    "es": "Backend de automatización no disponible. Inicie la pila de automatización completa para usar automatizaciones predefinidas.",
+    "ca": "El backend d'automatització no està disponible. Inicieu la pila d'automatització completa per a usar automatitzacions predefinides.",
+    "tr": "Otomasyon arka ucu mevcut değil. Önceden oluşturulmuş otomasyonları kullanmak için tam otomasyon yığınını başlatın.",
+    "uk": "Бекенд автоматизації недоступний. Запустіть повний стек автоматизації, щоб використовувати готові автоматизації."
+  },
   "BACKEND$NAME_REQUIRED": {
     "en": "Name is required",
     "ja": "名前は必須です",


### PR DESCRIPTION
Closes #986

## What changed

Clicking a recommended automation card now sends a concise `/create-automation <id>` message to chat instead of a multi-paragraph implementation prompt that leaked internal scaffolding into the user-visible conversation.

### Before
`buildAutomationPrompt()` appended the full `automation.prompt` **plus** implementation runtime instructions:
- `Read the Automation backend URL from the <RUNTIME_SERVICES> block in your system context.`
- `Auth: X-Session-API-Key: $OPENHANDS_AUTOMATION_API_KEY`
- `If no local Automation backend is listed in <RUNTIME_SERVICES>, stop...`

This created two problems: the giant prompt was jarring for users, and the `<RUNTIME_SERVICES>` references weren't guaranteed to exist (e.g. the published npm package without the full automation stack).

### After
```
/create-automation github-pr-reviewer
```
One line. Machine-readable. No runtime scaffolding visible in chat. The agent already has the full routing context from the `<RUNTIME_SERVICES>` block injected into its system prompt when the automation stack is running.

## Changes

| File | What |
|------|------|
| `recommended-automations-launcher.tsx` | Remove `buildAutomationPrompt` + `trimTrailingSlashes`; add `buildAutomationSlashCommand(id)`; import `useAutomationHealth` and gate launch on `status === "error"` with an error toast |
| `src/i18n/translation.json` | Add `RECOMMENDED_AUTOMATIONS$BACKEND_UNAVAILABLE` key (15 languages) |
| `recommended-automations.test.tsx` | Replace `buildAutomationPrompt` test suite with `buildAutomationSlashCommand` suite; update launch assertion; add health-gate test; mock `useAutomationHealth` + `displayErrorToast` |

## Acceptance criteria from the issue

- ✅ Clicking a recommended automation no longer injects a giant runtime-instruction prompt into chat
- ✅ The launch path does not reference `<RUNTIME_SERVICES>` in the user message
- ✅ The user sees a concise, understandable slash-command action
- ✅ The UI detects when the local automation backend is unavailable and blocks with a clear error toast instead of asking the agent to infer missing state
- ✅ Tests cover the generated launch payload and the health-gate behavior

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@erisfully can click here to [continue refining the PR](https://app.all-hands.dev/conversations/75b53d5d-30cf-41e3-8bd0-d86037876b15)

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `21a547f3bb60f781bf4e65672d53cba05d727499` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-21a547f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-21a547f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-21a547f-amd64
ghcr.io/openhands/agent-canvas:fix-986-automation-slash-command-amd64
ghcr.io/openhands/agent-canvas:pr-1065-amd64
ghcr.io/openhands/agent-canvas:sha-21a547f-arm64
ghcr.io/openhands/agent-canvas:fix-986-automation-slash-command-arm64
ghcr.io/openhands/agent-canvas:pr-1065-arm64
ghcr.io/openhands/agent-canvas:sha-21a547f
ghcr.io/openhands/agent-canvas:fix-986-automation-slash-command
ghcr.io/openhands/agent-canvas:pr-1065
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-21a547f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-21a547f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->