### PR TITLE
[codex] Bump agent-server default to 1.25.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -511,10 +511,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.24.0")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.25.0")
   - `OH_SECRET_KEY` — secret key for settings encryption; auto-generated and persisted to `~/.openhands/agent-canvas/secret-key.txt` on first run (same file Docker uses), ensuring dev mode and Docker share the same key when both mount the same `~/.openhands` directory. Override with the env var to pin a specific key.
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.24.0` for agent-server SDK libraries
+  - Default: released PyPI version `1.25.0` for agent-server SDK libraries
 
 - Security: `scripts/dev-safe.mjs` and `scripts/dev-with-automation.mjs` auto-generate random API keys when needed and persist the defaults so static builds, localStorage, and restarted services stay in sync:
   - `SESSION_API_KEY` — 64-character hex (256-bit) for agent-server API authentication; persisted at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden via env var

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -389,16 +389,16 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.24.0",
+      "openhands-agent-server==1.25.0",
       "--with",
-      "openhands-sdk==1.24.0",
+      "openhands-sdk==1.25.0",
       "--with",
-      "openhands-tools==1.24.0",
+      "openhands-tools==1.25.0",
       "--with",
-      "openhands-workspace==1.24.0",
+      "openhands-workspace==1.25.0",
       "agent-server",
     ]);
-    expect(cmd.source).toBe("PyPI (1.24.0, default)");
+    expect(cmd.source).toBe("PyPI (1.25.0, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -2,7 +2,7 @@
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
 
   "versions": {
-    "agentServer": "1.24.0",
+    "agentServer": "1.25.0",
     "automation": "1.0.0a6",
     "automationSdk": "1.22.1"
   },

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.24.0 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.25.0 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -79,7 +79,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/agent-canvas/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.24.0"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.25.0"}}'
 `);
   process.exit(0);
 }
@@ -268,9 +268,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.24.0,<2.0.0"
- *   "openhands-tools==1.24.0"
- *   "openhands-workspace (>=1.24.0)"
+ *   "openhands-sdk>=1.25.0,<2.0.0"
+ *   "openhands-tools==1.25.0"
+ *   "openhands-workspace (>=1.25.0)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -284,7 +284,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.24.0", "==1.24.0", "(>=1.24.0)", "~=1.24.0"
+      // ">=1.25.0", "==1.25.0", "(>=1.25.0)", "~=1.25.0"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -393,7 +393,7 @@ export function validateFrontendDependencies(
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.24.0")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.25.0")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a


### PR DESCRIPTION
## Summary

- Bump the default `openhands-agent-server` version from `1.24.0` to `1.25.0`.
- Update the repository notes that document the default agent-server SDK version.

## Why

The current frontend expects MCP configuration to be available for ACP agents, but the `1.24.0` backend drops `agent_settings.mcp_config` when `agent_kind` is `acp`. Running the stack with `openhands-agent-server==1.25.0` preserves `mcp_config` for Codex ACP settings, allowing the MCP page to show the installed servers.

`versions.automationSdk` remains at `1.22.1` because it tracks the SDK dependency used by the currently pinned `openhands-automation==1.0.0a6` release and may intentionally lag the agent-server pin.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('config/defaults.json','utf8')); console.log(require('./config/defaults.json').versions.agentServer)"`
- `node scripts/check-sdk-version-sync.mjs`
- Restarted the local backend with `OH_AGENT_SERVER_VERSION=1.25.0` and verified `/server_info` reports agent-server/sdk/tools/workspace `1.25.0`.
- Verified `PATCH /api/settings` with `agent_settings_diff.mcp_config` persists under `agent_kind: "acp"`.


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.25.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `b6d491691a561b6f64d7af735b61adf3d12781d4` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-b6d4916
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-b6d4916
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-b6d4916-amd64
ghcr.io/openhands/agent-canvas:codex-bump-agent-server-125-amd64
ghcr.io/openhands/agent-canvas:pr-1161-amd64
ghcr.io/openhands/agent-canvas:sha-b6d4916-arm64
ghcr.io/openhands/agent-canvas:codex-bump-agent-server-125-arm64
ghcr.io/openhands/agent-canvas:pr-1161-arm64
ghcr.io/openhands/agent-canvas:sha-b6d4916
ghcr.io/openhands/agent-canvas:codex-bump-agent-server-125
ghcr.io/openhands/agent-canvas:pr-1161
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-b6d4916`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-b6d4916-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->