### PR TITLE
Identify users by email in Posthog

### DIFF
--- a/src/hooks/use-posthog-identify.ts
+++ b/src/hooks/use-posthog-identify.ts
@@ -31,7 +31,9 @@ export const usePostHogIdentify = () => {
     if (!posthog || !isCloud || settings === undefined) return;
 
     if (consent === true && userId) {
-      posthog.identify(userId, { email: settings.email ?? undefined });
+      posthog.identify(userId, {
+        email: settings.email ?? settings.git_user_email ?? undefined,
+      });
       hasIdentifiedRef.current = true;
       return;
     }


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

When identifying users in PostHog for analytics, the `email` property was only populated from `settings.email`. If a user had configured a git email (`git_user_email`) but not a separate settings email, the PostHog identify call would receive no email, reducing the usefulness of analytics profiles.

## Summary

- When calling `posthog.identify()`, fall back to `settings.git_user_email` if `settings.email` is not set

## Issue Number

<!-- Required if there is a relevant issue to this PR. -->

## How to Test

1. Trigger posthog events with no settings.email set
2. Trigger posthog events with settings.email set
3. Open PostHog debugging (e.g., in browser DevTools) to verify the `identify` call includes the correct `email`

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.
-->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

---


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `5cc4fd893c86a4857e21e0f311bc8f6c648a9fdc` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-5cc4fd8
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-5cc4fd8
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-5cc4fd8-amd64
ghcr.io/openhands/agent-canvas:APP-2168-posthog-identify-amd64
ghcr.io/openhands/agent-canvas:pr-1137-amd64
ghcr.io/openhands/agent-canvas:sha-5cc4fd8-arm64
ghcr.io/openhands/agent-canvas:APP-2168-posthog-identify-arm64
ghcr.io/openhands/agent-canvas:pr-1137-arm64
ghcr.io/openhands/agent-canvas:sha-5cc4fd8
ghcr.io/openhands/agent-canvas:APP-2168-posthog-identify
ghcr.io/openhands/agent-canvas:pr-1137
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-5cc4fd8`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-5cc4fd8-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->