### PR TITLE
fix: show the correct LLM profile per conversation (#1082)

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -624,6 +624,27 @@ describe("toAppConversation", () => {
     }
   });
 
+  it("hydrates active_profile from stored metadata so the switcher shows the exact profile (#1082)", () => {
+    setStoredConversationMetadata(baseInfo.id, {
+      selected_repository: null,
+      selected_branch: null,
+      git_provider: null,
+      active_profile: "claude-sonnet-4.6",
+    });
+    try {
+      const result = toAppConversation({
+        ...baseInfo,
+        agent: {
+          kind: "Agent",
+          llm: { model: "litellm_proxy/claude-sonnet-4-6" },
+        },
+      });
+      expect(result.active_profile).toBe("claude-sonnet-4.6");
+    } finally {
+      removeStoredConversationMetadata(baseInfo.id);
+    }
+  });
+
   it("marks openhands conversations and surfaces the agent.llm.model", () => {
     const result = toAppConversation({
       ...baseInfo,

--- a/__tests__/api/use-create-conversation-metadata.test.ts
+++ b/__tests__/api/use-create-conversation-metadata.test.ts
@@ -15,12 +15,14 @@ const {
   mockSettingsClient,
   mockGetSettings,
   mockGetSettingsForConversation,
+  mockUseLlmProfiles,
 } = vi.hoisted(() => ({
   mockHttpPost: vi.fn(),
   mockConversationClient: vi.fn(),
   mockSettingsClient: vi.fn(),
   mockGetSettings: vi.fn(),
   mockGetSettingsForConversation: vi.fn(),
+  mockUseLlmProfiles: vi.fn(),
 }));
 
 vi.mock("@openhands/typescript-client/clients", async () => {
@@ -66,6 +68,10 @@ vi.mock("#/hooks/use-tracking", () => ({
   useTracking: () => ({ trackConversationCreated: vi.fn() }),
 }));
 
+vi.mock("#/hooks/query/use-llm-profiles", () => ({
+  useLlmProfiles: () => mockUseLlmProfiles(),
+}));
+
 const wrapper = ({ children }: { children: React.ReactNode }) => {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -76,6 +82,10 @@ const wrapper = ({ children }: { children: React.ReactNode }) => {
 describe("useCreateConversation persists selected repository metadata", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    mockUseLlmProfiles.mockReset();
+    // Default: no active profile, so metadata is written only for repo/
+    // workspace attachments (as before). Individual tests override this.
+    mockUseLlmProfiles.mockReturnValue({ data: { active_profile: null } });
     mockHttpPost.mockReset();
     mockGetSettings.mockReset();
     mockGetSettingsForConversation.mockReset();
@@ -163,5 +173,25 @@ describe("useCreateConversation persists selected repository metadata", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(getStoredConversationMetadata("conv-new")).toBeNull();
+  });
+
+  it("stamps the active LLM profile even when no repo or workspace is attached (#1082)", async () => {
+    mockUseLlmProfiles.mockReturnValue({
+      data: { active_profile: "team-default" },
+    });
+
+    const { result } = renderHook(() => useCreateConversation(), { wrapper });
+
+    result.current.mutate({ query: "scratch session" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getStoredConversationMetadata("conv-new")).toEqual({
+      selected_repository: null,
+      selected_branch: null,
+      git_provider: null,
+      selected_workspace: null,
+      active_profile: "team-default",
+    });
   });
 });

--- a/__tests__/components/features/chat/switch-profile-button.test.tsx
+++ b/__tests__/components/features/chat/switch-profile-button.test.tsx
@@ -41,6 +41,24 @@ const profiles = [
   { name: "gpt", model: "openai/gpt-4o", base_url: null, api_key_set: true },
 ];
 
+// Two profiles that resolve to the SAME underlying model but differ by name
+// — the #1082 scenario. "broken" is listed first (alphabetical) so a
+// model-only match would wrongly pick it over the user's actual choice.
+const sameModelProfiles = [
+  {
+    name: "broken",
+    model: "litellm_proxy/claude-sonnet-4-6",
+    base_url: null,
+    api_key_set: true,
+  },
+  {
+    name: "claude-sonnet-4.6",
+    model: "litellm_proxy/claude-sonnet-4-6",
+    base_url: null,
+    api_key_set: true,
+  },
+];
+
 describe("SwitchProfileButton", () => {
   const switchAndLog = vi.fn();
 
@@ -163,5 +181,66 @@ describe("SwitchProfileButton", () => {
     expect(
       screen.queryByTestId("switch-profile-button"),
     ).not.toBeInTheDocument();
+  });
+
+  it("labels the button with the conversation's stamped profile when several profiles share a model (#1082)", () => {
+    useLlmProfilesMock.mockReturnValue({
+      data: { profiles: sameModelProfiles, active_profile: "broken" },
+    });
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        id: "conv-1",
+        agent_kind: "openhands",
+        llm_model: "litellm_proxy/claude-sonnet-4-6",
+        active_profile: "claude-sonnet-4.6",
+      },
+    });
+
+    renderWithProviders(<SwitchProfileButton />);
+
+    const button = screen.getByTestId("switch-profile-button");
+    expect(button).toHaveTextContent("claude-sonnet-4.6");
+    expect(button).not.toHaveTextContent("broken");
+  });
+
+  it("falls back to model-matching when the conversation has no stamped profile", () => {
+    useLlmProfilesMock.mockReturnValue({
+      data: { profiles: sameModelProfiles, active_profile: "broken" },
+    });
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        id: "conv-1",
+        agent_kind: "openhands",
+        llm_model: "litellm_proxy/claude-sonnet-4-6",
+      },
+    });
+
+    renderWithProviders(<SwitchProfileButton />);
+
+    // No stamp (e.g. created by an older client) → first profile whose model
+    // matches, preserving today's behavior.
+    expect(screen.getByTestId("switch-profile-button")).toHaveTextContent(
+      "broken",
+    );
+  });
+
+  it("ignores a stamped profile that no longer exists and falls back to model-matching", () => {
+    useLlmProfilesMock.mockReturnValue({
+      data: { profiles: sameModelProfiles, active_profile: "broken" },
+    });
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        id: "conv-1",
+        agent_kind: "openhands",
+        llm_model: "litellm_proxy/claude-sonnet-4-6",
+        active_profile: "deleted-profile",
+      },
+    });
+
+    renderWithProviders(<SwitchProfileButton />);
+
+    expect(screen.getByTestId("switch-profile-button")).toHaveTextContent(
+      "broken",
+    );
   });
 });

--- a/__tests__/hooks/mutation/use-create-conversation.test.tsx
+++ b/__tests__/hooks/mutation/use-create-conversation.test.tsx
@@ -11,6 +11,17 @@ vi.mock("#/hooks/use-tracking", () => ({
   }),
 }));
 
+// The hook stamps the active LLM profile onto the conversation (#1082).
+// Mock it so the captured value is deterministic — the real hook fires a
+// query the global MSW layer would answer non-deterministically under test
+// timing.
+const { useLlmProfilesMock } = vi.hoisted(() => ({
+  useLlmProfilesMock: vi.fn(() => ({ data: { active_profile: null } })),
+}));
+vi.mock("#/hooks/query/use-llm-profiles", () => ({
+  useLlmProfiles: () => useLlmProfilesMock(),
+}));
+
 describe("useCreateConversation", () => {
   it("passes suggested tasks to the V1 create conversation API", async () => {
     const createConversationSpy = vi
@@ -88,32 +99,33 @@ describe("useCreateConversation", () => {
   });
 
   it("invalidates the conversation list and start-tasks queries on success", async () => {
-    vi.spyOn(AgentServerConversationService, "createConversation").mockResolvedValue(
-      {
-        id: "task-id",
-        created_by_user_id: null,
-        status: "READY",
-        detail: null,
-        app_conversation_id: "conv-1",
-        agent_server_url: "http://agent-server.local",
-        request: {
-          initial_message: null,
-          processors: [],
-          llm_model: null,
-          selected_repository: null,
-          selected_branch: null,
-          git_provider: "github",
-          suggested_task: null,
-          title: null,
-          trigger: null,
-          pr_number: [],
-          parent_conversation_id: null,
-          agent_type: "default",
-        },
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockResolvedValue({
+      id: "task-id",
+      created_by_user_id: null,
+      status: "READY",
+      detail: null,
+      app_conversation_id: "conv-1",
+      agent_server_url: "http://agent-server.local",
+      request: {
+        initial_message: null,
+        processors: [],
+        llm_model: null,
+        selected_repository: null,
+        selected_branch: null,
+        git_provider: "github",
+        suggested_task: null,
+        title: null,
+        trigger: null,
+        pr_number: [],
+        parent_conversation_id: null,
+        agent_type: "default",
       },
-    );
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
 
     const queryClient = new QueryClient();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");

--- a/__tests__/hooks/mutation/use-switch-llm-profile-and-log.test.tsx
+++ b/__tests__/hooks/mutation/use-switch-llm-profile-and-log.test.tsx
@@ -1,0 +1,76 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// The wrapper drives the base mutation; mock it so we can deterministically
+// trigger the success / error callbacks the wrapper passes in.
+const switchMutateMock = vi.fn();
+vi.mock("#/hooks/mutation/use-switch-llm-profile", () => ({
+  useSwitchLlmProfile: () => ({ mutate: switchMutateMock, isPending: false }),
+}));
+
+vi.mock("#/hooks/chat/record-model-switch-message", () => ({
+  recordModelSwitchMessage: vi.fn(),
+}));
+
+vi.mock("#/hooks/chat/model-command-event-anchor", () => ({
+  getLastRenderableEventId: () => null,
+}));
+
+vi.mock("#/utils/custom-toast-handlers", () => ({
+  displayErrorToast: vi.fn(),
+}));
+
+import { useSwitchLlmProfileAndLog } from "#/hooks/mutation/use-switch-llm-profile-and-log";
+import {
+  getStoredConversationMetadata,
+  setStoredConversationMetadata,
+} from "#/api/conversation-metadata-store";
+
+describe("useSwitchLlmProfileAndLog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("stamps the switched-to profile onto the conversation metadata, preserving repo/workspace (#1082)", () => {
+    switchMutateMock.mockImplementation((_vars, opts) => opts?.onSuccess?.());
+    // Repo metadata persisted at creation must survive the merge.
+    setStoredConversationMetadata("conv-1", {
+      selected_repository: "octocat/hello-world",
+      selected_branch: "main",
+      git_provider: "github",
+    });
+
+    const { result } = renderHook(() => useSwitchLlmProfileAndLog());
+    result.current.switchAndLog("conv-1", "claude-sonnet-4.6");
+
+    expect(getStoredConversationMetadata("conv-1")).toEqual({
+      selected_repository: "octocat/hello-world",
+      selected_branch: "main",
+      git_provider: "github",
+      selected_workspace: null,
+      active_profile: "claude-sonnet-4.6",
+    });
+  });
+
+  it("does not stamp metadata for the home-page activate path (conversationId === null)", () => {
+    switchMutateMock.mockImplementation((_vars, opts) => opts?.onSuccess?.());
+
+    const { result } = renderHook(() => useSwitchLlmProfileAndLog());
+    result.current.switchAndLog(null, "claude-sonnet-4.6");
+
+    // No conversation to scope the stamp to → nothing written.
+    expect(getStoredConversationMetadata("conv-1")).toBeNull();
+  });
+
+  it("does not stamp metadata when the switch fails", () => {
+    switchMutateMock.mockImplementation((_vars, opts) =>
+      opts?.onError?.(new Error("boom")),
+    );
+
+    const { result } = renderHook(() => useSwitchLlmProfileAndLog());
+    result.current.switchAndLog("conv-1", "claude-sonnet-4.6");
+
+    expect(getStoredConversationMetadata("conv-1")).toBeNull();
+  });
+});

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -268,6 +268,7 @@ export function toAppConversation(
     selected_branch: metadata?.selected_branch ?? null,
     git_provider: metadata?.git_provider ?? null,
     selected_workspace: metadata?.selected_workspace ?? null,
+    active_profile: metadata?.active_profile ?? null,
     title: info.title?.trim()
       ? info.title
       : getDefaultConversationTitle(info.id),

--- a/src/api/conversation-metadata-store.ts
+++ b/src/api/conversation-metadata-store.ts
@@ -15,6 +15,14 @@ export interface ConversationMetadata {
    * git baseline to compare against.
    */
   selected_workspace?: string | null;
+  /**
+   * The LLM profile the conversation was created with (or last switched to).
+   * Client-side only. Lets the chat-header switcher show the exact profile
+   * name even when several profiles share the same underlying model — the
+   * agent-server only round-trips the model string, so matching on it alone
+   * is ambiguous (issue #1082).
+   */
+  active_profile?: string | null;
 }
 
 type StoredMetadata = Record<string, ConversationMetadata>;

--- a/src/api/conversation-service/agent-server-conversation-service.types.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.types.ts
@@ -166,6 +166,15 @@ export interface AppConversation {
    * the runtime actually operates in).
    */
   selected_workspace?: string | null;
+  /**
+   * The LLM profile this conversation was created with / last switched to.
+   * Hydrated from client-side metadata (see
+   * `ConversationMetadata.active_profile`). Preferred over matching
+   * `llm_model` against the profile list, which is ambiguous when several
+   * profiles share a model (#1082). Null when unknown (e.g. created by an
+   * older client) — consumers fall back to model-matching.
+   */
+  active_profile?: string | null;
   public?: boolean;
   sub_conversation_ids: string[];
 }

--- a/src/components/features/chat/switch-profile-button.tsx
+++ b/src/components/features/chat/switch-profile-button.tsx
@@ -49,11 +49,21 @@ export function SwitchProfileButton() {
 
   // Resolution priority for the active profile name:
   //   1. Optimistic (just-clicked) — instant feedback before the refetch.
-  //   2. Profile whose model matches the running llm_model — cold loads.
-  //   3. User-level active_profile — home page / before the conversation has
+  //   2. Profile stamped on the conversation at creation / last switch —
+  //      exact identity, survives reload, and is unambiguous when several
+  //      profiles share one underlying model (#1082). Validated against the
+  //      live list so a since-deleted/renamed profile falls through.
+  //   3. Profile whose model matches the running llm_model — legacy fallback.
+  //   4. User-level active_profile — home page / before the conversation has
   //      sent any messages.
+  const stampedProfile = conversation?.active_profile ?? null;
+  const conversationProfile =
+    stampedProfile && profiles.some((p) => p.name === stampedProfile)
+      ? stampedProfile
+      : null;
   const activeProfileName =
     optimisticActiveProfile ??
+    conversationProfile ??
     (conversationModel
       ? (profiles.find((p) => p.model === conversationModel)?.name ?? null)
       : (data?.active_profile ?? null));

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -4,6 +4,11 @@ import { PluginSpec } from "#/api/conversation-service/agent-server-conversation
 import { SuggestedTask } from "#/utils/types";
 import { Provider } from "#/types/settings";
 import { useTracking } from "#/hooks/use-tracking";
+import { useLlmProfiles } from "#/hooks/query/use-llm-profiles";
+import {
+  getStoredConversationMetadata,
+  setStoredConversationMetadata,
+} from "#/api/conversation-metadata-store";
 
 interface CreateConversationVariables {
   query?: string;
@@ -30,6 +35,10 @@ interface CreateConversationResponse {
 export const useCreateConversation = () => {
   const queryClient = useQueryClient();
   const { trackConversationCreated } = useTracking();
+  // Cache-warm on the home page (the profile picker reads the same query).
+  // Stamped onto the conversation at creation so the switcher can show the
+  // exact profile even when several profiles share a model (#1082).
+  const { data: llmProfiles } = useLlmProfiles();
 
   return useMutation({
     mutationKey: ["create-conversation"],
@@ -62,6 +71,23 @@ export const useCreateConversation = () => {
           parentConversationId,
           agentType,
         );
+
+      // Stamp the active LLM profile onto the (local) conversation so the
+      // chat switcher shows the exact profile even when several profiles
+      // share a model (#1082). Cloud conversations don't use local profiles
+      // (app_conversation_id stays null until the sandbox is READY). Merge so
+      // the repo/workspace metadata the service just persisted is preserved.
+      const localConversationId = conversation.app_conversation_id;
+      if (localConversationId && llmProfiles?.active_profile) {
+        const prev = getStoredConversationMetadata(localConversationId);
+        setStoredConversationMetadata(localConversationId, {
+          selected_repository: prev?.selected_repository ?? null,
+          selected_branch: prev?.selected_branch ?? null,
+          git_provider: prev?.git_provider ?? null,
+          selected_workspace: prev?.selected_workspace ?? null,
+          active_profile: llmProfiles.active_profile,
+        });
+      }
 
       // OpenHands cloud pattern: when the start task isn't immediately
       // READY (cloud sandbox is still provisioning),

--- a/src/hooks/mutation/use-switch-llm-profile-and-log.ts
+++ b/src/hooks/mutation/use-switch-llm-profile-and-log.ts
@@ -3,6 +3,10 @@ import { useTranslation } from "react-i18next";
 import { getLastRenderableEventId } from "#/hooks/chat/model-command-event-anchor";
 import { recordModelSwitchMessage } from "#/hooks/chat/record-model-switch-message";
 import { useSwitchLlmProfile } from "#/hooks/mutation/use-switch-llm-profile";
+import {
+  getStoredConversationMetadata,
+  setStoredConversationMetadata,
+} from "#/api/conversation-metadata-store";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { I18nKey } from "#/i18n/declaration";
 
@@ -32,6 +36,17 @@ export function useSwitchLlmProfileAndLog() {
                 profileName,
                 anchorEventId,
               );
+              // Keep the per-conversation profile identity fresh so the
+              // chat-header switcher shows the right name after a reload
+              // (the agent-server only round-trips the model string). #1082
+              const prev = getStoredConversationMetadata(conversationId);
+              setStoredConversationMetadata(conversationId, {
+                selected_repository: prev?.selected_repository ?? null,
+                selected_branch: prev?.selected_branch ?? null,
+                git_provider: prev?.git_provider ?? null,
+                selected_workspace: prev?.selected_workspace ?? null,
+                active_profile: profileName,
+              });
             }
           },
           onError: (err: unknown) => {


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why

When two LLM profiles resolve to the same underlying model (e.g. both `litellm_proxy/claude-sonnet-4-6`), the chat-header profile switcher showed the **wrong** profile once a conversation started.
  
A conversation only round-trips the LLM **model string**, not a profile identity.
The switcher reconstructed "which profile" by matching `conversation.llm_model` against the profile list (`switch-profile-button.tsx`), and the profiles endpoint returns them alphabetically — so `.find()` returned the first profile with that model, not the one the user picked. 

The credential used was already correct (built from `agent_settings.llm`); only the displayed identity was wrong, which is why two same-model profiles were indistinguishable in the UI.

## Summary

- Stamp the active profile name onto the conversation's client-side metadata at
    creation (`use-create-conversation.ts`) and on a per-conversation switch
    (`use-switch-llm-profile-and-log.ts`), reusing the existing
    `conversation-metadata-store` (same mechanism as repo/branch/workspace).
- Surface `active_profile` on `AppConversation` via `toAppConversation`; the switcher
    prefers the stamped profile, validated against the live list so a deleted/renamed
    profile falls back to model-matching.
- Canvas-only — no backend change.

## Issue Number
Closes #1082.

## How to Test
1. Create two LLM profiles with the **same model** but different names (e.g. `broken`
     and `claude-sonnet-4.6`).  
2. Activate `claude-sonnet-4.6` and start a conversation.
3. The chat-input profile pill shows **`claude-sonnet-4.6`** (previously showed
     `broken`, the first alphabetically). It persists across reload and updates when you
     switch profiles in-chat.


## Video/Screenshots


https://github.com/user-attachments/assets/f0291c93-48e1-4567-988a-1081499aee57



## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Tradeoff:** the stamp lives in `localStorage`, so it is per-browser — opening the
    same conversation in another browser falls back to model-matching (today's
    behavior). A device-independent fix would need the agent-server to carry the profile
    identity on the conversation.
- The stamp is written in the create/switch hooks rather than the `createConversation`
    service because the profile name comes from `useLlmProfiles`, which the service layer
    can't read.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `3e401cb8b53f00a85b62c3aff77226a208d4000e` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-3e401cb
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-3e401cb
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-3e401cb-amd64
ghcr.io/openhands/agent-canvas:vasco-fix-conversation-profile-identity-amd64
ghcr.io/openhands/agent-canvas:pr-1123-amd64
ghcr.io/openhands/agent-canvas:sha-3e401cb-arm64
ghcr.io/openhands/agent-canvas:vasco-fix-conversation-profile-identity-arm64
ghcr.io/openhands/agent-canvas:pr-1123-arm64
ghcr.io/openhands/agent-canvas:sha-3e401cb
ghcr.io/openhands/agent-canvas:vasco-fix-conversation-profile-identity
ghcr.io/openhands/agent-canvas:pr-1123
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-3e401cb`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-3e401cb-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->