### PR TITLE
fix(frontend): migrate Linear integration to streamable HTTP /mcp endpoint

### DIFF
--- a/__tests__/components/features/mcp-page/install-server-modal.test.tsx
+++ b/__tests__/components/features/mcp-page/install-server-modal.test.tsx
@@ -11,6 +11,7 @@ import {
   INTEGRATION_CATALOG as MCP_MARKETPLACE,
   type IntegrationCatalogEntry as MarketplaceEntry,
 } from "@openhands/extensions/integrations";
+import { getMcpMarketplaceCatalog } from "#/utils/mcp-marketplace-utils";
 
 function renderWith(ui: React.ReactNode) {
   return render(ui, {
@@ -205,6 +206,53 @@ describe("InstallServerModal", () => {
     fireEvent.click(screen.getByTestId("mcp-install-submit"));
 
     await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it("installs Linear over streamable HTTP with the api key as a bearer credential", async () => {
+    // Arrange: the marketplace serves the patched Linear entry (shttp
+    // /mcp endpoint, bearer auth) — the UI must never touch the removed
+    // /sse transport.
+    const linear = getMcpMarketplaceCatalog(MCP_MARKETPLACE).find(
+      (e) => e.id === "linear",
+    )!;
+    const testSpy = vi
+      .spyOn(McpService, "testServer")
+      .mockResolvedValue({ ok: true, tools: [] });
+    const getSpy = vi
+      .spyOn(SettingsService, "getSettings")
+      .mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);
+    const saveSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+
+    renderWith(<InstallServerModal entry={linear} onClose={vi.fn()} />);
+    await screen.findByTestId("mcp-install-modal");
+    // Wait for useSettings() so the add-mcp-server mutation doesn't bail.
+    await waitFor(() => expect(getSpy).toHaveBeenCalled());
+
+    // Act: provide the optional Linear API key and install.
+    fireEvent.change(screen.getByTestId("mcp-install-field-api_key"), {
+      target: { value: "lin_api_secret" },
+    });
+    fireEvent.click(screen.getByTestId("mcp-install-submit"));
+
+    // Assert: both the pre-flight test and the persisted config target
+    // the new endpoint over streamable HTTP with the bearer credential.
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
+    expect(testSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "shttp",
+        url: "https://mcp.linear.app/mcp",
+        api_key: "lin_api_secret",
+      }),
+    );
+    const sent = (saveSpy.mock.calls[0][0] as Record<string, unknown>)
+      .agent_settings_diff as {
+      mcp_config: { mcpServers: Record<string, unknown> };
+    };
+    expect(sent.mcp_config.mcpServers).toMatchObject({
+      shttp: { url: "https://mcp.linear.app/mcp", auth: "lin_api_secret" },
+    });
   });
 
   it("closes from the top-right close button", async () => {

--- a/__tests__/constants/extensions-catalogs.test.ts
+++ b/__tests__/constants/extensions-catalogs.test.ts
@@ -34,6 +34,43 @@ describe("OpenHands extensions catalogs", () => {
     );
   });
 
+  it("patches Linear to the streamable HTTP /mcp endpoint with bearer auth", () => {
+    // Arrange: upstream still ships the removed /sse SSE transport; the
+    // marketplace catalog must serve the patched entry instead.
+    const catalog = getMcpMarketplaceCatalog(INTEGRATION_CATALOG);
+
+    // Act
+    const linear = catalog.find((entry) => entry.id === "linear")!;
+
+    // Assert
+    expect(getDefaultMcpTransport(linear)).toEqual({
+      kind: "shttp",
+      url: "https://mcp.linear.app/mcp",
+      apiKeyOptional: true,
+    });
+    expect(linear.docsUrl).toBe("https://linear.app/docs/mcp");
+    const mcpOption = linear.connectionOptions.find(
+      (option) => option.transport?.kind === "shttp",
+    );
+    expect(mcpOption?.auth.strategy).toBe("bearer");
+  });
+
+  it("does not mutate the imported catalog when patching Linear", () => {
+    // Arrange/Act: run the patch, then inspect the raw imported entry.
+    getMcpMarketplaceCatalog(INTEGRATION_CATALOG);
+    const raw = INTEGRATION_CATALOG.find((entry) => entry.id === "linear");
+
+    // Assert: the shared JSON module still carries the upstream values.
+    const rawOption = raw?.connectionOptions.find(
+      (option) => option.transport?.kind === "sse",
+    );
+    expect(rawOption?.transport).toEqual({
+      kind: "sse",
+      url: "https://mcp.linear.app/sse",
+      apiKeyOptional: true,
+    });
+  });
+
   it("drops deprecated MCP entries that no longer have maintained replacements", () => {
     const catalogIds = new Set(
       getMcpMarketplaceCatalog(INTEGRATION_CATALOG).map((entry) => entry.id),

--- a/__tests__/utils/mcp-config.test.ts
+++ b/__tests__/utils/mcp-config.test.ts
@@ -151,3 +151,102 @@ describe("toSdkMcpConfig", () => {
     expect("myname" in out2).toBe(true);
   });
 });
+
+describe("parseMcpConfig — deprecated Linear SSE migration", () => {
+  // Linear removed its MCP SSE transport; persisted configs that still
+  // point at https://mcp.linear.app/sse must be rewritten to streamable
+  // HTTP at https://mcp.linear.app/mcp.
+
+  it("migrates a legacy Linear SSE server to the /mcp endpoint", () => {
+    // Arrange
+    const persisted = {
+      mcpServers: {
+        sse: { url: "https://mcp.linear.app/sse", transport: "sse" },
+      },
+    };
+
+    // Act
+    const parsed = parseMcpConfig(persisted);
+
+    // Assert
+    expect(parsed.sse_servers).toEqual([]);
+    expect(parsed.shttp_servers).toEqual([
+      { url: "https://mcp.linear.app/mcp" },
+    ]);
+  });
+
+  it("preserves the api key and tolerates a trailing slash when migrating", () => {
+    // Arrange
+    const persisted = {
+      mcpServers: {
+        sse: {
+          url: "https://mcp.linear.app/sse/",
+          transport: "sse",
+          auth: "lin_api_secret",
+        },
+      },
+    };
+
+    // Act
+    const parsed = parseMcpConfig(persisted);
+
+    // Assert
+    expect(parsed.shttp_servers).toEqual([
+      { url: "https://mcp.linear.app/mcp", api_key: "lin_api_secret" },
+    ]);
+  });
+
+  it("leaves non-Linear SSE servers untouched", () => {
+    // Arrange
+    const persisted = {
+      mcpServers: {
+        sse: { url: "https://other.example/sse", transport: "sse" },
+      },
+    };
+
+    // Act
+    const parsed = parseMcpConfig(persisted);
+
+    // Assert
+    expect(parsed.sse_servers).toEqual([{ url: "https://other.example/sse" }]);
+    expect(parsed.shttp_servers).toEqual([]);
+  });
+
+  it("keeps a hand-added /mcp entry instead of duplicating it on migration", () => {
+    // Arrange: legacy SSE install plus a manual /mcp entry that already
+    // carries its own credential — the manual entry must win.
+    const persisted = {
+      mcpServers: {
+        sse: { url: "https://mcp.linear.app/sse", transport: "sse" },
+        shttp: { url: "https://mcp.linear.app/mcp", auth: "manual_key" },
+      },
+    };
+
+    // Act
+    const parsed = parseMcpConfig(persisted);
+
+    // Assert
+    expect(parsed.shttp_servers).toEqual([
+      { url: "https://mcp.linear.app/mcp", api_key: "manual_key" },
+    ]);
+  });
+
+  it("persists the migration as an shttp server on the next save", () => {
+    // Arrange: the exact broken state from the field — the server key
+    // "sse" is what produced the rejected `sse_save_comment` tool name.
+    const persisted = {
+      mcpServers: {
+        sse: { url: "https://mcp.linear.app/sse", transport: "sse" },
+      },
+    };
+
+    // Act: parse (load) then serialize (what every MCP save does).
+    const written = toSdkMcpConfig(parseMcpConfig(persisted));
+
+    // Assert: re-persisted under the shttp key with no transport field,
+    // so the backend connects via streamable HTTP to the new endpoint.
+    expect(written).toEqual({
+      mcpServers: { shttp: { url: "https://mcp.linear.app/mcp" } },
+    });
+  });
+});

--- a/__tests__/utils/mcp-marketplace-utils.test.ts
+++ b/__tests__/utils/mcp-marketplace-utils.test.ts
@@ -69,22 +69,22 @@ describe("findInstalledMatch", () => {
     expect(result).toEqual(expect.objectContaining({ id: "stdio-0" }));
   });
 
-  it("matches SSE servers loosely on URL", () => {
+  it("matches HTTP servers loosely on URL", () => {
     const result = findInstalledMatch(getDefaultMcpTransport(linearEntry)!, [
       {
-        id: "sse-0",
-        type: "sse",
-        url: "https://mcp.linear.app/sse/",
+        id: "shttp-0",
+        type: "shttp",
+        url: "https://mcp.linear.app/mcp/",
       },
     ]);
-    expect(result).toEqual(expect.objectContaining({ id: "sse-0" }));
+    expect(result).toEqual(expect.objectContaining({ id: "shttp-0" }));
   });
 
   it("returns null when servers carry malformed urls (defensive)", () => {
     const result = findInstalledMatch(getDefaultMcpTransport(linearEntry)!, [
       // Cast to any to simulate runtime data slipping past the type.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { id: "sse-0", type: "sse", url: undefined as any },
+      { id: "shttp-0", type: "shttp", url: undefined as any },
     ]);
     expect(result).toBeNull();
   });
@@ -236,19 +236,19 @@ describe("findCatalogEntryForServer", () => {
     ).toBeUndefined();
   });
 
-  it("matches an SSE server whose URL differs only by trailing slash", () => {
+  it("matches an HTTP server whose URL differs only by trailing slash", () => {
     // Regression coverage for the strict-=== URL match that previously
     // diverged from findInstalledMatch and caused installed cards to
     // render the generic icon while the marketplace tile said
     // "Installed".
     const linear = mcpMarketplace.find((e) => e.id === "linear")!;
     const linearTransport = getDefaultMcpTransport(linear);
-    if (linearTransport?.kind !== "sse") {
-      throw new Error("Linear template should be SSE");
+    if (linearTransport?.kind !== "shttp") {
+      throw new Error("Linear template should be shttp");
     }
     const normalizedUrl = linearTransport.url.replace(/\/$/, "");
     const match = findCatalogEntryForServer(
-      { id: "sse-0", type: "sse", url: `${normalizedUrl}/` },
+      { id: "shttp-0", type: "shttp", url: `${normalizedUrl}/` },
       mcpMarketplace,
     );
     expect(match?.id).toBe("linear");

--- a/src/utils/mcp-config.ts
+++ b/src/utils/mcp-config.ts
@@ -12,6 +12,25 @@ const EMPTY_MCP_CONFIG: MCPConfig = {
   shttp_servers: [],
 };
 
+const LINEAR_DEPRECATED_SSE_URL = "https://mcp.linear.app/sse";
+const LINEAR_SHTTP_URL = "https://mcp.linear.app/mcp";
+
+/**
+ * Linear removed its MCP SSE transport (the /sse endpoint rejects every
+ * call since 2026-04-08). Detect persisted configs that still point at
+ * the dead endpoint so they can be migrated to streamable HTTP at the
+ * /mcp replacement. Matches only the exact deprecated URL (tolerating a
+ * trailing slash or query string) — nothing else is rewritten.
+ */
+function isDeprecatedLinearSse(
+  url: string,
+  transport: string | undefined,
+): boolean {
+  if (transport !== "sse") return false;
+  const normalized = url.split("?")[0].replace(/\/+$/, "");
+  return normalized === LINEAR_DEPRECATED_SSE_URL;
+}
+
 type SdkMcpServerConfig = Record<string, SettingsValue>;
 type SdkMcpConfig = { mcpServers: Record<string, SdkMcpServerConfig> };
 
@@ -37,6 +56,10 @@ export function parseMcpConfig(value: unknown): MCPConfig {
   const sseServers: (string | MCPSSEServer)[] = [];
   const stdioServers: MCPStdioServer[] = [];
   const shttpServers: (string | MCPSHTTPServer)[] = [];
+  // Legacy Linear SSE entries rewritten to the /mcp endpoint. Collected
+  // separately and merged after the loop so an existing hand-added /mcp
+  // entry (with its own api_key/timeout) wins over the migrated one.
+  const migratedShttpServers: MCPSHTTPServer[] = [];
 
   const mcpServers = obj.mcpServers as Record<string, Record<string, unknown>>;
 
@@ -51,7 +74,11 @@ export function parseMcpConfig(value: unknown): MCPConfig {
       const apiKey =
         typeof auth === "string" && auth !== "oauth" ? auth : undefined;
 
-      if (transport === "sse") {
+      if (isDeprecatedLinearSse(url, transport)) {
+        const server: MCPSHTTPServer = { url: LINEAR_SHTTP_URL };
+        if (apiKey) server.api_key = apiKey;
+        migratedShttpServers.push(server);
+      } else if (transport === "sse") {
         const server: MCPSSEServer = { url };
         if (apiKey) server.api_key = apiKey;
         sseServers.push(server);
@@ -76,6 +103,15 @@ export function parseMcpConfig(value: unknown): MCPConfig {
       }
       stdioServers.push(stdioServer);
     }
+  }
+
+  const normalizeUrl = (u: string) => u.replace(/\/+$/, "");
+  for (const migrated of migratedShttpServers) {
+    const alreadyPresent = shttpServers.some((entry) => {
+      const entryUrl = typeof entry === "string" ? entry : entry.url;
+      return normalizeUrl(entryUrl) === normalizeUrl(migrated.url);
+    });
+    if (!alreadyPresent) shttpServers.push(migrated);
   }
 
   return {

--- a/src/utils/mcp-marketplace-utils.ts
+++ b/src/utils/mcp-marketplace-utils.ts
@@ -59,10 +59,56 @@ export function getDefaultMcpTransport(
   return getDefaultMcpConnectionOption(entry)?.transport;
 }
 
+const LINEAR_DEPRECATED_SSE_URL = "https://mcp.linear.app/sse";
+const LINEAR_SHTTP_URL = "https://mcp.linear.app/mcp";
+const LINEAR_DOCS_URL = "https://linear.app/docs/mcp";
+
+/**
+ * Upstream @openhands/extensions still ships Linear's deprecated SSE
+ * transport (removed upstream on 2026-04-08; the /sse endpoint now
+ * rejects every call). Rewrite the entry to streamable HTTP at the
+ * /mcp replacement endpoint until the pinned dependency catches up.
+ *
+ * The /mcp endpoint authenticates via OAuth 2.1 or a Linear API key
+ * sent as "Authorization: Bearer <token>". This client has no
+ * interactive OAuth flow for MCP installs, so switch the auth
+ * strategy from "none" to "bearer" — the install modal then offers
+ * an (optional) API key field and the agent server forwards it as a
+ * Bearer header.
+ *
+ * Patches immutably — the imported catalog JSON is shared module
+ * state and must not be mutated.
+ */
+function patchLinearEntry(entry: MarketplaceEntry): MarketplaceEntry {
+  if (entry.id !== "linear") return entry;
+  return {
+    ...entry,
+    docsUrl: LINEAR_DOCS_URL,
+    installHint:
+      "Authenticate with a Linear API key (Linear → Settings → Security & access) — sent as a Bearer token. Optional when the endpoint accepts your OAuth session.",
+    connectionOptions: entry.connectionOptions.map((option) =>
+      option.transport?.kind === "sse" &&
+      urlsMatch(option.transport.url, LINEAR_DEPRECATED_SSE_URL)
+        ? {
+            ...option,
+            auth: { ...option.auth, strategy: "bearer" as const },
+            transport: {
+              kind: "shttp" as const,
+              url: LINEAR_SHTTP_URL,
+              apiKeyOptional: option.transport.apiKeyOptional,
+            },
+          }
+        : option,
+    ),
+  };
+}
+
 export function getMcpMarketplaceCatalog(
   catalog: MarketplaceEntry[],
 ): MarketplaceEntry[] {
-  return catalog.filter((entry) => !!getDefaultMcpConnectionOption(entry));
+  return catalog
+    .map(patchLinearEntry)
+    .filter((entry) => !!getDefaultMcpConnectionOption(entry));
 }
 
 const tryUrl = (raw: string): URL | null => {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

Linear removed its MCP SSE transport (`https://mcp.linear.app/sse`, removal date 2026-04-08). Every call through the old endpoint is now rejected, which breaks our Linear integration end-to-end:

- **Agent runtime:** tool calls fail with a deprecation rejection, e.g.
  `Tool 'sse_save_comment' — DEPRECATED TRANSPORT — REMOVAL DATE 2026-04-08 (past). Replacement endpoint: https://mcp.linear.app/mcp`
- **MCP Servers page (`/mcp`):** installing Linear fails its pre-flight connection test with `401 Unauthorized` for `https://mcp.linear.app/sse`.

### Root cause

1. **Marketplace catalog** — the Linear entry ships from the pinned `@openhands/extensions` git dependency with `transport: { kind: "sse", url: "https://mcp.linear.app/sse" }`. Upstream HEAD still carries the deprecated entry, so bumping the pin cannot fix it.
2. **Persisted settings** — existing installs saved `{ mcpServers: { sse: { url: "https://mcp.linear.app/sse", transport: "sse" } } }`. The backend prefixes tool names with the server key, producing the rejected `sse_*` tools.
3. **Auth gap** — the new `/mcp` endpoint authenticates via OAuth 2.1 *or* an API key sent as `Authorization: Bearer <token>` ([docs](https://linear.app/docs/mcp)). The catalog option's `auth.strategy: "none"` meant the install modal never offered a credential field, and the GUI has no interactive OAuth flow for MCP installs — so even against `/mcp`, unauthenticated probes return 401.

### Scope

- Patch the Linear marketplace entry at catalog load: `sse` → `shttp`, `/sse` → `https://mcp.linear.app/mcp`, auth strategy `none` → `bearer` (key optional), docs link → migration guide.
- Auto-migrate persisted legacy Linear SSE configs at parse time; the migration persists on the next MCP settings save.
- No `software-agent-sdk` changes (no Linear hardcoding there; transport is derived from the persisted config).

### Acceptance criteria

- [ ] Linear marketplace tile shows **HTTP**; install modal shows `https://mcp.linear.app/mcp` and an optional **API Key** field.
- [ ] Installing Linear persists an `shttp` server pointing at `/mcp`; an entered API key is forwarded as a Bearer token in both the pre-flight test and at agent runtime.
- [ ] Existing installs pointing at `/sse` are shown migrated on the MCP page (Linear branding + “Installed” badge) and re-persist as `shttp` + `/mcp` on the next MCP settings save.
- [ ] Running the agent no longer produces the `sse_save_comment` deprecation rejection.
- [ ] No usage of `https://mcp.linear.app/sse` remains in the install or persistence flow.

### References

- Replacement endpoint: https://mcp.linear.app/mcp
- Migration guide: https://linear.app/docs/mcp

## Summary

<!-- 1-3 bullets describing what changed. -->

### Problem

Linear removed its MCP SSE transport (`https://mcp.linear.app/sse`, removal date 2026-04-08). The replacement is streamable HTTP at `https://mcp.linear.app/mcp` ([migration guide](https://linear.app/docs/mcp)).

With the old endpoint dead, the integration is broken in two ways:

- **Agent runtime** — tool calls are rejected: `Tool 'sse_save_comment' — DEPRECATED TRANSPORT — REMOVAL DATE 2026-04-08 (past)`
- **MCP Servers page** — installing Linear fails its pre-flight connection test with `401 Unauthorized` against `/sse`.

### Root cause

1. The Linear marketplace entry ships from the pinned `@openhands/extensions` git dependency with the deprecated `sse` transport — upstream HEAD still carries it, so a pin bump can't fix this.
2. Existing installs persisted `mcpServers.sse → /sse`; the backend prefixes tool names with the server key, hence the rejected `sse_*` tools.
3. The new `/mcp` endpoint requires credentials (OAuth 2.1 **or** an API key as `Authorization: Bearer <token>`), but the catalog option's `auth.strategy: "none"` meant the install modal never offered a credential field — and this client has no interactive OAuth flow for MCP installs.

### Changes

**`src/utils/mcp-marketplace-utils.ts`** — `patchLinearEntry()`, applied in `getMcpMarketplaceCatalog()` (the single choke point all five catalog consumers go through; zero import changes). Immutably rewrites the Linear option:
- transport `{ kind: "sse", url: …/sse }` → `{ kind: "shttp", url: …/mcp }`
- auth strategy `"none"` → `"bearer"` (key stays optional) so the modal renders an optional **API Key** field; the agent server forwards it as `Authorization: Bearer <token>` in the pre-flight test and at runtime
- `docsUrl` → the official migration guide; install hint corrected

**`src/utils/mcp-config.ts`** — parse-time migration of legacy installs in `parseMcpConfig()`: persisted Linear `/sse` SSE servers are rewritten to `shttp` at `/mcp` (`api_key` preserved; trailing slash/query tolerated; non-Linear SSE servers untouched; deduped against a hand-added `/mcp` entry, which wins). The next MCP settings save persists the migration — the server key moves `sse` → `shttp`, eliminating the rejected `sse_*` tool prefix.

**No `software-agent-sdk` changes** — it has no Linear hardcoding; transport and auth are derived generically from the persisted config.

### Tests

- `__tests__/constants/extensions-catalogs.test.ts` — catalog patch (shttp + `/mcp` + bearer + docsUrl) and patch immutability.
- `__tests__/utils/mcp-config.test.ts` — migration to `/mcp`, api-key preservation + trailing-slash tolerance, non-Linear SSE untouched, dedup against a manual `/mcp` entry, and round-trip persistence to the `shttp` SDK shape.
- `__tests__/components/features/mcp-page/install-server-modal.test.tsx` — Linear install flow: pre-flight tested and persisted as `shttp` + `/mcp` with the bearer credential.
- Updated existing fixtures in `__tests__/utils/mcp-marketplace-utils.test.ts` that asserted the old SSE transport.

`npm test`: 402 files passed (2984 tests) · `npm run lint`: clean (typecheck + eslint + prettier).

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves #873 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev` → http://localhost:3001/mcp — the Linear tile shows **HTTP**; the install modal shows `https://mcp.linear.app/mcp` with an optional API key field; install passes pre-flight with a valid Linear API key (Linear → Settings → Security & access).
2. With a legacy settings blob (`mcpServers.sse → /sse`), the installed card renders the `/mcp` URL with Linear branding; after any MCP save the persisted config contains `shttp` + `/mcp`.
3. Agent runs no longer hit the deprecation rejection — Linear tools are exposed under the `shttp_*` prefix against the new endpoint.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->


**Video 1:**

https://github.com/user-attachments/assets/725381a6-3c17-437f-af8c-fcd2b804f0e7

**Video 2:**

https://github.com/user-attachments/assets/0c561053-099c-4887-9927-23e6b215453e

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `a3f1c37df0cf052034c80484f650b60282c722f6` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-a3f1c37
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-a3f1c37
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-a3f1c37-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2017-amd64
ghcr.io/openhands/agent-canvas:pr-1132-amd64
ghcr.io/openhands/agent-canvas:sha-a3f1c37-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2017-arm64
ghcr.io/openhands/agent-canvas:pr-1132-arm64
ghcr.io/openhands/agent-canvas:sha-a3f1c37
ghcr.io/openhands/agent-canvas:hieptl-app-2017
ghcr.io/openhands/agent-canvas:pr-1132
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-a3f1c37`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-a3f1c37-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->