### PR TITLE
fix: raise contrast of loading/status text on the Change/Diffs tab

### DIFF
--- a/__tests__/components/features/conversation/conversation-loading.test.tsx
+++ b/__tests__/components/features/conversation/conversation-loading.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ConversationLoading } from "#/components/features/conversation/conversation-loading";
+
+// react-i18next is mocked globally in vitest.setup.ts (t returns the key), so
+// the rendered text is the I18nKey itself (HOME$LOADING).
+describe("ConversationLoading", () => {
+  it("renders the loading message", () => {
+    // Arrange & Act
+    render(<ConversationLoading />);
+
+    // Assert — the loading status text is surfaced to the user
+    expect(screen.getByText("HOME$LOADING")).toBeInTheDocument();
+  });
+});

--- a/__tests__/routes/changes-tab.test.tsx
+++ b/__tests__/routes/changes-tab.test.tsx
@@ -113,7 +113,7 @@ describe("Changes Tab", () => {
 
   it("should show the loading message while git changes are loading", () => {
     vi.mocked(useUnifiedGetGitChanges).mockReturnValue({
-      data: undefined,
+      data: [],
       isLoading: true,
       isFetching: true,
       isSuccess: false,

--- a/__tests__/routes/changes-tab.test.tsx
+++ b/__tests__/routes/changes-tab.test.tsx
@@ -110,4 +110,23 @@ describe("Changes Tab", () => {
       screen.getByText("DIFF_VIEWER$NOT_A_GIT_REPO"),
     ).toBeInTheDocument();
   });
+
+  it("should show the loading message while git changes are loading", () => {
+    vi.mocked(useUnifiedGetGitChanges).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isSuccess: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(useAgentState).mockReturnValue({
+      curAgentState: AgentState.RUNNING,
+    });
+
+    render(<GitChanges />, { wrapper });
+
+    expect(screen.getByText("DIFF_VIEWER$LOADING")).toBeInTheDocument();
+  });
 });

--- a/src/components/features/chat/waiting-for-runtime-message.tsx
+++ b/src/components/features/chat/waiting-for-runtime-message.tsx
@@ -16,7 +16,7 @@ export function WaitingForRuntimeMessage({
     <div
       data-testid={testId}
       className={cn(
-        "w-full h-full flex items-center text-center justify-center text-2xl text-tertiary-light",
+        "w-full h-full flex items-center text-center justify-center text-2xl text-foreground",
         className,
       )}
     >

--- a/src/components/features/conversation/conversation-loading.tsx
+++ b/src/components/features/conversation/conversation-loading.tsx
@@ -18,10 +18,10 @@ export function ConversationLoading({ className }: ConversationLoadingProps) {
       )}
     >
       <LoaderCircle
-        className="h-8 w-8 shrink-0 animate-spin text-[var(--oh-text-secondary)]"
+        className="h-8 w-8 shrink-0 animate-spin text-foreground"
         aria-hidden
       />
-      <span className="text-base font-normal leading-5 text-[var(--oh-text-secondary)]">
+      <span className="text-base font-normal leading-5 text-foreground">
         {t(I18nKey.HOME$LOADING)}
       </span>
     </div>

--- a/src/routes/changes-tab.tsx
+++ b/src/routes/changes-tab.tsx
@@ -14,7 +14,7 @@ const GIT_REPO_ERROR_PATTERN = /not a git repository/i;
 
 function StatusMessage({ children }: React.PropsWithChildren) {
   return (
-    <div className="w-full h-full flex flex-col items-center text-center justify-center text-2xl text-tertiary-light">
+    <div className="w-full h-full flex flex-col items-center text-center justify-center text-2xl text-foreground">
       {children}
     </div>
   );


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

<img width="1440" height="794" alt="app-2214-issue" src="https://github.com/user-attachments/assets/49e1b3da-40b7-45f1-92e6-0dae57d846b4" />

While a conversation is initializing, the right-hand workspace panel hides its tab body and shows a full-panel loading screen. On the **Change/Diffs** (Files → diff) tab the user sees a spinner and "Loading…" rendered in a muted grey that is very hard to read against the dark-grey panel background — dark-on-dark, poor contrast.

### Steps to reproduce

1. `npm run dev`
2. Go to the home page and create a new conversation.
3. On the conversation page, while it is initializing ("Starting" / "Connecting"), watch the loading state on the **Change/Diffs** tab.
4. Observe the "Loading…" spinner and text are barely legible (low-contrast muted grey on dark grey).

### Current behavior

The loading / status screens paint their spinner and text with the **secondary / muted** grey token (`--oh-text-secondary` and `text-tertiary-light`, both resolving to `--cool-grey-300`), which is too low-contrast for a primary loading message on the dark panel.

### Expected behavior

Loading and status text maintain sufficient contrast to stay readable in all states, including the loading/initialization state.

### Root cause

This is **not** an unresolved-CSS-variable problem — `body` and the whole app carry `data-agent-server-ui`, the scope variables resolve, and the inherited default is actually the brighter `text-foreground`. The components simply chose the muted secondary token. During init, `agent-status.tsx` sets `shouldShownAgentLoading = true`, so `ConversationTabContent` renders `ConversationLoading` (the component in the screenshot) inside the `--oh-surface` panel, and its muted text is the low-contrast result. Two sibling status screens (`changes-tab.tsx`'s `StatusMessage`, `waiting-for-runtime-message.tsx`) share the same muted token.

### Proposed fix

Swap the muted token for the primary foreground token `text-foreground` (`--oh-foreground` = `--cool-grey-100`) — the app's standard body-text color, already the inherited default on the `AgentServerUIRoot` content wrapper (~12:1 contrast). Apply to all three status screens.

### Acceptance criteria

- [ ] "Loading…" spinner + text on the Change/Diffs tab are clearly readable during conversation init.
- [ ] "Loading changes…", error, and not-a-git-repo messages on the diff tab are readable.
- [ ] The waiting-for-runtime message is readable.
- [ ] Functional tests cover the loading/status states (no CSS/style assertions).

## Summary

<!-- 1-3 bullets describing what changed. -->
While a conversation is initializing, the Change/Diffs tab's loading screen rendered its spinner and "Loading…" text in a muted grey that was nearly illegible on the dark panel background. This PR makes that text (and the two sibling status screens) use the primary foreground color so it stays readable.

### Root cause

Not a broken CSS variable. The app scope resolves correctly and the inherited default is the brighter `text-foreground`; the loading/status components just opted into the **secondary/muted** token instead:

- During init `agent-status.tsx` sets `shouldShownAgentLoading = true`, so `ConversationTabContent` renders `ConversationLoading` inside the `--oh-surface` panel.
- `ConversationLoading` painted its spinner + text with `text-[var(--oh-text-secondary)]` → `--cool-grey-300` — muted grey on dark grey.
- `changes-tab.tsx`'s `StatusMessage` and `waiting-for-runtime-message.tsx` use the equivalent `text-tertiary-light` (also `--cool-grey-300`).

### Changes

Token swap only — no logic changes, no new design tokens (`text-foreground` already exists via `@theme inline` and is used across the app):

| File                                                            | Change                                        |
| --------------------------------------------------------------- | --------------------------------------------- |
| `src/components/features/conversation/conversation-loading.tsx` | spinner + "Loading…" text → `text-foreground` |
| `src/routes/changes-tab.tsx`                                    | `StatusMessage` → `text-foreground`           |
| `src/components/features/chat/waiting-for-runtime-message.tsx`  | status text → `text-foreground`               |

In `ConversationLoading` both the spinner and the text are brightened together so the loading screen reads as one coherent, high-contrast unit.

### Testing

Functional tests only (no CSS/style assertions), per the team's testing rules:

- New `conversation-loading.test.tsx` — asserts the real `ConversationLoading` renders the loading message (the existing `conversation-tab-content.test.tsx` mocks the component out, so it can't cover it).
- Extend `changes-tab.test.tsx` — loading-state case asserting `DIFF_VIEWER$LOADING` renders.
- `waiting-for-runtime` rendering already covered by `vscode-tab.test.tsx`.

Run: `npm test`

### Manual verification

`npm run dev` → create a conversation. During "Starting/Connecting" the right panel's "Loading…" spinner + text are clearly readable on the dark panel. On the Change/Diffs view, "Loading changes…" and the waiting-for-runtime message are likewise readable.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/agent-canvas/issues/1195

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm run dev`
2. Go to the home page and create a new conversation.
3. On the conversation page, while it is initializing ("Starting" / "Connecting"), watch the loading state on the **Change/Diffs** tab.
4. Observe the "Loading…" spinner and text are barely legible (low-contrast muted grey on dark grey).

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="794" alt="app-2214-output" src="https://github.com/user-attachments/assets/154abdb5-4069-493b-b7ff-d670f55bbe39" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.26.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `5fbe86a8d484cb89c9b409e78bbaaba579bc35b8` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-5fbe86a
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-5fbe86a
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-5fbe86a-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2214-amd64
ghcr.io/openhands/agent-canvas:pr-1253-amd64
ghcr.io/openhands/agent-canvas:sha-5fbe86a-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2214-arm64
ghcr.io/openhands/agent-canvas:pr-1253-arm64
ghcr.io/openhands/agent-canvas:sha-5fbe86a
ghcr.io/openhands/agent-canvas:hieptl-app-2214
ghcr.io/openhands/agent-canvas:pr-1253
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-5fbe86a`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-5fbe86a-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->