### PR TITLE
fix: recover stale cloud conversations on refresh

### DIFF
--- a/src/api/automation-service/automation-service.api.ts
+++ b/src/api/automation-service/automation-service.api.ts
@@ -164,23 +164,38 @@ class AutomationService {
 
   static async listAutomationRuns(
     id: string,
-    params: { limit?: number; offset?: number } = {},
+    params: {
+      limit?: number;
+      offset?: number;
+      stateType?: string;
+      stateName?: string;
+    } = {},
   ): Promise<AutomationRunsResponse> {
-    const { limit = 50, offset = 0 } = params;
+    const { limit = 50, offset = 0, stateType, stateName } = params;
     const active = getActiveBackend().backend;
     const basePath = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}/runs`;
 
     if (active.kind === "cloud") {
+      const query = new URLSearchParams(buildPaginationQuery(limit, offset));
+      if (stateType) query.set("state_type", stateType);
+      if (stateName) query.set("state_name", stateName);
       return callAutomationCloudProxy<AutomationRunsResponse>({
         backend: active,
         method: "GET",
-        path: `${basePath}?${buildPaginationQuery(limit, offset)}`,
+        path: `${basePath}?${query.toString()}`,
       });
     }
 
     const { data } = await localAutomationAxios.get<AutomationRunsResponse>(
       basePath,
-      { params: { limit, offset } },
+      {
+        params: {
+          limit,
+          offset,
+          ...(stateType ? { state_type: stateType } : null),
+          ...(stateName ? { state_name: stateName } : null),
+        },
+      },
     );
     return data;
   }

--- a/src/contexts/conversation-websocket-context.tsx
+++ b/src/contexts/conversation-websocket-context.tsx
@@ -107,6 +107,7 @@ export function ConversationWebSocketProvider({
   children,
   conversationId,
   conversationUrl,
+  backendKind,
   sessionApiKey,
   subConversations,
   subConversationIds,
@@ -114,6 +115,7 @@ export function ConversationWebSocketProvider({
   children: React.ReactNode;
   conversationId?: string;
   conversationUrl?: string | null;
+  backendKind?: "local" | "cloud";
   sessionApiKey?: string | null;
   subConversations?: AppConversation[];
   subConversationIds?: string[];
@@ -131,6 +133,9 @@ export function ConversationWebSocketProvider({
 
   const posthog = usePostHog();
   const queryClient = useQueryClient();
+  const [suppressMainWebSocket, setSuppressMainWebSocket] =
+    useState<boolean>(false);
+  const suppressedForUrlRef = useRef<string | null>(null);
   const addEvent = useEventStore((state) => state.addEvent);
   const addEvents = useEventStore((state) => state.addEvents);
   const clearEventsForConversation = useEventStore(
@@ -287,6 +292,16 @@ export function ConversationWebSocketProvider({
     return latest.timestamp;
   }, [preloadedHistory, isPreloadingHistory]);
 
+  useEffect(() => {
+    if (!suppressMainWebSocket) return;
+    const suppressedForUrl = suppressedForUrlRef.current;
+    if (!suppressedForUrl || !conversationUrl) return;
+    if (conversationUrl !== suppressedForUrl) {
+      suppressedForUrlRef.current = null;
+      setSuppressMainWebSocket(false);
+    }
+  }, [conversationUrl, suppressMainWebSocket]);
+
   // Build WebSocket URL from props.
   //
   // We deliberately wait for the initial REST history fetch to settle before
@@ -296,6 +311,9 @@ export function ConversationWebSocketProvider({
   // to `resend_mode='all'`) or miss events that arrived between REST and WS.
   const wsUrl = useMemo(() => {
     if (!conversationId || !conversationUrl) {
+      return null;
+    }
+    if (suppressMainWebSocket) {
       return null;
     }
     // Don't connect while we're still fetching the initial history. If the
@@ -308,6 +326,7 @@ export function ConversationWebSocketProvider({
   }, [
     conversationId,
     conversationUrl,
+    suppressMainWebSocket,
     isPreloadingHistory,
     isPreloadHistoryError,
   ]);
@@ -821,6 +840,29 @@ export function ConversationWebSocketProvider({
         // Only show error message if we've previously connected successfully
         if (hasConnectedRefMain.current) {
           setErrorMessage(SERVER_CONNECTION_ERROR_MESSAGE, "connection");
+          return;
+        }
+
+        if (
+          backendKind === "cloud" &&
+          conversationId &&
+          conversationUrl &&
+          !suppressMainWebSocket
+        ) {
+          suppressedForUrlRef.current = conversationUrl;
+          setSuppressMainWebSocket(true);
+          queryClient.invalidateQueries({
+            predicate: (query) => {
+              const key = query.queryKey;
+              return (
+                Array.isArray(key) &&
+                key.length >= 3 &&
+                key[0] === "user" &&
+                key[1] === "conversation" &&
+                key[2] === conversationId
+              );
+            },
+          });
         }
       },
       onMessage: handleMainMessage,
@@ -831,6 +873,11 @@ export function ConversationWebSocketProvider({
     clearConnectionError,
     sessionApiKey,
     initialAfterTimestamp,
+    backendKind,
+    conversationId,
+    conversationUrl,
+    suppressMainWebSocket,
+    queryClient,
   ]);
 
   // Separate WebSocket options for planning agent connection

--- a/src/contexts/websocket-provider-wrapper.tsx
+++ b/src/contexts/websocket-provider-wrapper.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ConversationWebSocketProvider } from "#/contexts/conversation-websocket-context";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useSubConversations } from "#/hooks/query/use-sub-conversations";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 
 interface WebSocketProviderWrapperProps {
   children: React.ReactNode;
@@ -12,6 +13,7 @@ export function WebSocketProviderWrapper({
   children,
   conversationId,
 }: WebSocketProviderWrapperProps) {
+  const active = useActiveBackend();
   const { data: conversation } = useActiveConversation();
   const { data: subConversations } = useSubConversations(
     conversation?.sub_conversation_ids ?? [],
@@ -36,6 +38,7 @@ export function WebSocketProviderWrapper({
     <ConversationWebSocketProvider
       conversationId={conversationId}
       conversationUrl={conversationUrl}
+      backendKind={active.backend.kind}
       sessionApiKey={conversation?.session_api_key}
       subConversationIds={conversation?.sub_conversation_ids}
       subConversations={filteredSubConversations}

--- a/src/hooks/query/use-automation-detail.ts
+++ b/src/hooks/query/use-automation-detail.ts
@@ -34,21 +34,36 @@ interface UseAutomationRunsOptions {
   id: string;
   limit?: number;
   offset?: number;
+  stateType?: string;
+  stateName?: string;
   enabled?: boolean;
 }
 
 export function useAutomationRuns(options: UseAutomationRunsOptions) {
-  const { id, limit = 20, offset = 0, enabled = true } = options;
+  const {
+    id,
+    limit = 20,
+    offset = 0,
+    stateType,
+    stateName,
+    enabled = true,
+  } = options;
   const active = useActiveBackend();
   return useQuery({
     queryKey: [
       ...AUTOMATION_RUNS_QUERY_KEY,
       id,
-      { limit, offset },
+      { limit, offset, stateType, stateName },
       active.backend.id,
       active.orgId,
     ],
-    queryFn: () => AutomationService.getAutomationRuns(id, limit, offset),
+    queryFn: () =>
+      AutomationService.listAutomationRuns(id, {
+        limit,
+        offset,
+        stateType,
+        stateName,
+      }),
     staleTime: 60 * 1000,
     enabled: !!id && enabled,
     // Poll while any run is non-terminal so status and conversation_id


### PR DESCRIPTION
#### Why
- Stale cloud conversation_url causes WebSocket reconnect loops on refresh.

#### Summary

- Suppress WS on first connect failure, refetch conversation, reconnect when URL updates
- Gate recovery to cloud backends only
- Add state_type / state_name filters to automation runs API

fix : #1159

#### How to Test
- Open stale cloud conversation on Vercel
- Refresh page
- Confirm conversation reconnects
- Run npx vitest run __tests__/contexts/websocket-provider-wrapper.test.tsx

#### Video/Screenshots
N/A

#### Type
- Bug fix