### PR TITLE
fix: single-line agent-server logs in dev:automation mode

### DIFF
--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -119,6 +119,38 @@ function logError(message) {
   console.error(`${c.red}✗${c.reset} ${message}`);
 }
 
+/**
+ * Parse one JSON log line produced by the SDK's JsonFormatter and return a
+ * single-line human-readable string + an appropriate ANSI color.
+ *
+ * Returns null for non-JSON lines so callers can fall back to the raw text.
+ *
+ * @param {string} rawLine
+ * @returns {{ text: string; color: string } | null}
+ */
+function parseAgentServerLogLine(rawLine) {
+  try {
+    const obj = JSON.parse(rawLine);
+    if (!obj.levelname || obj.message === undefined) return null;
+    const level = obj.levelname.padEnd(8);
+    const location =
+      obj.filename && obj.lineno ? `  ${obj.filename}:${obj.lineno}` : "";
+    const text = `${level} ${obj.message}${location}`;
+    const lvl = obj.levelname;
+    const color =
+      lvl === "DEBUG"
+        ? c.dim
+        : lvl === "WARNING"
+          ? c.yellow
+          : lvl === "ERROR" || lvl === "CRITICAL"
+            ? c.red
+            : c.blue;
+    return { text, color };
+  } catch {
+    return null;
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Configuration
 // ═══════════════════════════════════════════════════════════════════════════
@@ -521,6 +553,7 @@ function spawnService(name, command, args, options = {}) {
   );
 
   const color = options.color || c.reset;
+  const parseLogLine = options.parseLogLine;
 
   proc.stdout.on("data", (data) => {
     data
@@ -528,7 +561,8 @@ function spawnService(name, command, args, options = {}) {
       .split("\n")
       .filter(Boolean)
       .forEach((line) => {
-        logService(name, line.trim(), color);
+        const parsed = parseLogLine ? parseLogLine(line.trim()) : null;
+        logService(name, parsed ? parsed.text : line.trim(), parsed ? parsed.color : color);
       });
   });
 
@@ -538,7 +572,8 @@ function spawnService(name, command, args, options = {}) {
       .split("\n")
       .filter(Boolean)
       .forEach((line) => {
-        logService(name, line.trim(), c.yellow);
+        const parsed = parseLogLine ? parseLogLine(line.trim()) : null;
+        logService(name, parsed ? parsed.text : line.trim(), parsed ? parsed.color : c.yellow);
       });
   });
 
@@ -699,6 +734,11 @@ function startAgentServer(config) {
     // Ensure the agent-server uses the resolved key from config. This is
     // LOCAL_BACKEND_API_KEY when set, or the auto-generated persisted key.
     OH_SESSION_API_KEYS_0: config.sessionApiKey,
+    // Emit structured JSON log lines instead of Rich-formatted output.
+    // Rich wraps long messages across multiple lines and prepends its own
+    // timestamp; LOG_JSON=true produces one JSON object per record which
+    // parseAgentServerLogLine re-formats into a clean single-line entry.
+    LOG_JSON: "true",
   };
 
   spawnService(
@@ -715,6 +755,7 @@ function startAgentServer(config) {
       cwd: safeConfig.workspacesPath,
       env: agentServerEnv,
       color: c.blue,
+      parseLogLine: parseAgentServerLogLine,
     },
   );
 }


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

In `npm run dev` / `dev:automation` mode, agent-server log lines were hard to read for two reasons:

1. **Duplicate timestamp** — Python's `RichHandler` prepends its own `[HH:MM:SS]` column on top of the `HH:MM:SS [agent-server]` prefix that `logService` already adds.
2. **Line wrapping** — Rich wraps long log messages (e.g. HTTP access log URLs) across multiple lines based on terminal width. `spawnService` splits piped output on `\n`, so each continuation line gets its own `logService` prefix, turning one log record into 2–3 entries.

## Summary

- Set `LOG_JSON=true` for the agent-server process in `dev-with-automation.mjs` so the SDK emits one compact JSON object per log record (no Rich formatting, no wrapping, no duplicate timestamp).
- Add `parseAgentServerLogLine()` which parses each JSON line and re-formats it as a single human-readable string: `LEVEL     <message>  filename.py:lineno`.
- Add a `parseLogLine` option to `spawnService`

## Screenshots

**Before**
<img width="850" height="335" alt="image" src="https://github.com/user-attachments/assets/31fef509-25f7-4175-b388-055fe2a7d0f1" />

**After**
<img width="1029" height="310" alt="image" src="https://github.com/user-attachments/assets/741e255a-8c95-4ebd-9429-36cb1608fdce" />


_This PR was created by an AI agent (OpenHands) on behalf of the user._