### PR TITLE
Fix global CLI installs missing logger runtime dependencies

### DIFF
--- a/__tests__/package-library.test.ts
+++ b/__tests__/package-library.test.ts
@@ -74,6 +74,17 @@ describe("package library metadata", () => {
     expect(violations).toEqual([]);
   });
 
+  it("ships runtime logger dependencies for the published CLI", () => {
+    expect(packageJson.dependencies).toMatchObject({
+      winston: "^3.19.0",
+      "winston-daily-rotate-file": "^5.0.0",
+    });
+    expect(packageJson.devDependencies?.winston).toBeUndefined();
+    expect(
+      packageJson.devDependencies?.["winston-daily-rotate-file"],
+    ).toBeUndefined();
+  });
+
   it("uses local dev commands without Docker", () => {
     expect(packageJson.scripts.dev).toBe(
       "node --env-file-if-exists=.env scripts/dev-with-automation.mjs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,8 @@
         "unist-util-visit": "5.1.0",
         "uuid": "14.0.0",
         "vite": "8.0.10",
+        "winston": "^3.19.0",
+        "winston-daily-rotate-file": "^5.0.0",
         "zustand": "5.0.12"
       },
       "bin": {
@@ -101,9 +103,7 @@
         "tailwindcss": "4.2.4",
         "typescript": "6.0.3",
         "vite-plugin-svgr": "5.2.0",
-        "vitest": "4.1.5",
-        "winston": "^3.19.0",
-        "winston-daily-rotate-file": "^5.0.0"
+        "vitest": "4.1.5"
       },
       "engines": {
         "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "unist-util-visit": "5.1.0",
     "uuid": "14.0.0",
     "vite": "8.0.10",
+    "winston": "^3.19.0",
+    "winston-daily-rotate-file": "^5.0.0",
     "zustand": "5.0.12"
   },
   "scripts": {
@@ -153,9 +155,7 @@
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3",
     "vite-plugin-svgr": "5.2.0",
-    "vitest": "4.1.5",
-    "winston": "^3.19.0",
-    "winston-daily-rotate-file": "^5.0.0"
+    "vitest": "4.1.5"
   },
   "packageManager": "npm@10.5.0",
   "volta": {


### PR DESCRIPTION
## Summary

- move `winston` and `winston-daily-rotate-file` from `devDependencies` to `dependencies`
- add a regression test that keeps those runtime logger packages in production deps for the published CLI
- fix global/npm installs that fail before startup when `scripts/logger.mjs` is imported at runtime

Closes #1197.

## Why this happens

`bin/agent-canvas.mjs` imports `scripts/dev-with-automation.mjs`, which imports `scripts/logger.mjs` at runtime. `scripts/logger.mjs` depends on `winston` and `winston-daily-rotate-file`, so those packages must be installed for the published CLI. Because they were in `devDependencies`, a normal `npm install -g @openhands/agent-canvas@latest` omitted them and the CLI crashed with `Cannot find package 'winston'`.

## Validation

- `npm ci`
- `npx vitest run __tests__/package-library.test.ts`
- packed the package locally and verified the CLI gets past the previous `Cannot find package 'winston'` failure during a production-style install

## Windows Terminal clone + test instructions for this branch

```powershell
git clone https://github.com/jamiechicago312/agent-canvas.git
cd agent-canvas
git checkout fix/windows-global-cli-winston
npm install
npx vitest run __tests__/package-library.test.ts

# Optional: verify the packaged CLI on this branch
$prefix = Join-Path $env:TEMP "agent-canvas-test-global"
Remove-Item -Recurse -Force $prefix -ErrorAction SilentlyContinue
$tarball = npm pack | Select-Object -Last 1
npm install -g ".\\$tarball" --prefix $prefix
& "$prefix\agent-canvas.cmd" --backend-only
```

Expected result: the branch should no longer fail with `Cannot find package 'winston'`. The final command should proceed past that import step and either start normally or fail later for an unrelated local prerequisite such as ports, `uvx`, or other runtime setup.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._