### PR TITLE
fix(cloud): route every cloud call through /api/cloud-proxy to fix CO…

### DIFF
--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -5,6 +5,10 @@ import {
   SettingsClient,
 } from "@openhands/typescript-client/clients";
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./cloud/_proxy-test-helpers";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -813,7 +817,7 @@ describe("AgentServerConversationService", () => {
       __resetActiveStoreForTests();
       setRegisteredBackends([cloudBackend]);
       setActiveSelection({ backendId: cloudBackend.id });
-      vi.mocked(axios.request).mockReset();
+      resetCloudProxyMock();
     });
 
     afterEach(() => {
@@ -823,7 +827,7 @@ describe("AgentServerConversationService", () => {
 
     it("forwards parent_conversation_id, agent_type, and sandbox_id to the cloud createConversation payload", async () => {
       // Arrange
-      vi.mocked(axios.request).mockResolvedValue({
+      vi.mocked(axios.post).mockResolvedValue({
         data: {
           id: "task-1",
           status: "WORKING",
@@ -848,7 +852,7 @@ describe("AgentServerConversationService", () => {
       );
 
       // Assert
-      const [config] = vi.mocked(axios.request).mock.calls[0]!;
+      const config = capturedUpstreamRequest(0);
       expect(config).toMatchObject({
         url: `${cloudBackend.host}/api/v1/app-conversations`,
         method: "POST",
@@ -863,7 +867,7 @@ describe("AgentServerConversationService", () => {
 
     it("routes readConversationFile to the cloud file endpoint with the file_path query param", async () => {
       // Arrange
-      vi.mocked(axios.request).mockResolvedValue({ data: "# PLAN content" });
+      vi.mocked(axios.post).mockResolvedValue({ data: "# PLAN content" });
 
       // Act
       const content =
@@ -873,7 +877,7 @@ describe("AgentServerConversationService", () => {
 
       // Assert
       expect(content).toBe("# PLAN content");
-      const [config] = vi.mocked(axios.request).mock.calls[0]!;
+      const config = capturedUpstreamRequest(0);
       expect(config).toMatchObject({
         method: "GET",
         headers: { Authorization: "Bearer bearer-token" },

--- a/__tests__/api/cloud/_proxy-test-helpers.ts
+++ b/__tests__/api/cloud/_proxy-test-helpers.ts
@@ -1,0 +1,112 @@
+import axios from "axios";
+import type { Mock } from "vitest";
+import { vi } from "vitest";
+
+/**
+ * Shape of an "upstream request" — what tests want to assert on regardless
+ * of whether `callCloudProxy` is making a direct browser call or wrapping
+ * the request in an envelope POSTed to /api/cloud-proxy.
+ *
+ * Matches the subset of AxiosRequestConfig that existing cloud-service
+ * tests care about.
+ */
+export interface UpstreamRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  data: unknown;
+  /**
+   * Mirrors AxiosRequestConfig.responseType. In the new envelope-based
+   * flow, `responseType` is set on the OUTER axios.post call (the one to
+   * /api/cloud-proxy) rather than on the upstream request itself. This
+   * field surfaces it so tests asserting "this is a binary download"
+   * remain meaningful.
+   */
+  responseType?: "blob";
+}
+
+/**
+ * Extract the upstream request from a captured `axios.post(...)` call
+ * targeted at /api/cloud-proxy. Use this in any test that wants to assert
+ * on what the cloud backend was supposed to receive — without caring that
+ * `callCloudProxy` wraps every upstream request in an envelope and POSTs
+ * to the local agent-server's /api/cloud-proxy endpoint.
+ *
+ * Why this shim exists: PR #1046 collapsed `callCloudProxy` to a direct
+ * `axios.request` for cloud-host calls, then a follow-up reverted that to
+ * always envelope-POST through /api/cloud-proxy (CORS regression fix —
+ * the cloud only allows CORS from `https://app.all-hands.dev` itself, so
+ * direct browser→cloud calls fail from every other origin). Existing
+ * tests were written against the direct-call shape (`axios.request.mock.
+ * calls[0][0]` = AxiosRequestConfig). Rewriting all 13+ cloud-service
+ * tests by hand to inspect the envelope shape would obscure what each
+ * test actually asserts. This helper lets them keep asserting on
+ * url/method/headers/data with one line of plumbing.
+ */
+export function capturedUpstreamRequest(callIndex = 0): UpstreamRequest {
+  const calls = (axios.post as unknown as Mock).mock.calls;
+  if (!calls[callIndex]) {
+    throw new Error(
+      `capturedUpstreamRequest: no axios.post call at index ${callIndex} ` +
+        `(only ${calls.length} call(s) recorded). Did you forget to await ` +
+        `the callCloudProxy invocation, or to mockResolvedValueOnce?`,
+    );
+  }
+  const [proxyUrl, envelope, outerConfig] = calls[callIndex] as [
+    string,
+    {
+      host: string;
+      method: string;
+      path: string;
+      headers: Record<string, string>;
+      body: unknown;
+    },
+    { responseType?: "blob" } | undefined,
+  ];
+  // Sanity check: every envelope must target /api/cloud-proxy.
+  // If a test accidentally captures a non-proxy axios.post call, fail
+  // loudly so the failure message points at the real culprit.
+  if (!proxyUrl.endsWith("/api/cloud-proxy")) {
+    throw new Error(
+      `capturedUpstreamRequest: expected axios.post[${callIndex}] to target ` +
+        `/api/cloud-proxy, got "${proxyUrl}". This helper only adapts ` +
+        `cloud-proxy envelopes.`,
+    );
+  }
+  return {
+    url: `${envelope.host.replace(/\/+$/, "")}${envelope.path}`,
+    method: envelope.method,
+    headers: envelope.headers,
+    data: envelope.body,
+    ...(outerConfig?.responseType
+      ? { responseType: outerConfig.responseType }
+      : {}),
+  };
+}
+
+/**
+ * Stub the next `callCloudProxy` invocation to resolve with the given
+ * upstream response body. Pair with `capturedUpstreamRequest()` to fully
+ * abstract over the cloud-proxy envelope plumbing.
+ */
+export function mockUpstreamResponse(responseBody: unknown): void {
+  vi.mocked(axios.post).mockResolvedValueOnce({ data: responseBody });
+}
+
+/**
+ * Stub the next `callCloudProxy` invocation to reject. The error is
+ * thrown out of `callCloudProxy` unchanged — most service-layer code
+ * either rethrows or maps it to a domain error.
+ */
+export function mockUpstreamFailure(err: unknown): void {
+  vi.mocked(axios.post).mockRejectedValueOnce(err);
+}
+
+/**
+ * Convenience: reset the axios.post mock between tests. Equivalent to
+ * `vi.mocked(axios.post).mockReset()` but spelled in a way that reads at
+ * the call site as "reset the cloud-proxy plumbing".
+ */
+export function resetCloudProxyMock(): void {
+  vi.mocked(axios.post).mockReset();
+}

--- a/__tests__/api/cloud/conversation-create.test.ts
+++ b/__tests__/api/cloud/conversation-create.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -23,7 +27,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -33,7 +37,7 @@ afterEach(() => {
 
 describe("AgentServerConversationService cloud branch", () => {
   it("createConversation POSTs the cloud payload directly and returns a WORKING task", async () => {
-    vi.mocked(axios.request).mockResolvedValue({
+    vi.mocked(axios.post).mockResolvedValue({
       data: {
         id: "task-123",
         created_by_user_id: null,
@@ -59,8 +63,8 @@ describe("AgentServerConversationService cloud branch", () => {
       },
     );
 
-    expect(axios.request).toHaveBeenCalledOnce();
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    expect(axios.post).toHaveBeenCalledOnce();
+    const config = capturedUpstreamRequest(0);
 
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/app-conversations`,
@@ -89,7 +93,7 @@ describe("AgentServerConversationService cloud branch", () => {
   });
 
   it("getStartTask polls /api/v1/app-conversations/start-tasks?ids= directly", async () => {
-    vi.mocked(axios.request).mockResolvedValue({
+    vi.mocked(axios.post).mockResolvedValue({
       data: [
         {
           id: "task-123",
@@ -108,7 +112,7 @@ describe("AgentServerConversationService cloud branch", () => {
     const result =
       await AgentServerConversationService.getStartTask("task-123");
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/app-conversations/start-tasks?ids=task-123`,
       method: "GET",

--- a/__tests__/api/cloud/conversation-delete.test.ts
+++ b/__tests__/api/cloud/conversation-delete.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -23,7 +27,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -33,12 +37,12 @@ afterEach(() => {
 
 describe("AgentServerConversationService.deleteConversation cloud branch", () => {
   it("calls the cloud DELETE app-conversations endpoint directly", async () => {
-    vi.mocked(axios.request).mockResolvedValue({ data: { success: true } });
+    vi.mocked(axios.post).mockResolvedValue({ data: { success: true } });
 
     await AgentServerConversationService.deleteConversation("conv-abc");
 
-    expect(axios.request).toHaveBeenCalledOnce();
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    expect(axios.post).toHaveBeenCalledOnce();
+    const config = capturedUpstreamRequest(0);
 
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/app-conversations/conv-abc`,

--- a/__tests__/api/cloud/conversation-download.test.ts
+++ b/__tests__/api/cloud/conversation-download.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -23,7 +27,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -34,13 +38,13 @@ afterEach(() => {
 describe("AgentServerConversationService.downloadConversation cloud branch", () => {
   it("calls the cloud download endpoint directly with responseType blob and returns the Blob", async () => {
     const zipBlob = new Blob(["zip-bytes"], { type: "application/zip" });
-    vi.mocked(axios.request).mockResolvedValue({ data: zipBlob });
+    vi.mocked(axios.post).mockResolvedValue({ data: zipBlob });
 
     const result =
       await AgentServerConversationService.downloadConversation("conv-abc");
 
-    expect(axios.request).toHaveBeenCalledOnce();
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    expect(axios.post).toHaveBeenCalledOnce();
+    const config = capturedUpstreamRequest(0);
 
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/app-conversations/conv-abc/download`,

--- a/__tests__/api/cloud/conversation-pause.test.ts
+++ b/__tests__/api/cloud/conversation-pause.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -49,7 +53,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -64,12 +68,12 @@ describe("pauseConversation cloud branch", () => {
       AgentServerConversationService,
       "batchGetAppConversations",
     ).mockResolvedValue([buildConversation({ sandbox_id: "sandbox-xyz" })]);
-    vi.mocked(axios.request).mockResolvedValue({ data: { success: true } });
+    vi.mocked(axios.post).mockResolvedValue({ data: { success: true } });
 
     await pauseConversation("conv-abc");
 
-    expect(axios.request).toHaveBeenCalledOnce();
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    expect(axios.post).toHaveBeenCalledOnce();
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/sandboxes/sandbox-xyz/pause`,
       method: "POST",
@@ -84,6 +88,6 @@ describe("pauseConversation cloud branch", () => {
     ).mockResolvedValue([buildConversation({ sandbox_id: null })]);
 
     await expect(pauseConversation("conv-abc")).rejects.toThrow(/sandbox_id/);
-    expect(axios.request).not.toHaveBeenCalled();
+    expect(axios.post).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/cloud/conversation-public-flag.test.ts
+++ b/__tests__/api/cloud/conversation-public-flag.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -21,7 +25,7 @@ const cloudBackend: Backend = {
 beforeEach(() => {
   window.localStorage.clear();
   __resetActiveStoreForTests();
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -33,7 +37,7 @@ describe("AgentServerConversationService.updateConversationPublicFlag", () => {
   it("PATCHes /api/v1/app-conversations/{id} directly on a cloud backend", async () => {
     setRegisteredBackends([cloudBackend]);
     setActiveSelection({ backendId: cloudBackend.id });
-    vi.mocked(axios.request).mockResolvedValue({
+    vi.mocked(axios.post).mockResolvedValue({
       data: { id: "conv-abc", public: true },
     });
 
@@ -42,8 +46,8 @@ describe("AgentServerConversationService.updateConversationPublicFlag", () => {
       true,
     );
 
-    expect(axios.request).toHaveBeenCalledOnce();
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    expect(axios.post).toHaveBeenCalledOnce();
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/app-conversations/conv-abc`,
       method: "PATCH",
@@ -60,6 +64,6 @@ describe("AgentServerConversationService.updateConversationPublicFlag", () => {
         true,
       ),
     ).rejects.toThrow(/cloud backend/);
-    expect(axios.request).not.toHaveBeenCalled();
+    expect(axios.post).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/cloud/git-service.test.ts
+++ b/__tests__/api/cloud/git-service.test.ts
@@ -1,4 +1,8 @@
-import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  mockUpstreamResponse,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -27,7 +31,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -38,7 +42,7 @@ afterEach(() => {
 describe("getCloudRepositoryBranches", () => {
   it("includes an empty query parameter when listing all branches so the upstream schema is satisfied", async () => {
     // Arrange
-    vi.mocked(axios.request).mockResolvedValueOnce(emptyBranchPage);
+    mockUpstreamResponse(emptyBranchPage.data);
 
     // Act
     await getCloudRepositoryBranches({
@@ -47,14 +51,14 @@ describe("getCloudRepositoryBranches", () => {
     });
 
     // Assert
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     const url = (config as { url: string }).url;
     expect(url).toMatch(/[?&]query=(&|$)/);
   });
 
   it("forwards a non-empty query parameter when searching branches", async () => {
     // Arrange
-    vi.mocked(axios.request).mockResolvedValueOnce(emptyBranchPage);
+    mockUpstreamResponse(emptyBranchPage.data);
 
     // Act
     await getCloudRepositoryBranches({
@@ -64,7 +68,7 @@ describe("getCloudRepositoryBranches", () => {
     });
 
     // Assert
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     const url = (config as { url: string }).url;
     expect(url).toContain("query=feature%2Flogin");
   });

--- a/__tests__/api/cloud/organization-me.test.ts
+++ b/__tests__/api/cloud/organization-me.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -23,7 +27,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -34,7 +38,7 @@ afterEach(() => {
 describe("cloud organization /me", () => {
   it("calls /api/organizations/{orgId}/me directly and returns user_id", async () => {
     const orgId = "0b93b5f2-5396-49f2-8d98-61f906184270";
-    vi.mocked(axios.request).mockResolvedValue({
+    vi.mocked(axios.post).mockResolvedValue({
       data: {
         org_id: orgId,
         user_id: orgId,
@@ -45,7 +49,7 @@ describe("cloud organization /me", () => {
 
     const result = await getCloudOrganizationMe(orgId);
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/organizations/${orgId}/me`,
       method: "GET",

--- a/__tests__/api/cloud/organization-service.test.ts
+++ b/__tests__/api/cloud/organization-service.test.ts
@@ -1,4 +1,9 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  mockUpstreamFailure,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -24,18 +29,18 @@ beforeEach(() => {
   window.localStorage.clear();
   __resetActiveStoreForTests();
   setRegisteredBackends([]);
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
   window.localStorage.clear();
   __resetActiveStoreForTests();
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 describe("cloud organization-service", () => {
   it("getCloudOrganizations calls the cloud API directly and returns normalized data", async () => {
-    vi.mocked(axios.request).mockResolvedValue({
+    vi.mocked(axios.post).mockResolvedValue({
       data: {
         items: [{ id: "org-1", name: "Personal" }],
         current_org_id: "org-1",
@@ -44,8 +49,8 @@ describe("cloud organization-service", () => {
 
     const result = await getCloudOrganizations(cloudBackend);
 
-    expect(axios.request).toHaveBeenCalledOnce();
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    expect(axios.post).toHaveBeenCalledOnce();
+    const config = capturedUpstreamRequest(0);
 
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/organizations`,
@@ -60,7 +65,7 @@ describe("cloud organization-service", () => {
   });
 
   it("getCurrentCloudApiKey hits /api/keys/current and returns the bound orgId", async () => {
-    vi.mocked(axios.request).mockResolvedValue({
+    vi.mocked(axios.post).mockResolvedValue({
       data: {
         id: "key-1",
         name: "k",
@@ -72,7 +77,7 @@ describe("cloud organization-service", () => {
 
     const result = await getCurrentCloudApiKey(cloudBackend);
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/keys/current`,
       method: "GET",
@@ -86,7 +91,7 @@ describe("cloud organization-service", () => {
       response: { status: 400 },
     });
     vi.mocked(axios.isAxiosError).mockReturnValueOnce(true);
-    vi.mocked(axios.request).mockRejectedValueOnce(error);
+    mockUpstreamFailure(error);
 
     const result = await getCurrentCloudApiKey(cloudBackend);
 
@@ -98,7 +103,7 @@ describe("cloud organization-service", () => {
       response: { status: 401 },
     });
     vi.mocked(axios.isAxiosError).mockReturnValueOnce(true);
-    vi.mocked(axios.request).mockRejectedValueOnce(error);
+    mockUpstreamFailure(error);
 
     await expect(getCurrentCloudApiKey(cloudBackend)).rejects.toBe(error);
   });

--- a/__tests__/api/cloud/proxy.test.ts
+++ b/__tests__/api/cloud/proxy.test.ts
@@ -29,18 +29,117 @@ const cloudAcme: Backend = {
 beforeEach(() => {
   window.localStorage.clear();
   __resetActiveStoreForTests();
-  vi.mocked(axios.request).mockReset();
-  vi.mocked(axios.request).mockResolvedValue({ data: {} });
+  vi.mocked(axios.post).mockReset();
+  vi.mocked(axios.post).mockResolvedValue({ data: {} });
 });
 
 afterEach(() => {
   window.localStorage.clear();
   __resetActiveStoreForTests();
-  vi.mocked(axios.request).mockReset();
+  vi.mocked(axios.post).mockReset();
+});
+
+// `callCloudProxy` MUST POST every request to /api/cloud-proxy on the local
+// agent-server rather than making a direct browser → cloud call.
+//
+// Why: the cloud app host (and per-conversation runtime sandboxes) only allow
+// CORS from `https://app.all-hands.dev` itself. Direct browser calls from any
+// other origin (Vite dev, Electron, self-hosted static deployments) get HTTP
+// 400 on the CORS preflight and surface to the user as opaque failures like
+// "Automations Unavailable" (see fix for issue #XYZ — regression from #1046).
+describe("callCloudProxy envelope routing", () => {
+  it("POSTs to <local agent-server>/api/cloud-proxy instead of calling the cloud host directly", async () => {
+    setRegisteredBackends([cloudPersonal]);
+    setActiveSelection({ backendId: cloudPersonal.id, orgId: null });
+
+    await callCloudProxy({
+      backend: cloudPersonal,
+      method: "GET",
+      path: "/api/automation/health",
+    });
+
+    // Exactly one POST, to /api/cloud-proxy on the local agent-server.
+    // jsdom's default origin is http://localhost:3000, so window.location.origin
+    // is the proxy base URL here.
+    expect(vi.mocked(axios.post)).toHaveBeenCalledTimes(1);
+    const [url, body] = vi.mocked(axios.post).mock.calls[0]!;
+    expect(url).toBe("http://localhost:3000/api/cloud-proxy");
+
+    // The envelope describes the upstream request the proxy should make.
+    expect(body).toMatchObject({
+      host: cloudPersonal.host,
+      method: "GET",
+      path: "/api/automation/health",
+    });
+
+    // The cloud's bearer token is carried INSIDE the envelope so it
+    // never crosses an origin boundary in the browser.
+    const envelope = body as { headers: Record<string, string> };
+    expect(envelope.headers.Authorization).toBe(
+      `Bearer ${cloudPersonal.apiKey}`,
+    );
+
+    // And `axios.request` is never used for the upstream call — the proxy
+    // POST is the only outbound request.
+    expect(vi.mocked(axios.request)).not.toHaveBeenCalled();
+  });
+
+  it("uses the local agent-server's session API key on the OUTER POST, not the cloud bearer token", async () => {
+    // The local agent-server expects X-Session-API-Key authentication.
+    // The cloud bearer token must only appear inside the envelope.body.headers.
+    // The session key value here ("test-session-key") is whatever
+    // vitest.setup.ts stubs `VITE_SESSION_API_KEY` to — what matters for
+    // this regression test is that some X-Session-API-Key is sent AND
+    // that no bearer token leaks onto the outer POST.
+    setRegisteredBackends([cloudPersonal]);
+    setActiveSelection({ backendId: cloudPersonal.id, orgId: null });
+
+    await callCloudProxy({
+      backend: cloudPersonal,
+      method: "GET",
+      path: "/api/automation/v1",
+    });
+
+    const [, , config] = vi.mocked(axios.post).mock.calls[0]!;
+    const outerHeaders = (config as { headers: Record<string, string> })
+      .headers;
+    expect(outerHeaders).toHaveProperty("X-Session-API-Key");
+    expect(outerHeaders["X-Session-API-Key"]).toBeTruthy();
+    expect(outerHeaders.Authorization).toBeUndefined();
+  });
+
+  it("also routes runtime-sandbox calls (hostOverride) through the same proxy", async () => {
+    // Same flow whether we target the cloud app host or a per-conversation
+    // runtime sandbox — neither allows CORS from a non-app.all-hands.dev
+    // browser origin.
+    setRegisteredBackends([cloudPersonal]);
+    setActiveSelection({ backendId: cloudPersonal.id, orgId: null });
+
+    await callCloudProxy({
+      backend: cloudPersonal,
+      method: "GET",
+      hostOverride: "https://abc.prod-runtime.all-hands.dev",
+      path: "/api/git/changes",
+      authMode: "session-api-key",
+      sessionApiKey: "runtime-sandbox-session-key",
+    });
+
+    const [url, body] = vi.mocked(axios.post).mock.calls[0]!;
+    expect(url).toBe("http://localhost:3000/api/cloud-proxy");
+    expect(body).toMatchObject({
+      host: "https://abc.prod-runtime.all-hands.dev",
+      path: "/api/git/changes",
+    });
+    const envelope = body as { headers: Record<string, string> };
+    expect(envelope.headers["X-Session-API-Key"]).toBe(
+      "runtime-sandbox-session-key",
+    );
+    expect(envelope.headers.Authorization).toBeUndefined();
+  });
 });
 
 describe("callCloudProxy X-Org-Id injection", () => {
-  it("sends X-Org-Id when targeting the active cloud backend with a selected orgId", async () => {
+  it("includes X-Org-Id in the envelope when targeting the active cloud backend with a selected orgId", async () => {
     // Arrange — active selection points at the cloud backend with a
     // resolved orgId. This is the steady-state case after the user picks
     // an org row in the BackendSelector.
@@ -50,48 +149,40 @@ describe("callCloudProxy X-Org-Id injection", () => {
       orgId: "org-personal-uuid",
     });
 
-    // Act
     await callCloudProxy({
       backend: cloudPersonal,
       method: "GET",
       path: "/api/v1/app-conversations/search",
     });
 
-    // Assert — the request carries the X-Org-Id of the active selection so the
-    // cloud backend can scope this request to the user's locally-chosen org
-    // without depending on user.current_org_id.
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
-    expect(config).toMatchObject({
-      url: `${cloudPersonal.host}/api/v1/app-conversations/search`,
-      method: "GET",
-    });
-    expect(
-      (config as { headers: Record<string, string> }).headers["X-Org-Id"],
-    ).toBe("org-personal-uuid");
+    // X-Org-Id is part of the upstream auth headers carried in the envelope
+    // body so the cloud backend can scope this request to the user's
+    // locally-chosen org without depending on user.current_org_id.
+    const [, body] = vi.mocked(axios.post).mock.calls[0]!;
+    const envelope = body as { headers: Record<string, string> };
+    expect(envelope.headers["X-Org-Id"]).toBe("org-personal-uuid");
   });
 
   it("omits X-Org-Id when targeting a different cloud backend than the active one", async () => {
-    // Arrange — the BackendSelector fan-out (e.g. useAllCloudOrganizations)
-    // calls callCloudProxy(b) for every registered cloud backend. Sending
-    // the active backend's orgId across an unrelated API key would cause
-    // the cloud backend to 403 on api_key_org_id / X-Org-Id mismatch.
+    // The BackendSelector fan-out (e.g. useAllCloudOrganizations) calls
+    // callCloudProxy(b) for every registered cloud backend. Sending the
+    // active backend's orgId across an unrelated API key would cause the
+    // cloud backend to 403 on api_key_org_id / X-Org-Id mismatch.
     setRegisteredBackends([cloudPersonal, cloudAcme]);
     setActiveSelection({
       backendId: cloudPersonal.id,
       orgId: "org-personal-uuid",
     });
 
-    // Act — request targets the non-active backend.
+    // Request targets the non-active backend.
     await callCloudProxy({
       backend: cloudAcme,
       method: "GET",
       path: "/api/keys/current",
     });
 
-    // Assert
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
-    expect(
-      (config as { headers: Record<string, string> }).headers,
-    ).not.toHaveProperty("X-Org-Id");
+    const [, body] = vi.mocked(axios.post).mock.calls[0]!;
+    const envelope = body as { headers: Record<string, string> };
+    expect(envelope.headers).not.toHaveProperty("X-Org-Id");
   });
 });

--- a/__tests__/api/cloud/sandbox-service.test.ts
+++ b/__tests__/api/cloud/sandbox-service.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -23,14 +27,14 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
-  vi.mocked(axios.request).mockResolvedValue({ data: [] });
+  resetCloudProxyMock();
+  vi.mocked(axios.post).mockResolvedValue({ data: [] });
 });
 
 afterEach(() => {
   window.localStorage.clear();
   __resetActiveStoreForTests();
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 describe("batchGetCloudSandboxes", () => {
@@ -44,7 +48,7 @@ describe("batchGetCloudSandboxes", () => {
     // Act
     await batchGetCloudSandboxes(ids);
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       method: "GET",
       headers: { Authorization: "Bearer bearer-token" },

--- a/__tests__/api/cloud/secrets-service.test.ts
+++ b/__tests__/api/cloud/secrets-service.test.ts
@@ -1,4 +1,9 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  mockUpstreamResponse,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -23,7 +28,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -33,7 +38,7 @@ afterEach(() => {
 
 describe("SecretsService against cloud backend", () => {
   it("paginates getSecrets directly and returns the merged list", async () => {
-    vi.mocked(axios.request)
+    vi.mocked(axios.post)
       .mockResolvedValueOnce({
         data: {
           items: [
@@ -52,9 +57,9 @@ describe("SecretsService against cloud backend", () => {
 
     const secrets = await SecretsService.getSecrets();
 
-    expect(vi.mocked(axios.request)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(axios.post)).toHaveBeenCalledTimes(2);
 
-    const [firstConfig] = vi.mocked(axios.request).mock.calls[0]!;
+    const firstConfig = capturedUpstreamRequest(0);
     expect(firstConfig).toMatchObject({
       method: "GET",
       headers: { Authorization: "Bearer bearer-token" },
@@ -64,14 +69,14 @@ describe("SecretsService against cloud backend", () => {
     );
     expect((firstConfig as { url: string }).url).not.toContain("page_id=");
 
-    const [secondConfig] = vi.mocked(axios.request).mock.calls[1]!;
+    const secondConfig = capturedUpstreamRequest(1);
     expect((secondConfig as { url: string }).url).toContain("page_id=BETA");
 
     expect(secrets.map((s) => s.name)).toEqual(["ALPHA", "BETA", "GAMMA"]);
   });
 
   it("creates a secret via direct POST /api/v1/secrets", async () => {
-    vi.mocked(axios.request).mockResolvedValueOnce({ data: {} });
+    mockUpstreamResponse({});
 
     await SecretsService.createSecret(
       "OPENAI_API_KEY",
@@ -79,7 +84,7 @@ describe("SecretsService against cloud backend", () => {
       "OpenAI key",
     );
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/secrets`,
       method: "POST",
@@ -93,12 +98,12 @@ describe("SecretsService against cloud backend", () => {
   });
 
   it("updates a secret via PUT /api/v1/secrets/{id} with name + description only", async () => {
-    vi.mocked(axios.request).mockResolvedValueOnce({ data: {} });
+    mockUpstreamResponse({});
 
     // The form/hook calls updateSecret(secretToEdit, newName, description).
     await SecretsService.updateSecret("OLD_NAME", "NEW_NAME", "renamed");
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/secrets/OLD_NAME`,
       method: "PUT",
@@ -108,11 +113,11 @@ describe("SecretsService against cloud backend", () => {
   });
 
   it("deletes a secret via direct DELETE /api/v1/secrets/{id}", async () => {
-    vi.mocked(axios.request).mockResolvedValueOnce({ data: {} });
+    mockUpstreamResponse({});
 
     await SecretsService.deleteSecret("token with space");
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/secrets/token%20with%20space`,
       method: "DELETE",

--- a/__tests__/api/cloud/settings-service.test.ts
+++ b/__tests__/api/cloud/settings-service.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -27,7 +31,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -37,7 +41,7 @@ afterEach(() => {
 
 describe("cloud settings", () => {
   it("fetchCloudSettings preserves provider_tokens_set so the repo chain can fire", async () => {
-    vi.mocked(axios.request).mockResolvedValue({
+    vi.mocked(axios.post).mockResolvedValue({
       data: {
         llm_model: "anthropic/claude-3-5-sonnet",
         llm_base_url: "https://api.anthropic.com",
@@ -52,7 +56,7 @@ describe("cloud settings", () => {
 
     const result = await fetchCloudSettings();
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/settings`,
       method: "GET",
@@ -80,7 +84,7 @@ describe("cloud settings", () => {
   });
 
   it("saveCloudSettings forwards diffs verbatim and omits the legacy keys the cloud rejects", async () => {
-    vi.mocked(axios.request).mockResolvedValue({ data: {} });
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
 
     const agentDiff = {
       llm: { model: "openai/gpt-4o", base_url: "https://api.openai.com" },
@@ -93,7 +97,7 @@ describe("cloud settings", () => {
       conversation_settings_diff: conversationDiff,
     });
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/settings`,
       method: "POST",
@@ -110,7 +114,7 @@ describe("cloud settings", () => {
 
   it("SettingsService.saveSettings forwards disabled_skills to cloud when active backend is cloud", async () => {
     // Arrange: cloud backend already active via beforeEach; mock cloud response.
-    vi.mocked(axios.request).mockResolvedValue({ data: {} });
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
 
     // Act: save a skills-only update — previously this short-circuited and
     // sent nothing at all, leaving the toggle un-persisted.
@@ -120,8 +124,8 @@ describe("cloud settings", () => {
 
     // Assert: a single POST /api/v1/settings reached the wire with
     // disabled_skills as a top-level field.
-    expect(vi.mocked(axios.request)).toHaveBeenCalledTimes(1);
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    expect(vi.mocked(axios.post)).toHaveBeenCalledTimes(1);
+    const config = capturedUpstreamRequest(0);
     expect(config).toMatchObject({
       url: `${cloudBackend.host}/api/v1/settings`,
       method: "POST",
@@ -133,7 +137,7 @@ describe("cloud settings", () => {
   });
 
   it("saveCloudSettings omits an empty conversation_settings_diff (LLM-only save)", async () => {
-    vi.mocked(axios.request).mockResolvedValue({ data: {} });
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
 
     await saveCloudSettings({
       agent_settings_diff: {
@@ -142,7 +146,7 @@ describe("cloud settings", () => {
       conversation_settings_diff: {},
     });
 
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     const requestBody = (config as { data: Record<string, unknown> }).data;
     expect(requestBody).toEqual({
       agent_settings_diff: {
@@ -155,7 +159,7 @@ describe("cloud settings", () => {
 describe("saveCloudSettings drops agent_context: null (agent-canvas#981)", () => {
   it("strips a null agent_context while preserving sibling agent settings", async () => {
     // Arrange: the cloud rejects agent_context: null against OpenHandsAgentSettings.
-    vi.mocked(axios.request).mockResolvedValue({ data: {} });
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
 
     // Act
     await saveCloudSettings({
@@ -166,7 +170,7 @@ describe("saveCloudSettings drops agent_context: null (agent-canvas#981)", () =>
     });
 
     // Assert: agent_context never reaches the wire, but the real llm change does.
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     const requestBody = (config as { data: Record<string, unknown> }).data;
     expect(requestBody).toEqual({
       agent_settings_diff: {
@@ -177,7 +181,7 @@ describe("saveCloudSettings drops agent_context: null (agent-canvas#981)", () =>
 
   it("preserves a null mcp_config so clearing MCP config still round-trips", async () => {
     // Arrange: mcp_config: null is an intentional "clear" signal, not an error.
-    vi.mocked(axios.request).mockResolvedValue({ data: {} });
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
 
     // Act
     await saveCloudSettings({
@@ -185,14 +189,14 @@ describe("saveCloudSettings drops agent_context: null (agent-canvas#981)", () =>
     });
 
     // Assert: the null mcp_config must survive (don't over-strip nulls).
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     const requestBody = (config as { data: Record<string, unknown> }).data;
     expect(requestBody).toEqual({ agent_settings_diff: { mcp_config: null } });
   });
 
   it("omits agent_settings_diff when agent_context: null is its only key", async () => {
     // Arrange
-    vi.mocked(axios.request).mockResolvedValue({ data: {} });
+    vi.mocked(axios.post).mockResolvedValue({ data: {} });
 
     // Act
     await saveCloudSettings({
@@ -200,7 +204,7 @@ describe("saveCloudSettings drops agent_context: null (agent-canvas#981)", () =>
     });
 
     // Assert: nothing is left to send, so no agent_settings_diff goes on the wire.
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     const requestBody = (config as { data: Record<string, unknown> }).data;
     expect(requestBody).toEqual({});
   });

--- a/__tests__/api/cloud/skills-service.test.ts
+++ b/__tests__/api/cloud/skills-service.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -23,7 +27,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 afterEach(() => {
@@ -33,7 +37,7 @@ afterEach(() => {
 
 describe("SkillsService.getSkills against cloud backend", () => {
   it("paginates /api/v1/skills/search directly and returns the merged list", async () => {
-    vi.mocked(axios.request)
+    vi.mocked(axios.post)
       .mockResolvedValueOnce({
         data: {
           items: [
@@ -57,9 +61,9 @@ describe("SkillsService.getSkills against cloud backend", () => {
 
     const skills = await SkillsService.getSkills();
 
-    expect(vi.mocked(axios.request)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(axios.post)).toHaveBeenCalledTimes(2);
 
-    const [firstConfig] = vi.mocked(axios.request).mock.calls[0]!;
+    const firstConfig = capturedUpstreamRequest(0);
     expect(firstConfig).toMatchObject({
       method: "GET",
       headers: { Authorization: "Bearer bearer-token" },
@@ -69,7 +73,7 @@ describe("SkillsService.getSkills against cloud backend", () => {
     );
     expect((firstConfig as { url: string }).url).not.toContain("page_id=");
 
-    const [secondConfig] = vi.mocked(axios.request).mock.calls[1]!;
+    const secondConfig = capturedUpstreamRequest(1);
     expect((secondConfig as { url: string }).url).toContain("page_id=beta");
 
     expect(skills.map((s) => s.name)).toEqual(["alpha", "beta", "gamma"]);

--- a/__tests__/api/cloud/suggestions-service.test.ts
+++ b/__tests__/api/cloud/suggestions-service.test.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import {
+  capturedUpstreamRequest,
+  resetCloudProxyMock,
+} from "./_proxy-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetActiveStoreForTests,
@@ -22,15 +26,15 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id });
-  vi.mocked(axios.request).mockReset();
-  vi.mocked(axios.request).mockResolvedValue({
+  resetCloudProxyMock();
+  vi.mocked(axios.post).mockResolvedValue({
     data: { items: [], next_page_id: null },
   });
 });
 
 afterEach(() => {
   __resetActiveStoreForTests();
-  vi.mocked(axios.request).mockReset();
+  resetCloudProxyMock();
 });
 
 describe("getCloudSuggestedTasks", () => {
@@ -39,7 +43,7 @@ describe("getCloudSuggestedTasks", () => {
     await getCloudSuggestedTasks({ limit: 10, pageId: "p2" });
 
     // Assert
-    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    const config = capturedUpstreamRequest(0);
     const url = (config as { url: string }).url;
     expect(url).toContain("/api/v1/git/suggested-tasks/search");
     expect(url).toContain("limit=10");

--- a/src/api/cloud/proxy.ts
+++ b/src/api/cloud/proxy.ts
@@ -63,13 +63,38 @@ function buildUpstreamAuthHeaders(
 }
 
 /**
- * Send a cloud request. App-host calls (`backend.host`) go directly to the
- * cloud API with the cloud backend's auth headers. Runtime-sandbox calls pass
- * `hostOverride`, and those still go through `/api/cloud-proxy` because the
- * per-conversation runtime hosts are not the configured cloud app origin.
+ * Send a cloud request via `/api/cloud-proxy` on the local agent-server.
  *
- * App-host auth headers are sent directly to the cloud host. Runtime auth
- * headers are carried in the proxy envelope and attached server-side.
+ * Both the cloud app host (`backend.host`, e.g. `https://app.all-hands.dev`)
+ * and per-conversation runtime sandboxes (`*.prod-runtime.all-hands.dev`,
+ * passed via `hostOverride`) only allow CORS from `https://app.all-hands.dev`
+ * itself. Any other browser origin — Vite dev, the standalone Electron
+ * `.app`, a self-hosted static build at a custom domain — gets HTTP 400 on
+ * the CORS preflight, so a direct `fetch`/`axios` from the browser fails
+ * with no response body, surfaced to the user as e.g. "Automations
+ * Unavailable".
+ *
+ * The fix is to never make the call from the browser. Every cloud request
+ * is wrapped in an envelope and POSTed to `/api/cloud-proxy` on the local
+ * agent-server (`getAgentServerBaseUrl()`); the local server unwraps the
+ * envelope and makes the upstream call server-side, where CORS does not
+ * apply. The local agent-server's own origin is either:
+ *   - the configured `VITE_BACKEND_BASE_URL` (Electron, dev, self-hosted) —
+ *     CORS-allowed by the local server, OR
+ *   - `window.location.origin` (cloud-served embedded UI) — same-origin.
+ *
+ * Upstream auth headers (bearer for the cloud app, `X-Session-API-Key` for
+ * a runtime sandbox) are carried in the envelope body and attached
+ * server-side; they never cross an origin boundary in the browser. The
+ * outer POST to the local agent-server uses the local session API key.
+ *
+ * Regression history: PR #1046 collapsed the cloud-host path into a direct
+ * `axios.request`, on the assumption that the cloud allowed CORS from the
+ * frontend's origin. That works only when agent-canvas is served from
+ * `app.all-hands.dev` itself. For every other deployment (standalone
+ * Electron, `npm run dev`, self-hosted), cloud calls were silently broken
+ * — most pages tolerated the failure by rendering empty state, but the
+ * automations page's up-front health probe surfaced it as a hard error.
  */
 export async function callCloudProxy<TResponse = unknown>(
   req: CloudProxyRequest,
@@ -92,19 +117,6 @@ export async function callCloudProxy<TResponse = unknown>(
     ...(req.headers ?? {}),
   };
   const upstreamHost = req.hostOverride ?? req.backend.host;
-
-  if (!req.hostOverride) {
-    const response = await axios.request<TResponse>({
-      url: `${upstreamHost.replace(/\/+$/, "")}${req.path}`,
-      method: req.method,
-      headers: upstreamHeaders,
-      ...(req.body !== undefined ? { data: req.body } : {}),
-      timeout: (req.timeoutSeconds ?? 30) * 1000,
-      ...(req.responseType ? { responseType: req.responseType } : {}),
-    });
-
-    return response.data;
-  }
 
   const proxyBaseUrl = getAgentServerBaseUrl();
   if (!proxyBaseUrl) throw new NoBackendAvailableError();


### PR DESCRIPTION
…RS regression

User report: with a Cloud backend selected, the Automations page renders 'Automations Unavailable'. Other cloud-backed pages silently degrade to empty state.

Root cause: PR #1046 ("Simplify backend registry selection") collapsed the cloud-host branch of callCloudProxy() into a direct `axios.request` to backend.host, on the assumption that the cloud app allowed CORS from the frontend's origin. That assumption holds only when agent-canvas is served from `https://app.all-hands.dev` itself (the embedded UI case). For every other deployment — Vite dev (`localhost:3000`), the standalone Electron `.app` (`null` / `file://` origin), and self-hosted static builds at custom domains — the CORS preflight to `app.all-hands.dev/api/automation/health` returns HTTP 400 with no `Access-Control-Allow-Origin` header, the browser blocks the request, and `AutomationService.checkHealth()`'s try/catch returns `{status: "error"}`. The automations route interprets that as 'backend not configured' and renders the unavailable screen. Other cloud routes mostly hid the failure by rendering empty state when their queries failed.

Verified by CORS preflight from three representative origins:
  https://app.all-hands.dev  → HTTP 200, ACAO header present
  http://localhost:3000      → HTTP 400, no ACAO header (blocked)
  null (Electron/file://)    → HTTP 400, no ACAO header (blocked)

Fix: remove the direct-call short-circuit so EVERY cloud request — both the cloud app host and per-conversation runtime sandboxes (`*.prod-runtime.all-hands.dev`) — is wrapped in an envelope and POSTed to `/api/cloud-proxy` on the local agent-server. The local server makes the upstream call server-side, where CORS does not apply. This restores the pre-#1046 behaviour described in "Rule 2 — Cloud backend routes must go through callCloudProxy" in AGENTS.md. The local agent-server's own origin is either the configured `VITE_BACKEND_BASE_URL` (Electron, dev, self-hosted) — which the local server permits via CORS — or `window.location.origin` (cloud-served embedded UI), which is same-origin. So the unified flow is correct in every deployment topology.

Upstream auth headers (cloud bearer or runtime-sandbox `X-Session-API-Key`) are carried in the envelope body and attached server-side; they never cross an origin boundary in the browser. The outer POST to the local agent-server uses the local session API key.

Test changes:
  * src/api/cloud/proxy.ts: remove the `if (!req.hostOverride)` short-circuit. Both branches collapse into the existing envelope-POST flow. JSDoc updated with the full regression history.
  * __tests__/api/cloud/_proxy-test-helpers.ts: new test helper (`capturedUpstreamRequest`, `mockUpstreamResponse`, `mockUpstreamFailure`, `resetCloudProxyMock`) that adapts the new envelope shape to the AxiosRequestConfig shape existing cloud-service tests were written against. Lets the 14+ tests keep their original assertions on url/method/headers/data with a one-line plumbing change. `responseType: 'blob'` is surfaced explicitly (it's on the outer axios.post config, not the envelope) so binary-download assertions remain meaningful.
  * __tests__/api/cloud/proxy.test.ts: rewritten to assert envelope shape directly. New regression coverage:
      - cloud-host calls POST to /api/cloud-proxy (not direct upstream)
      - the cloud bearer token rides in envelope.body.headers, not the outer POST headers - runtime-sandbox calls (`hostOverride`) route through the same proxy and carry X-Session-API-Key in envelope.body.headers - existing X-Org-Id behaviour preserved (now asserted on the envelope instead of the direct request)
  * 14 cloud-service tests migrated to the helpers (organization-me, organization-service, settings, skills, secrets, sandbox, suggestions, git, all conversation-* services, and agent-server-conversation-service). The migration was done as a one-shot codemod across the AxiosRequestConfig-shaped assertions; semantic intent ('cloud got this request') is unchanged.

Verification:
  * `npm run typecheck` ✅
  * `npm test` — 2965 passing, 12 skipped, 9 todo (unchanged from main)
  * `npm run build` ✅
  * `npm run lint` on changed files clean
  * Reproduced the upstream success against real cloud (`/api/automation/health` returns 200 `{"status":"ok"}` with a valid bearer token), confirming the fix unblocks the path the automations health probe was attempting.

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
