### PR TITLE
Preserve LLM profile base URL in Basic settings

### DIFF
--- a/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
+++ b/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
@@ -582,6 +582,42 @@ describe("LlmSettingsLocalView", () => {
       expect(savedLlm.model).toBe("openhands/claude-opus-4-5-20251101");
       expect(savedLlm.base_url).toBe(OPENHANDS_LLM_PROXY_BASE_URL);
     });
+
+    it("preserves an existing custom base_url for other providers", async () => {
+      const user = userEvent.setup();
+      vi.mocked(ProfilesService.getProfile).mockResolvedValue({
+        name: "gpt-4-profile",
+        api_key_set: true,
+        config: {
+          model: "openai/custom-model",
+          api_key: "gAAAA_encrypted_key",
+          base_url: "https://openai-compatible.example.com/v1",
+        },
+      });
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      renderWithProviders(<LlmSettingsLocalView />);
+
+      await user.click(screen.getAllByTestId("profile-menu-trigger")[0]);
+      await user.click(screen.getByTestId("profile-edit"));
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-name-input")).toHaveValue(
+          "gpt-4-profile",
+        );
+      });
+      await user.click(await screen.findByTestId("sdk-section-basic-toggle"));
+      await waitFor(() => {
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled();
+      });
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      await waitFor(() => expect(mockSaveMutateAsync).toHaveBeenCalled());
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.model).toBe("openai/custom-model");
+      expect(savedLlm.base_url).toBe(
+        "https://openai-compatible.example.com/v1",
+      );
+    });
   });
 
   describe("All tab save", () => {

--- a/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
+++ b/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
@@ -256,13 +256,11 @@ export function LlmSettingsLocalView() {
     // The Basic tab has no base_url field; the provider implies it. Persist
     // the All-Hands proxy explicitly for OpenHands models because older local
     // agent-server builds do not infer the LiteLLM proxy api_base on their own.
-    // For other providers, drop any stale custom value and let the backend use
-    // its normal provider defaults.
+    // For other providers, preserve any existing base_url because the Basic tab
+    // has no way for the user to review or change it.
     if (saveControl.view === "basic") {
       if (isOpenHandsProviderModel(llmConfig.model)) {
         llmConfig.base_url = OPENHANDS_LLM_PROXY_BASE_URL;
-      } else {
-        delete llmConfig.base_url;
       }
     }
 


### PR DESCRIPTION
## Summary

Keep the existing Basic-tab OpenHands behavior: when the model is `openhands/*`, save the All-Hands LiteLLM proxy `base_url` explicitly.

For every other provider, stop deleting `base_url` on Basic-tab save. The Basic form does not show `base_url`, so an existing custom endpoint should be preserved rather than silently removed.

## Validation

- `npm test -- __tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx`
- `npm run typecheck`


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `4e0363e8c960e2d37d753a9fafd5fc62a28ac483` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-4e0363e
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-4e0363e
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-4e0363e-amd64
ghcr.io/openhands/agent-canvas:codex-fix-llm-profile-proxy-base-url-amd64
ghcr.io/openhands/agent-canvas:pr-1134-amd64
ghcr.io/openhands/agent-canvas:sha-4e0363e-arm64
ghcr.io/openhands/agent-canvas:codex-fix-llm-profile-proxy-base-url-arm64
ghcr.io/openhands/agent-canvas:pr-1134-arm64
ghcr.io/openhands/agent-canvas:sha-4e0363e
ghcr.io/openhands/agent-canvas:codex-fix-llm-profile-proxy-base-url
ghcr.io/openhands/agent-canvas:pr-1134
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-4e0363e`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-4e0363e-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->