### PR TITLE
docs: clean up self-hosting VM setup instructions

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -94,11 +94,14 @@ in step 4.
 
 ## 3. Run Agent Canvas
 
-Install the prerequisites on the machine. On Ubuntu:
+Install the prerequisites on the machine — **Node.js 22.x** and **uv**.
+See the [main README quickstart](../README.md#quickstart) for install options.
+
+On Ubuntu the shortest path is:
 
 ```bash
-apt-get update
-apt-get install -y curl git
+sudo apt-get update
+sudo apt-get install -y curl
 # Node.js 22.x (use nvm, asdf, or NodeSource — whatever you prefer)
 # uv (for the agent-server uvx runtime):
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -126,6 +129,7 @@ To keep the service running after your SSH session ends, use a process manager.
 **Option A — tmux (quick):**
 
 ```bash
+sudo apt-get install -y tmux   # if not already installed
 export LOCAL_BACKEND_API_KEY=<your-saved-key>
 tmux new-session -d -s canvas 'npx @openhands/agent-canvas --public'
 # Reconnect later with: tmux attach -t canvas


### PR DESCRIPTION
## Summary

Small cleanup to the self-hosting guide based on real-world experience setting up a devbox.

## Changes

- **Remove `git` from prerequisites** — it comes pre-installed on all standard VM images (Ubuntu, Debian, etc.), so listing it was misleading
- **Add `sudo` to `apt-get` commands** — users aren't root by default on most VMs
- **Link to main README quickstart** for prerequisite install options (Node.js, uv) instead of only describing them inline
- **Add `tmux` install hint** — `sudo apt-get install -y tmux` before usage in Option A, since tmux isn't always pre-installed

---
_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b6f0869d-6044-42f2-9bbf-69286968429f)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `fda3aba6098c92e62d2ff08ff449d42a18320f26` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-fda3aba
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-fda3aba
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-fda3aba-amd64
ghcr.io/openhands/agent-canvas:docs-self-hosting-cleanup-amd64
ghcr.io/openhands/agent-canvas:pr-1096-amd64
ghcr.io/openhands/agent-canvas:sha-fda3aba-arm64
ghcr.io/openhands/agent-canvas:docs-self-hosting-cleanup-arm64
ghcr.io/openhands/agent-canvas:pr-1096-arm64
ghcr.io/openhands/agent-canvas:sha-fda3aba
ghcr.io/openhands/agent-canvas:docs-self-hosting-cleanup
ghcr.io/openhands/agent-canvas:pr-1096
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-fda3aba`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-fda3aba-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->