### PR TITLE
fix(frontend): keep modal open on errant outside click

### DIFF
--- a/__tests__/components/onboarding/onboarding-modal.test.tsx
+++ b/__tests__/components/onboarding/onboarding-modal.test.tsx
@@ -286,6 +286,26 @@ describe("OnboardingModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("stays open when the user clicks outside it or presses Escape", async () => {
+    // Arrange
+    const onClose = vi.fn();
+    renderModal(onClose);
+    const user = userEvent.setup();
+
+    // Act: errant interactions outside the modal box — click the dark
+    // backdrop overlay, then press Escape.
+    const backdrop = screen.getByRole("dialog")
+      .firstElementChild as HTMLElement;
+    await user.click(backdrop);
+    await user.keyboard("{Escape}");
+
+    // Assert: neither dismisses the flow nor marks onboarding completed
+    // (https://github.com/OpenHands/agent-canvas/issues/1085); the modal
+    // only closes via explicit actions (Skip / launch).
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId("onboarding-modal")).toBeInTheDocument();
+  });
+
   it("wraps the slide rail in a dedicated scroll region so the modal chrome stays put", () => {
     // Arrange + act: render the modal once.
     renderModal();

--- a/src/components/features/onboarding/onboarding-modal.tsx
+++ b/src/components/features/onboarding/onboarding-modal.tsx
@@ -108,11 +108,10 @@ export function OnboardingModal({ onClose }: OnboardingModalProps) {
   );
 
   return (
-    <ModalBackdrop
-      onClose={onClose}
-      closeOnEscape={false}
-      aria-label={t(I18nKey.ONBOARDING$TITLE)}
-    >
+    // No `onClose`: the flow must only be dismissed via explicit actions
+    // (the skip button or launching), never by an errant backdrop click or
+    // Escape press — see https://github.com/OpenHands/agent-canvas/issues/1085.
+    <ModalBackdrop aria-label={t(I18nKey.ONBOARDING$TITLE)}>
       <div className="relative flex flex-col items-center gap-4">
         <section
           data-testid="onboarding-modal"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Problem

While going through the first-run onboarding modal, accidentally clicking anywhere outside the modal (on the dark backdrop) instantly dismisses it. Worse, it never comes back: the dismissal also marks onboarding as completed, so even reloading the app won't re-show the flow.

GitHub issue: [https://github.com/OpenHands/agent-canvas/issues/1085](https://github.com/OpenHands/agent-canvas/issues/1085)

### Root cause

Two pieces compound:

1. `ModalBackdrop` (`src/components/shared/modals/modal-backdrop.tsx`) unconditionally calls `onClose()` when the backdrop overlay is clicked. It has a `closeOnEscape` opt-out (which the onboarding modal already used), but no equivalent opt-out for backdrop clicks.
2. The onboarding `onClose` is `markCompleted` (`onboarding-host.tsx` → `use-onboarding-completion.ts`), which writes the `openhands-onboarded` flag to localStorage. So a stray click doesn't just hide the modal mid-flow — it permanently flags onboarding as done.

### Fix

Stop passing `onClose` to `ModalBackdrop` in `src/components/features/onboarding/onboarding-modal.tsx`. The explicit dismissal paths — the "Skip for now" button and the final step's launch — use the `onClose` prop directly, not via the backdrop, so they keep working. This reuses the existing "suppress `onClose` to make a modal non-dismissable" idiom from `ConfirmationModal`; no shared-component change needed.

### Acceptance criteria

- [ ] Clicking the dark backdrop outside the onboarding modal does nothing
- [ ] Pressing Escape does nothing
- [ ] "Skip for now" still dismisses the modal and marks onboarding completed
- [ ] Completing the flow (launch on the final step) still dismisses the modal
- [ ] Regression test covers backdrop click + Escape

### Reproduction (before the fix)

1. `npm run dev`, open the app
2. DevTools console: `localStorage.removeItem("openhands-onboarded")`, reload
3. Onboarding modal appears → click anywhere on the dark overlay
4. Bug: modal vanishes; `localStorage.getItem("openhands-onboarded")` is `"1"`; onboarding never shows again

### Related (follow-up, out of scope)

`backend-form-modal.tsx` has the same latent bug: it disables Escape but still dismisses on backdrop click, losing form input. Worth its own ticket.

## Summary

<!-- 1-3 bullets describing what changed. -->
Fixes #1085 — the first-run onboarding modal was dismissed by an accidental click outside it, with no way to ever get it back.

## Root cause

Two pieces compound to make a stray click destructive:

1. **`ModalBackdrop` always dismisses on backdrop click** — `src/components/shared/modals/modal-backdrop.tsx` unconditionally calls `onClose()` when the dark overlay is clicked. There's a `closeOnEscape` opt-out (which the onboarding modal already used), but no equivalent for backdrop clicks.
2. **The onboarding `onClose` is permanent** — `OnboardingHost` passes `onClose={markCompleted}`, which writes the `openhands-onboarded` flag to localStorage. So an errant outside click didn't just hide the modal mid-flow — it marked onboarding as done **forever**; the modal never re-appeared, even after reload.

## Fix

`src/components/features/onboarding/onboarding-modal.tsx`: stop passing `onClose` to `ModalBackdrop` (and drop the now-dead `closeOnEscape={false}`). The explicit dismissal paths — the "Skip for now" button and the final step's `onLaunched` — use the `onClose` prop directly, not through the backdrop, so they keep working unchanged.

This reuses the existing "suppress `onClose` to make a modal non-dismissable" idiom from `ConfirmationModal`; no shared-component change needed.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #1085 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev`, open the app
2. DevTools console: `localStorage.removeItem("openhands-onboarded")`, reload
3. Onboarding modal appears → click anywhere on the dark overlay
4. Bug: modal vanishes and `localStorage.getItem("openhands-onboarded")` is now `"1"` — onboarding never shows again

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/95e97f79-31a2-4737-b8e7-3c8e6b2ebbf4

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a5` |
| **Commit** | `969e8b5f71424c7c292a46bb546160bbd5189274` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-969e8b5
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-969e8b5
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-969e8b5-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2156-amd64
ghcr.io/openhands/agent-canvas:pr-1100-amd64
ghcr.io/openhands/agent-canvas:sha-969e8b5-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2156-arm64
ghcr.io/openhands/agent-canvas:pr-1100-arm64
ghcr.io/openhands/agent-canvas:sha-969e8b5
ghcr.io/openhands/agent-canvas:hieptl-app-2156
ghcr.io/openhands/agent-canvas:pr-1100
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-969e8b5`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-969e8b5-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->