### PR TITLE
chore: simplify README.windows.md (bare-bones Option 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,7 +505,7 @@ When adding code that needs a new string, decide up front which rule it falls un
 
 - README expectation: keep the first section as a concrete, chronological from-scratch quickstart for running this frontend against a real `openhands-agent-server` (clone, install prerequisites, optional `.env`, run `npm run dev`).
 - Keep README user-focused and move contributor/developer-specific workflows (`dev:safe`, mock mode, detailed env vars/build-test notes) into `DEVELOPMENT.md`.
-- Windows-specific command syntax (PowerShell) lives in `README.windows.md`, which should contain **Windows-only deltas** and link back to `README.md` for everything else. `README.md` is the source of truth — when updating shared items (notably screenshots/diagrams and the Docker sandbox flow), update `README.windows.md` in the same PR so the shared content stays consistent.
+- Windows-specific command syntax (PowerShell) lives in `README.windows.md` and should stay **bare-bones**: just the Windows-specific delta for the Docker sandbox (Option 2) plus a link back to `README.md`. When the Docker sandbox instructions change in `README.md`, update `README.windows.md` in the same PR.
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,7 +505,7 @@ When adding code that needs a new string, decide up front which rule it falls un
 
 - README expectation: keep the first section as a concrete, chronological from-scratch quickstart for running this frontend against a real `openhands-agent-server` (clone, install prerequisites, optional `.env`, run `npm run dev`).
 - Keep README user-focused and move contributor/developer-specific workflows (`dev:safe`, mock mode, detailed env vars/build-test notes) into `DEVELOPMENT.md`.
-- Windows-specific command syntax (PowerShell) lives in `README.windows.md`. When changing install / Docker sandbox instructions in `README.md`, update `README.windows.md` in the same PR to keep them in sync.
+- Windows-specific command syntax (PowerShell) lives in `README.windows.md`. `README.md` is the source of truth — when updating `README.md` (including screenshots/diagrams and quickstart content), apply the equivalent update to `README.windows.md` in the same PR unless the change is explicitly non-Windows-specific.
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,7 +505,7 @@ When adding code that needs a new string, decide up front which rule it falls un
 
 - README expectation: keep the first section as a concrete, chronological from-scratch quickstart for running this frontend against a real `openhands-agent-server` (clone, install prerequisites, optional `.env`, run `npm run dev`).
 - Keep README user-focused and move contributor/developer-specific workflows (`dev:safe`, mock mode, detailed env vars/build-test notes) into `DEVELOPMENT.md`.
-- Windows-specific command syntax (PowerShell) lives in `README.windows.md`. `README.md` is the source of truth — when updating `README.md` (including screenshots/diagrams and quickstart content), apply the equivalent update to `README.windows.md` in the same PR unless the change is explicitly not applicable to Windows.
+- Windows-specific command syntax (PowerShell) lives in `README.windows.md`, which should contain **Windows-only deltas** and link back to `README.md` for everything else. `README.md` is the source of truth — when updating shared items (notably screenshots/diagrams and the Docker sandbox flow), update `README.windows.md` in the same PR so the shared content stays consistent.
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,7 +505,7 @@ When adding code that needs a new string, decide up front which rule it falls un
 
 - README expectation: keep the first section as a concrete, chronological from-scratch quickstart for running this frontend against a real `openhands-agent-server` (clone, install prerequisites, optional `.env`, run `npm run dev`).
 - Keep README user-focused and move contributor/developer-specific workflows (`dev:safe`, mock mode, detailed env vars/build-test notes) into `DEVELOPMENT.md`.
-- Windows-specific command syntax (PowerShell) lives in `README.windows.md`. `README.md` is the source of truth — when updating `README.md` (including screenshots/diagrams and quickstart content), apply the equivalent update to `README.windows.md` in the same PR unless the change is explicitly non-Windows-specific.
+- Windows-specific command syntax (PowerShell) lives in `README.windows.md`. `README.md` is the source of truth — when updating `README.md` (including screenshots/diagrams and quickstart content), apply the equivalent update to `README.windows.md` in the same PR unless the change is explicitly not applicable to Windows.
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)

--- a/README.windows.md
+++ b/README.windows.md
@@ -1,15 +1,80 @@
-# Windows quickstart (PowerShell)
+# agent-canvas
 
-This doc contains **Windows-specific** command syntax for running Agent Canvas with the **Docker sandbox**.
+> [!WARNING]
+> This project is in the **Beta** phase. It may be vibecoded, untested, or out of date. OpenHands takes no responsibility for the code or its support. [Learn more](https://github.com/OpenHands/incubator-program).
 
-For the main install options and overall context, see [README.md](./README.md).
+[![Project Status: Beta](https://img.shields.io/badge/status-beta-blue)](https://github.com/OpenHands/incubator-program)
 
-## Option 2: With a Docker Sandbox (Windows)
+This doc mirrors [README.md](./README.md), but includes **Windows-specific** command syntax where needed.
+
+OpenHands is a platform for orchestrating coding agents across different environments. You can:
+
+- ⌨️ prompt agents manually
+- 🕐 run agents on a schedule
+- ⚡ trigger agents automatically — e.g. from Slack, GitHub, or Datadog.
+
+Agents can run anywhere:
+
+- 🧑‍💻 on your laptop
+- 🖥️ on a remote virtual machine
+- ☁️ in our hosted cloud
+- 🏢 or inside your company’s infrastructure
+
+The same Agent Canvas frontend can swap between each of these environments, so you can see everything in one place.
+
+OpenHands works with any agent harness (e.g. Claude Code, Codex)
+or connect directly to an LLM (e.g. Anthropic, OpenAI, Gemini, Mistral, Minimax, Kimi).
+
+If you have questions or feedback, please open a GitHub issue or join the [#proj-agent-canvas channel in Slack](https://openhands.dev/joinslack).
+
+<img width="1509" height="826" alt="Screenshot 2026-05-11 at 10 13 19 AM" src="https://github.com/user-attachments/assets/71ef41ae-8f6d-4fbf-990f-d672175d93d1" />
+
+## Project ownership and support
+
+- **Current status**: Beta.
+- **Support channel**: [#proj-agent-canvas](https://openhands.dev/joinslack).
+- **Support level**: Best effort while the project remains in Beta.
+
+## Quickstart
+
+You can install OpenHands to run agents on any machine: on your laptop, on a dedicated computer like a Mac Mini,
+or on a server in the cloud.
+
+The most powerful way to run OpenHands is on a server in the cloud. This allows your agents to continue running
+even when your laptop is shut, and makes it easier to trigger your agents through third-party services
+like Slack, GitHub, and Datadog. See [SELF_HOSTING.md](docs/SELF_HOSTING.md) for details, especially with respect to security hardening.
+
+Notably, you can run the backend in _multiple different environments_, and switch between
+them from the same Agent Canvas frontend. E.g. you can share an Agent Server with your team for agents doing
+code review and dependency updates, then have your personal agents running on your laptop.
+
+### Option 1: Without a Sandbox
+
+> [!WARNING]
+> This runs the agent-server directly on the machine you're installing on — the agent will have full access to your filesystem!
+
+**Prerequisites**: Node.js 22.12.x or later, `uv`
+
+```sh
+npm install -g @openhands/agent-canvas
+agent-canvas
+```
+
+The `agent-canvas` command starts the full local stack by default. You can also split it when you want to run pieces separately:
+
+```sh
+agent-canvas --frontend-only  # static frontend + ingress only
+agent-canvas --backend-only   # agent server + automation backend + ingress only
+```
+
+### Option 2: With a Docker Sandbox
 
 **Prerequisites**:
 
 - Docker Desktop for Windows
-- A host directory for `PROJECTS_PATH` containing the project folders you want the agent to access (create it before starting the container)
+- A host directory for `PROJECTS_PATH` containing the project folders you want the agent to access. Create it before starting the container.
+
+**Windows (PowerShell / Windows Terminal):**
 
 ```powershell
 docker pull ghcr.io/openhands/agent-canvas:1.0.0-rc.3
@@ -25,3 +90,43 @@ docker run -it --rm `
 ```
 
 The agent will be able to access any project under `PROJECTS_PATH`.
+
+### Option 3: From Source
+
+> [!WARNING]
+> This runs the agent-server directly on the machine you're installing on — the agent will have full access to your filesystem!
+
+**Prerequisites**: Node.js 22.12.x or later, `npm`, `uv` (for running the agent server via `uvx`)
+
+```sh
+git clone https://github.com/OpenHands/agent-canvas.git
+cd agent-canvas
+npm install
+npm run dev
+```
+
+---
+
+Access the UI at [http://localhost:8000](http://localhost:8000). You can add additional backends directly from the UI.
+
+# Architecture
+
+Agent Canvas is powered by the [OpenHands Agent Server](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server/openhands/agent_server), a REST API for running multiple agents on a single machine. Each Agent Server runs on a single host/port; the Agent Canvas can connect to multiple Agent Servers and easily flip between them.
+
+You can run an Agent Server anywhere:
+
+- Directly on your laptop (be careful!)
+- On a dedicated machine like a Mac Mini
+- On a virtual machine in the cloud
+- Inside OpenHands Cloud (our commercial offering)
+
+The Agent Server is often paired with an [Automation Server](https://github.com/OpenHands/automation), which lets you set up agents that run on a schedule or in response to events.
+
+<img width="1456" height="1258" alt="image" src="https://github.com/user-attachments/assets/cb6de6f5-ac30-4d04-a76a-b5c259f0c163" />
+
+## More documentation
+
+- [Documentation index](./docs/README.md)
+- [Architecture overview](./docs/architecture.md)
+- [Development guide](./docs/DEVELOPMENT.md)
+- [Self-hosting guide](./docs/SELF_HOSTING.md)

--- a/README.windows.md
+++ b/README.windows.md
@@ -1,14 +1,10 @@
 # Windows quickstart (PowerShell)
 
-This doc contains **Windows-specific** command syntax.
+Windows-specific PowerShell commands for running Agent Canvas with the **Docker sandbox**.
 
-For the main install options, overall context, and non-Windows-specific instructions, see [README.md](./README.md).
-
-<img width="1509" height="826" alt="Screenshot 2026-05-11 at 10 13 19 AM" src="https://github.com/user-attachments/assets/71ef41ae-8f6d-4fbf-990f-d672175d93d1" />
+For all other install options and background, see [README.md](./README.md).
 
 ## Option 2: With a Docker Sandbox (Windows)
-
-This section matches the Docker sandbox flow from [README.md](./README.md), but uses Windows PowerShell syntax.
 
 **Prerequisites**:
 
@@ -30,6 +26,4 @@ docker run -it --rm `
 
 The agent will be able to access any project under `PROJECTS_PATH`.
 
-## Architecture
-
-<img width="1456" height="1258" alt="image" src="https://github.com/user-attachments/assets/cb6de6f5-ac30-4d04-a76a-b5c259f0c163" />
+Access the UI at [http://localhost:8000](http://localhost:8000).

--- a/README.windows.md
+++ b/README.windows.md
@@ -1,80 +1,19 @@
-# agent-canvas
+# Windows quickstart (PowerShell)
 
-> [!WARNING]
-> This project is in the **Beta** phase. It may be vibecoded, untested, or out of date. OpenHands takes no responsibility for the code or its support. [Learn more](https://github.com/OpenHands/incubator-program).
+This doc contains **Windows-specific** command syntax.
 
-[![Project Status: Beta](https://img.shields.io/badge/status-beta-blue)](https://github.com/OpenHands/incubator-program)
-
-This doc mirrors [README.md](./README.md), but includes **Windows-specific** command syntax where needed.
-
-OpenHands is a platform for orchestrating coding agents across different environments. You can:
-
-- ⌨️ prompt agents manually
-- 🕐 run agents on a schedule
-- ⚡ trigger agents automatically — e.g. from Slack, GitHub, or Datadog.
-
-Agents can run anywhere:
-
-- 🧑‍💻 on your laptop
-- 🖥️ on a remote virtual machine
-- ☁️ in our hosted cloud
-- 🏢 or inside your company’s infrastructure
-
-The same Agent Canvas frontend can swap between each of these environments, so you can see everything in one place.
-
-OpenHands works with any agent harness (e.g. Claude Code, Codex)
-or connect directly to an LLM (e.g. Anthropic, OpenAI, Gemini, Mistral, Minimax, Kimi).
-
-If you have questions or feedback, please open a GitHub issue or join the [#proj-agent-canvas channel in Slack](https://openhands.dev/joinslack).
+For the main install options, overall context, and non-Windows-specific instructions, see [README.md](./README.md).
 
 <img width="1509" height="826" alt="Screenshot 2026-05-11 at 10 13 19 AM" src="https://github.com/user-attachments/assets/71ef41ae-8f6d-4fbf-990f-d672175d93d1" />
 
-## Project ownership and support
+## Option 2: With a Docker Sandbox (Windows)
 
-- **Current status**: Beta.
-- **Support channel**: [#proj-agent-canvas](https://openhands.dev/joinslack).
-- **Support level**: Best effort while the project remains in Beta.
-
-## Quickstart
-
-You can install OpenHands to run agents on any machine: on your laptop, on a dedicated computer like a Mac Mini,
-or on a server in the cloud.
-
-The most powerful way to run OpenHands is on a server in the cloud. This allows your agents to continue running
-even when your laptop is shut, and makes it easier to trigger your agents through third-party services
-like Slack, GitHub, and Datadog. See [SELF_HOSTING.md](docs/SELF_HOSTING.md) for details, especially with respect to security hardening.
-
-Notably, you can run the backend in _multiple different environments_, and switch between
-them from the same Agent Canvas frontend. E.g. you can share an Agent Server with your team for agents doing
-code review and dependency updates, then have your personal agents running on your laptop.
-
-### Option 1: Without a Sandbox
-
-> [!WARNING]
-> This runs the agent-server directly on the machine you're installing on — the agent will have full access to your filesystem!
-
-**Prerequisites**: Node.js 22.12.x or later, `uv`
-
-```sh
-npm install -g @openhands/agent-canvas
-agent-canvas
-```
-
-The `agent-canvas` command starts the full local stack by default. You can also split it when you want to run pieces separately:
-
-```sh
-agent-canvas --frontend-only  # static frontend + ingress only
-agent-canvas --backend-only   # agent server + automation backend + ingress only
-```
-
-### Option 2: With a Docker Sandbox
+This section matches the Docker sandbox flow from [README.md](./README.md), but uses Windows PowerShell syntax.
 
 **Prerequisites**:
 
 - Docker Desktop for Windows
-- A host directory for `PROJECTS_PATH` containing the project folders you want the agent to access. Create it before starting the container.
-
-**Windows (PowerShell / Windows Terminal):**
+- A host directory for `PROJECTS_PATH` containing the project folders you want the agent to access (create it before starting the container)
 
 ```powershell
 docker pull ghcr.io/openhands/agent-canvas:1.0.0-rc.3
@@ -91,42 +30,6 @@ docker run -it --rm `
 
 The agent will be able to access any project under `PROJECTS_PATH`.
 
-### Option 3: From Source
-
-> [!WARNING]
-> This runs the agent-server directly on the machine you're installing on — the agent will have full access to your filesystem!
-
-**Prerequisites**: Node.js 22.12.x or later, `npm`, `uv` (for running the agent server via `uvx`)
-
-```sh
-git clone https://github.com/OpenHands/agent-canvas.git
-cd agent-canvas
-npm install
-npm run dev
-```
-
----
-
-Access the UI at [http://localhost:8000](http://localhost:8000). You can add additional backends directly from the UI.
-
-# Architecture
-
-Agent Canvas is powered by the [OpenHands Agent Server](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server/openhands/agent_server), a REST API for running multiple agents on a single machine. Each Agent Server runs on a single host/port; the Agent Canvas can connect to multiple Agent Servers and easily flip between them.
-
-You can run an Agent Server anywhere:
-
-- Directly on your laptop (be careful!)
-- On a dedicated machine like a Mac Mini
-- On a virtual machine in the cloud
-- Inside OpenHands Cloud (our commercial offering)
-
-The Agent Server is often paired with an [Automation Server](https://github.com/OpenHands/automation), which lets you set up agents that run on a schedule or in response to events.
+## Architecture
 
 <img width="1456" height="1258" alt="image" src="https://github.com/user-attachments/assets/cb6de6f5-ac30-4d04-a76a-b5c259f0c163" />
-
-## More documentation
-
-- [Documentation index](./docs/README.md)
-- [Architecture overview](./docs/architecture.md)
-- [Development guide](./docs/DEVELOPMENT.md)
-- [Self-hosting guide](./docs/SELF_HOSTING.md)


### PR DESCRIPTION
Fixes #1180.

- Simplified README.windows.md back to a bare-bones Windows-only doc: just Docker sandbox (Option 2) PowerShell commands + link to README.md
- Updated AGENTS.md to document this bare-bones Windows README policy

_This PR was created by an AI agent (OpenHands) on behalf of jamiechicago312._