### PR TITLE
build(deps): move @openhands/extensions to npm 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/extensions": "github:OpenHands/extensions#8a6690071e0e9229ae70b30ff0352aff9e6fca21",
+        "@openhands/extensions": "0.2.0",
         "@openhands/typescript-client": "1.24.3",
         "@react-router/node": "7.14.2",
         "@react-router/serve": "7.14.2",
@@ -3464,9 +3464,9 @@
       "license": "MIT"
     },
     "node_modules/@openhands/extensions": {
-      "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/OpenHands/extensions.git#8a6690071e0e9229ae70b30ff0352aff9e6fca21",
-      "integrity": "sha512-GjqvmlDWOWnWRtvqM65B3xWKphhBD3nuckOcWKZsrt2TithPg5YTptbj5mdcbm2MWV9gIk5uo8wknjGUIR994g==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.2.0.tgz",
+      "integrity": "sha512-tG459KZtB+UkuNt7IAkfp/sEGQxcXJzs3cixiw+fbT+n3rBqjjf16GfyLLxSHggQmT1f0mLF52n8iC9SPgPjyA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/extensions": "github:OpenHands/extensions#8a6690071e0e9229ae70b30ff0352aff9e6fca21",
+    "@openhands/extensions": "0.2.0",
     "@openhands/typescript-client": "1.24.3",
     "@react-router/node": "7.14.2",
     "@react-router/serve": "7.14.2",


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

`@openhands/extensions` was pinned to a git commit SHA. That's fragile - it bypasses the registry, makes the resolved code hard to audit, and won't pick up published releases. The package is now on npm, so this moves us onto a real, versioned dependency.

## Summary

- Point `@openhands/extensions` at npm `0.2.0` instead of the `git+https://...#<sha>` ref.

## Issue Number

## How to Test

Run `npm install` and confirm `node_modules/@openhands/extensions/package.json` resolves to `0.2.0`. Then build/run the app to confirm nothing in the extensions API surface broke.

## Video/Screenshots

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This jumps across the published `0.0.1-alpha` and `0.1.0` releases straight to `0.2.0` (current `latest`). On 0.x semver, minor bumps can carry breaking changes, so the build check above is worth doing. The lockfile resolved cleanly with no peer-dependency complaints.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.26.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `9630ea01e1bee68687d9c9e28665bf0f20ef71fa` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-9630ea0
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-9630ea0
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-9630ea0-amd64
ghcr.io/openhands/agent-canvas:jl-extensions-npm-0-2-0-amd64
ghcr.io/openhands/agent-canvas:pr-1189-amd64
ghcr.io/openhands/agent-canvas:sha-9630ea0-arm64
ghcr.io/openhands/agent-canvas:jl-extensions-npm-0-2-0-arm64
ghcr.io/openhands/agent-canvas:pr-1189-arm64
ghcr.io/openhands/agent-canvas:sha-9630ea0
ghcr.io/openhands/agent-canvas:jl-extensions-npm-0-2-0
ghcr.io/openhands/agent-canvas:pr-1189
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-9630ea0`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-9630ea0-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->