### PR TITLE
refactor(acp): import ACP_SETTINGS_KEYS from typescript-client; deprecate acp_env forwarding

### DIFF
--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -580,6 +580,8 @@ function buildConfiguredAcpAgentSettings(
     // ``acp_model`` is resolved separately below so a saved ``null`` still
     // falls back to the provider's default rather than being dropped.
     if (key === "acp_model") continue;
+    // ``acp_env`` is deprecated — provider creds now route via agent_context.secrets.
+    if (key === "acp_env") continue;
     const value =
       key === "acp_command"
         ? resolveAcpCommand(agentSettings)

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -1,3 +1,4 @@
+import { ACP_SETTINGS_KEYS } from "@openhands/typescript-client";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 import { ExecutionStatus } from "#/types/agent-server/core";
 import { Settings, SettingsValue } from "#/types/settings";
@@ -395,14 +396,6 @@ type ConversationSettingsPayload = SettingsRecord & {
   workspace: LocalWorkspacePayload;
   initial_message?: InitialMessagePayload;
 };
-
-const ACP_SETTINGS_KEYS = [
-  "acp_command",
-  "acp_args",
-  "acp_model",
-  "acp_session_mode",
-  "acp_prompt_timeout",
-] as const;
 
 export const ACP_SERVER_TAG_KEY = "acpserver";
 


### PR DESCRIPTION
## Summary

- Removes the locally-defined `ACP_SETTINGS_KEYS` constant from `agent-server-adapter.ts` and imports it from `@openhands/typescript-client` (already a direct dependency, already used in `acp-providers.ts` for `ACP_PROVIDERS`).
- The TS client's list is the canonical mirror of `ACPAgentSettings`'s field set — importing it here means the allow-list stays in sync with the SDK model automatically.
- **Bug fix bonus**: the local copy was missing `acp_server`; the TS client version includes it, so `acp_server` is now correctly stripped when switching from an ACP agent to a non-ACP agent kind.
- deprecate acp_env forwarding

## Test plan

- [ ] TypeScript build passes (`npx tsc --noEmit`)
- [ ] Switching from an ACP agent to a non-ACP agent kind strips `acp_server` from the settings payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.25.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `f30057bbd5febb6b61b0b0c8cf8a285c8b621b98` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f30057b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f30057b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f30057b-amd64
ghcr.io/openhands/agent-canvas:simplify-acp-settings-keys-amd64
ghcr.io/openhands/agent-canvas:pr-1173-amd64
ghcr.io/openhands/agent-canvas:sha-f30057b-arm64
ghcr.io/openhands/agent-canvas:simplify-acp-settings-keys-arm64
ghcr.io/openhands/agent-canvas:pr-1173-arm64
ghcr.io/openhands/agent-canvas:sha-f30057b
ghcr.io/openhands/agent-canvas:simplify-acp-settings-keys
ghcr.io/openhands/agent-canvas:pr-1173
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f30057b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f30057b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->