### PR TITLE
fix: Changes tab uses correct workspace directory after repo switch (Fix #1193)

### DIFF
--- a/__tests__/components/features/chat/git-control-bar.test.tsx
+++ b/__tests__/components/features/chat/git-control-bar.test.tsx
@@ -176,6 +176,39 @@ describe("GitControlBar repo button visibility", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows the repo button on a local backend when localGitInfo detects a repository", () => {
+    vi.mocked(useActiveBackend).mockReturnValue(makeBackend("local"));
+    vi.mocked(useLocalGitInfo).mockReturnValue({
+      data: {
+        repository: "owner/repo",
+        branch: "main",
+        provider: "github",
+        remoteUrl: "https://github.com/owner/repo",
+      },
+    } as unknown as ReturnType<typeof useLocalGitInfo>);
+
+    renderWithProviders(<GitControlBar onSuggestionsClick={vi.fn()} />);
+
+    expect(screen.getByTestId("git-control-bar-repo-button")).toBeInTheDocument();
+  });
+
+  it("renders the repo button as NOT disabled on local backend when localGitInfo detects repo", () => {
+    vi.mocked(useActiveBackend).mockReturnValue(makeBackend("local"));
+    vi.mocked(useLocalGitInfo).mockReturnValue({
+      data: {
+        repository: "owner/repo",
+        branch: "main",
+        provider: "github",
+        remoteUrl: "https://github.com/owner/repo",
+      },
+    } as unknown as ReturnType<typeof useLocalGitInfo>);
+
+    renderWithProviders(<GitControlBar onSuggestionsClick={vi.fn()} />);
+
+    const button = screen.getByTestId("git-control-bar-repo-button");
+    expect(button).toHaveAttribute("data-disabled", "false");
+  });
+
   it("shows the repo button on a cloud backend with no repository connected", () => {
     vi.mocked(useActiveBackend).mockReturnValue(makeBackend("cloud"));
 

--- a/__tests__/utils/get-git-path.test.ts
+++ b/__tests__/utils/get-git-path.test.ts
@@ -34,16 +34,17 @@ describe("getGitPath", () => {
   });
 
   describe("with a backend-provided workspace path", () => {
-    // When a repo is selected, we compute the path from selectedRepository
-    // rather than trusting workingDir. This avoids stale workingDir issues
-    // during repo switches (where workingDir lags behind selectedRepository).
-    it("prefers selectedRepository over workingDir when both are present", () => {
+    it("prefers the explicit workspace path over derived git paths", () => {
+      // When a repo is selected, we still prefer the explicit workingDir
+      // because it comes from the backend and represents the actual runtime state.
+      // The fresh-fetch pattern in useUnifiedGetGitChanges ensures workingDir
+      // is not stale, so we can trust it.
       expect(
         getGitPath(
           "OpenHands/software-agent-sdk",
           "/workspace/project/agent-canvas",
         ),
-      ).toBe(`${DEFAULT_WORKING_DIR}/software-agent-sdk`);
+      ).toBe("/workspace/project/agent-canvas");
     });
 
     it("ignores blank workspace paths and falls back to repo-derived path", () => {

--- a/__tests__/utils/get-git-path.test.ts
+++ b/__tests__/utils/get-git-path.test.ts
@@ -34,18 +34,27 @@ describe("getGitPath", () => {
   });
 
   describe("with a backend-provided workspace path", () => {
-    it("prefers the explicit workspace path over derived git paths", () => {
+    // When a repo is selected, we compute the path from selectedRepository
+    // rather than trusting workingDir. This avoids stale workingDir issues
+    // during repo switches (where workingDir lags behind selectedRepository).
+    it("prefers selectedRepository over workingDir when both are present", () => {
       expect(
         getGitPath(
           "OpenHands/software-agent-sdk",
           "/workspace/project/agent-canvas",
         ),
-      ).toBe("/workspace/project/agent-canvas");
+      ).toBe(`${DEFAULT_WORKING_DIR}/software-agent-sdk`);
     });
 
-    it("ignores blank workspace paths and falls back to heuristics", () => {
+    it("ignores blank workspace paths and falls back to repo-derived path", () => {
       expect(getGitPath("OpenHands/software-agent-sdk", "  ")).toBe(
         `${DEFAULT_WORKING_DIR}/software-agent-sdk`,
+      );
+    });
+
+    it("uses workingDir only when no repository is selected", () => {
+      expect(getGitPath(null, "/workspace/project/agent-canvas")).toBe(
+        "/workspace/project/agent-canvas",
       );
     });
   });

--- a/src/components/features/chat/git-control-bar.tsx
+++ b/src/components/features/chat/git-control-bar.tsx
@@ -204,13 +204,14 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
   // Local backends never use the remote-repo "Connect Repo" CTA, so suppress the
   // empty-state button there. A repo or workspace label inferred from local git
   // metadata is still informational and stays visible.
+  const localGitDetectedRepo = !!localGitInfo?.repository;
   const showRepoButton =
-    !isLocalBackend || !!selectedRepository || !!workspaceName;
+    !isLocalBackend || !!selectedRepository || !!workspaceName || localGitDetectedRepo;
   // On a local backend the informational pill (e.g. workspace name, or a repo
   // detected without a recognized provider) should not open the remote-repo
   // modal — that flow is cloud-only. Disable the button in that case so the
   // click is a no-op. Linkable repos render as <a> and ignore `disabled`.
-  const isRepoButtonInert = isLocalBackend && !hasRepository;
+  const isRepoButtonInert = isLocalBackend && !hasRepository && !localGitDetectedRepo;
 
   // True when the bar will render at least one chip (cloud always shows
   // "Open Repository"; local needs a repo or a workspace name; selected

--- a/src/hooks/query/use-unified-get-git-changes.ts
+++ b/src/hooks/query/use-unified-get-git-changes.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import AgentServerGitService from "#/api/git-service/agent-server-git-service.api";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { useConversationId } from "#/hooks/use-conversation-id";
@@ -11,6 +11,7 @@ import type { GitChange } from "#/api/open-hands.types";
 export const useUnifiedGetGitChanges = () => {
   const { conversationId } = useConversationId();
   const { data: conversation } = useActiveConversation();
+  const queryClient = useQueryClient();
   const [orderedChanges, setOrderedChanges] = React.useState<GitChange[]>([]);
   const previousDataRef = React.useRef<GitChange[] | null>(null);
   const runtimeIsReady = useRuntimeIsReady();
@@ -39,6 +40,9 @@ export const useUnifiedGetGitChanges = () => {
       const freshWorkingDir = freshConversation?.workspace?.working_dir?.trim();
 
       const freshGitPath = getGitPath(freshSelectedRepository, freshWorkingDir);
+
+      // Invalidate localGitInfo to ensure repo bar updates after workspace change
+      queryClient.invalidateQueries({ queryKey: ["localGitInfo"] });
 
       return AgentServerGitService.getGitChanges(
         conversationUrl,

--- a/src/hooks/query/use-unified-get-git-changes.ts
+++ b/src/hooks/query/use-unified-get-git-changes.ts
@@ -3,39 +3,47 @@ import { useQuery } from "@tanstack/react-query";
 import AgentServerGitService from "#/api/git-service/agent-server-git-service.api";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { useConversationId } from "#/hooks/use-conversation-id";
+import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 import { getGitPath } from "#/utils/get-git-path";
 import type { GitChange } from "#/api/open-hands.types";
 
 export const useUnifiedGetGitChanges = () => {
   const { conversationId } = useConversationId();
+  const { data: conversation } = useActiveConversation();
   const [orderedChanges, setOrderedChanges] = React.useState<GitChange[]>([]);
   const previousDataRef = React.useRef<GitChange[] | null>(null);
   const runtimeIsReady = useRuntimeIsReady();
+
+  // Compute gitPath outside queryFn so it can be used in queryKey
+  const selectedRepository = conversation?.selected_repository;
+  const workingDir = conversation?.workspace?.working_dir?.trim();
+  const gitPath = getGitPath(selectedRepository, workingDir);
 
   const result = useQuery({
     queryKey: [
       "file_changes",
       conversationId,
+      gitPath,
     ],
     queryFn: async () => {
       if (!conversationId) throw new Error("No conversation ID");
 
       // Fetch fresh conversation data directly (like VSCode tab does) to avoid
       // stale cache issues where workspace.working_dir lags behind after repo switch
-      const [conversation] = await AgentServerConversationService.batchGetAppConversations([conversationId]);
+      const [freshConversation] = await AgentServerConversationService.batchGetAppConversations([conversationId]);
 
-      const conversationUrl = conversation?.conversation_url;
-      const sessionApiKey = conversation?.session_api_key;
-      const selectedRepository = conversation?.selected_repository;
-      const workingDir = conversation?.workspace?.working_dir?.trim();
+      const conversationUrl = freshConversation?.conversation_url;
+      const sessionApiKey = freshConversation?.session_api_key;
+      const freshSelectedRepository = freshConversation?.selected_repository;
+      const freshWorkingDir = freshConversation?.workspace?.working_dir?.trim();
 
-      const gitPath = getGitPath(selectedRepository, workingDir);
+      const freshGitPath = getGitPath(freshSelectedRepository, freshWorkingDir);
 
       return AgentServerGitService.getGitChanges(
         conversationUrl,
         sessionApiKey,
-        gitPath,
+        freshGitPath,
       );
     },
     retry: false,
@@ -47,6 +55,12 @@ export const useUnifiedGetGitChanges = () => {
       disableToast: true,
     },
   });
+
+  // Reset orderedChanges when gitPath changes (e.g., repo switch)
+  React.useEffect(() => {
+    setOrderedChanges([]);
+    previousDataRef.current = null;
+  }, [gitPath]);
 
   // Latest changes should be on top
   React.useEffect(() => {
@@ -80,7 +94,7 @@ export const useUnifiedGetGitChanges = () => {
         }
       }
     }
-  }, [result.isFetching, result.isSuccess, result.data]);
+  }, [result.isFetching, result.isSuccess, result.data, gitPath]);
 
   return {
     data: orderedChanges,

--- a/src/hooks/query/use-unified-get-git-changes.ts
+++ b/src/hooks/query/use-unified-get-git-changes.ts
@@ -1,39 +1,36 @@
 import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import AgentServerGitService from "#/api/git-service/agent-server-git-service.api";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { useConversationId } from "#/hooks/use-conversation-id";
-import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 import { getGitPath } from "#/utils/get-git-path";
 import type { GitChange } from "#/api/open-hands.types";
 
 export const useUnifiedGetGitChanges = () => {
   const { conversationId } = useConversationId();
-  const { data: conversation } = useActiveConversation();
   const [orderedChanges, setOrderedChanges] = React.useState<GitChange[]>([]);
   const previousDataRef = React.useRef<GitChange[] | null>(null);
   const runtimeIsReady = useRuntimeIsReady();
-
-  const conversationUrl = conversation?.conversation_url;
-  const sessionApiKey = conversation?.session_api_key;
-  const selectedRepository = conversation?.selected_repository;
-  const workingDir = conversation?.workspace?.working_dir?.trim();
-
-  const gitPath = React.useMemo(
-    () => getGitPath(selectedRepository, workingDir),
-    [selectedRepository, workingDir],
-  );
 
   const result = useQuery({
     queryKey: [
       "file_changes",
       conversationId,
-      conversationUrl,
-      sessionApiKey,
-      gitPath,
     ],
     queryFn: async () => {
       if (!conversationId) throw new Error("No conversation ID");
+
+      // Fetch fresh conversation data directly (like VSCode tab does) to avoid
+      // stale cache issues where workspace.working_dir lags behind after repo switch
+      const [conversation] = await AgentServerConversationService.batchGetAppConversations([conversationId]);
+
+      const conversationUrl = conversation?.conversation_url;
+      const sessionApiKey = conversation?.session_api_key;
+      const selectedRepository = conversation?.selected_repository;
+      const workingDir = conversation?.workspace?.working_dir?.trim();
+
+      const gitPath = getGitPath(selectedRepository, workingDir);
 
       return AgentServerGitService.getGitChanges(
         conversationUrl,

--- a/src/utils/get-git-path.ts
+++ b/src/utils/get-git-path.ts
@@ -4,22 +4,17 @@ export function getGitPath(
   selectedRepository: string | null | undefined,
   workingDir?: string | null,
 ): string {
-  // When a repo is selected, compute the path from selectedRepository
-  // rather than trusting workingDir. The workingDir may be stale during
-  // a repo switch (updated by the agent after cloning) while
-  // selectedRepository is updated optimistically, causing the Changes tab
-  // to show the wrong directory until the agent finishes cloning.
-  if (selectedRepository) {
-    const parts = selectedRepository.split("/");
-    const repoName = parts[parts.length - 1];
-    return `${DEFAULT_WORKING_DIR}/${repoName}`;
-  }
-
-  // No repo selected - use workingDir or default
   const normalizedWorkingDir = workingDir?.trim();
   if (normalizedWorkingDir) {
     return normalizedWorkingDir;
   }
 
-  return DEFAULT_WORKING_DIR;
+  if (!selectedRepository) {
+    return DEFAULT_WORKING_DIR;
+  }
+
+  const parts = selectedRepository.split("/");
+  const repoName = parts[parts.length - 1];
+
+  return `${DEFAULT_WORKING_DIR}/${repoName}`;
 }

--- a/src/utils/get-git-path.ts
+++ b/src/utils/get-git-path.ts
@@ -4,17 +4,22 @@ export function getGitPath(
   selectedRepository: string | null | undefined,
   workingDir?: string | null,
 ): string {
+  // When a repo is selected, compute the path from selectedRepository
+  // rather than trusting workingDir. The workingDir may be stale during
+  // a repo switch (updated by the agent after cloning) while
+  // selectedRepository is updated optimistically, causing the Changes tab
+  // to show the wrong directory until the agent finishes cloning.
+  if (selectedRepository) {
+    const parts = selectedRepository.split("/");
+    const repoName = parts[parts.length - 1];
+    return `${DEFAULT_WORKING_DIR}/${repoName}`;
+  }
+
+  // No repo selected - use workingDir or default
   const normalizedWorkingDir = workingDir?.trim();
   if (normalizedWorkingDir) {
     return normalizedWorkingDir;
   }
 
-  if (!selectedRepository) {
-    return DEFAULT_WORKING_DIR;
-  }
-
-  const parts = selectedRepository.split("/");
-  const repoName = parts[parts.length - 1];
-
-  return `${DEFAULT_WORKING_DIR}/${repoName}`;
+  return DEFAULT_WORKING_DIR;
 }


### PR DESCRIPTION
See original PR description


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.26.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `72130fbccc55b4353a27142903dc605c861d83a4` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-72130fb
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-72130fb
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-72130fb-amd64
ghcr.io/openhands/agent-canvas:fix-1193-changes-tab-workspace-directory-amd64
ghcr.io/openhands/agent-canvas:pr-1261-amd64
ghcr.io/openhands/agent-canvas:sha-72130fb-arm64
ghcr.io/openhands/agent-canvas:fix-1193-changes-tab-workspace-directory-arm64
ghcr.io/openhands/agent-canvas:pr-1261-arm64
ghcr.io/openhands/agent-canvas:sha-72130fb
ghcr.io/openhands/agent-canvas:fix-1193-changes-tab-workspace-directory
ghcr.io/openhands/agent-canvas:pr-1261
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-72130fb`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-72130fb-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->