### PR TITLE
fix(acp): deliver ACP credentials inline to avoid agent-server self-deadlock

### DIFF
--- a/src/api/agent-server-adapter.secrets.test.ts
+++ b/src/api/agent-server-adapter.secrets.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The secret-building path reads the active backend for auth headers; stub it
+// so the unit under test stays focused on secret *shape* (Static vs Lookup).
+vi.mock("./backend-registry/active-store", () => ({
+  getEffectiveLocalBackend: () => null,
+}));
+vi.mock("./backend-registry/auth", () => ({
+  buildAuthHeaders: () => ({}),
+}));
+
+import { buildStartConversationRequest } from "./agent-server-adapter";
+import type { Settings } from "#/types/settings";
+
+const ACP_SETTINGS = {
+  agent_settings: { agent_kind: "acp", acp_server: "claude-code" },
+  conversation_settings: {},
+} as unknown as Settings;
+
+const OPENHANDS_SETTINGS = {
+  agent_settings: { agent_kind: "openhands", llm: { model: "gpt-5.5" } },
+  conversation_settings: {},
+} as unknown as Settings;
+
+describe("buildStartConversationRequest — ACP credential delivery", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("sends ACP custom secrets inline as StaticSecret (regression: agent-canvas#1072)", () => {
+    const payload = buildStartConversationRequest({
+      settings: ACP_SETTINGS,
+      secretsEncrypted: true,
+      customSecrets: [{ name: "ANTHROPIC_API_KEY", description: "key" }],
+      acpInlineSecretValues: { ANTHROPIC_API_KEY: "sk-ant-test" },
+    });
+
+    const secret = (payload.secrets as Record<string, unknown>)
+      .ANTHROPIC_API_KEY;
+    expect(secret).toEqual({
+      kind: "StaticSecret",
+      value: "sk-ant-test",
+      description: "key",
+    });
+
+    // ACPAgent's spawn-time env loop reads agent_context.secrets, so the inline
+    // value must be mirrored there too.
+    const ctxSecrets = (
+      payload.agent_settings.agent_context as Record<string, unknown>
+    ).secrets as Record<string, unknown>;
+    expect(ctxSecrets.ANTHROPIC_API_KEY).toEqual({
+      kind: "StaticSecret",
+      value: "sk-ant-test",
+      description: "key",
+    });
+
+    // secrets_encrypted must NOT be set for ACP: the inline value is plaintext
+    // and would be cipher-decrypted (→ dropped to None) on the server.
+    expect(payload.secrets_encrypted).toBeUndefined();
+  });
+
+  it("falls back to a LookupSecret when no inline value is available", () => {
+    const payload = buildStartConversationRequest({
+      settings: ACP_SETTINGS,
+      secretsEncrypted: true,
+      customSecrets: [{ name: "ANTHROPIC_API_KEY", description: "key" }],
+      acpInlineSecretValues: {},
+    });
+
+    const secret = (payload.secrets as Record<string, unknown>)
+      .ANTHROPIC_API_KEY as Record<string, unknown>;
+    expect(secret.kind).toBe("LookupSecret");
+    expect(payload.secrets_encrypted).toBeUndefined();
+  });
+
+  it("leaves non-ACP conversations on LookupSecret with secrets_encrypted", () => {
+    const payload = buildStartConversationRequest({
+      settings: OPENHANDS_SETTINGS,
+      secretsEncrypted: true,
+      customSecrets: [{ name: "GITHUB_TOKEN", description: "tok" }],
+      // An inline map must be ignored for non-ACP agents.
+      acpInlineSecretValues: { GITHUB_TOKEN: "ghp-test" },
+    });
+
+    const secret = (payload.secrets as Record<string, unknown>)
+      .GITHUB_TOKEN as Record<string, unknown>;
+    expect(secret.kind).toBe("LookupSecret");
+    expect(payload.secrets_encrypted).toBe(true);
+    // Non-ACP agents must not get a surprise agent_context.secrets map.
+    const ctx = payload.agent_settings.agent_context as
+      | Record<string, unknown>
+      | undefined;
+    expect(ctx?.secrets).toBeUndefined();
+  });
+});

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -696,6 +696,21 @@ interface LookupSecret {
   description?: string;
 }
 
+/**
+ * A secret whose value travels inline in the request. Used for ACP
+ * conversations: the SDK resolves an ACP agent's secrets *eagerly* on its
+ * event loop while spawning the CLI, and a {@link LookupSecret} that points
+ * back at the same single-process agent-server self-deadlocks
+ * (agent-canvas#1072). An inline value needs no fetch, so it can't stall.
+ */
+interface StaticSecret {
+  kind: "StaticSecret";
+  value: string;
+  description?: string;
+}
+
+type ConversationSecret = LookupSecret | StaticSecret;
+
 type StartConversationPayload = Record<string, unknown> & {
   agent_settings: AgentSettingsPayload;
   workspace: LocalWorkspacePayload;
@@ -708,7 +723,7 @@ type StartConversationPayload = Record<string, unknown> & {
   worktree: true;
   secrets_encrypted?: true;
   conversation_id?: string;
-  secrets?: Record<string, LookupSecret>;
+  secrets?: Record<string, ConversationSecret>;
   tags?: Record<string, string>;
   tool_module_qualnames?: Record<string, string>;
 };
@@ -724,6 +739,13 @@ export interface StartConversationOptions {
   encryptedConversationSettings?: Record<string, SettingsValue>;
   secretsEncrypted?: boolean;
   customSecrets?: Array<{ name: string; description?: string }>;
+  /**
+   * Plaintext values for custom secrets, by name. Supplied for ACP
+   * conversations so each secret rides inline as a {@link StaticSecret}
+   * instead of a loopback {@link LookupSecret} that would deadlock the
+   * agent-server's event loop at ACP spawn time (agent-canvas#1072).
+   */
+  acpInlineSecretValues?: Record<string, string>;
 }
 
 export function buildStartConversationRequest(
@@ -771,7 +793,13 @@ export function buildStartConversationRequest(
     payload.tags = { [ACP_SERVER_TAG_KEY]: acpServerTag };
   }
 
-  if (options.secretsEncrypted) {
+  // ``secrets_encrypted`` tells the agent-server to ``cipher.decrypt()`` every
+  // secret value in the request. Suppress it for ACP: an ACP agent carries no
+  // encrypted agent secret (no LLM api_key), and its provider credentials ride
+  // inline as plaintext StaticSecrets below — flagging those as encrypted makes
+  // the server decrypt plaintext, which silently drops the value to None.
+  // Non-ACP conversations still need it for their encrypted LLM key.
+  if (options.secretsEncrypted && !acpMode) {
     payload.secrets_encrypted = true;
   }
 
@@ -811,9 +839,24 @@ export function buildStartConversationRequest(
   if (options.customSecrets && options.customSecrets.length > 0) {
     const backend = getEffectiveLocalBackend();
     const headers = backend ? buildAuthHeaders(backend) : {};
+    const inlineValues = options.acpInlineSecretValues ?? {};
 
-    const secrets: Record<string, LookupSecret> = {};
+    const secrets: Record<string, ConversationSecret> = {};
     for (const secret of options.customSecrets) {
+      // ACP: send the value inline so the SDK's eager, on-event-loop secret
+      // resolution at CLI spawn never makes a blocking loopback fetch
+      // (agent-canvas#1072). Fall back to a LookupSecret if the value
+      // couldn't be read back. Non-ACP keeps the LookupSecret as-is.
+      const inlineValue = acpMode ? inlineValues[secret.name] : undefined;
+      if (inlineValue) {
+        secrets[secret.name] = {
+          kind: "StaticSecret",
+          value: inlineValue,
+          description: secret.description,
+        };
+        continue;
+      }
+
       const lookupSecret: LookupSecret = {
         kind: "LookupSecret",
         url: `/api/settings/secrets/${encodeURIComponent(secret.name)}`,
@@ -858,12 +901,24 @@ export async function buildStartConversationRequestWithEncryptedSettings(options
   const { agentSettings, conversationSettings, secretsEncrypted } =
     settingsResult;
 
+  // For ACP conversations, read back the values of the saved custom secrets so
+  // they travel inline as StaticSecrets. The SDK resolves an ACP agent's
+  // secrets eagerly on its event loop at CLI spawn; a loopback LookupSecret
+  // there self-deadlocks the single-process agent-server (agent-canvas#1072).
+  let acpInlineSecretValues: Record<string, string> | undefined;
+  if (agentSettings.agent_kind === "acp" && customSecrets.length > 0) {
+    acpInlineSecretValues = await SecretsService.getSecretValues(
+      customSecrets.map((secret) => secret.name),
+    );
+  }
+
   return buildStartConversationRequest({
     ...options,
     encryptedAgentSettings: agentSettings,
     encryptedConversationSettings: conversationSettings,
     secretsEncrypted,
     customSecrets,
+    acpInlineSecretValues,
   });
 }
 

--- a/src/api/secrets-service.ts
+++ b/src/api/secrets-service.ts
@@ -63,6 +63,36 @@ export class SecretsService {
   }
 
   /**
+   * Fetch the plaintext values of named secrets from the local agent-server
+   * store (GET /api/settings/secrets/{name}). Returns a name -> value map,
+   * silently skipping any that fail (missing / unreadable).
+   *
+   * Local backend only: it reads values back over the same localhost channel
+   * the onboarding form wrote them through. Cloud keeps secrets server-side
+   * and never exposes plaintext, so this returns an empty map there.
+   */
+  static async getSecretValues(
+    names: string[],
+  ): Promise<Record<string, string>> {
+    if (names.length === 0 || getActiveBackend().backend.kind === "cloud") {
+      return {};
+    }
+    const client = new SettingsClient(getAgentServerClientOptions());
+    const entries = await Promise.all(
+      names.map(async (name) => {
+        try {
+          const value = await client.getSecret(name);
+          return [name, typeof value === "string" ? value : ""] as const;
+        } catch (error) {
+          console.error(`Failed to fetch secret value for ${name}:`, error);
+          return [name, ""] as const;
+        }
+      }),
+    );
+    return Object.fromEntries(entries.filter(([, value]) => value !== ""));
+  }
+
+  /**
    * Create or update a custom secret (upsert by name).
    * Uses the agent-server API endpoint: PUT /api/settings/secrets
    *


### PR DESCRIPTION
## Problem

Onboarding **Claude Code** (or any ACP agent) with an API key hangs forever on the first turn — issue #1072. The user sees the "hello world" prompt spin, and the agent-server logs a `litellm.AuthenticationError: Missing Anthropic API Key` (title gen) followed ~60s later by:

```
WARNING  Unexpected error retrieving secret 'ANTHROPIC_API_KEY': ReadTimeout: timed out
ERROR    Failed to start ACP server: timed out
  ... acp_agent._start_acp_server -> secret/secrets.py get_value -> httpx.ReadTimeout
```

### Root cause — a self-deadlock

The conversation builder sends every custom secret as a **loopback `LookupSecret`** (`/api/settings/secrets/{name}`). For an ACP agent the SDK resolves the conversation's secrets **eagerly, on its event loop**, while building the subprocess env at CLI spawn — and `LookupSecret.get_value()` is a **synchronous `httpx.get`**.

In the single-process agent-canvas image, that GET (default `OH_INTERNAL_SERVER_URL=http://127.0.0.1:8000`) points **back at the same agent-server** whose event loop is blocked making the call. The request can never be served → `ReadTimeout` after 30s. The key is resolved twice (registry + `agent_context.secrets`), so the UI hangs ~60s before ACP startup fails permanently.

(Reproduced byte-for-byte in `ghcr.io/openhands/agent-canvas:1.0.0-beta.6`.)

## Fix

For **ACP** conversations, read the saved custom-secret values back from the agent-server store (`SecretsService.getSecretValues`, local backend only) and send them **inline as `StaticSecret`s**. An inline value needs no fetch, so the eager on-loop resolution can't stall. Also suppress `secrets_encrypted` for ACP: an ACP request carries no encrypted agent secret (no LLM api_key), and flagging the inline plaintext as encrypted would make the server `cipher.decrypt()` it and drop the value to `None`.

Non-ACP conversations are **unchanged** (LookupSecret + `secrets_encrypted`).

This fixes the hang on the **currently-shipped** agent-server, independent of the deeper SDK-side fix (OpenHands/software-agent-sdk#3510) that stops the event loop from blocking on *any* LookupSecret.

## Verification (real calls)

Built the exact payload this change produces (StaticSecret in `secrets` + `agent_context.secrets`, `secrets_encrypted` omitted) and POSTed it to the shipped beta.6 image (agent-server SDK 1.24.0):

```
ACP server initialized: agent_name='@agentclientprotocol/claude-agent-acp', agent_version='0.41.0'
Setting ACP session mode: bypassPermissions
Sending ACP prompt ...
```

→ `claude-agent-acp` initializes and **reaches Anthropic** (the remaining `[-32603] Credit balance is too low` is an account-billing matter, not the bug) — **no `ReadTimeout`, no deadlock**, vs the reproduced 60s hang with the LookupSecret payload.

## Tests

`src/api/agent-server-adapter.secrets.test.ts`: ACP custom secrets emit `StaticSecret` (in both `secrets` and `agent_context.secrets`) with `secrets_encrypted` omitted; fall back to `LookupSecret` when no value is available; non-ACP keeps `LookupSecret` + `secrets_encrypted`.

## Note on #1102

PR #1102 (`docker-acp`) already inlines *reserved* ACP creds as StaticSecrets. This PR is a focused, independently-mergeable fix for the release-blocking #1072 and additionally covers **all** custom secrets (a non-reserved custom secret would still deadlock ACP init under #1102). The two can be reconciled on rebase.

Fixes #1072
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `b90e0722d27f4cde62fdc27d52dc2bbcd0f1335b` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-b90e072
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-b90e072
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-b90e072-amd64
ghcr.io/openhands/agent-canvas:fix-acp-claude-code-secret-deadlock-amd64
ghcr.io/openhands/agent-canvas:pr-1135-amd64
ghcr.io/openhands/agent-canvas:sha-b90e072-arm64
ghcr.io/openhands/agent-canvas:fix-acp-claude-code-secret-deadlock-arm64
ghcr.io/openhands/agent-canvas:pr-1135-arm64
ghcr.io/openhands/agent-canvas:sha-b90e072
ghcr.io/openhands/agent-canvas:fix-acp-claude-code-secret-deadlock
ghcr.io/openhands/agent-canvas:pr-1135
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-b90e072`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-b90e072-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->