### PR TITLE
fix: refresh diff after git state changes

### DIFF
--- a/__tests__/hooks/use-auto-refresh-files-on-edit.test.tsx
+++ b/__tests__/hooks/use-auto-refresh-files-on-edit.test.tsx
@@ -21,8 +21,9 @@ function makeObservationEvent(
 ): OHEvent {
   return {
     id,
-    timestamp: new Date(Date.now() + Number(id.replace(/\D/g, "")) * 1000)
-      .toISOString(),
+    timestamp: new Date(
+      Date.now() + Number(id.replace(/\D/g, "")) * 1000,
+    ).toISOString(),
     source: "environment",
     tool_name: "str_replace_based_edit_tool",
     tool_call_id: `tc-${id}`,
@@ -34,6 +35,32 @@ function makeObservationEvent(
       old_content: null,
       new_content: "hello",
       output: "ok",
+    },
+  } as unknown as OHEvent;
+}
+
+function makeBashObservationEvent(
+  id: string,
+  command: string,
+  exitCode = 0,
+): OHEvent {
+  return {
+    id,
+    timestamp: new Date(
+      Date.now() + Number(id.replace(/\D/g, "")) * 1000,
+    ).toISOString(),
+    source: "environment",
+    tool_name: "execute_bash",
+    tool_call_id: `tc-${id}`,
+    action_id: `act-${id}`,
+    observation: {
+      kind: "ExecuteBashObservation",
+      command,
+      exit_code: exitCode,
+      content: [],
+      error: false,
+      timeout: false,
+      metadata: {},
     },
   } as unknown as OHEvent;
 }
@@ -102,9 +129,45 @@ describe("useAutoRefreshFilesOnEdit", () => {
     act(() => {
       useEventStore
         .getState()
-        .addEvent(
-          makeObservationEvent("1", "ExecuteBashObservation", "ls"),
-        );
+        .addEvent(makeObservationEvent("1", "ExecuteBashObservation", "ls"));
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("refreshes git changes after successful git commands that change diff state", () => {
+    const client = new QueryClient();
+    const spy = vi.spyOn(client, "invalidateQueries");
+
+    renderHook(() => useAutoRefreshFilesOnEdit(), {
+      wrapper: makeWrapper(client),
+    });
+
+    act(() => {
+      useEventStore
+        .getState()
+        .addEvent(makeBashObservationEvent("1", "git commit -m 'done'"));
+    });
+
+    const invalidatedKeys = spy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey[0],
+    );
+    expect(invalidatedKeys).toEqual(["file_changes"]);
+    expect(useWorkspaceMutationCounter.getState().count).toBe(0);
+  });
+
+  it("does not refresh git changes for failed git commands", () => {
+    const client = new QueryClient();
+    const spy = vi.spyOn(client, "invalidateQueries");
+
+    renderHook(() => useAutoRefreshFilesOnEdit(), {
+      wrapper: makeWrapper(client),
+    });
+
+    act(() => {
+      useEventStore
+        .getState()
+        .addEvent(makeBashObservationEvent("1", "git commit -m 'done'", 1));
     });
 
     expect(spy).not.toHaveBeenCalled();
@@ -132,11 +195,7 @@ describe("useAutoRefreshFilesOnEdit", () => {
       useEventStore
         .getState()
         .addEvent(
-          makeObservationEvent(
-            "2",
-            "StrReplaceEditorObservation",
-            "create",
-          ),
+          makeObservationEvent("2", "StrReplaceEditorObservation", "create"),
         );
     });
     expect(useWorkspaceMutationCounter.getState().count).toBe(2);
@@ -155,9 +214,7 @@ describe("useAutoRefreshFilesOnEdit", () => {
         .addEvent(makeObservationEvent("1", "FileEditorObservation", "view"));
       useEventStore
         .getState()
-        .addEvent(
-          makeObservationEvent("2", "ExecuteBashObservation", "ls"),
-        );
+        .addEvent(makeObservationEvent("2", "ExecuteBashObservation", "ls"));
     });
 
     expect(useWorkspaceMutationCounter.getState().count).toBe(0);
@@ -182,10 +239,14 @@ describe("useAutoRefreshFilesOnEdit", () => {
     act(() => {
       useEventStore
         .getState()
-        .addEvent(makeObservationEvent("10", "FileEditorObservation", "create"));
+        .addEvent(
+          makeObservationEvent("10", "FileEditorObservation", "create"),
+        );
       useEventStore
         .getState()
-        .addEvent(makeObservationEvent("20", "FileEditorObservation", "create"));
+        .addEvent(
+          makeObservationEvent("20", "FileEditorObservation", "create"),
+        );
     });
     const callsAfterInitial = spy.mock.calls.length;
     expect(callsAfterInitial).toBeGreaterThan(0);

--- a/src/hooks/use-auto-refresh-files-on-edit.ts
+++ b/src/hooks/use-auto-refresh-files-on-edit.ts
@@ -26,6 +26,30 @@ function isFileMutationObservation(event: OHEvent): boolean {
   return true;
 }
 
+const GIT_DIFF_MUTATION_COMMAND =
+  /^git\s+(?:add|apply|checkout|cherry-pick|clean|commit|merge|pull|rebase|reset|restore|stash|switch)\b/;
+
+function isGitDiffMutationObservation(event: OHEvent): boolean {
+  const obs = (
+    event as {
+      observation?: {
+        kind?: string;
+        command?: string | null;
+        exit_code?: number | null;
+      };
+    }
+  ).observation;
+  if (!obs || typeof obs.kind !== "string") return false;
+  if (
+    obs.kind !== "ExecuteBashObservation" &&
+    obs.kind !== "TerminalObservation"
+  ) {
+    return false;
+  }
+  if (obs.exit_code !== 0 || typeof obs.command !== "string") return false;
+  return GIT_DIFF_MUTATION_COMMAND.test(obs.command.trim());
+}
+
 /**
  * Watches the conversation event stream and invalidates the workspace file
  * queries whenever the agent commits a file-editor mutation (create / edit /
@@ -74,6 +98,7 @@ export function useAutoRefreshFilesOnEdit(): void {
 
   useEffect(() => {
     const newMutationEvents: OHEvent[] = [];
+    const newGitDiffMutationEvents: OHEvent[] = [];
     for (const event of events) {
       const id: string | number | undefined =
         "id" in event ? event.id : undefined;
@@ -89,14 +114,25 @@ export function useAutoRefreshFilesOnEdit(): void {
           processedEventsRef.current.add(event);
         }
         if (isFileMutationObservation(event)) newMutationEvents.push(event);
+        if (isGitDiffMutationObservation(event)) {
+          newGitDiffMutationEvents.push(event);
+        }
       }
     }
+
+    if (
+      newMutationEvents.length === 0 &&
+      newGitDiffMutationEvents.length === 0
+    ) {
+      return;
+    }
+
+    queryClient.invalidateQueries({ queryKey: ["file_changes"] });
 
     if (newMutationEvents.length === 0) return;
 
     queryClient.invalidateQueries({ queryKey: ["workspace-files"] });
     queryClient.invalidateQueries({ queryKey: ["workspace-file-content"] });
-    queryClient.invalidateQueries({ queryKey: ["file_changes"] });
     // Force iframes / <img> tags pointing at the static workspace
     // fileserver to re-fetch. Without this they happily keep showing the
     // stale (browser-cached) bytes even after the agent has rewritten the


### PR DESCRIPTION
## Summary
Refresh the Files tab diff cache when successful git commands change the repository diff state.

## Root Cause
The Files tab already invalidated file and diff queries when file-editor observations arrived, but it did not react to successful git commands such as `git commit`. After the agent committed changes, the cached `file_changes` query could still contain the pre-commit diff until the user manually clicked refresh.

## Fix
Detect successful bash/terminal observations for git commands that can mutate diff state, then invalidate the `file_changes` query. This keeps git-only state changes scoped to the diff cache and avoids unnecessary file-content cache busting.

## Impact
After commands like `git commit`, `git reset`, `git checkout`, or `git stash` complete successfully, the diff view refreshes automatically and stale diffs disappear without a manual refresh.

## Tests
- `npm test -- __tests__/hooks/use-auto-refresh-files-on-edit.test.tsx`
- `npm run typecheck`
- `npm run lint -- --quiet`

Fixes #1087