### PR TITLE
fix: remove duplicate OpenHands-Neo color theme (#862)

### DIFF
--- a/__tests__/themes/color-themes.test.tsx
+++ b/__tests__/themes/color-themes.test.tsx
@@ -1,70 +1,19 @@
-import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { AgentServerUIRoot } from "#/components/providers/agent-server-ui-root";
-import {
-  AVAILABLE_COLOR_THEMES,
-  COLOR_THEMES,
-  applyColorTheme,
-} from "#/themes/color-themes";
+import { AVAILABLE_COLOR_THEMES, COLOR_THEMES } from "#/themes/color-themes";
 
 describe("color themes", () => {
-  it("includes OpenHands-Neo as a neutral-based theme with white button tokens", () => {
-    const neo = COLOR_THEMES["openhands-neo"];
-
-    expect(neo.label).toBe("OpenHands-Neo");
-    expect(neo.scale).toEqual(COLOR_THEMES["openhands-neutral"].scale);
-    expect(neo.heroui).toEqual(COLOR_THEMES["openhands-neutral"].heroui);
-    expect(neo.tokens?.["--oh-color-primary"]).toBe("#ffffff");
-    expect(neo.tokens?.["--oh-accent"]).toBe("#ffffff");
+  it("exposes only the distinct Neutral and DeepSea themes", () => {
+    expect(AVAILABLE_COLOR_THEMES.map((theme) => theme.key)).toEqual([
+      "openhands-deepsea",
+      "openhands-neutral",
+    ]);
   });
 
-  it("exposes Neo in the settings theme picker", () => {
-    expect(AVAILABLE_COLOR_THEMES.map((theme) => theme.key)).toContain(
-      "openhands-neo",
-    );
-    expect(
-      AVAILABLE_COLOR_THEMES.find((theme) => theme.key === "openhands-neo")
-        ?.label,
-    ).toBe("OpenHands-Neo");
-  });
+  it("keeps DeepSea visually distinct from Neutral", () => {
+    const deepsea = COLOR_THEMES["openhands-deepsea"];
+    const neutral = COLOR_THEMES["openhands-neutral"];
 
-  it("injects white primary tokens when applying OpenHands-Neo", () => {
-    document.body.setAttribute("data-agent-server-ui", "");
-
-    applyColorTheme("openhands-neo");
-
-    const styleEl = document.getElementById("oh-color-theme-override");
-    expect(styleEl?.textContent).toContain("--oh-color-primary: #ffffff;");
-    expect(styleEl?.textContent).toContain("--oh-accent: #ffffff;");
-
-    styleEl?.remove();
-    document.body.removeAttribute("data-agent-server-ui");
-    document.body.style.removeProperty("--oh-color-primary");
-    document.body.style.removeProperty("--oh-accent");
-    document.body.style.removeProperty("--oh-warning");
-  });
-
-  it("applies Neo button tokens on the scoped UI root used by primary buttons", () => {
-    render(
-      <AgentServerUIRoot>
-        <button type="button" data-testid="primary-button">
-          Save
-        </button>
-      </AgentServerUIRoot>,
-    );
-
-    applyColorTheme("openhands-neo");
-
-    const scopeRoot = screen.getByTestId("primary-button").closest(
-      "[data-agent-server-ui]",
-    ) as HTMLElement;
-
-    expect(scopeRoot.style.getPropertyValue("--oh-color-primary")).toBe(
-      "#ffffff",
-    );
-
-    applyColorTheme("openhands-neutral");
-
-    expect(scopeRoot.style.getPropertyValue("--oh-color-primary")).toBe("");
+    expect(deepsea.scale).not.toEqual(neutral.scale);
+    expect(deepsea.heroui).not.toEqual(neutral.heroui);
   });
 });

--- a/src/themes/color-themes.ts
+++ b/src/themes/color-themes.ts
@@ -1,7 +1,4 @@
-export type ColorThemeKey =
-  | "openhands-deepsea"
-  | "openhands-neutral"
-  | "openhands-neo";
+export type ColorThemeKey = "openhands-deepsea" | "openhands-neutral";
 
 export interface ColorThemeDefinition {
   label: string;
@@ -95,16 +92,6 @@ import { AGENT_SERVER_UI_THEMEABLE_BRAND_VARIABLES } from "#/styles/agent-server
 /** CSS custom properties overridden by color themes (see applyColorTheme). */
 export const COLOR_THEME_TOKEN_KEYS = AGENT_SERVER_UI_THEMEABLE_BRAND_VARIABLES;
 
-/** White primary/accent tokens — used by OpenHands-Neo for button surfaces. */
-const NEO_WHITE_BUTTON_TOKENS: Record<
-  (typeof COLOR_THEME_TOKEN_KEYS)[number],
-  string
-> = {
-  "--oh-color-primary": "#ffffff",
-  "--oh-accent": "#ffffff",
-  "--oh-warning": "#ffffff",
-};
-
 export const COLOR_THEMES: Record<ColorThemeKey, ColorThemeDefinition> = {
   "openhands-deepsea": {
     label: "OpenHands-DeepSea",
@@ -172,13 +159,6 @@ export const COLOR_THEMES: Record<ColorThemeKey, ColorThemeDefinition> = {
     //   heroui-default-200 ← cool-grey-925 position ← neutral-900 (#202020)
     //   ...etc.
     heroui: NEUTRAL_HEROUI,
-  },
-
-  "openhands-neo": {
-    label: "OpenHands-Neo",
-    scale: NEUTRAL_SCALE,
-    heroui: NEUTRAL_HEROUI,
-    tokens: NEO_WHITE_BUTTON_TOKENS,
   },
 };
 


### PR DESCRIPTION
## Summary
Fixes #862. Switching between the color themes showed no visible difference because **OpenHands-Neo** and **OpenHands-Neutral** were near-duplicates.

## Root cause
In `src/themes/color-themes.ts`, Neo reused the exact same `NEUTRAL_SCALE` and `NEUTRAL_HEROUI` as Neutral, differing only by a `tokens` override that set button accents to white (`#ffffff`). That single accent change was too subtle to perceive, so the themes looked identical. DeepSea already has its own distinct blue-grey palette.

## Changes
- Removed the `openhands-neo` theme entry and its key from the `ColorThemeKey` union.
- Removed the now-unused `NEO_WHITE_BUTTON_TOKENS` constant.
- Kept the generic token infrastructure (still referenced, reusable for future themes).
- Updated `__tests__/themes/color-themes.test.tsx` to assert only Neutral + DeepSea are exposed and that they remain visually distinct.

The default theme (`openhands-neutral`) is unchanged.

## Verification
- tsc --noEmit: passed
- eslint on changed files: passed
- prettier --check: passed
- vitest run __tests__/themes/color-themes.test.tsx: 2 passed