### PR TITLE
fix(frontend): route automation requests through cloud proxy for cloud backends

### DIFF
--- a/__tests__/api/automation-service.test.ts
+++ b/__tests__/api/automation-service.test.ts
@@ -359,6 +359,7 @@ describe("AutomationService", () => {
         backend: cloudBackend,
         method: "GET",
         path: "/api/automation/v1?limit=10&offset=5",
+        forceProxy: true,
       });
       expect(mockGet).not.toHaveBeenCalled();
       expect(result).toEqual(response);
@@ -373,6 +374,7 @@ describe("AutomationService", () => {
         backend: cloudBackend,
         method: "GET",
         path: "/api/automation/v1/abc",
+        forceProxy: true,
       });
       expect(result).toEqual(mockAutomation);
     });
@@ -386,6 +388,7 @@ describe("AutomationService", () => {
         backend: cloudBackend,
         method: "POST",
         path: "/api/automation/v1/abc/dispatch",
+        forceProxy: true,
       });
       expect(mockPost).not.toHaveBeenCalled();
       expect(result).toEqual(mockRun);
@@ -404,6 +407,7 @@ describe("AutomationService", () => {
         method: "PATCH",
         path: "/api/automation/v1/abc",
         body: { enabled: false },
+        forceProxy: true,
       });
       expect(mockPatch).not.toHaveBeenCalled();
       expect(result).toEqual(updated);
@@ -418,6 +422,7 @@ describe("AutomationService", () => {
         backend: cloudBackend,
         method: "DELETE",
         path: "/api/automation/v1/abc",
+        forceProxy: true,
       });
       expect(mockDelete).not.toHaveBeenCalled();
     });
@@ -440,9 +445,34 @@ describe("AutomationService", () => {
         backend: cloudBackend,
         method: "POST",
         path: "/api/automation/v1/abc/dispatch",
+        forceProxy: true,
       });
       expect(mockPost).not.toHaveBeenCalled();
       expect(result).toEqual(run);
+    });
+
+    it("checkHealth tunnels through the cloud proxy with a fail-fast timeout and returns the upstream status", async () => {
+      mockCallCloudProxy.mockResolvedValue({ status: "ok" });
+
+      const result = await AutomationService.checkHealth();
+
+      // Property access (vs whole-object matching) keeps these assertions
+      // resilient to future additive CloudProxyRequest fields.
+      const call = mockCallCloudProxy.mock.calls[0]![0];
+      expect(call.method).toBe("GET");
+      expect(call.path).toBe("/api/automation/health");
+      expect(call.forceProxy).toBe(true);
+      expect(call.timeoutSeconds).toBe(5);
+      expect(mockGet).not.toHaveBeenCalled();
+      expect(result).toEqual({ status: "ok" });
+    });
+
+    it("checkHealth resolves to an error status instead of throwing when the proxy call fails", async () => {
+      mockCallCloudProxy.mockRejectedValue(new Error("proxy unreachable"));
+
+      const result = await AutomationService.checkHealth();
+
+      expect(result).toEqual({ status: "error" });
     });
   });
 

--- a/__tests__/api/cloud/proxy.test.ts
+++ b/__tests__/api/cloud/proxy.test.ts
@@ -31,12 +31,15 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   vi.mocked(axios.request).mockReset();
   vi.mocked(axios.request).mockResolvedValue({ data: {} });
+  vi.mocked(axios.post).mockReset();
+  vi.mocked(axios.post).mockResolvedValue({ data: {} });
 });
 
 afterEach(() => {
   window.localStorage.clear();
   __resetActiveStoreForTests();
   vi.mocked(axios.request).mockReset();
+  vi.mocked(axios.post).mockReset();
 });
 
 describe("callCloudProxy X-Org-Id injection", () => {
@@ -93,5 +96,65 @@ describe("callCloudProxy X-Org-Id injection", () => {
     expect(
       (config as { headers: Record<string, string> }).headers,
     ).not.toHaveProperty("X-Org-Id");
+  });
+});
+
+describe("callCloudProxy forceProxy routing", () => {
+  it("routes through the local /api/cloud-proxy instead of the cloud host when forceProxy is set", async () => {
+    // Arrange — automation endpoints opt into the proxy hop because the
+    // standalone automation service's CORS allowlist rejects browser
+    // requests from the local GUI origin.
+    setRegisteredBackends([cloudPersonal]);
+    setActiveSelection({ backendId: cloudPersonal.id, orgId: null });
+    vi.mocked(axios.post).mockResolvedValue({ data: { status: "ok" } });
+
+    // Act
+    const result = await callCloudProxy({
+      backend: cloudPersonal,
+      method: "GET",
+      path: "/api/automation/health",
+      forceProxy: true,
+    });
+
+    // Assert — the browser only makes a same-origin POST to the bundled
+    // agent-server's proxy endpoint carrying the upstream call as an
+    // envelope, and the upstream payload is unwrapped for the caller.
+    expect(axios.request).not.toHaveBeenCalled();
+    const [url, envelope] = vi.mocked(axios.post).mock.calls[0]!;
+    expect(url).toMatch(/\/api\/cloud-proxy$/);
+    expect(envelope).toMatchObject({
+      host: cloudPersonal.host,
+      method: "GET",
+      path: "/api/automation/health",
+    });
+    expect(result).toEqual({ status: "ok" });
+  });
+
+  it("carries bearer auth and X-Org-Id inside the proxy envelope", async () => {
+    // Arrange — org scoping must survive the server-side hop: the envelope
+    // headers are what the agent-server attaches to the upstream call in
+    // place of the headers a direct browser request would have sent.
+    setRegisteredBackends([cloudPersonal]);
+    setActiveSelection({
+      backendId: cloudPersonal.id,
+      orgId: "org-personal-uuid",
+    });
+
+    // Act
+    await callCloudProxy({
+      backend: cloudPersonal,
+      method: "GET",
+      path: "/api/automation/health",
+      forceProxy: true,
+    });
+
+    // Assert
+    const [, envelope] = vi.mocked(axios.post).mock.calls[0]!;
+    expect(
+      (envelope as { headers: Record<string, string> }).headers,
+    ).toMatchObject({
+      Authorization: `Bearer ${cloudPersonal.apiKey}`,
+      "X-Org-Id": "org-personal-uuid",
+    });
   });
 });

--- a/src/api/automation-service/automation-service.api.ts
+++ b/src/api/automation-service/automation-service.api.ts
@@ -10,7 +10,7 @@ import {
   getEffectiveLocalBackend,
 } from "../backend-registry/active-store";
 import { NoBackendAvailableError } from "../agent-server-client-options";
-import { callCloudProxy } from "../cloud/proxy";
+import { callCloudProxy, type CloudProxyRequest } from "../cloud/proxy";
 
 const AUTOMATION_BASE_PATH = "/api/automation";
 
@@ -53,6 +53,18 @@ function buildPaginationQuery(limit: number, offset: number): string {
   return params.toString();
 }
 
+// All /api/automation/* paths are served by the standalone automation
+// service, whose CORS allowlist (unlike the main cloud API's bearer-aware
+// CORS) excludes the local GUI origin — so cloud calls must tunnel through
+// the agent-server's /api/cloud-proxy instead of going direct from the
+// browser. Funnel every cloud branch through here so a future method can't
+// reintroduce the CORS failure.
+function callAutomationCloudProxy<TResponse>(
+  req: Omit<CloudProxyRequest, "forceProxy">,
+): Promise<TResponse> {
+  return callCloudProxy<TResponse>({ ...req, forceProxy: true });
+}
+
 class AutomationService {
   static async listAutomations(
     params: { limit?: number; offset?: number } = {},
@@ -61,7 +73,7 @@ class AutomationService {
     const active = getActiveBackend().backend;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<AutomationsResponse>({
+      return callAutomationCloudProxy<AutomationsResponse>({
         backend: active,
         method: "GET",
         path: `${AUTOMATION_BASE_PATH}/v1?${buildPaginationQuery(limit, offset)}`,
@@ -87,7 +99,7 @@ class AutomationService {
     const path = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}`;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<Automation>({
+      return callAutomationCloudProxy<Automation>({
         backend: active,
         method: "GET",
         path,
@@ -106,7 +118,7 @@ class AutomationService {
     const path = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}`;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<Automation>({
+      return callAutomationCloudProxy<Automation>({
         backend: active,
         method: "PATCH",
         path,
@@ -123,7 +135,7 @@ class AutomationService {
     const path = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}`;
 
     if (active.kind === "cloud") {
-      await callCloudProxy<unknown>({
+      await callAutomationCloudProxy<unknown>({
         backend: active,
         method: "DELETE",
         path,
@@ -139,7 +151,7 @@ class AutomationService {
     const path = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}/dispatch`;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<AutomationRun>({
+      return callAutomationCloudProxy<AutomationRun>({
         backend: active,
         method: "POST",
         path,
@@ -159,7 +171,7 @@ class AutomationService {
     const basePath = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}/runs`;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<AutomationRunsResponse>({
+      return callAutomationCloudProxy<AutomationRunsResponse>({
         backend: active,
         method: "GET",
         path: `${basePath}?${buildPaginationQuery(limit, offset)}`,
@@ -194,7 +206,7 @@ class AutomationService {
 
     let blob: Blob;
     if (active.kind === "cloud") {
-      blob = await callCloudProxy<Blob>({
+      blob = await callAutomationCloudProxy<Blob>({
         backend: active,
         method: "GET",
         path,
@@ -221,11 +233,14 @@ class AutomationService {
 
     try {
       if (active.kind === "cloud") {
-        const response = await callCloudProxy<AutomationHealthResponse>({
-          backend: active,
-          method: "GET",
-          path,
-        });
+        const response =
+          await callAutomationCloudProxy<AutomationHealthResponse>({
+            backend: active,
+            method: "GET",
+            path,
+            // Fail fast, matching the local branch's 5s timeout below.
+            timeoutSeconds: 5,
+          });
         return response;
       }
 

--- a/src/api/cloud/proxy.ts
+++ b/src/api/cloud/proxy.ts
@@ -8,7 +8,7 @@ import { NoBackendAvailableError } from "../agent-server-client-options";
 import { buildAuthHeaders } from "../backend-registry/auth";
 import type { Backend } from "../backend-registry/types";
 
-interface CloudProxyRequest {
+export interface CloudProxyRequest {
   /**
    * Cloud backend whose bearer token authenticates the upstream call.
    * `backend.host` is also the default upstream host unless `hostOverride`
@@ -49,6 +49,18 @@ interface CloudProxyRequest {
    * payload (e.g. ZIP downloads); leave undefined for default JSON.
    */
   responseType?: "blob";
+  /**
+   * Force this app-host call through the bundled agent-server's
+   * `/api/cloud-proxy` instead of calling the cloud host directly from the
+   * browser. App-host calls normally go direct because the main cloud API
+   * loosens CORS for bearer-token requests (ApiKeyAwareCORSMiddleware →
+   * `Access-Control-Allow-Origin: *`). The standalone automation service
+   * (`/api/automation/*`) uses a strict origin allowlist instead, so direct
+   * browser requests fail CORS preflight; the same-origin proxy hop avoids
+   * cross-origin entirely while attaching the same auth and `X-Org-Id`
+   * headers server-side.
+   */
+  forceProxy?: boolean;
 }
 
 function buildUpstreamAuthHeaders(
@@ -64,11 +76,12 @@ function buildUpstreamAuthHeaders(
 
 /**
  * Send a cloud request. App-host calls (`backend.host`) go directly to the
- * cloud API with the cloud backend's auth headers. Runtime-sandbox calls pass
- * `hostOverride`, and those still go through `/api/cloud-proxy` because the
- * per-conversation runtime hosts are not the configured cloud app origin.
+ * cloud API with the cloud backend's auth headers, unless `forceProxy` is
+ * set. Runtime-sandbox calls pass `hostOverride`, and those still go through
+ * `/api/cloud-proxy` because the per-conversation runtime hosts are not the
+ * configured cloud app origin.
  *
- * App-host auth headers are sent directly to the cloud host. Runtime auth
+ * App-host auth headers are sent directly to the cloud host. Proxied auth
  * headers are carried in the proxy envelope and attached server-side.
  */
 export async function callCloudProxy<TResponse = unknown>(
@@ -93,7 +106,7 @@ export async function callCloudProxy<TResponse = unknown>(
   };
   const upstreamHost = req.hostOverride ?? req.backend.host;
 
-  if (!req.hostOverride) {
+  if (!req.hostOverride && !req.forceProxy) {
     const response = await axios.request<TResponse>({
       url: `${upstreamHost.replace(/\/+$/, "")}${req.path}`,
       method: req.method,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

With a **cloud** backend selected (e.g. `https://staging.all-hands.dev`), the Automations page (`/automations`) always renders **"Automations Unavailable"**. DevTools shows `GET https://staging.all-hands.dev/api/automation/health` blocked at CORS preflight (provisional headers, 0 response headers).

## Reproduction

1. `npm run dev` in `agent-server-gui`
2. BackendSelector → **Add Backend** → Host `https://staging.all-hands.dev`, Type `Cloud`, valid API key → select **Staging – Personal Workspace**
3. Navigate to `http://localhost:3001/automations`

**Current:** "Automations Unavailable" error state.
**Expected:** the automations list loads, and all automation actions work.

## Root cause

- Cloud automation calls were issued **directly from the browser** to the cloud host with `Authorization: Bearer` + `X-Org-Id` headers (non-simple headers → CORS preflight required).
- `/api/automation/*` is served by the **standalone automation FastAPI service** (`automation` repo, `openhands/automation/app.py`), which uses a plain `CORSMiddleware` whose origin allowlist defaults to the cloud app's own origin only — `http://localhost:3001` is rejected at preflight.
- Every other cloud endpoint works direct-from-browser only because the main SaaS API wraps requests in `ApiKeyAwareCORSMiddleware` (`OpenHands/enterprise/server/middleware.py`), which answers bearer-token requests with `Access-Control-Allow-Origin: *`. The automation service has no such middleware — hence `/api/settings` succeeds while `/api/automation/health` fails.
- `AutomationService.checkHealth()` swallows the network error into `{status: "error"}`, and the page gates on health → permanent "Automations Unavailable".

All 8 cloud branches of `AutomationService` are affected (list, get, update, delete, dispatch, runs, tarball, health) — health just fails first.

## Fix

Tunnel cloud automation calls through the bundled agent-server's existing server-side forwarder `POST /api/cloud-proxy` (SSRF allowlist already permits `*.all-hands.dev`), the same proven mechanism used by runtime-sandbox calls. The browser then only makes a same-origin request; the upstream call happens server-side where CORS does not apply.

- `src/api/cloud/proxy.ts`: opt-in `forceProxy` flag on `CloudProxyRequest`
- `src/api/automation-service/automation-service.api.ts`: all 8 cloud branches funneled through a `callAutomationCloudProxy` helper that injects the flag; 5s fail-fast timeout on the cloud health probe (parity with local)

## Acceptance criteria

- [ ] `/automations` loads with a cloud backend (staging and prod) selected
- [ ] DevTools shows a same-origin `POST /api/cloud-proxy` and **no** direct cross-origin request to `<cloud-host>/api/automation/*`
- [ ] List, detail, runs, toggle, Run Now, delete, and tarball download all work against a cloud backend
- [ ] Local backends are unaffected (automation sidecar path unchanged)
- [ ] Unit tests cover forceProxy routing, envelope auth/org headers, and cloud `checkHealth` success/error mapping

## Follow-up (separate ticket, `automation` repo)

Consider adopting the main API's bearer-aware CORS behavior (`ApiKeyAwareCORSMiddleware`) in the automation service so any external client works without a proxy. Requires a staging/prod deploy; not a substitute for the client-side fix against already-deployed environments.

## Summary

<!-- 1-3 bullets describing what changed. -->
- **`cloud/proxy.ts`** — new opt-in `forceProxy` flag on `CloudProxyRequest` (now exported). When set, app-host calls go through the bundled agent-server's same-origin `POST /api/cloud-proxy` hop instead of straight to the cloud host; the upstream call is made server-side where CORS does not apply. Auth + `X-Org-Id` ride in the proxy envelope exactly as the runtime-sandbox calls already do, and the proxy's SSRF allowlist already permits `*.all-hands.dev`.
- **`automation-service.api.ts`** — all 8 cloud branches (list, get, update, delete, dispatch, runs, tarball, health) are funneled through a `callAutomationCloudProxy` helper that injects `forceProxy: true`, so a future method can't reintroduce the direct cross-origin call. The cloud health probe also gets `timeoutSeconds: 5` for parity with the local branch's fail-fast timeout.
- **Tests** — `proxy.test.ts`: forceProxy routes via `POST /api/cloud-proxy` with the upstream call as an envelope (and no direct `axios.request`), and the envelope carries `Authorization` + `X-Org-Id`. `automation-service.test.ts`: cloud `checkHealth` tunnels through the proxy with the fail-fast timeout and maps proxy rejections to `{status: "error"}` instead of throwing; the six existing exact-match cloud-routing assertions gained the new flag. Red-check: with the src fix reverted, 9 of these tests fail.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #1088 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev`
2. BackendSelector → Add Backend → Host `https://staging.all-hands.dev`, Type `Cloud`, valid API key → select **Staging – Personal Workspace**
3. Open `http://localhost:3001/automations`
4. **Before:** failed cross-origin `GET .../api/automation/health` → page shows "Automations Unavailable". **After:** a same-origin `POST http://localhost:3001/api/cloud-proxy` returns 200 `{status:"ok"}` and the automations list renders.
5. Spot-check the other paths through the proxy: open a detail page, toggle enabled, Run Now, delete, download tarball — each appears in DevTools as `POST /api/cloud-proxy`, with no direct `staging.all-hands.dev` automation request.
6. Switch to a local backend and confirm automations still work (local sidecar path is unchanged).

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/f290632d-bc42-4031-8e27-8da54d6a7418

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- Follows the established cloud/local branching pattern; the proxy hop is the same mechanism runtime-sandbox calls already use in production (including blob downloads), so the blast radius is small.
- Cloud hosts outside `*.all-hands.dev` would get a 403 from the proxy's SSRF allowlist (`OH_CLOUD_PROXY_ALLOWED_HOSTS` overrides it) — the same end state as today's CORS failure, so no regression.
- Server-side follow-up (separate, `automation` repo): adopt the main API's bearer-aware CORS (`ApiKeyAwareCORSMiddleware`) so external clients work without a proxy; requires a deploy and doesn't help currently-deployed environments, hence the client-side fix here.


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `082cd40e83be618240d22cf5db341a1116903264` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-082cd40
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-082cd40
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-082cd40-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2159-amd64
ghcr.io/openhands/agent-canvas:pr-1121-amd64
ghcr.io/openhands/agent-canvas:sha-082cd40-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2159-arm64
ghcr.io/openhands/agent-canvas:pr-1121-arm64
ghcr.io/openhands/agent-canvas:sha-082cd40
ghcr.io/openhands/agent-canvas:hieptl-app-2159
ghcr.io/openhands/agent-canvas:pr-1121
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-082cd40`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-082cd40-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->