### PR TITLE
fix: mask saved LLM API key field with fixed-length placeholder instead of stored-value-length dots

### DIFF
--- a/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
+++ b/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
@@ -388,8 +388,8 @@ describe("LlmSettingsLocalView", () => {
       });
 
       // The LlmSettingsScreen component receives initialValueOverrides
-      // with the profile's LLM config values. We verify this by checking
-      // that getProfile was called and the form is in edit mode.
+      // with the profile's non-secret LLM config values. The saved API key is
+      // intentionally represented by an empty field plus a hidden placeholder.
       expect(ProfilesService.getProfile).toHaveBeenCalledWith(
         "gpt-4-profile",
         "encrypted",
@@ -398,6 +398,114 @@ describe("LlmSettingsLocalView", () => {
       // Verify we're in edit mode (back button and save button visible)
       expect(screen.getByTestId("back-to-profiles")).toBeInTheDocument();
       expect(screen.getByTestId("save-profile-btn")).toBeInTheDocument();
+    });
+
+    it("shows a fixed hidden placeholder instead of the saved API key value when editing", async () => {
+      const user = userEvent.setup();
+      const longSavedApiKey = `sk-${"x".repeat(96)}`;
+
+      vi.mocked(ProfilesService.getProfile).mockResolvedValue({
+        name: "gpt-4-profile",
+        api_key_set: true,
+        config: {
+          model: "openai/gpt-4",
+          api_key: longSavedApiKey,
+          base_url: "https://api.openai.com/v1",
+        },
+      });
+
+      renderWithProviders(<LlmSettingsLocalView />);
+
+      await user.click(screen.getAllByTestId("profile-menu-trigger")[0]);
+      await user.click(screen.getByTestId("profile-edit"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-name-input")).toHaveValue(
+          "gpt-4-profile",
+        );
+      });
+
+      const apiKeyInput = await screen.findByTestId("llm-api-key-input");
+      expect(apiKeyInput).toHaveValue("");
+      expect(apiKeyInput).not.toHaveValue(longSavedApiKey);
+      await waitFor(() => {
+        expect(apiKeyInput).toHaveAttribute("placeholder", "<hidden>");
+      });
+    });
+
+    it("keeps the saved API key when the edit form is submitted with a blank key field", async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(ProfilesService.getProfile).mockResolvedValue({
+        name: "gpt-4-profile",
+        api_key_set: true,
+        config: {
+          model: "openai/gpt-4",
+          api_key: "gAAAA_encrypted_key",
+          base_url: "https://api.openai.com/v1",
+        },
+      });
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      renderWithProviders(<LlmSettingsLocalView />);
+
+      await user.click(screen.getAllByTestId("profile-menu-trigger")[0]);
+      await user.click(screen.getByTestId("profile-edit"));
+
+      const apiKeyInput = await screen.findByTestId("llm-api-key-input");
+      expect(apiKeyInput).toHaveValue("");
+      await waitFor(() => {
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled();
+      });
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      await waitFor(() => expect(mockSaveMutateAsync).toHaveBeenCalled());
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.api_key).toBe("gAAAA_encrypted_key");
+    });
+
+    it("replaces the saved API key when a new key is entered during edit", async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(ProfilesService.getProfile).mockResolvedValue({
+        name: "gpt-4-profile",
+        api_key_set: true,
+        config: {
+          model: "openai/gpt-4",
+          api_key: "gAAAA_encrypted_key",
+          base_url: "https://api.openai.com/v1",
+        },
+      });
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      renderWithProviders(<LlmSettingsLocalView />);
+
+      await user.click(screen.getAllByTestId("profile-menu-trigger")[0]);
+      await user.click(screen.getByTestId("profile-edit"));
+
+      const apiKeyInput = await screen.findByTestId("llm-api-key-input");
+      await user.type(apiKeyInput, "sk-new-profile-key");
+      await waitFor(() => {
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled();
+      });
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      await waitFor(() => expect(mockSaveMutateAsync).toHaveBeenCalled());
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.api_key).toBe("sk-new-profile-key");
+    });
+  });
+
+  describe("create mode API key field", () => {
+    it("shows an empty API key field with no hidden placeholder", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<LlmSettingsLocalView />);
+
+      await user.click(screen.getByTestId("add-llm-profile"));
+
+      const apiKeyInput = await screen.findByTestId("llm-api-key-input");
+      expect(apiKeyInput).toHaveValue("");
+      expect(apiKeyInput).toHaveAttribute("placeholder", "");
     });
   });
 

--- a/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
+++ b/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
@@ -42,6 +42,8 @@ import {
 
 type ViewMode = "list" | "create" | "edit";
 
+const HIDDEN_API_KEY_PLACEHOLDER = "<hidden>";
+
 interface EditingProfile {
   profile: ProfileInfo;
   initialValues: SettingsFormValues;
@@ -52,6 +54,7 @@ interface EditingProfile {
    * preserved instead of being reset to LLM defaults by the full-replace save.
    */
   baseConfig: Record<string, unknown>;
+  hasSavedApiKey: boolean;
 }
 
 export function shouldReapplyProfileAfterSave({
@@ -107,11 +110,36 @@ export function LlmSettingsLocalView() {
     null,
   );
   const [isSaving, setIsSaving] = useState(false);
+  const profileFormRef = useRef<HTMLDivElement>(null);
+  const shouldShowSavedApiKeyPlaceholder =
+    viewMode === "edit" && Boolean(editingProfile?.hasSavedApiKey);
+  const apiKeyFormValue = saveControl?.values["llm.api_key"];
+  const apiKeyPlaceholderRefreshKey =
+    typeof apiKeyFormValue === "string" ? apiKeyFormValue : "";
+  const activeSettingsView = saveControl?.view;
 
   useEffect(() => {
     setHideSectionHeader(viewMode !== "list");
     return () => setHideSectionHeader(false);
   }, [viewMode, setHideSectionHeader]);
+
+  useEffect(() => {
+    const apiKeyInput = profileFormRef.current?.querySelector<HTMLInputElement>(
+      '[data-testid="llm-api-key-input"]',
+    );
+    if (!apiKeyInput) return;
+
+    // Profile edit mode intentionally leaves the value empty so saving an
+    // untouched key preserves the encrypted secret. The placeholder is the only
+    // visible hint that the profile already has a saved key.
+    apiKeyInput.placeholder = shouldShowSavedApiKeyPlaceholder
+      ? HIDDEN_API_KEY_PLACEHOLDER
+      : "";
+  }, [
+    shouldShowSavedApiKeyPlaceholder,
+    apiKeyPlaceholderRefreshKey,
+    activeSettingsView,
+  ]);
 
   // Get existing profile names for validation
   const existingNames = useMemo(
@@ -155,6 +183,9 @@ export function LlmSettingsLocalView() {
         // The structure is: { model, api_key, base_url, ... }
         // (NOT nested under a "llm" key)
         const config = (detail.config ?? {}) as Record<string, unknown>;
+        const hasSavedApiKey =
+          Boolean(detail.api_key_set) ||
+          (typeof config.api_key === "string" && config.api_key.trim() !== "");
 
         // Seed every llm.* form field from the profile config so all tabs —
         // including "All" — reflect the profile's real values rather than the
@@ -170,21 +201,28 @@ export function LlmSettingsLocalView() {
           const flatKey = field.key.startsWith("llm.")
             ? field.key.slice("llm.".length)
             : field.key;
-          initialValues[field.key] = normalizeFieldValue(
-            field,
-            config[flatKey],
-          );
+          initialValues[field.key] =
+            field.key === "llm.api_key" && hasSavedApiKey
+              ? ""
+              : normalizeFieldValue(field, config[flatKey]);
         }
 
         // Safety net for the specially-rendered keys when the schema is
         // unavailable, so editing still works without it.
         if (llmFields.length === 0) {
           initialValues["llm.model"] = (config.model as string) ?? "";
-          initialValues["llm.api_key"] = (config.api_key as string) ?? "";
+          initialValues["llm.api_key"] = hasSavedApiKey
+            ? ""
+            : ((config.api_key as string) ?? "");
           initialValues["llm.base_url"] = (config.base_url as string) ?? "";
         }
 
-        setEditingProfile({ profile, initialValues, baseConfig: config });
+        setEditingProfile({
+          profile,
+          initialValues,
+          baseConfig: config,
+          hasSavedApiKey,
+        });
         setProfileName(profile.name);
         setViewMode("edit");
       } catch (error) {
@@ -399,23 +437,25 @@ export function LlmSettingsLocalView() {
       />
 
       {/* Profile form - key ensures form remounts when switching profiles */}
-      <LlmSettingsScreen
-        key={
-          viewMode === "edit"
-            ? `edit-${editingProfile?.profile.name}`
-            : "new-profile"
-        }
-        embedded
-        hideSaveButton
-        initialValueOverrides={
-          viewMode === "edit" && editingProfile?.initialValues
-            ? // Edit mode: use the existing profile values
-              editingProfile.initialValues
-            : // Create mode: start with empty fields for a fresh profile
-              { "llm.model": "", "llm.api_key": "", "llm.base_url": "" }
-        }
-        onSaveControlChange={handleSaveControlChange}
-      />
+      <div ref={profileFormRef}>
+        <LlmSettingsScreen
+          key={
+            viewMode === "edit"
+              ? `edit-${editingProfile?.profile.name}`
+              : "new-profile"
+          }
+          embedded
+          hideSaveButton
+          initialValueOverrides={
+            viewMode === "edit" && editingProfile?.initialValues
+              ? // Edit mode: use the existing profile values
+                editingProfile.initialValues
+              : // Create mode: start with empty fields for a fresh profile
+                { "llm.model": "", "llm.api_key": "", "llm.base_url": "" }
+          }
+          onSaveControlChange={handleSaveControlChange}
+        />
+      </div>
 
       {/* Action buttons */}
       <div className="flex justify-start gap-3 pt-4">


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

After an LLM API key is saved, re-opening the LLM settings panel rendered a masked password field whose dot count matched the length of the stored key, stretching the row well past a reasonable width and making the field hard to select or clear. The legacy `settings-form.tsx` already seeds an empty value with a `"<hidden>"` placeholder when a key is set, but the newer LLM-profiles edit flow in `llm-settings-local-view.tsx` seeded the input with the actual stored value.

## Summary

- In `llm-settings-local-view.tsx`, seed the `llm.api_key` field empty when a key is already set (instead of `initialValues["llm.api_key"] = config.api_key`) and surface a fixed-length placeholder indicating a key is present.
- Preserve the existing submit logic so a blank field still means "keep the saved key" rather than "clear it."

## Issue Number

Fixes #1078

## How to Test

Run `npm install` then start the dev build. Save an LLM profile with an API key, reopen the settings panel, and confirm the key field shows a fixed-width placeholder rather than a dot row matching the key length. Submit with the field left blank and confirm the stored key is kept; enter a new value and confirm it replaces the stored key on submit.

## Video/Screenshots

N/A. Behavior change is covered by the unit tests listed in Notes; no UI recording was captured.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Covered by updated cases in `llm-settings-local-view.test.tsx`: edit mode shows the placeholder-masked field, blank submit keeps the key, a new value replaces it, and create mode shows an empty field with no misleading dots.
