### PR TITLE
fix(tests): remove racy home-route wait in collapsible-thinking snapshot spec

### DIFF
--- a/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
+++ b/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
@@ -284,9 +284,10 @@ async function navigateToConversation(page: Page, events: unknown[]) {
   // Belt-and-braces: even after the network response landed, React Query
   // needs a tick to propagate the new state. Assert the banner is gone
   // before returning so the screenshot always matches the seeded profile.
-  await expect(
-    page.getByTestId("home-llm-not-configured-banner"),
-  ).toHaveCount(0, { timeout: 5000 });
+  await expect(page.getByTestId("home-llm-not-configured-banner")).toHaveCount(
+    0,
+    { timeout: 5000 },
+  );
 
   return chatInterface;
 }

--- a/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
+++ b/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
@@ -201,41 +201,63 @@ async function navigateToConversation(page: Page, events: unknown[]) {
   // unless an active profile with a key exists — see useLlmConfigured. Seed
   // one so the empty conversation renders normally and the banner stays out
   // of the captured screenshots (matching the baselines).
-  await page.route(
-    (url) => url.pathname.endsWith("/api/profiles"),
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          profiles: [
-            {
-              name: "mock",
-              model: "anthropic/claude-sonnet-4-20250514",
-              base_url: null,
-              api_key_set: true,
-            },
-          ],
-          active_profile: "mock",
-        }),
-      });
-    },
-  );
+  //
+  // We override window.fetch via addInitScript instead of using page.route:
+  // the mock dev server registers an MSW Service Worker on app startup, and
+  // SWs intercept fetch *before* Playwright's network layer sees it — so a
+  // page.route for /api/profiles never fires (its handler is dead code).
+  // addInitScript runs in the page context before any app JS, so our wrapped
+  // fetch is installed before MSW's worker.start() and before React mounts,
+  // and any /api/profiles request is served synchronously from the wrapper
+  // without ever reaching MSW or the network. This is what makes the
+  // useLlmConfigured signal deterministic across the full render lifecycle.
+  await page.addInitScript(() => {
+    const mockProfilesResponse = {
+      profiles: [
+        {
+          name: "mock",
+          model: "anthropic/claude-sonnet-4-20250514",
+          base_url: null,
+          api_key_set: true,
+        },
+      ],
+      active_profile: "mock",
+    };
+
+    const isProfilesListUrl = (rawUrl: string): boolean => {
+      try {
+        const pathname = new URL(rawUrl, window.location.origin).pathname;
+        return pathname.endsWith("/api/profiles");
+      } catch {
+        return false;
+      }
+    };
+
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const requestUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const method = (
+        init?.method ?? (input instanceof Request ? input.method : "GET")
+      ).toUpperCase();
+      if (method === "GET" && isProfilesListUrl(requestUrl)) {
+        return new Response(JSON.stringify(mockProfilesResponse), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return originalFetch(input as RequestInfo, init);
+    };
+  });
 
   await stubWebSocket(page);
-
-  // Arm a wait for the mocked /api/profiles response BEFORE navigating, so
-  // we don't miss it if the request races page.goto. The seeded profile is
-  // what flips useLlmConfigured → true; without it the GUI renders the
-  // "Your LLM isn't set up yet" banner, which then ends up in the snapshot
-  // (see the diff that surfaced after the original #1200 flake fix).
-  const profilesResponsePromise = page.waitForResponse(
-    (response) => {
-      const pathname = new URL(response.url()).pathname;
-      return pathname.endsWith("/api/profiles") && response.status() === 200;
-    },
-    { timeout: 20000 },
-  );
 
   await page.goto(`/conversations/${CONVERSATION_ID}`, {
     waitUntil: "domcontentloaded",
@@ -270,20 +292,15 @@ async function navigateToConversation(page: Page, events: unknown[]) {
     { timeout: 20000 },
   );
 
-  // Make sure our mocked /api/profiles response landed before we screenshot,
-  // so the LLM-not-configured banner doesn't flash. Without this the first
-  // test in the serial spec could screenshot before React Query settled with
-  // the mocked profile, leaving the warning banner in the captured image.
-  await profilesResponsePromise;
-
   await injectEvents(page, events);
 
   const chatInterface = page.getByTestId("chat-interface");
   await expect(chatInterface).toBeVisible({ timeout: 20000 });
 
-  // Belt-and-braces: even after the network response landed, React Query
-  // needs a tick to propagate the new state. Assert the banner is gone
-  // before returning so the screenshot always matches the seeded profile.
+  // Sanity-check that the seeded profile took effect — if it didn't, the
+  // LLM-not-configured banner overlays the chat-interface and shifts the
+  // snapshot. Asserting absence here also forces React Query to settle
+  // before the screenshot is captured.
   await expect(page.getByTestId("home-llm-not-configured-banner")).toHaveCount(
     0,
     { timeout: 5000 },

--- a/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
+++ b/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
@@ -224,6 +224,19 @@ async function navigateToConversation(page: Page, events: unknown[]) {
 
   await stubWebSocket(page);
 
+  // Arm a wait for the mocked /api/profiles response BEFORE navigating, so
+  // we don't miss it if the request races page.goto. The seeded profile is
+  // what flips useLlmConfigured → true; without it the GUI renders the
+  // "Your LLM isn't set up yet" banner, which then ends up in the snapshot
+  // (see the diff that surfaced after the original #1200 flake fix).
+  const profilesResponsePromise = page.waitForResponse(
+    (response) => {
+      const pathname = new URL(response.url()).pathname;
+      return pathname.endsWith("/api/profiles") && response.status() === 200;
+    },
+    { timeout: 20000 },
+  );
+
   await page.goto(`/conversations/${CONVERSATION_ID}`, {
     waitUntil: "domcontentloaded",
   });
@@ -257,10 +270,24 @@ async function navigateToConversation(page: Page, events: unknown[]) {
     { timeout: 20000 },
   );
 
+  // Make sure our mocked /api/profiles response landed before we screenshot,
+  // so the LLM-not-configured banner doesn't flash. Without this the first
+  // test in the serial spec could screenshot before React Query settled with
+  // the mocked profile, leaving the warning banner in the captured image.
+  await profilesResponsePromise;
+
   await injectEvents(page, events);
 
   const chatInterface = page.getByTestId("chat-interface");
   await expect(chatInterface).toBeVisible({ timeout: 20000 });
+
+  // Belt-and-braces: even after the network response landed, React Query
+  // needs a tick to propagate the new state. Assert the banner is gone
+  // before returning so the screenshot always matches the seeded profile.
+  await expect(
+    page.getByTestId("home-llm-not-configured-banner"),
+  ).toHaveCount(0, { timeout: 5000 });
+
   return chatInterface;
 }
 

--- a/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
+++ b/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
@@ -197,11 +197,10 @@ async function navigateToConversation(page: Page, events: unknown[]) {
     });
   });
 
-  // The GUI now hides ChatSuggestions (and shows the "LLM not configured"
-  // banner) unless an active profile with a key exists — see useLlmConfigured.
-  // Seed one so the empty conversation renders normally: it restores the
-  // "Let's start building!" readiness signal below and keeps the banner out of
-  // the captured screenshots (matching the baselines).
+  // The GUI hides ChatSuggestions (and shows the "LLM not configured" banner)
+  // unless an active profile with a key exists — see useLlmConfigured. Seed
+  // one so the empty conversation renders normally and the banner stays out
+  // of the captured screenshots (matching the baselines).
   await page.route(
     (url) => url.pathname.endsWith("/api/profiles"),
     async (route) => {
@@ -229,10 +228,14 @@ async function navigateToConversation(page: Page, events: unknown[]) {
     waitUntil: "domcontentloaded",
   });
   await dismissConsentModal(page);
-  await expect(page.getByText("Let's start building!")).toBeVisible({
-    timeout: 20000,
-  });
 
+  // Don't wait for any home-route text here: we navigated directly to
+  // /conversations/<id>, and "Let's start building!" only renders on the
+  // home route. Relying on a brief home flash was racy and caused the
+  // 20s timeout flake tracked in #1200. `injectEvents` already waits on
+  // window.__OH_EVENT_STORE__, which is a route-stable readiness signal
+  // (the store module is loaded as part of the conversation route), and
+  // the chat-interface testid wait below confirms the route mounted.
   await injectEvents(page, events);
 
   const chatInterface = page.getByTestId("chat-interface");

--- a/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
+++ b/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
@@ -229,13 +229,34 @@ async function navigateToConversation(page: Page, events: unknown[]) {
   });
   await dismissConsentModal(page);
 
-  // Don't wait for any home-route text here: we navigated directly to
-  // /conversations/<id>, and "Let's start building!" only renders on the
-  // home route. Relying on a brief home flash was racy and caused the
-  // 20s timeout flake tracked in #1200. `injectEvents` already waits on
-  // window.__OH_EVENT_STORE__, which is a route-stable readiness signal
-  // (the store module is loaded as part of the conversation route), and
-  // the chat-interface testid wait below confirms the route mounted.
+  // Wait for the conversation route to mount before injecting events.
+  // ConversationWebSocketContext runs a useLayoutEffect on mount that
+  // calls clearEventsForConversation(<id>) — if we inject events first,
+  // that effect wipes them and the UI renders the empty state. Use the
+  // store's `loadedConversationId` as a route-stable readiness signal:
+  // it flips from null → CONVERSATION_ID inside that layoutEffect, so
+  // observing it means the clear-and-set has already happened and any
+  // subsequent addEvents will survive.
+  //
+  // We deliberately don't wait on the home route's "Let's start
+  // building!" text here — it only renders on the home route, so relying
+  // on a brief home flash before the conversation hydrates is racy and
+  // caused the 20s timeout flake tracked in #1200.
+  await page.waitForFunction(
+    (expectedId) => {
+      const store = (
+        window as unknown as {
+          __OH_EVENT_STORE__?: {
+            getState: () => { loadedConversationId: string | null };
+          };
+        }
+      ).__OH_EVENT_STORE__;
+      return store?.getState().loadedConversationId === expectedId;
+    },
+    CONVERSATION_ID,
+    { timeout: 20000 },
+  );
+
   await injectEvents(page, events);
 
   const chatInterface = page.getByTestId("chat-interface");

--- a/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
+++ b/tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts
@@ -201,61 +201,26 @@ async function navigateToConversation(page: Page, events: unknown[]) {
   // unless an active profile with a key exists — see useLlmConfigured. Seed
   // one so the empty conversation renders normally and the banner stays out
   // of the captured screenshots (matching the baselines).
-  //
-  // We override window.fetch via addInitScript instead of using page.route:
-  // the mock dev server registers an MSW Service Worker on app startup, and
-  // SWs intercept fetch *before* Playwright's network layer sees it — so a
-  // page.route for /api/profiles never fires (its handler is dead code).
-  // addInitScript runs in the page context before any app JS, so our wrapped
-  // fetch is installed before MSW's worker.start() and before React mounts,
-  // and any /api/profiles request is served synchronously from the wrapper
-  // without ever reaching MSW or the network. This is what makes the
-  // useLlmConfigured signal deterministic across the full render lifecycle.
-  await page.addInitScript(() => {
-    const mockProfilesResponse = {
-      profiles: [
-        {
-          name: "mock",
-          model: "anthropic/claude-sonnet-4-20250514",
-          base_url: null,
-          api_key_set: true,
-        },
-      ],
-      active_profile: "mock",
-    };
-
-    const isProfilesListUrl = (rawUrl: string): boolean => {
-      try {
-        const pathname = new URL(rawUrl, window.location.origin).pathname;
-        return pathname.endsWith("/api/profiles");
-      } catch {
-        return false;
-      }
-    };
-
-    const originalFetch = window.fetch.bind(window);
-    window.fetch = async (
-      input: RequestInfo | URL,
-      init?: RequestInit,
-    ): Promise<Response> => {
-      const requestUrl =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : input.url;
-      const method = (
-        init?.method ?? (input instanceof Request ? input.method : "GET")
-      ).toUpperCase();
-      if (method === "GET" && isProfilesListUrl(requestUrl)) {
-        return new Response(JSON.stringify(mockProfilesResponse), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
-      }
-      return originalFetch(input as RequestInfo, init);
-    };
-  });
+  await page.route(
+    (url) => url.pathname.endsWith("/api/profiles"),
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          profiles: [
+            {
+              name: "mock",
+              model: "anthropic/claude-sonnet-4-20250514",
+              base_url: null,
+              api_key_set: true,
+            },
+          ],
+          active_profile: "mock",
+        }),
+      });
+    },
+  );
 
   await stubWebSocket(page);
 
@@ -296,16 +261,6 @@ async function navigateToConversation(page: Page, events: unknown[]) {
 
   const chatInterface = page.getByTestId("chat-interface");
   await expect(chatInterface).toBeVisible({ timeout: 20000 });
-
-  // Sanity-check that the seeded profile took effect — if it didn't, the
-  // LLM-not-configured banner overlays the chat-interface and shifts the
-  // snapshot. Asserting absence here also forces React Query to settle
-  // before the screenshot is captured.
-  await expect(page.getByTestId("home-llm-not-configured-banner")).toHaveCount(
-    0,
-    { timeout: 5000 },
-  );
-
   return chatInterface;
 }
 


### PR DESCRIPTION
Fixes #1200.

## Problem

`tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts` has been flaking on `main` and across PRs. The crash happens in the file's `navigateToConversation` helper, which after navigating directly to `/conversations/<id>` waits up to **20 s** for the **home-page** CTA text `Let's start building!` to become visible:

```ts
await page.goto(`/conversations/${CONVERSATION_ID}`, { waitUntil: "domcontentloaded" });
await dismissConsentModal(page);
await expect(page.getByText("Let's start building!")).toBeVisible({ timeout: 20000 });
await injectEvents(page, events);
```

`Let's start building!` (the `HOME$LETS_START_BUILDING` i18n key) is rendered by `HomeHeaderTitle`, which is only mounted by `HomeChatLauncher` (in `src/routes/home.tsx`) and `HomeHeader`. Neither is rendered on the conversation route. The wait was effectively relying on a brief flash of home-route content before the conversation route hydrated; when the conversation route hydrated fast enough, the home text never appeared and the wait timed out.

Because the spec is `test.describe.configure({ mode: "serial" })` with `test.setTimeout(60000)`, a single timeout in this helper cascades into `1 failed / 1 skipped / 3 did not run` for the whole spec, which then trips the `Visual Snapshot Tests` workflow's step 22 even when `Changed: 0, New: 0, Unchanged: 73`.

See #1200 for the full failure signature and recent occurrences.

## Fix

Drop the home-route wait entirely. The helper already has two stronger, route-stable readiness signals immediately after it:

1. `injectEvents` does `page.waitForFunction(() => window.__OH_EVENT_STORE__?.getState().addEvents)`. `__OH_EVENT_STORE__` is set by `src/stores/use-event-store.ts` as a module side effect, so this guarantees the conversation-route JS has loaded and hydrated before we touch the store.
2. The subsequent `await expect(page.getByTestId("chat-interface")).toBeVisible({ timeout: 20000 })` confirms the chat interface itself mounted.

No screenshot can run before both of those, so the home-page wait was redundant in the happy path and the source of flakes in the racy path. This is option 1 from the issue's "Suggested fixes" list.

I also tightened the now-stale comment above the seeded mock profile (it previously claimed the seeded profile "restores the 'Let's start building!' readiness signal").

## Scope

- One file changed: `tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts`.
- No production code, no other specs, no baselines touched. The actual snapshot comparisons are unchanged.
- I did not touch the workflow-level guardrail (step 22 of `snapshot-tests.yml`) mentioned in the issue — happy to do that in a follow-up if maintainers want, but keeping this PR minimal so it can land as the targeted flake fix.

## Verification

- `npx prettier --check tests/e2e/snapshots/collapsible-thinking.snapshot.spec.ts` → ok.
- Project `lint` script only covers `src/`, so no project lint regressions are possible from this change.
- The real verification is the snapshot workflow itself; I've added the `e2e-tests` label so the mock-LLM E2E tests run on this PR.

---
_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3016badb-5b86-41e6-90b7-07a2a398baaf)




<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.26.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `790c87fe17f9d394ffcf8770f52d2980f5f2a90d` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-790c87f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-790c87f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-790c87f-amd64
ghcr.io/openhands/agent-canvas:fix-snapshot-test-flake-1200-amd64
ghcr.io/openhands/agent-canvas:pr-1201-amd64
ghcr.io/openhands/agent-canvas:sha-790c87f-arm64
ghcr.io/openhands/agent-canvas:fix-snapshot-test-flake-1200-arm64
ghcr.io/openhands/agent-canvas:pr-1201-arm64
ghcr.io/openhands/agent-canvas:sha-790c87f
ghcr.io/openhands/agent-canvas:fix-snapshot-test-flake-1200
ghcr.io/openhands/agent-canvas:pr-1201
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-790c87f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-790c87f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->