### PR TITLE
fix(frontend): keep Extensions secondary nav visible at tablet widths

### DIFF
--- a/__tests__/components/features/skills/extensions-navigation.test.tsx
+++ b/__tests__/components/features/skills/extensions-navigation.test.tsx
@@ -56,11 +56,11 @@ describe("ExtensionsNavigation", () => {
     expect(skillsItem.tagName).toBe("A");
   });
 
-  // When the primary Sidebar is expanded, an iPad-portrait viewport
-  // (768–1023px) doesn't have horizontal room for both sidebars plus the
-  // page content, so this nav suppresses itself. The three cases below
-  // pin down the gating logic by varying one input at a time.
-  describe("suppresses itself when the Sidebar is expanded at iPad portrait widths", () => {
+  // Regression: the nav used to suppress itself at iPad-portrait widths
+  // (768–1023px) whenever the primary Sidebar was expanded, leaving users
+  // on /skills, /mcp, and /plugins with no way to switch between those
+  // pages. It must stay rendered there, like the Settings secondary nav.
+  describe("tablet viewports", () => {
     const originalInnerWidth = window.innerWidth;
 
     function setViewport(width: number) {
@@ -73,45 +73,15 @@ describe("ExtensionsNavigation", () => {
 
     afterEach(() => {
       setViewport(originalInnerWidth);
-      // The Zustand sidebar store is a module singleton — reset it so
-      // a `collapsed: true` from one case doesn't bleed into the next.
+      // The Zustand sidebar store is a module singleton — reset it so this
+      // suite's state doesn't bleed into other tests.
       useSidebarStore.setState({ collapsed: false });
     });
 
-    it("hides the aside when the Sidebar is expanded and the viewport is in the iPad portrait range (768–1023)", () => {
-      // Arrange: iPad Air portrait, Sidebar expanded.
+    it("stays rendered at iPad portrait width while the Sidebar is expanded", () => {
+      // Arrange: iPad Air portrait viewport with the primary Sidebar
+      // expanded — the exact conditions that previously hid the nav.
       setViewport(820);
-      useSidebarStore.setState({ collapsed: false });
-
-      // Act
-      renderExtensionsNavigation(<ExtensionsNavigation />);
-
-      // Assert: no aside renders, freeing the row for the page's main
-      // column to take the full width.
-      expect(
-        screen.queryByTestId("extensions-navbar-desktop"),
-      ).not.toBeInTheDocument();
-    });
-
-    it("renders the aside in the iPad portrait range once the Sidebar is collapsed", () => {
-      // Arrange: same viewport as above, but the user has collapsed the
-      // primary Sidebar to the icon rail, so there's room for this nav.
-      setViewport(820);
-      useSidebarStore.setState({ collapsed: true });
-
-      // Act
-      renderExtensionsNavigation(<ExtensionsNavigation />);
-
-      // Assert
-      expect(
-        screen.getByTestId("extensions-navbar-desktop"),
-      ).toBeInTheDocument();
-    });
-
-    it("renders the aside at lg+ viewports even when the Sidebar is expanded", () => {
-      // Arrange: desktop viewport (≥1024). The rule only applies in the
-      // md→<lg band, so an expanded Sidebar here should not suppress us.
-      setViewport(1280);
       useSidebarStore.setState({ collapsed: false });
 
       // Act

--- a/src/components/features/skills/extensions-navigation.tsx
+++ b/src/components/features/skills/extensions-navigation.tsx
@@ -9,8 +9,6 @@ import {
   sidebarNavRowClassName,
 } from "#/components/features/sidebar/sidebar-layout";
 import { I18nKey } from "#/i18n/declaration";
-import { useSidebarStore } from "#/stores/sidebar-store";
-import { useBreakpoint } from "#/hooks/use-breakpoint";
 
 interface ExtensionNavItem {
   to: string;
@@ -61,15 +59,6 @@ export const EXTENSIONS_NAV_ITEMS: ExtensionNavItem[] = [
 
 export function ExtensionsNavigation() {
   const { t } = useTranslation("openhands");
-  const sidebarCollapsed = useSidebarStore((state) => state.collapsed);
-  // At iPad portrait widths (md to <lg) an expanded primary Sidebar (300px)
-  // plus this nav (260px) leaves the main content unreadable. Hide ourselves
-  // until the user collapses the Sidebar or the viewport reaches `lg`.
-  const belowLg = useBreakpoint(1023);
-  const belowMd = useBreakpoint(767);
-  const hideForExpandedSidebar = !sidebarCollapsed && belowLg && !belowMd;
-
-  if (hideForExpandedSidebar) return null;
 
   return (
     <aside


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

<img width="1742" height="610" alt="image" src="https://github.com/user-attachments/assets/1e5902a4-11dc-44ba-ad6e-0a73d2e9a5e3" />

<img width="1320" height="538" alt="image" src="https://github.com/user-attachments/assets/529b39a8-a2d7-4856-a931-605ffd8cbabc" />

On smaller screens, the "Extensions" secondary navigation is cut off, leaving only the page content (e.g. Skills) visible. Users cannot switch between Skills, MCP Servers, and Plugins.

### Steps to Reproduce

1. Run `npm run dev` and open http://localhost:3001/mcp
2. Keep the primary sidebar **expanded**
3. Resize the browser window to a tablet width (768–1023 px, e.g. iPad portrait at 820 px)

### Current Behavior

The Extensions secondary nav vanishes entirely. The only escapes are non-obvious: collapse the sidebar or widen the window. The mobile fallbacks don't apply in this band — the back-button top bar and `/customize` hub only exist below 768 px, and `/customize` redirects straight to `/skills` above it.

### Expected Behavior

The secondary navigation remains fully visible on smaller devices, exactly like the Settings page's secondary nav (`SettingsDesktopSidebar`), which uses the identical layout and never hides itself.

### Root Cause

`src/components/features/skills/extensions-navigation.tsx` — JS suppression introduced in #710 (`ef61ae5b`):

```tsx
const hideForExpandedSidebar = !sidebarCollapsed && belowLg && !belowMd;
if (hideForExpandedSidebar) return null;
```

It removes the nav at 768–1023 px whenever the sidebar is expanded, with no alternative navigation rendered in that band.

### Acceptance Criteria

- [ ] On `/skills`, `/mcp`, and `/plugins`, the Extensions nav is visible and clickable at 768–1023 px with the sidebar expanded
- [ ] Behavior matches the Settings secondary nav at the same widths
- [ ] Mobile flow (<768 px: back button → `/customize` hub) is unchanged
- [ ] Regression test covers the tablet-width + expanded-sidebar scenario

## Summary

<!-- 1-3 bullets describing what changed. -->
Fixes the Extensions secondary navigation (Skills / MCP Servers / Plugins) disappearing on `/skills`, `/mcp`, and `/plugins` at tablet widths (768–1023 px) when the primary sidebar is expanded — leaving users with no way to switch between those pages.

### Root Cause

`ExtensionsNavigation` contained viewport/sidebar-state suppression logic (introduced in #710) that returned `null` at iPad-portrait widths whenever the sidebar was expanded:

```tsx
const hideForExpandedSidebar = !sidebarCollapsed && belowLg && !belowMd;
if (hideForExpandedSidebar) return null;
```

That band has no fallback navigation: the mobile back-button top bar and the `/customize` hub are `md:hidden` (below 768 px only), and `/customize` redirects to `/skills` above 768 px. Meanwhile the Settings page's `SettingsDesktopSidebar` uses the identical layout (sticky 260 px aside beside the scrolling main column, under the same primary sidebar) with no such suppression — the Extensions behavior was the inconsistency.

### Changes

| File | Change |
| --- | --- |
| `src/components/features/skills/extensions-navigation.tsx` | Remove the `hideForExpandedSidebar` suppression and the now-unused `useSidebarStore` / `useBreakpoint` imports — the nav now always renders at `md+`, matching `SettingsDesktopSidebar` |
| `__tests__/components/features/skills/extensions-navigation.test.tsx` | Drop the tests pinning the removed suppression; add a regression test asserting the nav stays rendered at 820 px with the sidebar expanded |

Not changed: the `<768 px` mobile flow (back button → `/customize` → `ExtensionsMobileHub`) and the aside's `hidden md:flex` classes.

**Tradeoff (intentional):** at 768 px with an expanded sidebar the main content gets ~150 px — identical to the already-shipped Settings page; users can collapse the sidebar for more room.

### Testing

- New regression test verified TDD-style: fails against the old component (nav suppressed at 820 px / sidebar expanded), passes with the fix
- Full unit suite: **402 test files / 3006 tests passed**
- `typecheck`, `eslint`, `prettier`: clean
- Manual: at 820–1000 px with the sidebar expanded, `/skills`, `/mcp`, `/plugins` keep the Extensions nav visible and clickable (matching `/settings`); below 768 px the mobile hub flow is unchanged


## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/agent-canvas/issues/1142

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. **Clone and start the project**
   Clone the `agent-server-gui` repository and launch the development server:

   ```bash
   npm run dev
   ```

2. **Open the MCP Servers page**
   Navigate to [http://localhost:3001/mcp](http://localhost:3001/mcp).

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/443985a6-ddf2-41a6-909a-b76778fe6066


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.25.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `6604fd477d17a601fffe73e88d717fb46f2f57d9` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-6604fd4
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-6604fd4
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-6604fd4-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2184-amd64
ghcr.io/openhands/agent-canvas:pr-1177-amd64
ghcr.io/openhands/agent-canvas:sha-6604fd4-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2184-arm64
ghcr.io/openhands/agent-canvas:pr-1177-arm64
ghcr.io/openhands/agent-canvas:sha-6604fd4
ghcr.io/openhands/agent-canvas:hieptl-app-2184
ghcr.io/openhands/agent-canvas:pr-1177
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-6604fd4`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-6604fd4-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->