### PR TITLE
[codex] Allow automation CORS origin override

### DIFF
--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -796,8 +796,10 @@ function startAutomationBackend(config) {
           join(config.stateDir, "workspaces"),
         // Session API key for self-hosted auth — shared with agent-server via X-Session-API-Key header
         AUTOMATION_LOCAL_API_KEY: config.sessionApiKey,
-        // CORS: allow localhost origins for dev
-        AUTOMATION_CORS_ORIGINS: `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:3001,http://127.0.0.1:3001`,
+        // CORS: allow localhost origins for dev, unless explicitly overridden.
+        AUTOMATION_CORS_ORIGINS:
+          process.env.AUTOMATION_CORS_ORIGINS ||
+          `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:3001,http://127.0.0.1:3001`,
         FILE_STORE: "local",
         LOCAL_STORAGE_PATH: join(config.stateDir, "storage"),
         OPENHANDS_SUPPRESS_BANNER: "1",


### PR DESCRIPTION
## Summary

- Let the dev launcher honor `AUTOMATION_CORS_ORIGINS` when starting the automation backend.
- Keep the existing localhost-only default when no override is provided.

## Why

Split frontend/backend deployments may need browser access from a non-localhost origin, such as separate ngrok domains. The agent-server already supports its own CORS override through `OH_ALLOW_CORS_ORIGINS`, but the automation launcher previously overwrote `AUTOMATION_CORS_ORIGINS` with localhost-only values, preventing wildcard or custom-origin deployments.

## Validation

- `node --check scripts/dev-with-automation.mjs`
- Manually restarted the backend with `AUTOMATION_CORS_ORIGINS="*"` and verified public ngrok CORS preflights for agent-server and automation routes returned `200`.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.24.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `b7a0b122a2884db7112909056e2fb82f41f175a4` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-b7a0b12
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-b7a0b12
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-b7a0b12-amd64
ghcr.io/openhands/agent-canvas:codex-allow-automation-cors-override-amd64
ghcr.io/openhands/agent-canvas:pr-1160-amd64
ghcr.io/openhands/agent-canvas:sha-b7a0b12-arm64
ghcr.io/openhands/agent-canvas:codex-allow-automation-cors-override-arm64
ghcr.io/openhands/agent-canvas:pr-1160-arm64
ghcr.io/openhands/agent-canvas:sha-b7a0b12
ghcr.io/openhands/agent-canvas:codex-allow-automation-cors-override
ghcr.io/openhands/agent-canvas:pr-1160
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-b7a0b12`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-b7a0b12-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->