### PR TITLE
fix(acp): single Save + auth banner + one toast on Settings → Agent

### DIFF
--- a/__tests__/components/settings/acp-credentials-section.test.tsx
+++ b/__tests__/components/settings/acp-credentials-section.test.tsx
@@ -1,30 +1,32 @@
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  __resetActiveStoreForTests,
-  setActiveSelection,
-  setRegisteredBackends,
-} from "#/api/backend-registry/active-store";
+import { __resetActiveStoreForTests } from "#/api/backend-registry/active-store";
 import { ActiveBackendProvider } from "#/contexts/active-backend-context";
 import { AcpCredentialsSection } from "#/components/features/settings/acp-credentials-section";
+import { useAcpCredentialForm } from "#/hooks/use-acp-credential-form";
 import { SecretsService } from "#/api/secrets-service";
 
-// Observe the save outcome (success vs orphaned-credential warning) without
-// rendering real toasts.
-const toastMocks = vi.hoisted(() => ({
-  success: vi.fn(),
-  warning: vi.fn(),
-  error: vi.fn(),
+// The login-detection probe is exercised in its own hook test; here we stub it
+// so rendering the section doesn't spin a subprocess and we can drive the auth
+// banner states directly.
+const acpAuthStatusMock = vi.hoisted(() => vi.fn());
+vi.mock("#/hooks/query/use-acp-auth-status", () => ({
+  useAcpAuthStatus: (...args: unknown[]) => acpAuthStatusMock(...args),
 }));
-vi.mock("#/utils/custom-toast-handlers", () => ({
-  displaySuccessToast: toastMocks.success,
-  displayWarningToast: toastMocks.warning,
-  displayErrorToast: toastMocks.error,
-}));
+
+// The section is presentational: the form lives in the parent (Settings →
+// Agent) so a single Save persists the agent spec + credentials together. These
+// tests drive the section through the real form hook to cover field rendering,
+// conflict warnings, and the auth banner; the save flow is covered in
+// __tests__/routes/agent-settings.test.tsx.
+function Harness({ providerKey }: { providerKey: string }) {
+  const form = useAcpCredentialForm(providerKey);
+  return <AcpCredentialsSection form={form} providerKey={providerKey} />;
+}
 
 function renderSection(providerKey: string) {
   const user = userEvent.setup();
@@ -35,34 +37,22 @@ function renderSection(providerKey: string) {
       }
     >
       <ActiveBackendProvider>
-        <AcpCredentialsSection providerKey={providerKey} />
+        <Harness providerKey={providerKey} />
       </ActiveBackendProvider>
     </QueryClientProvider>,
   );
   return { user };
 }
 
-function useCloudBackend() {
-  setRegisteredBackends([
-    {
-      id: "cloud-1",
-      name: "Cloud",
-      host: "https://app.example.dev",
-      apiKey: "key",
-      kind: "cloud",
-    },
-  ]);
-  setActiveSelection({ backendId: "cloud-1", orgId: null });
-}
-
 beforeEach(() => {
   vi.restoreAllMocks();
-  toastMocks.success.mockClear();
-  toastMocks.warning.mockClear();
-  toastMocks.error.mockClear();
   __resetActiveStoreForTests();
+  acpAuthStatusMock.mockReturnValue({
+    status: "unknown",
+    isChecking: false,
+    isSupported: true,
+  });
   vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([]);
-  vi.spyOn(SecretsService, "createSecret").mockResolvedValue();
 });
 afterEach(() => {
   __resetActiveStoreForTests();
@@ -72,46 +62,19 @@ describe("AcpCredentialsSection", () => {
   it("renders the provider's credential fields (blob as textarea, key as password)", () => {
     renderSection("codex");
 
-    const blob = screen.getByTestId("settings-acp-secret-CODEX_AUTH_JSON");
-    expect(blob.tagName).toBe("TEXTAREA");
+    expect(
+      screen.getByTestId("settings-acp-secret-CODEX_AUTH_JSON").tagName,
+    ).toBe("TEXTAREA");
     expect(
       screen.getByTestId("settings-acp-secret-OPENAI_API_KEY"),
     ).toHaveAttribute("type", "password");
-    // Pristine form — nothing to save yet.
-    expect(screen.getByTestId("acp-credentials-save-button")).toBeDisabled();
   });
 
   it("renders nothing for a provider without credential fields", () => {
     renderSection("custom");
     expect(
-      screen.queryByTestId("acp-credentials-save-button"),
+      screen.queryByTestId("settings-acp-secret-CODEX_AUTH_JSON"),
     ).not.toBeInTheDocument();
-  });
-
-  it("saves the filled fields as secrets and resets the form", async () => {
-    const { user } = renderSection("claude-code");
-
-    await user.type(
-      screen.getByTestId("settings-acp-secret-ANTHROPIC_API_KEY"),
-      "sk-ant-123",
-    );
-    await user.click(screen.getByTestId("acp-credentials-save-button"));
-
-    await waitFor(() => {
-      expect(SecretsService.createSecret).toHaveBeenCalledWith(
-        "ANTHROPIC_API_KEY",
-        "sk-ant-123",
-        undefined,
-      );
-      expect(toastMocks.success).toHaveBeenCalledTimes(1);
-    });
-    expect(
-      (
-        screen.getByTestId(
-          "settings-acp-secret-ANTHROPIC_API_KEY",
-        ) as HTMLInputElement
-      ).value,
-    ).toBe("");
   });
 
   it("warns when the Claude OAuth token and base URL are both set", async () => {
@@ -134,25 +97,48 @@ describe("AcpCredentialsSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("toasts success when a file credential is saved on a cloud backend (cloud materialises file secrets)", async () => {
-    // Cloud materialises file-content credentials from the encrypted secret
-    // store via agent_context.secrets at conversation start, so a saved blob is
-    // consumable — no orphaned-credential warning.
-    useCloudBackend();
-    const { user } = renderSection("codex");
-
-    await user.click(screen.getByTestId("settings-acp-secret-CODEX_AUTH_JSON"));
-    await user.paste('{"tokens":{}}');
-    await user.click(screen.getByTestId("acp-credentials-save-button"));
-
-    await waitFor(() => {
-      expect(SecretsService.createSecret).toHaveBeenCalledWith(
-        "CODEX_AUTH_JSON",
-        '{"tokens":{}}',
-        undefined,
-      );
-      expect(toastMocks.success).toHaveBeenCalled();
+  it("shows the 'already signed in' banner when the login probe detects a session", () => {
+    acpAuthStatusMock.mockReturnValue({
+      status: "authenticated",
+      isChecking: false,
+      isSupported: true,
     });
-    expect(toastMocks.warning).not.toHaveBeenCalled();
+    renderSection("claude-code");
+    expect(
+      screen.getByTestId("settings-acp-auth-detected"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("settings-acp-auth-checking"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the checking spinner while the login probe is in flight", () => {
+    acpAuthStatusMock.mockReturnValue({
+      status: "unknown",
+      isChecking: true,
+      isSupported: true,
+    });
+    renderSection("claude-code");
+    expect(
+      screen.getByTestId("settings-acp-auth-checking"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("settings-acp-auth-detected"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows no auth banner when there is no detected session", () => {
+    acpAuthStatusMock.mockReturnValue({
+      status: "unauthenticated",
+      isChecking: false,
+      isSupported: true,
+    });
+    renderSection("claude-code");
+    expect(
+      screen.queryByTestId("settings-acp-auth-detected"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("settings-acp-auth-checking"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/__tests__/routes/agent-settings.test.tsx
+++ b/__tests__/routes/agent-settings.test.tsx
@@ -5,8 +5,29 @@ import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AgentSettingsScreen from "#/routes/agent-settings";
 import SettingsService from "#/api/settings-service/settings-service.api";
+import { SecretsService } from "#/api/secrets-service";
 import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import { Settings } from "#/types/settings";
+
+// Stub the login-detection probe so the ACP credentials section doesn't spin a
+// subprocess; default to no detected session so existing tests are unaffected.
+const acpAuthStatusMock = vi.hoisted(() => vi.fn());
+vi.mock("#/hooks/query/use-acp-auth-status", () => ({
+  useAcpAuthStatus: (...args: unknown[]) => acpAuthStatusMock(...args),
+}));
+
+// Observe save toasts so we can assert the single Save shows one confirmation,
+// not one per persisted thing (agent spec + credentials).
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+}));
+vi.mock("#/utils/custom-toast-handlers", () => ({
+  displaySuccessToast: toastMocks.success,
+  displayErrorToast: toastMocks.error,
+  displayWarningToast: toastMocks.warning,
+}));
 
 function buildSettings(overrides: Partial<Settings> = {}): Settings {
   return {
@@ -37,6 +58,18 @@ describe("AgentSettingsScreen", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(SettingsService, "saveSettings").mockResolvedValue(true);
+    // The page owns the ACP credential form (single Save), so it reads/writes
+    // secrets even on non-ACP renders.
+    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([]);
+    vi.spyOn(SecretsService, "createSecret").mockResolvedValue();
+    acpAuthStatusMock.mockReturnValue({
+      status: "unknown",
+      isChecking: false,
+      isSupported: true,
+    });
+    toastMocks.success.mockClear();
+    toastMocks.error.mockClear();
+    toastMocks.warning.mockClear();
   });
 
   it("renders the agent type selector defaulting to OpenHands with sub-agents toggle", async () => {
@@ -265,7 +298,9 @@ describe("AgentSettingsScreen", () => {
     // a built-in provider's default.
     await user.click(screen.getByTestId("agent-preset-selector"));
     await user.click(
-      await screen.findByRole("option", { name: "SETTINGS$AGENT_PRESET_CUSTOM" }),
+      await screen.findByRole("option", {
+        name: "SETTINGS$AGENT_PRESET_CUSTOM",
+      }),
     );
     const commandInput = screen.getByTestId(
       "agent-command-input",
@@ -683,5 +718,120 @@ describe("AgentSettingsScreen", () => {
       "@some-future/amp-acp",
       "--new-flag",
     ]);
+  });
+
+  it("a single Save persists ACP credentials together with the agent spec", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        agent_settings: {
+          ...MOCK_DEFAULT_USER_SETTINGS.agent_settings,
+          agent_kind: "openhands",
+        },
+      }),
+    );
+    const saveSettings = vi.spyOn(SettingsService, "saveSettings");
+    const createSecret = vi.spyOn(SecretsService, "createSecret");
+
+    renderAgentSettingsScreen();
+    await screen.findByTestId("agent-settings-screen");
+
+    // Switch to ACP (Claude Code prefilled) and paste a credential — there is
+    // ONE Save button for the whole page; the credentials section has none.
+    await user.click(screen.getByTestId("agent-type-selector"));
+    await user.click(
+      await screen.findByRole("option", { name: "SETTINGS$AGENT_TYPE_ACP" }),
+    );
+    await user.type(
+      await screen.findByTestId("settings-acp-secret-ANTHROPIC_API_KEY"),
+      "sk-ant-xyz",
+    );
+    expect(
+      screen.queryByTestId("acp-credentials-save-button"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("agent-save-button"));
+
+    // One click persists both: the credential as a secret AND the agent spec.
+    await waitFor(() => {
+      expect(createSecret).toHaveBeenCalledWith(
+        "ANTHROPIC_API_KEY",
+        "sk-ant-xyz",
+        undefined,
+      );
+      expect(saveSettings).toHaveBeenCalledTimes(1);
+    });
+    const diff = (
+      saveSettings.mock.calls[0]?.[0] as {
+        agent_settings_diff?: Record<string, unknown>;
+      }
+    ).agent_settings_diff;
+    expect(diff?.agent_kind).toBe("acp");
+    expect(diff?.acp_server).toBe("claude-code");
+
+    // One click → one confirmation, even though it persisted both the spec and
+    // the credential (the credential save is silenced so it doesn't double up).
+    expect(toastMocks.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("a credentials-only change saves the secret without re-writing settings", async () => {
+    const user = userEvent.setup();
+    // Already on ACP, so loading introduces no settings change.
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        agent_settings: {
+          schema_version: 1,
+          agent_kind: "acp",
+          acp_server: "claude-code",
+          acp_command: ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+        },
+      }),
+    );
+    const saveSettings = vi.spyOn(SettingsService, "saveSettings");
+    const createSecret = vi.spyOn(SecretsService, "createSecret");
+
+    renderAgentSettingsScreen();
+    await screen.findByTestId("agent-settings-screen");
+
+    await user.type(
+      await screen.findByTestId("settings-acp-secret-ANTHROPIC_API_KEY"),
+      "sk-ant-only",
+    );
+    await user.click(screen.getByTestId("agent-save-button"));
+
+    await waitFor(() => {
+      expect(createSecret).toHaveBeenCalledWith(
+        "ANTHROPIC_API_KEY",
+        "sk-ant-only",
+        undefined,
+      );
+    });
+    // No spec change → no settings write (and no double toast).
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+
+  it("shows the 'already signed in' banner in the credentials section when authenticated", async () => {
+    acpAuthStatusMock.mockReturnValue({
+      status: "authenticated",
+      isChecking: false,
+      isSupported: true,
+    });
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        agent_settings: {
+          schema_version: 1,
+          agent_kind: "acp",
+          acp_server: "claude-code",
+          acp_command: ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+        },
+      }),
+    );
+
+    renderAgentSettingsScreen();
+    await screen.findByTestId("agent-settings-screen");
+
+    expect(
+      await screen.findByTestId("settings-acp-auth-detected"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
+++ b/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Check, Loader2 } from "lucide-react";
 import { BrandButton } from "#/components/features/settings/brand-button";
 import { AcpConflictWarnings } from "#/components/features/settings/acp-conflict-warnings";
+import { AcpAuthStatusBanner } from "#/components/features/settings/acp-auth-status-banner";
 import { AcpSecretField } from "#/components/features/settings/acp-secret-field";
 import { I18nKey } from "#/i18n/declaration";
 import { useAcpAuthStatus } from "#/hooks/query/use-acp-auth-status";
@@ -150,36 +150,12 @@ export function SetupAcpSecretsStep({
         )}
       </header>
 
-      {authStatus === "authenticated" ? (
-        <div
-          data-testid="onboarding-acp-auth-detected"
-          // Matches the onboarding "backend connected" success banner
-          // (check-backend-step.tsx) for a consistent look.
-          className="flex items-start gap-2 rounded-xl border border-green-500/40 bg-green-500/10 px-4 py-3 text-sm text-green-200"
-        >
-          <Check
-            className="mt-0.5 size-4 shrink-0 text-green-400"
-            aria-hidden
-          />
-          <span>
-            {t(I18nKey.ONBOARDING$ACP_AUTH_DETECTED, {
-              provider: providerName,
-            })}
-          </span>
-        </div>
-      ) : isCheckingAuth ? (
-        <div
-          data-testid="onboarding-acp-auth-checking"
-          className="flex items-center gap-2 text-sm text-[var(--oh-muted)]"
-        >
-          <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
-          <span>
-            {t(I18nKey.ONBOARDING$ACP_AUTH_CHECKING, {
-              provider: providerName,
-            })}
-          </span>
-        </div>
-      ) : null}
+      <AcpAuthStatusBanner
+        status={authStatus}
+        isChecking={isCheckingAuth}
+        providerName={providerName}
+        testIdPrefix="onboarding-acp-auth"
+      />
 
       <div className="flex flex-col gap-5">
         {fields.map((field) => (

--- a/src/components/features/settings/acp-auth-status-banner.tsx
+++ b/src/components/features/settings/acp-auth-status-banner.tsx
@@ -1,0 +1,63 @@
+import { Check, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { I18nKey } from "#/i18n/declaration";
+import type { AcpAuthStatus } from "#/hooks/query/use-acp-auth-status";
+
+interface AcpAuthStatusBannerProps {
+  status: AcpAuthStatus;
+  isChecking: boolean;
+  providerName: string;
+  /**
+   * Prefix for the banner test ids, e.g. ``"onboarding-acp-auth"`` →
+   * ``onboarding-acp-auth-detected`` / ``onboarding-acp-auth-checking``.
+   */
+  testIdPrefix: string;
+}
+
+/**
+ * Auth-status banner shared by the ACP credential forms (the onboarding step
+ * and Settings → Agent): a green "already signed in" banner when the local
+ * login probe detects a session, or a spinner while it's checking. Renders
+ * nothing otherwise (unauthenticated / unknown / non-local backend), so the
+ * caller falls back to the API-key fields.
+ */
+export function AcpAuthStatusBanner({
+  status,
+  isChecking,
+  providerName,
+  testIdPrefix,
+}: AcpAuthStatusBannerProps) {
+  const { t } = useTranslation("openhands");
+
+  if (status === "authenticated") {
+    return (
+      <div
+        data-testid={`${testIdPrefix}-detected`}
+        // Matches the onboarding "backend connected" success banner
+        // (check-backend-step.tsx) for a consistent look.
+        className="flex items-start gap-2 rounded-xl border border-green-500/40 bg-green-500/10 px-4 py-3 text-sm text-green-200"
+      >
+        <Check className="mt-0.5 size-4 shrink-0 text-green-400" aria-hidden />
+        <span>
+          {t(I18nKey.ONBOARDING$ACP_AUTH_DETECTED, { provider: providerName })}
+        </span>
+      </div>
+    );
+  }
+
+  if (isChecking) {
+    return (
+      <div
+        data-testid={`${testIdPrefix}-checking`}
+        className="flex items-center gap-2 text-sm text-[var(--oh-muted)]"
+      >
+        <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
+        <span>
+          {t(I18nKey.ONBOARDING$ACP_AUTH_CHECKING, { provider: providerName })}
+        </span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/features/settings/acp-credentials-section.tsx
+++ b/src/components/features/settings/acp-credentials-section.tsx
@@ -1,43 +1,34 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { AcpConflictWarnings } from "#/components/features/settings/acp-conflict-warnings";
+import { AcpAuthStatusBanner } from "#/components/features/settings/acp-auth-status-banner";
 import { AcpSecretField } from "#/components/features/settings/acp-secret-field";
-import { BrandButton } from "#/components/features/settings/brand-button";
 import { Typography } from "#/ui/typography";
 import { I18nKey } from "#/i18n/declaration";
-import { useAcpCredentialForm } from "#/hooks/use-acp-credential-form";
+import { useAcpAuthStatus } from "#/hooks/query/use-acp-auth-status";
+import { getAcpProviderDisplayName } from "#/constants/acp-providers";
+import type { AcpCredentialForm } from "#/hooks/use-acp-credential-form";
 
 /**
- * Settings → Agent credentials section for a built-in ACP provider: the same
- * fields the onboarding step collects, saved through the same flow
- * ({@link useAcpCredentialForm}), so credentials can be added or rotated after
- * onboarding. Renders nothing for providers without credential fields.
+ * Settings → Agent credentials section for a built-in ACP provider: renders the
+ * same fields the onboarding step collects (and the same "already signed in"
+ * auth banner), so credentials can be added or rotated after onboarding. The
+ * form state and the save are owned by the parent (Settings → Agent) so the
+ * page has a single Save button for both agent settings and credentials.
+ * Renders nothing for providers without credential fields.
  */
 export function AcpCredentialsSection({
+  form,
   providerKey,
 }: {
+  form: AcpCredentialForm;
   providerKey: string;
 }) {
   const { t } = useTranslation("openhands");
-  const {
-    fields,
-    values,
-    setValue,
-    secretExists,
-    conflicts,
-    isDirty,
-    save,
-    reset,
-    isSaving,
-  } = useAcpCredentialForm(providerKey);
+  const { fields, values, setValue, secretExists, conflicts } = form;
+  const { status: authStatus, isChecking } = useAcpAuthStatus(providerKey);
+  const providerName = getAcpProviderDisplayName(providerKey) ?? providerKey;
 
   if (fields.length === 0) return null;
-
-  const handleSave = async () => {
-    if (await save()) {
-      reset();
-    }
-  };
 
   return (
     <div className="flex flex-col gap-4">
@@ -49,6 +40,13 @@ export function AcpCredentialsSection({
           {t(I18nKey.SETTINGS$ACP_CREDENTIALS_DESCRIPTION)}
         </Typography.Text>
       </div>
+
+      <AcpAuthStatusBanner
+        status={authStatus}
+        isChecking={isChecking}
+        providerName={providerName}
+        testIdPrefix="settings-acp-auth"
+      />
 
       <div className="flex flex-col gap-5">
         {fields.map((field) => (
@@ -65,18 +63,6 @@ export function AcpCredentialsSection({
       </div>
 
       <AcpConflictWarnings conflicts={conflicts} />
-
-      <BrandButton
-        testId="acp-credentials-save-button"
-        type="button"
-        variant="primary"
-        isDisabled={isSaving || !isDirty}
-        onClick={handleSave}
-      >
-        {isSaving
-          ? t(I18nKey.SETTINGS$SAVING)
-          : t(I18nKey.SETTINGS$SAVE_CHANGES)}
-      </BrandButton>
     </div>
   );
 }

--- a/src/hooks/use-acp-credential-form.ts
+++ b/src/hooks/use-acp-credential-form.ts
@@ -25,8 +25,10 @@ export interface AcpCredentialForm {
   consumesFileCredentials: boolean;
   /** At least one field has a non-blank typed value. */
   isDirty: boolean;
-  /** Persist the filled fields; resolves ``true`` when everything saved. */
-  save: () => Promise<boolean>;
+  /** Persist the filled fields; resolves ``true`` when everything saved.
+   * ``silent`` suppresses the success toast so a caller saving credentials
+   * alongside other state can emit a single combined confirmation. */
+  save: (options?: { silent?: boolean }) => Promise<boolean>;
   reset: () => void;
   isSaving: boolean;
 }
@@ -92,7 +94,7 @@ export function useAcpCredentialForm(
     conflicts: getAcpCredentialConflicts(providerKey, hasValueFor),
     consumesFileCredentials,
     isDirty: fields.some((field) => Boolean(values[field.name]?.trim())),
-    save: () => saveFilled(values),
+    save: (options) => saveFilled(values, options),
     reset,
     isSaving,
   };

--- a/src/hooks/use-save-acp-secrets.ts
+++ b/src/hooks/use-save-acp-secrets.ts
@@ -39,7 +39,14 @@ export function useSaveAcpSecrets(
   const { mutateAsync: createSecret } = useCreateSecret();
   const [isSaving, setIsSaving] = React.useState(false);
 
-  const saveFilled = async (values: Record<string, string>) => {
+  // ``silent`` suppresses the success/warning toast (not errors) so a caller
+  // that persists credentials alongside something else — the Settings → Agent
+  // single Save, which also writes the agent spec — can emit one combined
+  // "Saved" instead of two. The standalone onboarding caller leaves it off.
+  const saveFilled = async (
+    values: Record<string, string>,
+    { silent = false }: { silent?: boolean } = {},
+  ) => {
     const toSave = fields
       .map((field) => ({ field, value: values[field.name]?.trim() }))
       .filter(
@@ -62,7 +69,7 @@ export function useSaveAcpSecrets(
         !consumesFileCredentials && toSave.some(({ field }) => field.multiline);
       if (savedOrphanedFileCredential) {
         displayWarningToast(t(I18nKey.ONBOARDING$ACP_SECRETS_ORPHANED_WARNING));
-      } else {
+      } else if (!silent) {
         displaySuccessToast(t(I18nKey.SETTINGS$SAVED));
       }
       return true;

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -8,6 +8,7 @@ import { SettingsDropdownInput } from "#/components/features/settings/settings-d
 import { SettingsInput } from "#/components/features/settings/settings-input";
 import { SettingsSwitch } from "#/components/features/settings/settings-switch";
 import { AcpCredentialsSection } from "#/components/features/settings/acp-credentials-section";
+import { useAcpCredentialForm } from "#/hooks/use-acp-credential-form";
 import { BrandButton } from "#/components/features/settings/brand-button";
 import { Typography } from "#/ui/typography";
 import { I18nKey } from "#/i18n/declaration";
@@ -116,6 +117,19 @@ function AgentSettingsScreen() {
   const [isCustomAcpModel, setIsCustomAcpModel] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
 
+  // ACP credentials live alongside the agent spec, so the page owns the
+  // credential form and a single Save persists both. Called unconditionally
+  // (no-ops to empty fields for a non-ACP / custom command) to keep hook order
+  // stable across the ``isLoading`` early-return below; ``detectPreset`` is a
+  // cheap pure lookup.
+  const acpPresetForCreds =
+    agentType === "acp" ? detectPreset(commandText, ACP_PROVIDERS) : null;
+  const acpCredentialForm = useAcpCredentialForm(
+    acpPresetForCreds && acpPresetForCreds !== ACP_CUSTOM_PRESET_KEY
+      ? acpPresetForCreds
+      : null,
+  );
+
   const lastInitializedSettingsRef = useRef<unknown>(null);
   const loadedAcpServerRef = useRef<string | null>(null);
   const loadedCommandTextRef = useRef<string>("");
@@ -199,9 +213,29 @@ function AgentSettingsScreen() {
   // Dirty tracking: for OpenHands path, also check sub-agents toggle
   const isOpenHandsDirty =
     !isAcp && subAgentsEnabled !== initialSubAgentsEnabled;
-  const effectiveIsDirty = isDirty || isOpenHandsDirty;
+  const settingsDirty = isDirty || isOpenHandsDirty;
+  // The single Save covers both the agent spec and ACP credentials, so it is
+  // active when either changed, and shows "Saving…" while either is in flight.
+  const credentialsDirty = isAcp && acpCredentialForm.isDirty;
+  const isAnyDirty = settingsDirty || credentialsDirty;
+  const isSavingAny = isSaving || acpCredentialForm.isSaving;
 
-  const handleSave = () => {
+  const handleSave = async () => {
+    // Persist ACP credentials first (if any were typed) so they exist when the
+    // agent spec is applied. When the spec is also changing, save silently so
+    // the settings save below owns the single "Saved" toast (otherwise the user
+    // sees it twice); a credentials-only save shows its own toast. Errors always
+    // toast and abort.
+    if (isAcp && acpCredentialForm.isDirty) {
+      const ok = await acpCredentialForm.save({ silent: settingsDirty });
+      if (!ok) return;
+      acpCredentialForm.reset();
+    }
+
+    // Only write the agent spec when it actually changed — a credentials-only
+    // edit must not re-push unchanged settings (or double-toast).
+    if (!settingsDirty) return;
+
     if (isAcp) {
       const useDefault = !!(selectedProvider && isDefaultProviderCommand);
       const loadedServer = loadedAcpServerRef.current;
@@ -479,7 +513,10 @@ function AgentSettingsScreen() {
       {isAcp && selectedPreset !== ACP_CUSTOM_PRESET_KEY && (
         <>
           <hr className="border-[#3D4046]" />
-          <AcpCredentialsSection providerKey={selectedPreset} />
+          <AcpCredentialsSection
+            form={acpCredentialForm}
+            providerKey={selectedPreset}
+          />
         </>
       )}
 
@@ -488,10 +525,10 @@ function AgentSettingsScreen() {
           testId="agent-save-button"
           type="button"
           variant="primary"
-          isDisabled={isSaving || !effectiveIsDirty || isAcpInvalid}
+          isDisabled={isSavingAny || !isAnyDirty || isAcpInvalid}
           onClick={handleSave}
         >
-          {isSaving
+          {isSavingAny
             ? t(I18nKey.SETTINGS$SAVING)
             : t(I18nKey.SETTINGS$SAVE_CHANGES)}
         </BrandButton>

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -216,7 +216,9 @@ function AgentSettingsScreen() {
   const settingsDirty = isDirty || isOpenHandsDirty;
   // The single Save covers both the agent spec and ACP credentials, so it is
   // active when either changed, and shows "Saving…" while either is in flight.
-  const credentialsDirty = isAcp && acpCredentialForm.isDirty;
+  // ``isDirty`` is already false off the ACP path (no credential fields), so no
+  // ``isAcp`` guard is needed.
+  const credentialsDirty = acpCredentialForm.isDirty;
   const isAnyDirty = settingsDirty || credentialsDirty;
   const isSavingAny = isSaving || acpCredentialForm.isSaving;
 
@@ -226,7 +228,7 @@ function AgentSettingsScreen() {
     // the settings save below owns the single "Saved" toast (otherwise the user
     // sees it twice); a credentials-only save shows its own toast. Errors always
     // toast and abort.
-    if (isAcp && acpCredentialForm.isDirty) {
+    if (acpCredentialForm.isDirty) {
       const ok = await acpCredentialForm.save({ silent: settingsDirty });
       if (!ok) return;
       acpCredentialForm.reset();


### PR DESCRIPTION
## Why

Three UX papercuts on **Settings → Agent** for ACP agents, found while validating the merged #1102:

1. **"Save Changes" appeared twice** — the credentials section had its own save button right above the page-level one (two identical labels doing different things: secrets vs the agent spec).
2. **No "already signed in" banner** in the credentials section, even though onboarding shows one — so there's no signal that a host login is detected.
3. **"Settings saved" toasted twice** on a single click when both the spec and a credential changed.

## Summary

- **Single Save.** Consolidate to one page-level Save that persists **both** the agent spec and the ACP credentials. `AcpCredentialsSection` becomes presentational; the page owns the credential form (lifted `useAcpCredentialForm` above the loading early-return). A credentials-only edit saves just the secret and skips a redundant settings write.
- **Shared auth banner.** New `AcpAuthStatusBanner` renders the "already signed in to {provider}" success banner (and a checking spinner); onboarding now uses it too, and the credentials section gains it. Driven by the local-backend login probe — silent on cloud/unknown, same as onboarding.
- **One toast.** When a single Save persists both spec + credential, the credential save is silenced so exactly one "Saved" shows (errors still surface).

## How to test

1. Settings → Agent → pick an ACP provider (Codex / Claude Code).
2. There's now a **single** "Save Changes". Change the model **and** paste a credential → one click saves both, **one** toast.
3. Paste only a credential → Save persists just the secret (no settings re-write).
4. On a local backend where you're logged into the provider, the credentials section shows the green **"already signed in"** banner (matches onboarding).

Typecheck + lint green; **50 tests** across `agent-settings` / `acp-credentials-section` / `setup-acp-secrets-step` pass, including new coverage for the single-save flow, the auth-banner states, and the single-toast assertion.

Follow-up to #1102. Part of #988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.26.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `3bb211770f8f8bf40ec1066d51bdc00db02f76f0` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-3bb2117
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-3bb2117
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-3bb2117-amd64
ghcr.io/openhands/agent-canvas:acp-settings-save-ux-amd64
ghcr.io/openhands/agent-canvas:pr-1251-amd64
ghcr.io/openhands/agent-canvas:sha-3bb2117-arm64
ghcr.io/openhands/agent-canvas:acp-settings-save-ux-arm64
ghcr.io/openhands/agent-canvas:pr-1251-arm64
ghcr.io/openhands/agent-canvas:sha-3bb2117
ghcr.io/openhands/agent-canvas:acp-settings-save-ux
ghcr.io/openhands/agent-canvas:pr-1251
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-3bb2117`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-3bb2117-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->