### PR TITLE
fix: support destructive profile deletion and align empty-state UI

### DIFF
--- a/__tests__/components/settings/llm-profiles/profile-actions-menu.test.tsx
+++ b/__tests__/components/settings/llm-profiles/profile-actions-menu.test.tsx
@@ -127,6 +127,12 @@ describe("ProfileActionsMenu", () => {
     expect(handleClose).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps Delete enabled for active profiles", () => {
+    render(<ProfileActionsMenu {...defaultProps} isActive />);
+
+    expect(screen.getByTestId("profile-delete")).toBeEnabled();
+  });
+
   it("calls onClose when clicking outside the menu", () => {
     const handleClose = vi.fn();
 

--- a/src/components/features/settings/llm-profiles/profiles-body.tsx
+++ b/src/components/features/settings/llm-profiles/profiles-body.tsx
@@ -52,9 +52,14 @@ export function ProfilesBody({
 
   if (profiles.length === 0) {
     return (
-      <p className="text-sm text-[var(--oh-muted)] italic">
-        {t(I18nKey.SETTINGS$PROFILES_EMPTY)}
-      </p>
+      <div
+        data-testid="profiles-empty-state"
+        className="rounded-xl border border-[var(--oh-border)] p-6 text-center"
+      >
+        <p className="text-sm text-tertiary-light">
+          {t(I18nKey.SETTINGS$PROFILES_EMPTY)}
+        </p>
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary
- keep destructive delete behavior supported for active profiles (users can intentionally delete the active/last profile)
- add regression coverage ensuring the Delete menu action remains enabled for active profiles
- render the no-profiles state in a bordered, centered container instead of italic-only text
- preserve existing translation key usage and include a stable empty-state test id

Fixes #1114

## Test plan
- [x] `npm test -- __tests__/components/settings/llm-profiles/profiles-body.test.tsx`
- [x] `npm test -- __tests__/hooks/mutation/use-delete-llm-profile.test.tsx`
- [x] `npm test -- __tests__/components/settings/llm-profiles/profile-actions-menu.test.tsx`