### PR TITLE
feat : dfault conversation sidebar to grouped-by-workspace view

### DIFF
--- a/__tests__/stores/conversation-panel-preferences-store.test.ts
+++ b/__tests__/stores/conversation-panel-preferences-store.test.ts
@@ -8,12 +8,12 @@ describe("conversation-panel-preferences store", () => {
     window.localStorage.clear();
   });
 
-  it("defaults to showing older conversations, chronological list, and expected toggles", () => {
+  it("defaults to showing older conversations, grouped list, and expected toggles", () => {
     const state = useConversationPanelPreferencesStore.getState();
     expect(state.showOlderConversations).toBe(true);
     expect(state.showRepoBranchMetadata).toBe(false);
     expect(state.showLlmProfiles).toBe(false);
-    expect(state.organizeMode).toBe("chronological");
+    expect(state.organizeMode).toBe("grouped");
     expect(state.conversationSort).toBe("updated");
     expect(state.threadScope).toBe("all");
   });
@@ -142,7 +142,7 @@ describe("conversation-panel-preferences store", () => {
       showRepoBranchMetadata: true,
       // Filled with defaults for missing fields.
       showLlmProfiles: false,
-      organizeMode: "chronological",
+      organizeMode: "grouped",
       conversationSort: "updated",
       threadScope: "all",
     });

--- a/src/stores/conversation-panel-preferences-store.ts
+++ b/src/stores/conversation-panel-preferences-store.ts
@@ -47,7 +47,7 @@ const initialState: ConversationPanelPreferencesState = {
   showOlderConversations: true,
   showRepoBranchMetadata: false,
   showLlmProfiles: false,
-  organizeMode: "chronological",
+  organizeMode: "grouped",
   conversationSort: "updated",
   threadScope: "all",
 };


### PR DESCRIPTION
#### why
- Flat sidebar list is hard to scan across multiple workspaces.

#### Summary
- Default sidebar to grouped-by-workspace view
- Update store tests

#### Issue Number
fix : #1153

#### How to Test

- Clear conversation-panel-preferences from localStorage
- Run npm run dev
- Confirm conversations are grouped by workspace

#### Video/Screenshots
N/A

#### Type
- Feature