### PR TITLE
Add frontend performance fixes for long conversations and load times

### DIFF
--- a/__tests__/components/chat-message.test.tsx
+++ b/__tests__/components/chat-message.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ChatMessage } from "#/components/features/chat/chat-message";
 
 describe("ChatMessage", () => {
@@ -45,8 +45,9 @@ describe("ChatMessage", () => {
   });
 
   it("should render a component passed as a prop", () => {
+    const customComponentText = "Custom Component";
     function Component() {
-      return <div data-testid="custom-component">Custom Component</div>;
+      return <div data-testid="custom-component">{customComponentText}</div>;
     }
     render(
       <ChatMessage type="user" message="Hello, World">
@@ -70,14 +71,47 @@ describe("ChatMessage", () => {
     const longMessage = `${"Here's a long message. ".repeat(40)}`.trim();
     render(<ChatMessage type="user" message={longMessage} />);
 
-    expect(screen.getByTestId("chat-message-truncation-gradient")).toBeInTheDocument();
-    expect(screen.getByTestId("chat-message-view-more")).toHaveClass("opacity-0");
+    expect(
+      screen.getByTestId("chat-message-truncation-gradient"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("chat-message-view-more")).toHaveClass(
+      "opacity-0",
+    );
 
     fireEvent.mouseEnter(screen.getByTestId("user-message"));
-    expect(screen.getByTestId("chat-message-view-more")).toHaveClass("opacity-100");
+    expect(screen.getByTestId("chat-message-view-more")).toHaveClass(
+      "opacity-100",
+    );
 
     fireEvent.click(screen.getByTestId("chat-message-expand"));
-    expect(screen.queryByTestId("chat-message-truncation-gradient")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("chat-message-view-more")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("chat-message-truncation-gradient"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("chat-message-view-more"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not issue a cross-component update warning when measuring truncation", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const longMessage = `${"Here's a long message. ".repeat(40)}`.trim();
+
+    try {
+      render(<ChatMessage type="user" message={longMessage} />);
+
+      expect(
+        screen.getByTestId("chat-message-truncation-gradient"),
+      ).toBeInTheDocument();
+
+      const consoleOutput = errorSpy.mock.calls
+        .flat()
+        .map((part) => String(part))
+        .join("\n");
+      expect(consoleOutput).not.toContain(
+        "Cannot update a component (`ChatMessage`) while rendering a different component (`UserMessageBody`)",
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/__tests__/components/conversation-events/chat/group-events.test.ts
+++ b/__tests__/components/conversation-events/chat/group-events.test.ts
@@ -4,6 +4,7 @@ import {
   isGroupableEvent,
   EVENT_GROUP_MIN_SIZE,
 } from "#/components/conversation-events/chat/group-events";
+import { buildActionById } from "#/components/conversation-events/chat/event-thought-helpers";
 import {
   ActionEvent,
   AgentErrorEvent,
@@ -338,6 +339,35 @@ describe("groupEvents", () => {
     if (result[2].kind === "group") {
       expect(result[2].events).toHaveLength(3);
     }
+  });
+
+  it("produces identical output whether passed a raw event list or a precomputed action lookup", () => {
+    // The production render path passes a precomputed Map (the O(1) optimization);
+    // direct tests/callers still pass a raw list (the compatibility fallback).
+    // Both branches must group identically.
+    const a1 = makeBashAction("a1");
+    const a2 = makeBashAction("a2");
+    const a3 = makeBashAction("a3");
+    const a4 = makeBashAction("a4", [
+      { type: "text", text: "Let me check tests for the new conversation button:" },
+    ]);
+    const a5 = makeBashAction("a5");
+    const a6 = makeBashAction("a6");
+
+    const events = [
+      makeBashObservation("o1", "a1"),
+      makeBashObservation("o2", "a2"),
+      makeBashObservation("o3", "a3"),
+      makeBashObservation("o4", "a4"),
+      makeBashObservation("o5", "a5"),
+      makeBashObservation("o6", "a6"),
+    ];
+    const allEvents = [a1, a2, a3, ...events.slice(0, 3), a4, a5, a6, ...events.slice(3)];
+
+    const fromList = groupEvents(events, undefined, allEvents);
+    const fromLookup = groupEvents(events, undefined, buildActionById(allEvents));
+
+    expect(fromLookup).toEqual(fromList);
   });
 
   it("hoists thoughts attached to action events that haven't been observed yet", () => {

--- a/__tests__/contexts/conversation-websocket-context.test.tsx
+++ b/__tests__/contexts/conversation-websocket-context.test.tsx
@@ -7,8 +7,13 @@ import { useEventStore } from "#/stores/use-event-store";
 import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
 import { useBrowserStore } from "#/stores/browser-store";
 import { useUserConversation } from "#/hooks/query/use-user-conversation";
+import { useWebSocket } from "#/hooks/use-websocket";
 import EventService from "#/api/event-service/event-service.api";
-import type { MessageEvent } from "#/types/agent-server/core";
+import type {
+  MessageEvent,
+  ObservationEvent,
+} from "#/types/agent-server/core";
+import type { BrowserObservation } from "#/types/agent-server/core/base/observation";
 
 // Keep the units under test real (the provider, `useConversationHistory`, the
 // event store). Only the network is stubbed: the WebSocket transport and the
@@ -150,6 +155,68 @@ describe("ConversationWebSocketProvider — conversation-scoped event store", ()
     // ...and the re-seed deduped against the existing user message rather than
     // appending a second copy — exactly two events, no double-insertion.
     expect(eventIds()).toHaveLength(2);
+  });
+
+  it("feeds the live Browser tab from the raw event while retaining a stripped history copy", async () => {
+    // Render with a real conversation URL so the main socket gets a non-empty
+    // URL — that lets us pick its onMessage handler out of the captured calls.
+    const conversationUrl = "http://localhost/api";
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ConversationWebSocketProvider
+          conversationId="conv-a"
+          conversationUrl={conversationUrl}
+        >
+          <div />
+        </ConversationWebSocketProvider>
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(eventIds()).toEqual(["user-msg-conv-a"]));
+
+    // The main connection is the useWebSocket call with a non-empty URL (the
+    // planning connection is passed ""). Grab its message handler.
+    const mainOnMessage = vi
+      .mocked(useWebSocket)
+      .mock.calls.filter((call) => call[0] !== "")
+      .at(-1)?.[1]?.onMessage;
+    expect(mainOnMessage).toBeDefined();
+    const dispatch = mainOnMessage as unknown as (e: { data: string }) => void;
+
+    const browserObservation: ObservationEvent<BrowserObservation> = {
+      id: "obs-browser-1",
+      timestamp: new Date(Date.now() + 1000).toISOString(),
+      source: "environment",
+      tool_name: "browser",
+      tool_call_id: "call_browser_1",
+      action_id: "act-browser-1",
+      observation: {
+        kind: "BrowserObservation",
+        output: "navigated",
+        error: null,
+        screenshot_data: "SHOT",
+      },
+    };
+
+    // Simulate the browser observation arriving over the WebSocket.
+    act(() => {
+      dispatch({ data: JSON.stringify(browserObservation) });
+    });
+
+    // The live Browser tab is populated from the raw event...
+    await waitFor(() =>
+      expect(useBrowserStore.getState().screenshotSrc).toBe(
+        "data:image/png;base64,SHOT",
+      ),
+    );
+
+    // ...but the copy retained in the event store has the heavy payload stripped.
+    const retained = useEventStore
+      .getState()
+      .events.find((event) => event.id === "obs-browser-1") as
+      | ObservationEvent<BrowserObservation>
+      | undefined;
+    expect(retained).toBeDefined();
+    expect(retained?.observation.screenshot_data).toBeNull();
   });
 
   it("consumes the optimistic pending bubble when the echoed user message arrives via REST preload", async () => {

--- a/__tests__/stores/command-store.test.ts
+++ b/__tests__/stores/command-store.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useCommandStore } from "#/stores/command-store";
+
+const MAX_RETAINED_COMMANDS = 400;
+const MAX_RETAINED_OUTPUT_LENGTH = 20_000;
+const TRUNCATION_MARKER = "\n\n[output truncated in terminal replay]";
+
+const commands = () => useCommandStore.getState().commands;
+
+describe("useCommandStore", () => {
+  beforeEach(() => {
+    useCommandStore.getState().clearTerminal();
+  });
+
+  it("appends input and output entries in order", () => {
+    const { appendInput, appendOutput } = useCommandStore.getState();
+
+    appendInput("echo hello");
+    appendOutput("hello");
+
+    expect(commands()).toEqual([
+      { content: "echo hello", type: "input" },
+      { content: "hello", type: "output" },
+    ]);
+  });
+
+  it("leaves output at or under the limit untouched", () => {
+    const content = "x".repeat(MAX_RETAINED_OUTPUT_LENGTH);
+
+    useCommandStore.getState().appendOutput(content);
+
+    const [entry] = commands();
+    expect(entry.content).toBe(content);
+    expect(entry.content).not.toContain(TRUNCATION_MARKER);
+  });
+
+  it("truncates oversized output and appends an explicit marker", () => {
+    const content = "y".repeat(MAX_RETAINED_OUTPUT_LENGTH + 5_000);
+
+    useCommandStore.getState().appendOutput(content);
+
+    const [entry] = commands();
+    expect(entry.content).toBe(
+      `${"y".repeat(MAX_RETAINED_OUTPUT_LENGTH)}${TRUNCATION_MARKER}`,
+    );
+    // The marker lets users tell a truncated replay apart from genuinely
+    // short output.
+    expect(entry.content).toContain(TRUNCATION_MARKER);
+  });
+
+  it("does not truncate input content", () => {
+    const content = "z".repeat(MAX_RETAINED_OUTPUT_LENGTH + 5_000);
+
+    useCommandStore.getState().appendInput(content);
+
+    expect(commands()[0].content).toBe(content);
+  });
+
+  it("caps retained commands and drops the oldest first (FIFO)", () => {
+    const { appendInput } = useCommandStore.getState();
+    const total = MAX_RETAINED_COMMANDS + 5;
+
+    for (let i = 0; i < total; i += 1) {
+      appendInput(`cmd-${i}`);
+    }
+
+    const retained = commands();
+    expect(retained).toHaveLength(MAX_RETAINED_COMMANDS);
+    // The five oldest (cmd-0..cmd-4) were dropped; cmd-5 is now the head and
+    // the most recent command is the tail.
+    expect(retained[0].content).toBe("cmd-5");
+    expect(retained[retained.length - 1].content).toBe(`cmd-${total - 1}`);
+  });
+
+  it("clears all retained commands", () => {
+    const { appendInput, clearTerminal } = useCommandStore.getState();
+    appendInput("echo hello");
+
+    clearTerminal();
+
+    expect(commands()).toEqual([]);
+  });
+});

--- a/__tests__/stores/use-event-store.test.ts
+++ b/__tests__/stores/use-event-store.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { useEventStore } from "#/stores/use-event-store";
 import {
   ActionEvent,
@@ -7,6 +7,30 @@ import {
   ObservationEvent,
   SecurityRisk,
 } from "#/types/agent-server/core";
+import type { BrowserObservation } from "#/types/agent-server/core/base/observation";
+
+const makeBrowserObservation = (): ObservationEvent<BrowserObservation> => ({
+  id: "obs-browser-1",
+  timestamp: "2024-01-01T00:00:05Z",
+  source: "environment",
+  tool_name: "browser",
+  tool_call_id: "call_browser_1",
+  action_id: "act-browser-1",
+  observation: {
+    kind: "BrowserObservation",
+    output: "navigated to https://example.com",
+    error: null,
+    screenshot_data: "BASE64_SCREENSHOT_BLOB",
+  },
+});
+
+const storedScreenshot = (eventId: string): string | null | undefined => {
+  const event = useEventStore
+    .getState()
+    .events.find((e) => (e as { id?: string }).id === eventId);
+  return (event as ObservationEvent<BrowserObservation> | undefined)
+    ?.observation.screenshot_data;
+};
 
 const mockUserMessageEvent: MessageEvent = {
   id: "test-event-1",
@@ -75,6 +99,15 @@ const mockObservationEvent: ObservationEvent = {
 };
 
 describe("useEventStore", () => {
+  beforeEach(() => {
+    useEventStore.setState({
+      events: [],
+      eventIds: new Set(),
+      uiEvents: [],
+      loadedConversationId: null,
+    });
+  });
+
   it("should render initial state correctly", () => {
     const { result } = renderHook(() => useEventStore());
     expect(result.current.events).toEqual([]);
@@ -187,5 +220,50 @@ describe("useEventStore", () => {
     // Verify events were cleared
     expect(result.current.events).toEqual([]);
     expect(result.current.uiEvents).toEqual([]);
+  });
+
+  it("strips browser screenshot payloads from the retained copy on addEvent", () => {
+    const { result } = renderHook(() => useEventStore());
+
+    act(() => {
+      result.current.addEvent(makeBrowserObservation());
+    });
+
+    expect(storedScreenshot("obs-browser-1")).toBeNull();
+  });
+
+  it("strips browser screenshot payloads on bulk addEvents", () => {
+    const { result } = renderHook(() => useEventStore());
+
+    act(() => {
+      result.current.addEvents([makeBrowserObservation()]);
+    });
+
+    expect(storedScreenshot("obs-browser-1")).toBeNull();
+  });
+
+  it("does not mutate the caller's event when stripping", () => {
+    // The WebSocket handler reads screenshot_data off the same object after
+    // handing it to the store (to populate the live Browser tab), so the store
+    // must strip a copy, never mutate the incoming event.
+    const { result } = renderHook(() => useEventStore());
+    const incoming = makeBrowserObservation();
+
+    act(() => {
+      result.current.addEvent(incoming);
+    });
+
+    expect(incoming.observation.screenshot_data).toBe("BASE64_SCREENSHOT_BLOB");
+  });
+
+  it("still de-duplicates browser observations by id after stripping", () => {
+    const { result } = renderHook(() => useEventStore());
+
+    act(() => {
+      result.current.addEvent(makeBrowserObservation());
+      result.current.addEvents([makeBrowserObservation()]);
+    });
+
+    expect(result.current.events).toHaveLength(1);
   });
 });

--- a/__tests__/utils/sanitize-conversation-event.test.ts
+++ b/__tests__/utils/sanitize-conversation-event.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  stripHeavyEventPayloads,
+  stripHeavyEventPayloadsFromList,
+} from "#/utils/sanitize-conversation-event";
+import type {
+  MessageEvent,
+  ObservationEvent,
+} from "#/types/agent-server/core";
+import type {
+  BrowserObservation,
+  ExecuteBashObservation,
+} from "#/types/agent-server/core/base/observation";
+
+const makeBrowserObservation = (
+  screenshotData: string | null,
+): ObservationEvent<BrowserObservation> => ({
+  id: "obs-browser-1",
+  timestamp: "2024-01-01T00:00:00Z",
+  source: "environment",
+  tool_name: "browser",
+  tool_call_id: "call_browser_1",
+  action_id: "act-browser-1",
+  observation: {
+    kind: "BrowserObservation",
+    output: "navigated to https://example.com",
+    error: null,
+    screenshot_data: screenshotData,
+  },
+});
+
+const makeBashObservation = (): ObservationEvent<ExecuteBashObservation> => ({
+  id: "obs-bash-1",
+  timestamp: "2024-01-01T00:00:01Z",
+  source: "environment",
+  tool_name: "execute_bash",
+  tool_call_id: "call_bash_1",
+  action_id: "act-bash-1",
+  observation: {
+    kind: "ExecuteBashObservation",
+    content: [{ type: "text", text: "hello\n" }],
+    command: "echo hello",
+    exit_code: 0,
+    error: false,
+    timeout: false,
+    metadata: {} as never,
+  },
+});
+
+const makeUserMessage = (): MessageEvent => ({
+  id: "msg-1",
+  timestamp: "2024-01-01T00:00:02Z",
+  source: "user",
+  llm_message: { role: "user", content: [{ type: "text", text: "hi" }] },
+  activated_microagents: [],
+  extended_content: [],
+});
+
+describe("stripHeavyEventPayloads", () => {
+  it("nulls screenshot_data on a browser observation and returns a new object", () => {
+    const event = makeBrowserObservation("BASE64_SCREENSHOT_BLOB");
+
+    const result = stripHeavyEventPayloads(event);
+
+    // A fresh copy is returned (so the retained history copy is distinct from
+    // the raw event the WebSocket handler still reads for the Browser tab).
+    expect(result).not.toBe(event);
+    expect(result.observation).not.toBe(event.observation);
+    expect(result.observation.screenshot_data).toBeNull();
+  });
+
+  it("does not mutate the input event — the raw payload survives for live panels", () => {
+    // This is the invariant the Browser tab depends on: the WebSocket handler
+    // reads screenshot_data off the same event object after handing it to the
+    // store, so stripping must never mutate in place.
+    const event = makeBrowserObservation("BASE64_SCREENSHOT_BLOB");
+
+    stripHeavyEventPayloads(event);
+
+    expect(event.observation.screenshot_data).toBe("BASE64_SCREENSHOT_BLOB");
+  });
+
+  it("preserves event identity, links, and visible text when stripping", () => {
+    const event = makeBrowserObservation("BASE64_SCREENSHOT_BLOB");
+
+    const result = stripHeavyEventPayloads(event);
+
+    expect(result.id).toBe(event.id);
+    expect(result.timestamp).toBe(event.timestamp);
+    expect(result.action_id).toBe(event.action_id);
+    expect(result.tool_call_id).toBe(event.tool_call_id);
+    expect(result.observation.output).toBe(event.observation.output);
+    expect(result.observation.error).toBe(event.observation.error);
+  });
+
+  it("returns the same reference for non-browser events", () => {
+    const event = makeBashObservation();
+    expect(stripHeavyEventPayloads(event)).toBe(event);
+
+    const message = makeUserMessage();
+    expect(stripHeavyEventPayloads(message)).toBe(message);
+  });
+
+  it("returns the same reference for a browser observation without a screenshot", () => {
+    const withNull = makeBrowserObservation(null);
+    expect(stripHeavyEventPayloads(withNull)).toBe(withNull);
+
+    // An empty string is falsy too — nothing heavy to strip, so no churn.
+    const withEmpty = makeBrowserObservation("");
+    expect(stripHeavyEventPayloads(withEmpty)).toBe(withEmpty);
+  });
+});
+
+describe("stripHeavyEventPayloadsFromList", () => {
+  it("preserves order and length, stripping only the heavy entries", () => {
+    const bash = makeBashObservation();
+    const browser = makeBrowserObservation("BASE64_SCREENSHOT_BLOB");
+    const message = makeUserMessage();
+
+    const result = stripHeavyEventPayloadsFromList([bash, browser, message]);
+
+    expect(result).toHaveLength(3);
+    // Untouched entries are returned by reference; only the browser obs is a
+    // new, stripped object.
+    expect(result[0]).toBe(bash);
+    expect(result[2]).toBe(message);
+    expect(result[1]).not.toBe(browser);
+    expect(
+      (result[1] as ObservationEvent<BrowserObservation>).observation
+        .screenshot_data,
+    ).toBeNull();
+    // The source list is left untouched.
+    expect(browser.observation.screenshot_data).toBe("BASE64_SCREENSHOT_BLOB");
+  });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 This directory contains the project documentation.
 
 - [Architecture](./architecture.md): system boundaries, runtime modes, and quality gates.
+- [Conversation performance](./conversation-performance.md): rendering and retention guardrails for long conversations.
 - [Using ACP agents](./ACP_AGENTS.md): onboard and configure external agents (Claude Code, Codex, Gemini CLI).
 - [Development guide](./DEVELOPMENT.md)
 - [Self-hosting guide](./SELF_HOSTING.md)

--- a/docs/conversation-performance.md
+++ b/docs/conversation-performance.md
@@ -1,0 +1,29 @@
+# Conversation performance notes
+
+The conversation view is the highest-risk UI surface for unbounded growth:
+long-running sessions accumulate events, tool outputs, browser screenshots, and
+rendered DOM. This document records the current performance guardrails so future
+changes can preserve the same invariants.
+
+## Event rendering action lookup
+
+Conversation rendering frequently needs to pair an observation with the action
+that produced it. The message list, event grouping, and group summary all use
+that relationship to render titles, thoughts, reasoning content, and tool
+details.
+
+The render path now builds a single `Map<eventId, ActionEvent>` for the current
+event history in `Messages`, then passes that lookup to children. This avoids
+repeated `Array.find` scans over the full conversation history for every
+observation or group. The compatibility fallback still accepts a raw event list
+for direct component tests and non-list callers, but production rendering should
+prefer the precomputed lookup.
+
+Invariants:
+
+- Build the lookup from the full event history, not only the UI-reduced event
+  list, because observations may need actions that have been replaced in
+  `uiEvents`.
+- Keep the lookup scoped to a render of `Messages`; it should not become a
+  long-lived global cache.
+- Do not reintroduce per-observation full-history scans in hot render paths.

--- a/docs/conversation-performance.md
+++ b/docs/conversation-performance.md
@@ -49,3 +49,24 @@ Invariants:
   links, or visible text.
 - If another event type starts carrying large binary or base64 data, add it to
   the same sanitizer rather than handling it in one fetch path only.
+
+## Terminal replay retention
+
+The Terminal tab replays command input and output from `useCommandStore` when
+the xterm instance remounts. Without retention bounds, long-running
+conversations can keep a large command array and very large output strings alive
+even when the terminal is not visible.
+
+The command store now keeps only the latest retained command entries and
+truncates very large output chunks before storing them. This preserves recent
+terminal context while bounding replay memory.
+
+Invariants:
+
+- Retention limits apply to terminal replay state only. They do not alter the
+  canonical conversation event history or chat transcript.
+- Keep the truncation marker explicit so users can distinguish missing replay
+  output from a command that produced short output.
+- If a future terminal implementation streams directly from server-side history,
+  reevaluate these client-side limits rather than stacking multiple retention
+  systems.

--- a/docs/conversation-performance.md
+++ b/docs/conversation-performance.md
@@ -27,3 +27,25 @@ Invariants:
 - Keep the lookup scoped to a render of `Messages`; it should not become a
   long-lived global cache.
 - Do not reintroduce per-observation full-history scans in hot render paths.
+
+## Retained event payload sanitizing
+
+Browser observations can include base64 screenshots. Those payloads are useful
+for the live Browser tab, but retaining every historical screenshot inside
+React Query and the event store causes conversation memory to grow with browser
+tool usage.
+
+Before events are retained in history or Zustand, browser observation
+`screenshot_data` is stripped through `stripHeavyEventPayloads`. The WebSocket
+handler still reads the raw event first, so the Browser tab can keep showing the
+latest screenshot. Only the retained history copy is sanitized.
+
+Invariants:
+
+- Sanitize both REST-loaded history pages and live events before they are stored
+  in `useEventStore`.
+- Keep the sanitizer narrow. It should remove payloads that are redundant for
+  historical chat rendering, not change event identity, timestamps, action
+  links, or visible text.
+- If another event type starts carrying large binary or base64 data, add it to
+  the same sanitizer rather than handling it in one fetch path only.

--- a/src/components/conversation-events/chat/event-message-components/event-group.tsx
+++ b/src/components/conversation-events/chat/event-message-components/event-group.tsx
@@ -11,17 +11,15 @@ import {
 import { I18nKey } from "#/i18n/declaration";
 import { getEventContent } from "../event-content-helpers/get-event-content";
 import { IsInEventGroupContext } from "../../../features/chat/is-in-event-group-context";
+import { buildActionById, type ActionById } from "../event-thought-helpers";
 
 interface EventGroupProps {
   /** The events represented by this group. Used to compute the summary. */
   events: OpenHandsEvent[];
-  /**
-   * Full event history. Used to resolve the action that produced the latest
-   * observation in the group so the summary title matches what the individual
-   * card would show (e.g. "Editing path/to/file"). Falls back to `events` when
-   * omitted.
-   */
+  /** Full event history fallback used by direct component tests/callers. */
   allEvents?: OpenHandsEvent[];
+  /** Precomputed action lookup used by the chat list render path. */
+  actionById?: ActionById;
   /**
    * `true` once an event outside this group has been emitted after it, so the
    * group is no longer the "live" tail of the chat. While `false` (the
@@ -58,6 +56,7 @@ interface EventGroupProps {
 export function EventGroup({
   events,
   allEvents,
+  actionById,
   isFinalized = false,
   children,
 }: EventGroupProps) {
@@ -65,6 +64,10 @@ export function EventGroup({
   const [expanded, setExpanded] = React.useState(false);
   const contentId = React.useId();
   const buttonId = `${contentId}-toggle`;
+  const actionLookup = React.useMemo(
+    () => actionById ?? buildActionById(allEvents ?? events),
+    [actionById, allEvents, events],
+  );
 
   if (events.length === 0) {
     return null;
@@ -88,11 +91,7 @@ export function EventGroup({
     if (isActionEvent(latestEvent)) {
       latestTitle = getEventContent(latestEvent).title;
     } else if (isObservationEvent(latestEvent)) {
-      const lookupSource = allEvents ?? events;
-      const correspondingAction = lookupSource.find(
-        (e): e is ActionEvent =>
-          isActionEvent(e) && e.id === latestEvent.action_id,
-      );
+      const correspondingAction = actionLookup.get(latestEvent.action_id);
       latestTitle = getEventContent(latestEvent, correspondingAction).title;
     }
   }

--- a/src/components/conversation-events/chat/event-message.tsx
+++ b/src/components/conversation-events/chat/event-message.tsx
@@ -31,11 +31,13 @@ import { CollapsibleThinking } from "./event-message-components/collapsible-thin
 import { HookExecutionEventMessage } from "./event-message-components/hook-execution-event-message";
 import { createSkillReadyEvent } from "./event-content-helpers/create-skill-ready-event";
 import { shouldShowPlanPreview } from "./hooks/use-plan-preview-events";
-import { getReasoningContent } from "./event-thought-helpers";
+import { buildActionById, getReasoningContent } from "./event-thought-helpers";
+import type { ActionById } from "./event-thought-helpers";
 
 interface EventMessageProps {
   event: OpenHandsEvent & { isFromPlanningAgent?: boolean };
-  messages: OpenHandsEvent[];
+  messages?: OpenHandsEvent[];
+  actionById?: ActionById;
   isLastMessage: boolean;
   isInLast10Actions: boolean;
   /** Set of event IDs that should render PlanPreview (one per user message phase) */
@@ -131,7 +133,8 @@ const renderUserMessageWithSkillReady = (
 
 export function EventMessage({
   event,
-  messages,
+  messages = [],
+  actionById,
   isLastMessage,
   isInLast10Actions,
   planPreviewEventIds,
@@ -140,6 +143,10 @@ export function EventMessage({
   const { data: config } = useConfig();
   const { planContent } = useConversationStore();
   const { curAgentState } = useAgentState();
+  const actionLookup = React.useMemo(
+    () => actionById ?? buildActionById(messages),
+    [actionById, messages],
+  );
 
   // Disable Build button while agent is running (streaming)
   const isAgentRunning =
@@ -240,22 +247,17 @@ export function EventMessage({
       return null;
     }
 
-    // Find the action that this observation is responding to
-    const correspondingAction = messages.find(
-      (msg) => isActionEvent(msg) && msg.id === event.action_id,
-    );
+    const correspondingAction = actionLookup.get(event.action_id);
 
     // Skip ThoughtEventMessage for ThinkAction (thought IS the action)
     const shouldShowThought =
       !suppressThought &&
       correspondingAction &&
-      isActionEvent(correspondingAction) &&
       correspondingAction.action.kind !== "ThinkAction";
 
-    const reasoningContent =
-      correspondingAction && isActionEvent(correspondingAction)
-        ? getReasoningContent(correspondingAction)
-        : "";
+    const reasoningContent = correspondingAction
+      ? getReasoningContent(correspondingAction)
+      : "";
 
     return (
       <>
@@ -269,11 +271,7 @@ export function EventMessage({
         <GenericEventMessageWrapper
           event={event}
           isLastMessage={isLastMessage}
-          correspondingAction={
-            correspondingAction && isActionEvent(correspondingAction)
-              ? correspondingAction
-              : undefined
-          }
+          correspondingAction={correspondingAction}
         />
       </>
     );

--- a/src/components/conversation-events/chat/event-thought-helpers.ts
+++ b/src/components/conversation-events/chat/event-thought-helpers.ts
@@ -5,6 +5,18 @@ import {
   isObservationEvent,
 } from "#/types/agent-server/type-guards";
 
+export type ActionById = ReadonlyMap<string, ActionEvent>;
+
+export const buildActionById = (allEvents: OpenHandsEvent[]): ActionById => {
+  const actionById = new Map<string, ActionEvent>();
+  for (const event of allEvents) {
+    if (isActionEvent(event)) {
+      actionById.set(event.id, event);
+    }
+  }
+  return actionById;
+};
+
 /**
  * Returns the displayable thought text of an `ActionEvent`, or an empty
  * string if the event has no usable thought content.
@@ -53,7 +65,7 @@ export const hasNonEmptyThought = (action: ActionEvent): boolean =>
  */
 export const getThoughtSourceAction = (
   event: OpenHandsEvent,
-  allEvents: OpenHandsEvent[],
+  actionById: ActionById,
 ): ActionEvent | null => {
   if (isActionEvent(event)) {
     if (event.action.kind === "ThinkAction") return null;
@@ -61,9 +73,7 @@ export const getThoughtSourceAction = (
   }
 
   if (isObservationEvent(event)) {
-    const action = allEvents.find(
-      (e): e is ActionEvent => isActionEvent(e) && e.id === event.action_id,
-    );
+    const action = actionById.get(event.action_id);
     if (!action) return null;
     if (action.action.kind === "ThinkAction") return null;
     return hasNonEmptyThought(action) ? action : null;

--- a/src/components/conversation-events/chat/group-events.ts
+++ b/src/components/conversation-events/chat/group-events.ts
@@ -4,7 +4,11 @@ import {
   isObservationEvent,
   isPlanningFileEditorObservationEvent,
 } from "#/types/agent-server/type-guards";
-import { getThoughtSourceAction } from "./event-thought-helpers";
+import {
+  ActionById,
+  buildActionById,
+  getThoughtSourceAction,
+} from "./event-thought-helpers";
 
 /** Minimum run-length before consecutive actions get folded into a single
  *  collapsible group. Even pairs are folded so the chat scroll stays compact
@@ -59,17 +63,22 @@ export type RenderedItem =
  * the event itself. This keeps reasoning text in the main message stream
  * instead of buried inside a collapsed action group.
  *
- * `allEvents` should be the full event history so observations can find
- * their matching action; if omitted, it defaults to `events`.
+ * `actionLookupOrEvents` should be an action lookup built from the full event
+ * history so observations can find their matching action in O(1). Passing the
+ * full event list is still accepted for direct tests/callers.
  */
 export const groupEvents = (
   events: OpenHandsEvent[],
   minSize: number = EVENT_GROUP_MIN_SIZE,
-  allEvents: OpenHandsEvent[] = events,
+  actionLookupOrEvents?: ActionById | OpenHandsEvent[],
 ): RenderedItem[] => {
   if (minSize < 1) {
     throw new Error("minSize must be at least 1");
   }
+
+  const actionById = Array.isArray(actionLookupOrEvents)
+    ? buildActionById(actionLookupOrEvents)
+    : (actionLookupOrEvents ?? buildActionById(events));
 
   const items: RenderedItem[] = [];
   const emittedThoughtActionIds = new Set<string>();
@@ -93,7 +102,7 @@ export const groupEvents = (
 
   events.forEach((event, index) => {
     if (isGroupableEvent(event)) {
-      const thoughtAction = getThoughtSourceAction(event, allEvents);
+      const thoughtAction = getThoughtSourceAction(event, actionById);
       if (thoughtAction && !emittedThoughtActionIds.has(thoughtAction.id)) {
         flushRun();
         emittedThoughtActionIds.add(thoughtAction.id);

--- a/src/components/conversation-events/chat/messages.tsx
+++ b/src/components/conversation-events/chat/messages.tsx
@@ -8,6 +8,7 @@ import { ThoughtEventMessage } from "./event-message-components/thought-event-me
 import { useModelStore } from "#/stores/model-store";
 import { ModelMessages } from "#/components/features/chat/model-messages";
 import { useOptionalConversationId } from "#/hooks/use-conversation-id";
+import { buildActionById } from "./event-thought-helpers";
 // TODO: Implement microagent functionality for V1 when APIs support V1 event IDs
 // import { AgentState } from "#/types/agent-state";
 // import MemoryIcon from "#/icons/memory_icon.svg?react";
@@ -22,6 +23,10 @@ const getLastEventId = (events: OpenHandsEvent[]) => events.at(-1)?.id;
 export const Messages: React.FC<MessagesProps> = React.memo(
   ({ messages, allEvents }) => {
     const { conversationId } = useOptionalConversationId();
+    const actionById = React.useMemo(
+      () => buildActionById(allEvents),
+      [allEvents],
+    );
     // Get the set of event IDs that should render PlanPreview
     // This ensures only one preview per user message "phase"
     const planPreviewEventIds = usePlanPreviewEvents(allEvents);
@@ -57,8 +62,8 @@ export const Messages: React.FC<MessagesProps> = React.memo(
     // hoisted out as their own rendered item so they always show up in the
     // message pane and a thought between actions starts a fresh group.
     const renderedItems = React.useMemo(
-      () => groupEvents(messages, undefined, allEvents),
-      [messages, allEvents],
+      () => groupEvents(messages, undefined, actionById),
+      [messages, actionById],
     );
 
     const renderEventMessage = (
@@ -69,7 +74,7 @@ export const Messages: React.FC<MessagesProps> = React.memo(
       <EventMessage
         key={event.id}
         event={event}
-        messages={allEvents}
+        actionById={actionById}
         isLastMessage={messages.length - 1 === index}
         isInLast10Actions={messages.length - 1 - index < 10}
         planPreviewEventIds={planPreviewEventIds}
@@ -111,7 +116,7 @@ export const Messages: React.FC<MessagesProps> = React.memo(
             <React.Fragment key={`group-${groupKey}`}>
               <EventGroup
                 events={item.events}
-                allEvents={allEvents}
+                actionById={actionById}
                 isFinalized={isFinalized}
               >
                 {item.events.map((event, offset) =>

--- a/src/components/features/chat/chat-message.tsx
+++ b/src/components/features/chat/chat-message.tsx
@@ -61,11 +61,14 @@ function UserMessageBody({
   const contentRef = React.useRef<HTMLDivElement>(null);
   const [isTruncatable, setIsTruncatable] = React.useState(false);
 
+  React.useEffect(() => {
+    onTruncatableChange(isTruncatable);
+  }, [isTruncatable, onTruncatableChange]);
+
   React.useLayoutEffect(() => {
     const content = contentRef.current;
     if (!content || isExpanded) {
       setIsTruncatable(false);
-      onTruncatableChange(false);
       return undefined;
     }
 
@@ -85,12 +88,7 @@ function UserMessageBody({
         newlineCount >= USER_MESSAGE_MAX_LINES ||
         message.trim().length > 220;
 
-      setIsTruncatable((previous) => {
-        if (previous !== truncatable) {
-          onTruncatableChange(truncatable);
-        }
-        return truncatable;
-      });
+      setIsTruncatable(truncatable);
     };
 
     measure();
@@ -99,7 +97,7 @@ function UserMessageBody({
     observer.observe(content);
 
     return () => observer.disconnect();
-  }, [message, isExpanded, onTruncatableChange]);
+  }, [message, isExpanded]);
 
   const isCollapsed = isTruncatable && !isExpanded;
 

--- a/src/hooks/query/use-conversation-history.ts
+++ b/src/hooks/query/use-conversation-history.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import EventService from "#/api/event-service/event-service.api";
 import { useUserConversation } from "#/hooks/query/use-user-conversation";
 import type { OpenHandsEvent } from "#/types/agent-server/core";
+import { stripHeavyEventPayloadsFromList } from "#/utils/sanitize-conversation-event";
 
 /**
  * Number of events to load on the initial REST history fetch and on each
@@ -62,7 +63,7 @@ export const useConversationHistory = (conversationId?: string) => {
       }
 
       // Reverse so callers can append in chronological order.
-      const events = [...page.items].reverse();
+      const events = stripHeavyEventPayloadsFromList([...page.items].reverse());
       return {
         events,
         hasMore:

--- a/src/hooks/use-load-older-events.ts
+++ b/src/hooks/use-load-older-events.ts
@@ -8,6 +8,7 @@ import {
 } from "#/hooks/query/use-conversation-history";
 import { isTaskConversationId } from "#/utils/conversation-local-storage";
 import type { OpenHandsEvent } from "#/types/agent-server/core";
+import { stripHeavyEventPayloadsFromList } from "#/utils/sanitize-conversation-event";
 
 const getEventTimestamp = (event: OpenHandsEvent): string | undefined =>
   "timestamp" in event ? event.timestamp : undefined;
@@ -138,7 +139,7 @@ export const useLoadOlderEvents = (
         );
       }
 
-      const older = [...page.items].reverse();
+      const older = stripHeavyEventPayloadsFromList([...page.items].reverse());
       if (older.length > 0) {
         addEvents(older);
       }

--- a/src/stores/command-store.ts
+++ b/src/stores/command-store.ts
@@ -5,6 +5,20 @@ export type Command = {
   type: "input" | "output";
 };
 
+const MAX_RETAINED_COMMANDS = 400;
+const MAX_RETAINED_OUTPUT_LENGTH = 20_000;
+
+const truncateOutput = (content: string): string => {
+  if (content.length <= MAX_RETAINED_OUTPUT_LENGTH) return content;
+  return `${content.slice(0, MAX_RETAINED_OUTPUT_LENGTH)}\n\n[output truncated in terminal replay]`;
+};
+
+const appendCommand = (commands: Command[], command: Command): Command[] => {
+  const next = [...commands, command];
+  if (next.length <= MAX_RETAINED_COMMANDS) return next;
+  return next.slice(next.length - MAX_RETAINED_COMMANDS);
+};
+
 interface CommandState {
   commands: Command[];
   appendInput: (content: string) => void;
@@ -16,11 +30,14 @@ export const useCommandStore = create<CommandState>((set) => ({
   commands: [],
   appendInput: (content: string) =>
     set((state) => ({
-      commands: [...state.commands, { content, type: "input" }],
+      commands: appendCommand(state.commands, { content, type: "input" }),
     })),
   appendOutput: (content: string) =>
     set((state) => ({
-      commands: [...state.commands, { content, type: "output" }],
+      commands: appendCommand(state.commands, {
+        content: truncateOutput(content),
+        type: "output",
+      }),
     })),
   clearTerminal: () => set({ commands: [] }),
 }));

--- a/src/stores/use-event-store.ts
+++ b/src/stores/use-event-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { OpenHandsEvent } from "#/types/agent-server/core";
 import { handleEventForUI } from "#/utils/handle-event-for-ui";
+import { stripHeavyEventPayloads } from "#/utils/sanitize-conversation-event";
 
 export type OHEvent = OpenHandsEvent & {
   isFromPlanningAgent?: boolean;
@@ -84,7 +85,9 @@ export interface EventState {
   clearEventsForConversation: (conversationId: string | null) => void;
 }
 
-const appendEvent = (state: EventState, event: OHEvent): EventState => {
+const appendEvent = (state: EventState, incomingEvent: OHEvent): EventState => {
+  const event = stripHeavyEventPayloads(incomingEvent);
+
   // Deduplicate: skip if event with same id already exists (O(1) lookup)
   const eventId = getEventId(event);
   if (eventId !== undefined && state.eventIds.has(eventId)) {
@@ -141,7 +144,8 @@ export const useEventStore = create<EventState>()((set) => ({
       let uiEvents = [...state.uiEvents];
       let added = false;
 
-      for (const event of incoming) {
+      for (const incomingEvent of incoming) {
+        const event = stripHeavyEventPayloads(incomingEvent);
         const eventId = getEventId(event);
         const isDuplicate = eventId !== undefined && eventIds.has(eventId);
 

--- a/src/utils/sanitize-conversation-event.ts
+++ b/src/utils/sanitize-conversation-event.ts
@@ -1,0 +1,26 @@
+import type { OpenHandsEvent } from "#/types/agent-server/core";
+import { isBrowserObservationEvent } from "#/types/agent-server/type-guards";
+
+/**
+ * Remove large payloads that are only needed transiently by side panels before
+ * retaining conversation events in React Query/Zustand history.
+ */
+export function stripHeavyEventPayloads<T extends OpenHandsEvent>(event: T): T {
+  if (!isBrowserObservationEvent(event) || !event.observation.screenshot_data) {
+    return event;
+  }
+
+  return {
+    ...event,
+    observation: {
+      ...event.observation,
+      screenshot_data: null,
+    },
+  } as T;
+}
+
+export function stripHeavyEventPayloadsFromList<T extends OpenHandsEvent>(
+  events: T[],
+): T[] {
+  return events.map(stripHeavyEventPayloads);
+}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why
<!-- Describe problem, motivation, etc.-->


## Summary
Improve long-conversation performance and retained memory behavior in the conversation view.

### Rendering lookup optimization

Conversation event rendering repeatedly needs to match observations back to their producing actions. The chat list now builds one `Map<eventId, ActionEvent>` from the full event history and passes it through the render/grouping path, avoiding repeated full-history `Array.find` scans while preserving compatibility fallbacks for direct callers and tests.

### Retained event payload sanitization

Browser observations can carry large base64 screenshots. Those screenshots are now stripped before events are retained in React Query/Zustand history, while the live WebSocket event remains available long enough to update the Browser tab. This reduces retained memory growth from browser-heavy conversations without changing visible chat history.

### Terminal replay retention

The terminal replay store now keeps only the latest retained entries and truncates oversized output chunks with an explicit marker. This bounds the common terminal-output memory path while preserving recent replay context.

### Remote-history render warning fix

Moved user-message truncation parent notification out of layout measurement and into an effect. This avoids React’s cross-component update warning when older messages load slowly from a remote/cloud backend.

### Documentation

Added `docs/conversation-performance.md` with invariants for action lookup, retained payload sanitization, and terminal replay retention.


## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
