### PR TITLE
feat(acp): cloud ACP native resume — wake recycled sandboxes + accept file creds (#988)

### DIFF
--- a/__tests__/api/cloud/conversation-create.test.ts
+++ b/__tests__/api/cloud/conversation-create.test.ts
@@ -117,4 +117,36 @@ describe("AgentServerConversationService cloud branch", () => {
     expect(result?.status).toBe("READY");
     expect(result?.app_conversation_id).toBe("conv-456");
   });
+
+  it("wakeRecycledCloudConversation re-provisions under the same conversation id", async () => {
+    const { wakeRecycledCloudConversation } =
+      await import("#/api/cloud/conversation-service.api");
+    vi.mocked(axios.request).mockResolvedValue({
+      data: {
+        id: "task-wake",
+        created_by_user_id: null,
+        status: "WORKING",
+        detail: null,
+        app_conversation_id: null,
+        agent_server_url: null,
+        request: {},
+        created_at: "2026-06-07T00:00:00Z",
+        updated_at: "2026-06-07T00:00:00Z",
+      },
+    });
+
+    const result = await wakeRecycledCloudConversation("conv-existing");
+
+    const [config] = vi.mocked(axios.request).mock.calls[0]!;
+    expect(config).toMatchObject({
+      url: `${cloudBackend.host}/api/v1/app-conversations`,
+      method: "POST",
+    });
+    const body = (config as { data: Record<string, unknown> }).data;
+    // The same conversation id is carried so the backend rebuilds (and, for
+    // ACP, natively resumes) the existing conversation rather than minting one.
+    expect(body.conversation_id).toBe("conv-existing");
+    expect(result.id).toBe("task-wake");
+    expect(result.status).toBe("WORKING");
+  });
 });

--- a/__tests__/api/cloud/conversation-create.test.ts
+++ b/__tests__/api/cloud/conversation-create.test.ts
@@ -135,7 +135,12 @@ describe("AgentServerConversationService cloud branch", () => {
       },
     });
 
-    const result = await wakeRecycledCloudConversation("conv-existing");
+    const result = await wakeRecycledCloudConversation("conv-existing", {
+      selected_repository: "user/repo",
+      selected_branch: "main",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      git_provider: "github" as any,
+    });
 
     const [config] = vi.mocked(axios.request).mock.calls[0]!;
     expect(config).toMatchObject({
@@ -146,6 +151,11 @@ describe("AgentServerConversationService cloud branch", () => {
     // The same conversation id is carried so the backend rebuilds (and, for
     // ACP, natively resumes) the existing conversation rather than minting one.
     expect(body.conversation_id).toBe("conv-existing");
+    // The repo selection rides along so the rebuilt working dir matches the
+    // original cwd — otherwise native resume falls back to bootstrap (#1126).
+    expect(body.selected_repository).toBe("user/repo");
+    expect(body.selected_branch).toBe("main");
+    expect(body.git_provider).toBe("github");
     expect(result.id).toBe("task-wake");
     expect(result.status).toBe("WORKING");
   });

--- a/__tests__/components/onboarding/setup-acp-secrets-step.test.tsx
+++ b/__tests__/components/onboarding/setup-acp-secrets-step.test.tsx
@@ -362,10 +362,11 @@ describe("SetupAcpSecretsStep", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not count a file blob toward the gate on a backend that can't materialise it (cloud)", async () => {
-    // Cloud can't materialise file-content credentials yet (agent-canvas#1016)
-    // — the save flow warns the blob is orphaned, so it must not be what
-    // satisfies a required step. An env-var credential (API key) still counts.
+  it("counts a Codex file blob toward the gate on cloud now that it materialises (agent-canvas#1126)", async () => {
+    // Cloud now materialises file-content credentials (Codex auth.json, Gemini
+    // Vertex SA) from the encrypted secret store via agent_context.secrets at
+    // conversation start (#1016/#1126), so a pasted blob satisfies a required
+    // step exactly like an env-var credential does.
     setRegisteredBackends([
       {
         id: "cloud-1",
@@ -378,20 +379,13 @@ describe("SetupAcpSecretsStep", () => {
     setActiveSelection({ backendId: "cloud-1", orgId: null });
     const { user } = renderStep("codex");
 
+    // Required on cloud, so initially blocked until a credential is supplied.
+    expect(screen.getByTestId("onboarding-acp-secrets-next")).toBeDisabled();
+
     await user.click(
       screen.getByTestId("onboarding-acp-secret-CODEX_AUTH_JSON"),
     );
     await user.paste('{"tokens":{}}');
-
-    expect(
-      screen.getByTestId("onboarding-acp-secrets-blocked"),
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("onboarding-acp-secrets-next")).toBeDisabled();
-
-    await user.type(
-      screen.getByTestId("onboarding-acp-secret-OPENAI_API_KEY"),
-      "sk-openai",
-    );
 
     expect(
       screen.queryByTestId("onboarding-acp-secrets-blocked"),

--- a/__tests__/components/settings/acp-credentials-section.test.tsx
+++ b/__tests__/components/settings/acp-credentials-section.test.tsx
@@ -134,9 +134,10 @@ describe("AcpCredentialsSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("toasts a warning (not success) when a file credential is saved on a cloud backend", async () => {
-    // Cloud can't materialise file-content credentials yet (agent-canvas#1016)
-    // — same orphaned-credential warning the onboarding step shows.
+  it("toasts success when a file credential is saved on a cloud backend (now materialised)", async () => {
+    // Cloud now materialises file-content credentials from the encrypted secret
+    // store via agent_context.secrets at conversation start (#1016/#1126), so a
+    // saved blob is consumable — no orphaned-credential warning.
     useCloudBackend();
     const { user } = renderSection("codex");
 
@@ -150,8 +151,8 @@ describe("AcpCredentialsSection", () => {
         '{"tokens":{}}',
         undefined,
       );
-      expect(toastMocks.warning).toHaveBeenCalledTimes(1);
+      expect(toastMocks.success).toHaveBeenCalled();
     });
-    expect(toastMocks.success).not.toHaveBeenCalled();
+    expect(toastMocks.warning).not.toHaveBeenCalled();
   });
 });

--- a/src/api/cloud/conversation-service.api.ts
+++ b/src/api/cloud/conversation-service.api.ts
@@ -221,6 +221,28 @@ export async function resumeCloudSandbox(sandboxId: string): Promise<void> {
 }
 
 /**
+ * Wake a conversation whose sandbox was recycled (STOPPED/MISSING, not just
+ * PAUSED). Unlike `resumeCloudSandbox`, a recycled sandbox no longer exists, so
+ * a fresh one must be provisioned by re-issuing the conversation-start with the
+ * SAME `conversation_id`. The backend rebuilds the conversation keyed on that
+ * id and, for ACP, restores the CLI session subtree + feeds
+ * `acp_resume_session_id` so the agent continues natively via `session/load`
+ * rather than starting over (#1126). Returns a WORKING task the caller polls
+ * to READY (same lifecycle as a fresh create).
+ */
+export async function wakeRecycledCloudConversation(
+  conversationId: string,
+): Promise<AppConversationStartTask> {
+  const backend = getActiveCloudBackend();
+  return callCloudProxy<AppConversationStartTask>({
+    backend,
+    method: "POST",
+    path: "/api/v1/app-conversations",
+    body: { conversation_id: conversationId },
+  });
+}
+
+/**
  * Read a file from a cloud conversation's sandbox workspace. Mirrors
  * OpenHands' `AgentServerConversationService.readConversationFile` — hits
  * `GET /api/v1/app-conversations/{id}/file?file_path=...` on the cloud backend

--- a/src/api/cloud/conversation-service.api.ts
+++ b/src/api/cloud/conversation-service.api.ts
@@ -232,13 +232,29 @@ export async function resumeCloudSandbox(sandboxId: string): Promise<void> {
  */
 export async function wakeRecycledCloudConversation(
   conversationId: string,
+  repoSelection?: {
+    selected_repository?: string | null;
+    selected_branch?: string | null;
+    git_provider?: AppConversationStartRequest["git_provider"];
+  },
 ): Promise<AppConversationStartTask> {
   const backend = getActiveCloudBackend();
+  // Carry the repo selection so the rebuilt sandbox's working dir matches the
+  // original conversation's cwd. Native ACP resume guards on cwd equality
+  // (acp_session_cwd == project_dir); a repo-backed conversation whose wake
+  // omitted the repo would resolve a different project dir and silently fall
+  // back to bootstrap-prompt resume instead of session/load (#1126).
+  const body: AppConversationStartRequest = {
+    conversation_id: conversationId,
+    selected_repository: repoSelection?.selected_repository ?? null,
+    selected_branch: repoSelection?.selected_branch ?? null,
+    git_provider: repoSelection?.git_provider ?? null,
+  };
   return callCloudProxy<AppConversationStartTask>({
     backend,
     method: "POST",
     path: "/api/v1/app-conversations",
-    body: { conversation_id: conversationId },
+    body: body as unknown as Record<string, unknown>,
   });
 }
 

--- a/src/api/conversation-service/agent-server-conversation-service.types.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.types.ts
@@ -60,6 +60,11 @@ export interface SendMessageRequest {
 }
 
 export interface AppConversationStartRequest {
+  // Re-provision an EXISTING conversation (waking a recycled sandbox) instead
+  // of minting a new one. The backend keys the rebuilt conversation on this id
+  // and, for ACP, restores the CLI session for native session/load resume
+  // (#1126). Omit/null to create a fresh conversation.
+  conversation_id?: string | null;
   initial_message?: SendMessageRequest | null;
   processors?: unknown[]; // EventCallbackProcessor - keeping as unknown for now
   llm_model?: string | null;

--- a/src/components/features/chat/acp-resume-archived-button.tsx
+++ b/src/components/features/chat/acp-resume-archived-button.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from "react-i18next";
+import { BrandButton } from "#/components/features/settings/brand-button";
+import { I18nKey } from "#/i18n/declaration";
+import { useWakeConversation } from "#/hooks/mutation/use-wake-conversation";
+import { displayErrorToast } from "#/utils/custom-toast-handlers";
+
+interface AcpResumeArchivedButtonProps {
+  conversationId: string;
+}
+
+/**
+ * Resume affordance shown in place of the read-only "archived" notice for an
+ * ACP conversation whose cloud sandbox was recycled. Waking re-provisions a
+ * fresh sandbox under the same conversation id; the backend restores the CLI
+ * session and continues natively via session/load (#1126). The active
+ * conversation query then polls the new sandbox to RUNNING and reconnects.
+ */
+export function AcpResumeArchivedButton({
+  conversationId,
+}: AcpResumeArchivedButtonProps) {
+  const { t } = useTranslation();
+  const { mutate: wake, isPending } = useWakeConversation();
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs text-[var(--oh-muted)]">
+        {t(I18nKey.CHAT_INTERFACE$ACP_RESUME_SANDBOX_DESCRIPTION)}
+      </p>
+      <BrandButton
+        type="button"
+        variant="primary"
+        isDisabled={isPending}
+        onClick={() =>
+          wake(
+            { conversationId },
+            {
+              onError: (error) =>
+                displayErrorToast(
+                  error instanceof Error ? error.message : String(error),
+                ),
+            },
+          )
+        }
+        testId="acp-resume-conversation-button"
+      >
+        {isPending
+          ? t(I18nKey.CHAT_INTERFACE$ACP_RESUME_STARTING)
+          : t(I18nKey.CHAT_INTERFACE$ACP_RESUME_BUTTON)}
+      </BrandButton>
+    </div>
+  );
+}

--- a/src/components/features/chat/acp-resume-archived-button.tsx
+++ b/src/components/features/chat/acp-resume-archived-button.tsx
@@ -3,9 +3,10 @@ import { BrandButton } from "#/components/features/settings/brand-button";
 import { I18nKey } from "#/i18n/declaration";
 import { useWakeConversation } from "#/hooks/mutation/use-wake-conversation";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
+import type { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
 
 interface AcpResumeArchivedButtonProps {
-  conversationId: string;
+  conversation: AppConversation;
 }
 
 /**
@@ -16,7 +17,7 @@ interface AcpResumeArchivedButtonProps {
  * conversation query then polls the new sandbox to RUNNING and reconnects.
  */
 export function AcpResumeArchivedButton({
-  conversationId,
+  conversation,
 }: AcpResumeArchivedButtonProps) {
   const { t } = useTranslation();
   const { mutate: wake, isPending } = useWakeConversation();
@@ -32,7 +33,7 @@ export function AcpResumeArchivedButton({
         isDisabled={isPending}
         onClick={() =>
           wake(
-            { conversationId },
+            { conversationId: conversation.id, conversation },
             {
               onError: (error) =>
                 displayErrorToast(

--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -39,6 +39,7 @@ import { useTaskPolling } from "#/hooks/query/use-task-polling";
 import { matchesPendingConversationId } from "#/utils/pending-task-message-link";
 import { useConversationWebSocket } from "#/contexts/conversation-websocket-context";
 import ChatStatusIndicator from "./chat-status-indicator";
+import { AcpResumeArchivedButton } from "./acp-resume-archived-button";
 import { getStatusColor, getStatusText } from "#/utils/utils";
 import { useNewConversationCommand } from "#/hooks/mutation/use-new-conversation-command";
 import { useOptionalConversationId } from "#/hooks/use-conversation-id";
@@ -107,6 +108,11 @@ export function ChatInterface() {
   const sandboxStatus = activeConversation?.sandbox_status ?? null;
   const isArchivedConversation =
     sandboxStatus === "MISSING" || sandboxStatus === "ERROR";
+  // A recycled (MISSING) sandbox for an ACP conversation can be resumed
+  // natively (#1126): re-provisioning restores the CLI session via
+  // session/load. ERROR is a genuine failure, so it stays read-only.
+  const isRecycledAcpConversation =
+    sandboxStatus === "MISSING" && activeConversation?.agent_kind === "acp";
 
   // Block sending in a resumed conversation that has no usable LLM, and show
   // the same setup banner as the home screen so the dead end is explained.
@@ -561,11 +567,21 @@ export function ChatInterface() {
                   ? t(I18nKey.CHAT_INTERFACE$ERROR_SANDBOX_TITLE)
                   : t(I18nKey.CHAT_INTERFACE$ARCHIVED_SANDBOX_TITLE)}
               </p>
-              <p className="text-xs text-[var(--oh-muted)] mt-0.5">
-                {sandboxStatus === "ERROR"
-                  ? t(I18nKey.CHAT_INTERFACE$ERROR_SANDBOX_DESCRIPTION)
-                  : t(I18nKey.CHAT_INTERFACE$ARCHIVED_SANDBOX_DESCRIPTION)}
-              </p>
+              {isRecycledAcpConversation && activeConversation?.id ? (
+                // ACP conversations resume natively from a recycled sandbox
+                // (#1126): offer to re-provision instead of dead-ending.
+                <div className="mt-2">
+                  <AcpResumeArchivedButton
+                    conversationId={activeConversation.id}
+                  />
+                </div>
+              ) : (
+                <p className="text-xs text-[var(--oh-muted)] mt-0.5">
+                  {sandboxStatus === "ERROR"
+                    ? t(I18nKey.CHAT_INTERFACE$ERROR_SANDBOX_DESCRIPTION)
+                    : t(I18nKey.CHAT_INTERFACE$ARCHIVED_SANDBOX_DESCRIPTION)}
+                </p>
+              )}
             </div>
           ) : (
             <div className="relative">

--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -567,13 +567,11 @@ export function ChatInterface() {
                   ? t(I18nKey.CHAT_INTERFACE$ERROR_SANDBOX_TITLE)
                   : t(I18nKey.CHAT_INTERFACE$ARCHIVED_SANDBOX_TITLE)}
               </p>
-              {isRecycledAcpConversation && activeConversation?.id ? (
+              {isRecycledAcpConversation && activeConversation ? (
                 // ACP conversations resume natively from a recycled sandbox
                 // (#1126): offer to re-provision instead of dead-ending.
                 <div className="mt-2">
-                  <AcpResumeArchivedButton
-                    conversationId={activeConversation.id}
-                  />
+                  <AcpResumeArchivedButton conversation={activeConversation} />
                 </div>
               ) : (
                 <p className="text-xs text-[var(--oh-muted)] mt-0.5">

--- a/src/hooks/mutation/use-wake-conversation.ts
+++ b/src/hooks/mutation/use-wake-conversation.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { wakeRecycledCloudConversation } from "#/api/cloud/conversation-service.api";
+
+/**
+ * Wake a recycled (STOPPED/MISSING) cloud conversation by re-provisioning its
+ * sandbox under the same conversation id. For ACP this triggers native
+ * session/load resume on the backend (#1126); for the UI it just needs to
+ * kick off the start task and then let the active-conversation poll pick up the
+ * new `conversation_url` once the fresh sandbox is RUNNING. Invalidating the
+ * conversation queries drops the cached MISSING/archived view so the chat
+ * reconnects automatically.
+ */
+export const useWakeConversation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (variables: { conversationId: string }) =>
+      wakeRecycledCloudConversation(variables.conversationId),
+    onSettled: (_, __, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["user", "conversation", variables.conversationId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["user", "conversations"] });
+      queryClient.invalidateQueries({
+        queryKey: ["v1-batch-get-app-conversations"],
+      });
+    },
+  });
+};

--- a/src/hooks/mutation/use-wake-conversation.ts
+++ b/src/hooks/mutation/use-wake-conversation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { wakeRecycledCloudConversation } from "#/api/cloud/conversation-service.api";
+import type { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
 
 /**
  * Wake a recycled (STOPPED/MISSING) cloud conversation by re-provisioning its
@@ -14,8 +15,16 @@ export const useWakeConversation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (variables: { conversationId: string }) =>
-      wakeRecycledCloudConversation(variables.conversationId),
+    mutationFn: (variables: {
+      conversationId: string;
+      conversation?: AppConversation | null;
+    }) =>
+      wakeRecycledCloudConversation(variables.conversationId, {
+        selected_repository:
+          variables.conversation?.selected_repository ?? null,
+        selected_branch: variables.conversation?.selected_branch ?? null,
+        git_provider: variables.conversation?.git_provider ?? null,
+      }),
     onSettled: (_, __, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["user", "conversation", variables.conversationId],

--- a/src/hooks/use-acp-credential-form.ts
+++ b/src/hooks/use-acp-credential-form.ts
@@ -1,7 +1,6 @@
 import React from "react";
 import { useSearchSecrets } from "#/hooks/query/use-get-secrets";
 import { useSaveAcpSecrets } from "#/hooks/use-save-acp-secrets";
-import { useActiveBackend } from "#/contexts/active-backend-context";
 import {
   getAcpCredentialConflicts,
   getAcpProviderSecrets,
@@ -43,18 +42,18 @@ export function useAcpCredentialForm(
   providerKey: string | null | undefined,
 ): AcpCredentialForm {
   const { data: existingSecrets } = useSearchSecrets();
-  const activeBackend = useActiveBackend();
   const fields = React.useMemo(
     () => getAcpProviderSecrets(providerKey),
     [providerKey],
   );
   const [values, setValues] = React.useState<Record<string, string>>({});
 
-  // Local agent-servers materialise file-content credentials via the SDK's
-  // acp_file_secrets defaults; cloud doesn't yet (agent-canvas#1016).
-  // TODO(#1016): once cloud materialises file secrets, a kind check can't tell
-  // a new cloud from an old one — replace with a capability/version probe.
-  const consumesFileCredentials = activeBackend.backend.kind === "local";
+  // Both local and cloud agent-servers materialise file-content credentials
+  // (Codex auth.json, Gemini Vertex SA) via the SDK's acp_file_secrets: locally
+  // from the user's machine, on cloud from the per-user encrypted secret store
+  // routed through agent_context.secrets at conversation start (#1016 / #1126).
+  // So a pasted file blob is consumable on every supported backend.
+  const consumesFileCredentials = true;
   const { saveFilled, isSaving } = useSaveAcpSecrets(
     fields,
     consumesFileCredentials,

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -22932,6 +22932,15 @@
     "tr": "Bu konuşmanın sandbox'ı kaldırıldı. Yukarıdaki geçmiş salt okunur modundadır.",
     "uk": "Пісочницю цієї розмови видалено. Наведена вище історія доступна лише для читання."
   },
+  "CHAT_INTERFACE$ACP_RESUME_SANDBOX_DESCRIPTION": {
+    "en": "This conversation's sandbox was recycled. Resume to restore the agent's session and continue where you left off."
+  },
+  "CHAT_INTERFACE$ACP_RESUME_BUTTON": {
+    "en": "Resume conversation"
+  },
+  "CHAT_INTERFACE$ACP_RESUME_STARTING": {
+    "en": "Resuming…"
+  },
   "CHAT_INTERFACE$ERROR_SANDBOX_TITLE": {
     "en": "Sandbox error",
     "ja": "サンドボックスエラー",


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

Completes the canvas half of cloud ACP with **native conversation resume**. The backend (software-agent-sdk#3562 + OpenHands#14709) now restores a recycled ACP conversation's CLI session and continues via `session/load`. Two canvas gaps remained: (1) a recycled (`MISSING`) cloud sandbox was a read-only dead end, and (2) file-content credentials (Codex `auth.json`, Gemini Vertex SA) were treated as un-consumable on cloud.

> **Stacked on `docker-acp`** (base branch). Review/merge `docker-acp` (#1102) first; this diff is `docker-acp..HEAD`.

## Summary

- **Wake recycled sandboxes:** an ACP cloud conversation whose sandbox is `MISSING` now offers **Resume** instead of the archived dead end. It re-provisions under the same `conversation_id` (`wakeRecycledCloudConversation` + `useWakeConversation`); the backend restores the CLI session + feeds `acp_resume_session_id`, so the agent continues via native `session/load`, and the active-conversation poll reconnects. `ERROR` sandboxes stay read-only.
- The wake carries `selected_repository`/`branch`/`git_provider` so the rebuilt working dir matches the original cwd (native resume guards on cwd equality — a repo-backed conversation would otherwise silently fall back to bootstrap).
- `AppConversationStartRequest` gains `conversation_id` for the cloud create path to target an existing conversation.
- `consumesFileCredentials` is now `true` on every backend: cloud materialises Codex `auth.json` / Gemini Vertex SA from the encrypted secret store via `agent_context.secrets` at start (OpenHands#14709), so a pasted blob is consumable and the onboarding/settings "orphaned credential" warning no longer fires on cloud. Updated the two tests that asserted the old can't-materialise behavior.

## Issue Number

#988 (#1126, #1016, #1013)

## How to Test

`npm ci && npm run typecheck` and `npx vitest run __tests__/api/cloud/conversation-create.test.ts __tests__/components/onboarding/setup-acp-secrets-step.test.tsx __tests__/components/settings/acp-credentials-section.test.tsx` (32 passed). End-to-end the cloud path is exercised by the OpenHands#14709 SaaS-equivalent harness (Codex + Claude Code both resume natively across a hard sandbox recycle); the canvas cloud-proxy forwards to the same app_server endpoints.

## Type

- [x] Feature