### PR TITLE
feat(backend-registry): seed deployment-provided default backends

### DIFF
--- a/__tests__/api/backend-registry/deployment-backends.test.ts
+++ b/__tests__/api/backend-registry/deployment-backends.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getDeploymentDefaultBackends } from "#/api/backend-registry/deployment-backends";
+
+type MutableWindow = Record<string, unknown>;
+
+function setInjectedBackends(value: unknown): void {
+  (window as unknown as MutableWindow).__AGENT_CANVAS_DEFAULT_BACKENDS__ =
+    value;
+}
+
+afterEach(() => {
+  delete (window as unknown as MutableWindow).__AGENT_CANVAS_DEFAULT_BACKENDS__;
+  vi.unstubAllEnvs();
+});
+
+describe("getDeploymentDefaultBackends", () => {
+  it("returns an empty list when nothing is configured", () => {
+    expect(getDeploymentDefaultBackends()).toEqual([]);
+  });
+
+  it("reads an injected window global (array form)", () => {
+    setInjectedBackends([
+      { host: "http://10.0.0.5:8000", apiKey: "key-a", name: "Box A" },
+    ]);
+
+    expect(getDeploymentDefaultBackends()).toEqual([
+      {
+        id: "deployment:http://10.0.0.5:8000",
+        name: "Box A",
+        host: "http://10.0.0.5:8000",
+        apiKey: "key-a",
+        kind: "local",
+      },
+    ]);
+  });
+
+  it("reads an injected window global (JSON string form)", () => {
+    setInjectedBackends(
+      JSON.stringify([{ host: "10.0.0.6:8000", apiKey: "key-b" }]),
+    );
+
+    const result = getDeploymentDefaultBackends();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      host: "http://10.0.0.6:8000",
+      apiKey: "key-b",
+      name: "http://10.0.0.6:8000",
+      kind: "local",
+    });
+  });
+
+  it("prefers the build-time env var over the window global", () => {
+    vi.stubEnv(
+      "VITE_DEFAULT_BACKENDS",
+      JSON.stringify([{ host: "http://env-host:8000", apiKey: "env-key" }]),
+    );
+    setInjectedBackends([
+      { host: "http://window-host:8000", apiKey: "window-key" },
+    ]);
+
+    const result = getDeploymentDefaultBackends();
+    expect(result).toHaveLength(1);
+    expect(result[0].host).toBe("http://env-host:8000");
+  });
+
+  it("drops entries missing host or apiKey and de-duplicates by host", () => {
+    setInjectedBackends([
+      { host: "http://dup:8000", apiKey: "k1" },
+      { host: "http://dup:8000", apiKey: "k2" },
+      { host: "http://no-key:8000" },
+      { apiKey: "no-host" },
+      { host: "http://ok:8000", apiKey: "k3", kind: "cloud" },
+    ]);
+
+    const result = getDeploymentDefaultBackends();
+    expect(result.map((b) => b.host)).toEqual([
+      "http://dup:8000",
+      "http://ok:8000",
+    ]);
+    expect(result[1].kind).toBe("cloud");
+  });
+
+  it("returns an empty list for malformed JSON", () => {
+    setInjectedBackends("{not-json");
+    expect(getDeploymentDefaultBackends()).toEqual([]);
+  });
+});

--- a/__tests__/api/backend-registry/storage.test.ts
+++ b/__tests__/api/backend-registry/storage.test.ts
@@ -265,4 +265,90 @@ describe("backend-registry storage", () => {
     window.localStorage.setItem(ACTIVE_BACKEND_STORAGE_KEY, "{broken");
     expect(readStoredActiveBackend()).toBeNull();
   });
+
+  describe("deployment default backends", () => {
+    type MutableWindow = Record<string, unknown>;
+
+    function setDeploymentBackends(value: unknown): void {
+      (window as unknown as MutableWindow).__AGENT_CANVAS_DEFAULT_BACKENDS__ =
+        value;
+    }
+
+    afterEach(() => {
+      delete (window as unknown as MutableWindow)
+        .__AGENT_CANVAS_DEFAULT_BACKENDS__;
+    });
+
+    it("seeds deployment defaults on first read even without a launcher local backend", () => {
+      vi.stubEnv("VITE_SESSION_API_KEY", "");
+      setDeploymentBackends([
+        { host: "http://10.0.0.5:8000", apiKey: "fleet-key", name: "Fleet A" },
+      ]);
+
+      const result = readStoredBackends();
+
+      expect(result).toEqual([
+        {
+          id: "deployment:http://10.0.0.5:8000",
+          name: "Fleet A",
+          host: "http://10.0.0.5:8000",
+          apiKey: "fleet-key",
+          kind: "local",
+        },
+      ]);
+      // Persisted so the rest of the app sees the same registry.
+      expect(window.localStorage.getItem(BACKENDS_STORAGE_KEY)).not.toBeNull();
+    });
+
+    it("merges deployment defaults into an existing registry and persists", () => {
+      const existing: Backend = {
+        id: "user-1",
+        name: "My Box",
+        host: "http://192.168.1.50:8000",
+        apiKey: "user-key",
+        kind: "local",
+      };
+      window.localStorage.setItem(
+        BACKENDS_STORAGE_KEY,
+        JSON.stringify([existing]),
+      );
+      setDeploymentBackends([
+        { host: "http://10.0.0.5:8000", apiKey: "fleet-key", name: "Fleet A" },
+      ]);
+
+      const result = readStoredBackends();
+
+      expect(result.map((b) => b.host)).toEqual([
+        "http://192.168.1.50:8000",
+        "http://10.0.0.5:8000",
+      ]);
+      const persisted = JSON.parse(
+        window.localStorage.getItem(BACKENDS_STORAGE_KEY) as string,
+      );
+      expect(persisted.map((b: Backend) => b.host)).toEqual([
+        "http://192.168.1.50:8000",
+        "http://10.0.0.5:8000",
+      ]);
+    });
+
+    it("does not duplicate a deployment default whose host is already registered", () => {
+      const existing: Backend = {
+        id: "user-edited",
+        name: "Renamed Fleet A",
+        host: "http://10.0.0.5:8000",
+        apiKey: "user-key",
+        kind: "local",
+      };
+      window.localStorage.setItem(
+        BACKENDS_STORAGE_KEY,
+        JSON.stringify([existing]),
+      );
+      setDeploymentBackends([
+        { host: "http://10.0.0.5:8000", apiKey: "fleet-key", name: "Fleet A" },
+      ]);
+
+      // User's own entry (name + key) is preserved, no duplicate added.
+      expect(readStoredBackends()).toEqual([existing]);
+    });
+  });
 });

--- a/__tests__/scripts/static-server.test.ts
+++ b/__tests__/scripts/static-server.test.ts
@@ -4,10 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import {
-  parseArgs,
-  startStaticServer,
-} from "../../scripts/static-server.mjs";
+import { parseArgs, startStaticServer } from "../../scripts/static-server.mjs";
 
 describe("static-server.mjs", () => {
   const servers: Server[] = [];
@@ -75,6 +72,22 @@ describe("static-server.mjs", () => {
     it("treats empty string as null for runtime services info", () => {
       const config = parseArgs(["--runtime-services-info", ""]);
       expect(config.runtimeServicesInfo).toBeNull();
+    });
+
+    it("defaults defaultBackends to null", () => {
+      const config = parseArgs([]);
+      expect(config.defaultBackends).toBeNull();
+    });
+
+    it("parses --default-backends", () => {
+      const json = '[{"host":"http://10.0.0.5:8000","apiKey":"k"}]';
+      const config = parseArgs(["--default-backends", json]);
+      expect(config.defaultBackends).toBe(json);
+    });
+
+    it("treats empty string as null for default backends", () => {
+      const config = parseArgs(["--default-backends", ""]);
+      expect(config.defaultBackends).toBeNull();
     });
   });
 
@@ -148,6 +161,80 @@ describe("static-server.mjs", () => {
 
       const body = await (await fetch(`${origin}/`)).text();
       expect(body).not.toContain("__AGENT_CANVAS_RUNTIME_SERVICES_INFO__");
+    });
+  });
+
+  describe("default backends injection", () => {
+    async function startServerWithDefaultBackends(
+      dir: string,
+      defaultBackends: string,
+    ) {
+      const server = await startStaticServer({
+        port: 0,
+        host: "127.0.0.1",
+        dir,
+        routes: {},
+        defaultBackends,
+      });
+      servers.push(server);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Static server did not bind to a TCP port");
+      }
+      return `http://127.0.0.1:${address.port}`;
+    }
+
+    function writeIndex(): string {
+      const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
+      tempDirs.push(buildDir);
+      writeFileSync(
+        path.join(buildDir, "index.html"),
+        "<html><head></head><body>app</body></html>",
+      );
+      return buildDir;
+    }
+
+    it("exposes the backends on window.__AGENT_CANVAS_DEFAULT_BACKENDS__", async () => {
+      const buildDir = writeIndex();
+      const json = JSON.stringify([
+        { host: "http://10.0.0.5:8000", apiKey: "fleet-key", name: "Fleet A" },
+      ]);
+      const origin = await startServerWithDefaultBackends(buildDir, json);
+      const body = await (await fetch(`${origin}/`)).text();
+
+      expect(body).toContain("window.__AGENT_CANVAS_DEFAULT_BACKENDS__");
+      // Emitted as a real array literal (no escaped quotes) so the client
+      // global is self-describing.
+      expect(body).toContain('"host":"http://10.0.0.5:8000"');
+      expect(body).toContain('"name":"Fleet A"');
+    });
+
+    it("ignores a non-array value without injecting the global", async () => {
+      const buildDir = writeIndex();
+      const origin = await startServerWithDefaultBackends(
+        buildDir,
+        '{"host":"http://10.0.0.5:8000"}',
+      );
+      const body = await (await fetch(`${origin}/`)).text();
+      expect(body).not.toContain("__AGENT_CANVAS_DEFAULT_BACKENDS__");
+    });
+
+    it("does not inject when defaultBackends is null", async () => {
+      const buildDir = writeIndex();
+      const server = await startStaticServer({
+        port: 0,
+        host: "127.0.0.1",
+        dir: buildDir,
+        routes: {},
+        defaultBackends: null,
+      });
+      servers.push(server);
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("No port");
+      const origin = `http://127.0.0.1:${(address as { port: number }).port}`;
+
+      const body = await (await fetch(`${origin}/`)).text();
+      expect(body).not.toContain("__AGENT_CANVAS_DEFAULT_BACKENDS__");
     });
   });
 

--- a/scripts/static-server.mjs
+++ b/scripts/static-server.mjs
@@ -76,6 +76,9 @@ export function parseArgs(argv = process.argv.slice(2)) {
     sessionApiKey: null,
     authRequired: false,
     runtimeServicesInfo: null,
+    // JSON array of backends to advertise to every browser. May also be
+    // supplied via the AGENT_CANVAS_DEFAULT_BACKENDS env var.
+    defaultBackends: process.env.AGENT_CANVAS_DEFAULT_BACKENDS || null,
   };
 
   for (let i = 0; i < argv.length; i++) {
@@ -113,6 +116,9 @@ export function parseArgs(argv = process.argv.slice(2)) {
         break;
       case "--runtime-services-info":
         config.runtimeServicesInfo = argv[++i] || null;
+        break;
+      case "--default-backends":
+        config.defaultBackends = argv[++i] || null;
         break;
       case "--auth-required":
         config.authRequired = true;
@@ -177,6 +183,13 @@ OPTIONS:
                                frontend can populate the agent's
                                <RUNTIME_SERVICES> system-prompt block without
                                VITE_RUNTIME_SERVICES_INFO baked in.
+  --default-backends <json>    Inject a JSON array of backends into index.html
+                               (window.__AGENT_CANVAS_DEFAULT_BACKENDS__) so
+                               every browser auto-registers a shared fleet
+                               without each user adding them by hand. Each entry
+                               needs at least {host, apiKey}; name/kind/id are
+                               optional. May also be set via the
+                               AGENT_CANVAS_DEFAULT_BACKENDS env var.
   --reject-prefix <prefix>     Return 503 for requests matching <prefix>
                                instead of SPA-fallbacking to index.html;
                                may be repeated. Useful in --frontend-only
@@ -230,6 +243,7 @@ function makeConfigInjectionScript(
   sessionApiKey,
   authRequired,
   runtimeServicesInfo,
+  defaultBackends,
 ) {
   const parts = [];
 
@@ -267,6 +281,27 @@ function makeConfigInjectionScript(
     );
   }
 
+  if (defaultBackends) {
+    // Validate + re-serialize so we embed a clean JS array literal and never
+    // inject malformed config. parseBackendList() on the client tolerates a
+    // string too, but emitting an array keeps the global self-describing.
+    let parsed = null;
+    try {
+      parsed = JSON.parse(defaultBackends);
+    } catch {
+      console.warn(
+        "WARN: --default-backends value is not valid JSON; ignoring.",
+      );
+    }
+    if (Array.isArray(parsed)) {
+      parts.push(
+        `window.__AGENT_CANVAS_DEFAULT_BACKENDS__=${JSON.stringify(parsed)};`,
+      );
+    } else if (parsed !== null) {
+      console.warn("WARN: --default-backends must be a JSON array; ignoring.");
+    }
+  }
+
   if (parts.length === 0) return "";
 
   return `<script>(function(){${parts.join("")}}());</script>`;
@@ -280,7 +315,7 @@ async function serveInjectedIndexHtml(
   req,
   res,
   indexPath,
-  { sessionApiKey, authRequired, runtimeServicesInfo } = {},
+  { sessionApiKey, authRequired, runtimeServicesInfo, defaultBackends } = {},
 ) {
   let content;
   try {
@@ -293,6 +328,7 @@ async function serveInjectedIndexHtml(
     sessionApiKey,
     authRequired,
     runtimeServicesInfo,
+    defaultBackends,
   );
   // Inject right before </head> so the key is available before any app code runs.
   // replace() targets the first (and only) </head> in well-formed HTML.
@@ -537,7 +573,8 @@ async function handleStatic(
   const needsInjection =
     injectionOpts.sessionApiKey ||
     injectionOpts.authRequired ||
-    injectionOpts.runtimeServicesInfo;
+    injectionOpts.runtimeServicesInfo ||
+    injectionOpts.defaultBackends;
 
   // Serve index.html with runtime config injection when configured.
   if (needsInjection && filePath.endsWith("index.html")) {
@@ -591,6 +628,7 @@ export function startStaticServer(config) {
     sessionApiKey: config.sessionApiKey || null,
     authRequired: config.authRequired || false,
     runtimeServicesInfo: config.runtimeServicesInfo || null,
+    defaultBackends: config.defaultBackends || null,
   };
   const rejectPrefixes = config.rejectPrefixes ?? [];
 
@@ -600,13 +638,15 @@ export function startStaticServer(config) {
       proxyRequest(req, res, backend);
       return;
     }
-    handleStatic(req, res, dirAbs, injectionOpts, rejectPrefixes).catch((err) => {
-      console.error(`Static handler error for ${req.url}:`, err);
-      if (!res.headersSent) {
-        res.writeHead(500);
-        res.end("Internal Server Error");
-      }
-    });
+    handleStatic(req, res, dirAbs, injectionOpts, rejectPrefixes).catch(
+      (err) => {
+        console.error(`Static handler error for ${req.url}:`, err);
+        if (!res.headersSent) {
+          res.writeHead(500);
+          res.end("Internal Server Error");
+        }
+      },
+    );
   });
 
   server.on("upgrade", (req, socket, head) => {

--- a/src/api/backend-registry/deployment-backends.ts
+++ b/src/api/backend-registry/deployment-backends.ts
@@ -1,0 +1,102 @@
+import type { Backend, BackendKind } from "./types";
+
+/**
+ * Backends supplied by the deployment host (not by an individual browser).
+ *
+ * A self-hosted Agent Canvas instance can advertise a fixed set of backends
+ * so that every browser which loads the app sees the same fleet without each
+ * user having to re-add them by hand. This is the multi-user / multi-device
+ * counterpart to the per-browser `openhands-backends` localStorage registry:
+ * deployment defaults are merged into that registry on read (see
+ * `readStoredBackends`).
+ *
+ * Two sources are consulted, in order (matching `getBakedSessionApiKey`):
+ *   1. `import.meta.env.VITE_DEFAULT_BACKENDS` — a JSON array baked into the
+ *      bundle at build time (handy for `npm run dev`).
+ *   2. `window.__AGENT_CANVAS_DEFAULT_BACKENDS__` — injected into `index.html`
+ *      at serve time by `scripts/static-server.mjs --default-backends <json>`.
+ *      This is the path used by the published binary / Docker image, where the
+ *      bundle ships with an empty `VITE_DEFAULT_BACKENDS`.
+ */
+const DEPLOYMENT_BACKEND_ID_PREFIX = "deployment:";
+
+function isValidKind(value: unknown): value is BackendKind {
+  return value === "local" || value === "cloud";
+}
+
+function normalizeHost(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) return null;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `http://${trimmed}`;
+}
+
+/**
+ * Coerce a loosely-typed config entry into a `Backend`. Only `host` and
+ * `apiKey` are required; `name` defaults to the host, `kind` to `"local"`,
+ * and `id` to a stable host-derived value so repeated merges are idempotent
+ * and the same backend gets the same id across browsers.
+ */
+function coerceBackend(value: unknown): Backend | null {
+  if (typeof value !== "object" || value === null) return null;
+  const v = value as Record<string, unknown>;
+
+  const host = normalizeHost(v.host);
+  const apiKey = typeof v.apiKey === "string" ? v.apiKey.trim() : "";
+  if (!host || !apiKey) return null;
+
+  const name =
+    typeof v.name === "string" && v.name.trim() ? v.name.trim() : host;
+  const kind = isValidKind(v.kind) ? v.kind : "local";
+  const id =
+    typeof v.id === "string" && v.id.trim()
+      ? v.id.trim()
+      : `${DEPLOYMENT_BACKEND_ID_PREFIX}${host}`;
+
+  return { id, name, host, apiKey, kind };
+}
+
+function parseBackendList(raw: unknown): Backend[] {
+  let source: unknown = raw;
+
+  if (typeof source === "string") {
+    const trimmed = source.trim();
+    if (!trimmed) return [];
+    try {
+      source = JSON.parse(trimmed);
+    } catch {
+      return [];
+    }
+  }
+
+  if (!Array.isArray(source)) return [];
+
+  const result: Backend[] = [];
+  const seenHosts = new Set<string>();
+  for (const entry of source) {
+    const backend = coerceBackend(entry);
+    if (backend && !seenHosts.has(backend.host)) {
+      seenHosts.add(backend.host);
+      result.push(backend);
+    }
+  }
+  return result;
+}
+
+/**
+ * Return the deployment-provided default backends, de-duplicated by host.
+ * Returns an empty array when the deployment did not configure any.
+ */
+export function getDeploymentDefaultBackends(): Backend[] {
+  const fromEnv = parseBackendList(import.meta.env.VITE_DEFAULT_BACKENDS);
+  if (fromEnv.length > 0) return fromEnv;
+
+  if (typeof window !== "undefined") {
+    const injected = (window as unknown as Record<string, unknown>)
+      .__AGENT_CANVAS_DEFAULT_BACKENDS__;
+    return parseBackendList(injected);
+  }
+
+  return [];
+}

--- a/src/api/backend-registry/index.ts
+++ b/src/api/backend-registry/index.ts
@@ -1,5 +1,6 @@
 export * from "./types";
 export * from "./storage";
 export * from "./default-backend";
+export * from "./deployment-backends";
 export * from "./active-store";
 export * from "./auth";

--- a/src/api/backend-registry/storage.ts
+++ b/src/api/backend-registry/storage.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_LOCAL_BACKEND_NAME,
   makeDefaultLocalBackend,
 } from "./default-backend";
+import { getDeploymentDefaultBackends } from "./deployment-backends";
 import type { Backend, BackendKind, BackendSelection } from "./types";
 
 export const BACKENDS_STORAGE_KEY = "openhands-backends";
@@ -71,6 +72,34 @@ function seedBackends(backends: Backend[]): Backend[] {
   writeStoredBackends(backends);
   clearLegacyBackendConfig();
   return backends;
+}
+
+/**
+ * Append any deployment-provided default backends that are not already present
+ * (matched by host) to the supplied list. This is what lets a self-hosted
+ * deployment expose a shared fleet to every browser without each user adding
+ * the backends by hand. User-added backends are never removed or modified;
+ * deployment defaults whose host already exists are skipped so a user can
+ * still rename/edit their local copy.
+ */
+function appendDeploymentDefaults(backends: Backend[]): {
+  backends: Backend[];
+  changed: boolean;
+} {
+  const deploymentDefaults = getDeploymentDefaultBackends();
+  if (deploymentDefaults.length === 0) {
+    return { backends, changed: false };
+  }
+
+  const existingHosts = new Set(backends.map((backend) => backend.host));
+  const additions = deploymentDefaults.filter(
+    (backend) => !existingHosts.has(backend.host),
+  );
+  if (additions.length === 0) {
+    return { backends, changed: false };
+  }
+
+  return { backends: [...backends, ...additions], changed: true };
 }
 
 function isLoopbackUrl(value: string): boolean {
@@ -146,12 +175,17 @@ export function readStoredBackends(): Backend[] {
     // local backend.
     if (raw === null) {
       const legacyBackend = readLegacyBackend();
-      if (legacyBackend) return seedBackends([legacyBackend]);
+      if (legacyBackend) {
+        return seedBackends(appendDeploymentDefaults([legacyBackend]).backends);
+      }
 
       const defaultBackend = makeDefaultLocalBackend();
-      if (!defaultBackend) return [];
+      const seed = appendDeploymentDefaults(
+        defaultBackend ? [defaultBackend] : [],
+      ).backends;
+      if (seed.length === 0) return [];
 
-      return seedBackends([defaultBackend]);
+      return seedBackends(seed);
     }
 
     const parsed = JSON.parse(raw);
@@ -159,17 +193,22 @@ export function readStoredBackends(): Backend[] {
     const valid = parsed.filter(isValidBackend);
 
     // If the stored array is empty (or everything in it failed validation),
-    // only re-seed when the launcher supplied both a host and API key.
+    // re-seed from the launcher default and/or any deployment defaults.
     if (valid.length === 0) {
       const defaultBackend = makeDefaultLocalBackend();
-      if (!defaultBackend) return [];
+      const seed = appendDeploymentDefaults(
+        defaultBackend ? [defaultBackend] : [],
+      ).backends;
+      if (seed.length === 0) return [];
 
-      return seedBackends([defaultBackend]);
+      return seedBackends(seed);
     }
 
     const synced = syncLauncherDefaultLocalBackend(valid);
+    const { backends: merged, changed } = appendDeploymentDefaults(synced);
+    if (changed) writeStoredBackends(merged);
     clearLegacyBackendConfig();
-    return synced;
+    return merged;
   } catch {
     return [];
   }


### PR DESCRIPTION
## Problem

The backend registry lives entirely in each browser's `localStorage` (`openhands-backends`). For a **self-hosted, multi-user / multi-device** Agent Canvas this is painful:

- If one person adds a backend, nobody else sees it — every teammate must re-add it by hand.
- The same user has to re-add backends on every browser/device (office, home, laptop, phone).
- There is currently no way for a deployment to ship a known fleet of backends to all of its users.

This is the gap behind the "Keep in browser localStorage … selected backend id" note in #68 and the bootstrap discussion in #233: today there's no server-owned/deployment-owned source for the backend list.

## What this does

Lets a deployment advertise a fixed list of default backends that are auto-registered in **every** browser, while leaving per-user customisation intact.

- **New** `getDeploymentDefaultBackends()` (`src/api/backend-registry/deployment-backends.ts`) reads a backend list from, in order:
  1. `import.meta.env.VITE_DEFAULT_BACKENDS` (baked at build time, handy for `npm run dev`), then
  2. the injected `window.__AGENT_CANVAS_DEFAULT_BACKENDS__` global (serve time).

  This mirrors exactly how `getBakedSessionApiKey()` sources the session key. Entries only need `{host, apiKey}`; `name` defaults to the host, `kind` to `"local"`, and `id` to a stable `deployment:<host>` value (so merges are idempotent and the same backend gets the same id across browsers). Invalid entries are dropped and the list is de-duplicated by host.

- `readStoredBackends()` (`storage.ts`) now **merges** these defaults into the registry **by host**:
  - seeds them on first load (even when no launcher local backend is available), and
  - appends any that are missing on subsequent reads,
  - **never** removing or overwriting user-added/edited entries (a default whose host already exists is skipped, so users can still rename/edit their local copy).

- `scripts/static-server.mjs` gains `--default-backends <json>` (and the `AGENT_CANVAS_DEFAULT_BACKENDS` env var). The value is validated (must be a JSON array) and injected as a clean JS array literal into `index.html`, alongside the existing session-key / runtime-services injection.

## Usage

```bash
# published binary / Docker entrypoint
node scripts/static-server.mjs \
  --default-backends '[{"name":"prod (.238)","host":"http://192.168.1.238:8000","apiKey":"<session-key>"}]'

# or via env
AGENT_CANVAS_DEFAULT_BACKENDS='[{"host":"http://10.0.0.5:8000","apiKey":"…"}]' node scripts/static-server.mjs
```

## Tests

- `__tests__/api/backend-registry/deployment-backends.test.ts` — parsing (array + JSON string), env-over-window precedence, validation, de-dup, malformed JSON.
- `__tests__/api/backend-registry/storage.test.ts` — seed-on-empty, merge-into-existing (+ persistence), no-duplicate when host already registered.
- `__tests__/scripts/static-server.test.ts` — `parseArgs` for `--default-backends`, HTML injection of the global, non-array ignored, null = no injection.

```
npm run make-i18n && npx vitest run __tests__/api/backend-registry __tests__/scripts/static-server.test.ts   # 67 passed
npm run typecheck   # clean
eslint + prettier   # clean on changed files
```

## Notes / follow-ups

- Backwards compatible: with no env/flag/global set, behaviour is unchanged.
- Removal semantics: a deployment default that a user deletes will reappear on next load (it is, by design, deployment-owned). If per-user opt-out is desired, a `openhands-backends-removed` tombstone set could be a small follow-up.
- Relates to #68 and #233.
