### PR TITLE
[codex] Fix tab-scoped active backend selection

### DIFF
--- a/__tests__/api/backend-registry/active-store.test.ts
+++ b/__tests__/api/backend-registry/active-store.test.ts
@@ -13,11 +13,13 @@ import type { Backend } from "#/api/backend-registry/types";
 
 beforeEach(() => {
   window.localStorage.clear();
+  window.sessionStorage.clear();
   __resetActiveStoreForTests();
 });
 
 afterEach(() => {
   window.localStorage.clear();
+  window.sessionStorage.clear();
   vi.unstubAllEnvs();
   __resetActiveStoreForTests();
 });
@@ -41,6 +43,7 @@ const localBackend: Backend = {
 describe("active-store", () => {
   it("uses the no-backend sentinel when no backend details are available", () => {
     window.localStorage.clear();
+    window.sessionStorage.clear();
     vi.stubEnv("VITE_SESSION_API_KEY", "");
     __resetActiveStoreForTests();
 

--- a/__tests__/api/backend-registry/storage.test.ts
+++ b/__tests__/api/backend-registry/storage.test.ts
@@ -11,6 +11,7 @@ import type { Backend } from "#/api/backend-registry/types";
 
 afterEach(() => {
   window.localStorage.clear();
+  window.sessionStorage.clear();
   vi.unstubAllEnvs();
 });
 
@@ -253,10 +254,41 @@ describe("backend-registry storage", () => {
     });
   });
 
+  it("prefers the tab-scoped active selection over the global fallback", () => {
+    window.localStorage.setItem(
+      ACTIVE_BACKEND_STORAGE_KEY,
+      JSON.stringify({ backendId: "global-backend", orgId: null }),
+    );
+    window.sessionStorage.setItem(
+      ACTIVE_BACKEND_STORAGE_KEY,
+      JSON.stringify({ backendId: "tab-backend", orgId: "org-1" }),
+    );
+
+    expect(readStoredActiveBackend()).toEqual({
+      backendId: "tab-backend",
+      orgId: "org-1",
+    });
+  });
+
+  it("falls back to the global active selection for new tabs", () => {
+    window.localStorage.setItem(
+      ACTIVE_BACKEND_STORAGE_KEY,
+      JSON.stringify({ backendId: "global-backend", orgId: null }),
+    );
+
+    expect(readStoredActiveBackend()).toEqual({
+      backendId: "global-backend",
+      orgId: null,
+    });
+  });
+
   it("clears storage when active selection is set to null", () => {
     writeStoredActiveBackend({ backendId: "xyz", orgId: "o" });
     writeStoredActiveBackend(null);
 
+    expect(
+      window.sessionStorage.getItem(ACTIVE_BACKEND_STORAGE_KEY),
+    ).toBeNull();
     expect(window.localStorage.getItem(ACTIVE_BACKEND_STORAGE_KEY)).toBeNull();
     expect(readStoredActiveBackend()).toBeNull();
   });

--- a/src/api/backend-registry/storage.ts
+++ b/src/api/backend-registry/storage.ts
@@ -175,11 +175,10 @@ export function readStoredBackends(): Backend[] {
   }
 }
 
-export function readStoredActiveBackend(): BackendSelection | null {
-  if (typeof window === "undefined") return null;
+function parseBackendSelection(raw: string | null): BackendSelection | null {
+  if (!raw) return null;
+
   try {
-    const raw = window.localStorage.getItem(ACTIVE_BACKEND_STORAGE_KEY);
-    if (!raw) return null;
     const parsed = JSON.parse(raw);
     if (
       typeof parsed !== "object" ||
@@ -199,23 +198,74 @@ export function readStoredActiveBackend(): BackendSelection | null {
   }
 }
 
+function readStorageItem(
+  storage: Storage | undefined,
+  key: string,
+): string | null {
+  try {
+    return storage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorageItem(
+  storage: Storage | undefined,
+  key: string,
+  value: string,
+): void {
+  try {
+    storage?.setItem(key, value);
+  } catch {
+    /* ignore */
+  }
+}
+
+function removeStorageItem(storage: Storage | undefined, key: string): void {
+  try {
+    storage?.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function readStoredActiveBackend(): BackendSelection | null {
+  if (typeof window === "undefined") return null;
+
+  // Active backend is tab-scoped so reloading tab A does not adopt tab B's
+  // backend. localStorage remains a last-used fallback for fresh tabs and old
+  // persisted state.
+  const sessionSelection = parseBackendSelection(
+    readStorageItem(window.sessionStorage, ACTIVE_BACKEND_STORAGE_KEY),
+  );
+  if (sessionSelection) return sessionSelection;
+
+  return parseBackendSelection(
+    readStorageItem(window.localStorage, ACTIVE_BACKEND_STORAGE_KEY),
+  );
+}
+
 export function writeStoredActiveBackend(
   selection: BackendSelection | null,
 ): void {
   if (typeof window === "undefined") return;
-  try {
-    if (!selection) {
-      window.localStorage.removeItem(ACTIVE_BACKEND_STORAGE_KEY);
-      return;
-    }
-    window.localStorage.setItem(
-      ACTIVE_BACKEND_STORAGE_KEY,
-      JSON.stringify({
-        backendId: selection.backendId,
-        orgId: selection.orgId ?? null,
-      }),
-    );
-  } catch {
-    /* ignore */
+
+  if (!selection) {
+    removeStorageItem(window.sessionStorage, ACTIVE_BACKEND_STORAGE_KEY);
+    removeStorageItem(window.localStorage, ACTIVE_BACKEND_STORAGE_KEY);
+    return;
   }
+
+  const serialized = JSON.stringify({
+    backendId: selection.backendId,
+    orgId: selection.orgId ?? null,
+  });
+  // Mirror to localStorage only as the default for new tabs/backward
+  // compatibility; reads in existing tabs prefer sessionStorage.
+  writeStorageItem(
+    window.sessionStorage,
+    ACTIVE_BACKEND_STORAGE_KEY,
+    serialized,
+  );
+  writeStorageItem(window.localStorage, ACTIVE_BACKEND_STORAGE_KEY, serialized);
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -112,6 +112,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   server.resetHandlers();
+  window.sessionStorage?.removeItem("openhands-active-backend");
   // Cleanup the document body after each test
   cleanup();
   // Drain any queued microtasks before jsdom is torn down between test files.


### PR DESCRIPTION
## Summary

Fix the active backend selection persistence so each browser tab keeps its own selected backend across reloads.

## Root Cause

The active backend selection was read from and written to a single `localStorage` key. When two tabs selected different backends, the later tab overwrote the shared key. Refreshing the earlier tab then restored the other tab's backend and attempted to load the conversation against the wrong backend.

## Changes

- Read active backend selection from `sessionStorage` first so existing tabs preserve their own backend on reload.
- Continue mirroring active selection to `localStorage` as a last-used fallback for newly opened tabs and existing persisted state.
- Keep the backend registry list shared in `localStorage`.
- Add focused tests for tab-scoped precedence, global fallback, and cleanup.

## Validation

- `npm test -- --run __tests__/api/backend-registry/storage.test.ts __tests__/api/backend-registry/active-store.test.ts`
- `npm test -- --run __tests__/components/backends/backend-selector.test.tsx __tests__/components/backends/add-backend-modal.test.tsx __tests__/components/backends/manage-backends-modal.test.tsx`
- `npm run typecheck`
- `npm run build`

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.26.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `1f24fb52d1569c092d45d982ca237188dc5fb565` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-1f24fb5
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-1f24fb5
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-1f24fb5-amd64
ghcr.io/openhands/agent-canvas:codex-tab-scoped-active-backend-amd64
ghcr.io/openhands/agent-canvas:pr-1217-amd64
ghcr.io/openhands/agent-canvas:sha-1f24fb5-arm64
ghcr.io/openhands/agent-canvas:codex-tab-scoped-active-backend-arm64
ghcr.io/openhands/agent-canvas:pr-1217-arm64
ghcr.io/openhands/agent-canvas:sha-1f24fb5
ghcr.io/openhands/agent-canvas:codex-tab-scoped-active-backend
ghcr.io/openhands/agent-canvas:pr-1217
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-1f24fb5`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-1f24fb5-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->