### PR TITLE
Add fresh child conversation tool for Agent Canvas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@
 - The UI keeps most OpenHands routes/layout intact, but hosted-only behavior (org, account management, integrations) has been removed via the fabricated OSS config because there is no separate app backend.
 - Verification command: `npm run typecheck && npm run build`.
 - GitHub automation now includes `.github/workflows/ci.yml` for `npm ci`, `npm test`, and `npm run build`, plus `.github/dependabot.yml` with weekly npm/github-actions updates gated by a 7-day cooldown.
+- Fresh child conversations inside Agent Canvas should use `/new` semantics, not SDK `fork()` semantics. The frontend-injected `canvas_conversation` tool (`tools/canvas_conversation_tool.py` + `src/services/canvas-conversation.ts`) creates a brand-new conversation from the current one while reusing the current runtime: local backends inherit `parent.workspace.working_dir`, cloud backends inherit `parent.sandbox_id`. Parent context must be explicitly packed into the handoff prompt because history is not copied.
+
 
 ## Tracking / Analytics Architecture
 

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -48,6 +48,19 @@ vi.mock("#/api/backend-registry/active-store", () => ({
   getEffectiveLocalBackend: mockGetEffectiveLocalBackend,
 }));
 
+vi.mock("@openhands/extensions/skills", () => ({
+  SKILLS_CATALOG: [
+    {
+      name: "demo-skill",
+      content: "Demo skill content",
+      triggers: ["demo"],
+      description: "Demo skill",
+      license: "MIT",
+      compatibility: ">=1.0.0",
+    },
+  ],
+}));
+
 beforeEach(() => {
   mockIsAgentServerToolAvailable.mockReturnValue(true);
   mockGetEffectiveLocalBackend.mockReturnValue({
@@ -113,6 +126,7 @@ describe("buildStartConversationRequest", () => {
       { name: "file_editor", params: {} },
       { name: "task_tracker", params: {} },
       { name: "canvas_ui", params: {} },
+      { name: "canvas_conversation", params: {} },
       { name: "browser_tool_set", params: {} },
       { name: "task_tool_set", params: {} },
     ]);
@@ -200,6 +214,7 @@ describe("buildStartConversationRequest", () => {
       { name: "file_editor", params: {} },
       { name: "task_tracker", params: {} },
       { name: "canvas_ui", params: {} },
+      { name: "canvas_conversation", params: {} },
     ]);
   });
 
@@ -228,6 +243,7 @@ describe("buildStartConversationRequest", () => {
       { name: "file_editor", params: {} },
       { name: "task_tracker", params: {} },
       { name: "canvas_ui", params: {} },
+      { name: "canvas_conversation", params: {} },
       { name: "task_tool_set", params: {} },
     ]);
   });
@@ -341,11 +357,12 @@ describe("buildStartConversationRequest", () => {
     }) as Record<string, unknown>;
 
     expect(payload.hook_config).toEqual({ on_start: [] });
-    // Canvas-UI tool is auto-injected; user-supplied entries are merged in
-    // alongside it. The dedicated canvas_ui describe block below pins the
-    // exact merge semantics.
+    // Frontend custom tools are auto-injected; user-supplied entries are
+    // merged in alongside them. The dedicated custom-tool describe block below
+    // pins the exact merge semantics.
     expect(payload.tool_module_qualnames).toEqual({
       canvas_ui: "canvas_ui_tool",
+      canvas_conversation: "canvas_conversation_tool",
       demo_tool: "pkg.tools.demo",
     });
     expect(payload.agent_definitions).toEqual([
@@ -524,18 +541,19 @@ describe("buildStartConversationRequest", () => {
     });
   });
 
-  describe("canvas_ui tool injection", () => {
-    it("always registers canvas_ui_tool in tool_module_qualnames, even when no user settings supply qualnames", () => {
+  describe("frontend custom tool injection", () => {
+    it("always registers the frontend tool modules in tool_module_qualnames, even when no user settings supply qualnames", () => {
       const payload = buildStartConversationRequest({
         settings: DEFAULT_SETTINGS,
       }) as { tool_module_qualnames: Record<string, string> };
 
       expect(payload.tool_module_qualnames).toMatchObject({
         canvas_ui: "canvas_ui_tool",
+        canvas_conversation: "canvas_conversation_tool",
       });
     });
 
-    it("merges user-supplied tool_module_qualnames alongside canvas_ui_tool without dropping either side", () => {
+    it("merges user-supplied tool_module_qualnames alongside the frontend tool modules without dropping either side", () => {
       const payload = buildStartConversationRequest({
         settings: {
           ...DEFAULT_SETTINGS,
@@ -548,6 +566,7 @@ describe("buildStartConversationRequest", () => {
 
       expect(payload.tool_module_qualnames).toEqual({
         canvas_ui: "canvas_ui_tool",
+        canvas_conversation: "canvas_conversation_tool",
         my_tool: "my_package.my_tool",
       });
     });

--- a/__tests__/services/canvas-conversation.test.ts
+++ b/__tests__/services/canvas-conversation.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AppConversation,
+  AppConversationStartTask,
+} from "#/api/conversation-service/agent-server-conversation-service.types";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import {
+  getStoredConversationMetadata,
+  setStoredConversationMetadata,
+} from "#/api/conversation-metadata-store";
+import { setQueryClient } from "#/query-client-config";
+import { handleCanvasConversationAction } from "#/services/canvas-conversation";
+import type { CanvasConversationAction } from "#/types/agent-server/core";
+
+const { invalidateQueries, displaySuccessToast, displayErrorToast } =
+  vi.hoisted(() => ({
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    displaySuccessToast: vi.fn(),
+    displayErrorToast: vi.fn(),
+  }));
+
+vi.mock(
+  "#/api/conversation-service/agent-server-conversation-service.api",
+  () => ({
+    default: {
+      batchGetAppConversations: vi.fn(),
+      createConversation: vi.fn(),
+    },
+  }),
+);
+
+vi.mock("#/query-client-config", async () => {
+  const actual = await vi.importActual<typeof import("#/query-client-config")>(
+    "#/query-client-config",
+  );
+  return {
+    ...actual,
+    queryClient: { invalidateQueries },
+  };
+});
+
+vi.mock("#/utils/custom-toast-handlers", () => ({
+  displaySuccessToast,
+  displayErrorToast,
+}));
+
+function action(prompt: string): CanvasConversationAction {
+  return {
+    kind: "CanvasConversationAction",
+    command: "create_child_conversation",
+    prompt,
+  };
+}
+
+function makeParentConversation(
+  overrides: Partial<AppConversation> = {},
+): AppConversation {
+  return {
+    id: "parent-conv",
+    created_by_user_id: null,
+    selected_repository: null,
+    selected_branch: null,
+    git_provider: null,
+    title: "Parent",
+    trigger: null,
+    pr_number: [],
+    llm_model: "gpt-5.5",
+    metrics: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    execution_status: null,
+    sandbox_status: null,
+    conversation_url: "http://localhost:3000/api/conversations/parent-conv",
+    session_api_key: null,
+    sandbox_id: null,
+    workspace: { working_dir: "/workspace/project/shared-dir" },
+    sub_conversation_ids: [],
+    ...overrides,
+  };
+}
+
+function makeStartTask(
+  overrides: Partial<AppConversationStartTask> = {},
+): AppConversationStartTask {
+  return {
+    id: "task-123",
+    created_by_user_id: null,
+    status: "READY",
+    detail: null,
+    app_conversation_id: "child-conv",
+    agent_server_url: "http://localhost:3000",
+    request: {
+      initial_message: null,
+      parent_conversation_id: null,
+      agent_type: "default",
+      sandbox_id: null,
+      plugins: null,
+    },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("handleCanvasConversationAction", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.clearAllMocks();
+    setQueryClient(null);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("creates a fresh local child conversation in the parent's working directory and preserves attached-workspace metadata semantics", async () => {
+    const parent = makeParentConversation();
+    const child = makeStartTask();
+
+    setStoredConversationMetadata("parent-conv", {
+      selected_repository: null,
+      selected_branch: null,
+      git_provider: null,
+      selected_workspace: null,
+      active_profile: "profile-a",
+    });
+
+    vi.mocked(
+      AgentServerConversationService.batchGetAppConversations,
+    ).mockResolvedValue([parent]);
+    vi.mocked(
+      AgentServerConversationService.createConversation,
+    ).mockResolvedValue(child);
+
+    await handleCanvasConversationAction(
+      action("Investigate the bug in fresh context."),
+      "parent-conv",
+    );
+
+    expect(
+      AgentServerConversationService.createConversation,
+    ).toHaveBeenCalledWith(
+      "Investigate the bug in fresh context.",
+      undefined,
+      undefined,
+      null,
+      "/workspace/project/shared-dir",
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(getStoredConversationMetadata("child-conv")).toEqual({
+      selected_repository: null,
+      selected_branch: null,
+      git_provider: null,
+      selected_workspace: null,
+      active_profile: "profile-a",
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["user", "conversations"],
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["start-tasks"],
+    });
+    expect(displaySuccessToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses the parent's sandbox for cloud-style fresh child conversations without passing a parent id", async () => {
+    const parent = makeParentConversation({
+      selected_repository: "OpenHands/agent-canvas",
+      selected_branch: "main",
+      git_provider: "github",
+      sandbox_id: "sandbox-9",
+    });
+
+    vi.mocked(
+      AgentServerConversationService.batchGetAppConversations,
+    ).mockResolvedValue([parent]);
+    vi.mocked(
+      AgentServerConversationService.createConversation,
+    ).mockResolvedValue(
+      makeStartTask({ app_conversation_id: null, status: "WORKING" }),
+    );
+
+    await handleCanvasConversationAction(
+      action("Take over this task."),
+      "parent-conv",
+    );
+
+    expect(
+      AgentServerConversationService.createConversation,
+    ).toHaveBeenCalledWith(
+      "Take over this task.",
+      undefined,
+      undefined,
+      {
+        selected_repository: "OpenHands/agent-canvas",
+        selected_branch: "main",
+        git_provider: "github",
+      },
+      "/workspace/project/shared-dir",
+      undefined,
+      undefined,
+      "sandbox-9",
+    );
+  });
+
+  it("ignores empty prompts without calling the API", async () => {
+    await handleCanvasConversationAction(action("   "), "parent-conv");
+
+    expect(
+      AgentServerConversationService.batchGetAppConversations,
+    ).not.toHaveBeenCalled();
+    expect(
+      AgentServerConversationService.createConversation,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/tools/canvas-conversation-tool.test.ts
+++ b/__tests__/tools/canvas-conversation-tool.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const toolSource = readFileSync(
+  resolve(repoRoot, "tools/canvas_conversation_tool.py"),
+  "utf8",
+);
+
+describe("canvas_conversation tool guidance", () => {
+  it("tells the agent the child conversation starts with fresh context", () => {
+    expect(toolSource).toContain("FRESH CONTEXT");
+    expect(toolSource).toContain("does NOT fork/copy");
+    expect(toolSource).toContain("include any relevant background");
+  });
+});

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -71,17 +71,20 @@ export interface DirectConversationInfo {
   tags?: Record<string, string> | null;
 }
 
-// Module qualname for the Canvas-UI tool. The agent-server imports this via
-// tool_module_qualnames; the host directory is exposed via OH_EXTRA_PYTHON_PATH
-// (see scripts/dev-safe.mjs).
+// Module qualnames for frontend-injected tools. The agent-server imports these
+// via tool_module_qualnames; the host directory is exposed via
+// OH_EXTRA_PYTHON_PATH (see scripts/dev-safe.mjs).
 const CANVAS_UI_TOOL_NAME = "canvas_ui";
 const CANVAS_UI_TOOL_MODULE = "canvas_ui_tool";
+const CANVAS_CONVERSATION_TOOL_NAME = "canvas_conversation";
+const CANVAS_CONVERSATION_TOOL_MODULE = "canvas_conversation_tool";
 
 const DEFAULT_TOOL_NAMES = [
   "terminal",
   "file_editor",
   "task_tracker",
   CANVAS_UI_TOOL_NAME,
+  CANVAS_CONVERSATION_TOOL_NAME,
 ];
 const BROWSER_TOOL_SET_NAME = "browser_tool_set";
 const TASK_TOOL_SET_NAME = "task_tool_set";
@@ -900,6 +903,7 @@ export function buildStartConversationRequest(
 
   payload.tool_module_qualnames = {
     [CANVAS_UI_TOOL_NAME]: CANVAS_UI_TOOL_MODULE,
+    [CANVAS_CONVERSATION_TOOL_NAME]: CANVAS_CONVERSATION_TOOL_MODULE,
     ...((conversationSettings.tool_module_qualnames as
       | Record<string, string>
       | undefined) ?? {}),

--- a/src/contexts/conversation-websocket-context.tsx
+++ b/src/contexts/conversation-websocket-context.tsx
@@ -36,8 +36,10 @@ import {
   isBrowserObservationEvent,
   isBrowserNavigateActionEvent,
   isSwitchLLMObservationEvent,
+  isCanvasConversationActionEvent,
   isCanvasUIActionEvent,
 } from "#/types/agent-server/type-guards";
+import { handleCanvasConversationAction } from "#/services/canvas-conversation";
 import { handleCanvasUIAction } from "#/services/canvas-ui";
 import { ConversationStateUpdateEventStats } from "#/types/agent-server/core/events/conversation-state-event";
 import type {
@@ -584,12 +586,15 @@ export function ConversationWebSocketProvider({
             invalidateConversationQueries(queryClient, conversationId);
           }
 
-          // Handle canvas_ui custom-tool ActionEvents - drive the frontend
-          // (navigate to a file, switch tabs, show a preview). The tool
-          // executes server-side as a no-op; the actual UI change happens
-          // here on the client.
+          // Handle frontend-injected custom-tool ActionEvents. These tools
+          // execute server-side as no-ops; the actual UI/conversation effects
+          // happen here on the client.
           if (isCanvasUIActionEvent(event)) {
             handleCanvasUIAction(event.action);
+          }
+
+          if (isCanvasConversationActionEvent(event)) {
+            void handleCanvasConversationAction(event.action, conversationId);
           }
         }
       } catch (error) {

--- a/src/services/canvas-conversation.ts
+++ b/src/services/canvas-conversation.ts
@@ -1,0 +1,137 @@
+import { AxiosError } from "axios";
+import i18n from "#/i18n";
+import { I18nKey } from "#/i18n/declaration";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import type {
+  AppConversation,
+  AppConversationStartTask,
+} from "#/api/conversation-service/agent-server-conversation-service.types";
+import {
+  getStoredConversationMetadata,
+  setStoredConversationMetadata,
+} from "#/api/conversation-metadata-store";
+import { queryClient } from "#/query-client-config";
+import {
+  displayErrorToast,
+  displaySuccessToast,
+} from "#/utils/custom-toast-handlers";
+import { retrieveAxiosErrorMessage } from "#/utils/retrieve-axios-error-message";
+import type { CanvasConversationAction } from "#/types/agent-server/core";
+
+function getRepositoryMetadata(parent: AppConversation) {
+  if (!parent.selected_repository) {
+    return null;
+  }
+
+  return {
+    selected_repository: parent.selected_repository,
+    selected_branch: parent.selected_branch,
+    git_provider: parent.git_provider,
+  };
+}
+
+function syncChildConversationMetadata(
+  parentConversationId: string,
+  child: AppConversationStartTask,
+  parent: AppConversation,
+) {
+  if (!child.app_conversation_id) {
+    return;
+  }
+
+  const parentMetadata = getStoredConversationMetadata(parentConversationId);
+  const childMetadata = getStoredConversationMetadata(
+    child.app_conversation_id,
+  );
+  const repositoryMetadata = getRepositoryMetadata(parent);
+
+  setStoredConversationMetadata(child.app_conversation_id, {
+    selected_repository:
+      repositoryMetadata?.selected_repository ??
+      childMetadata?.selected_repository ??
+      null,
+    selected_branch:
+      repositoryMetadata?.selected_branch ??
+      childMetadata?.selected_branch ??
+      null,
+    git_provider:
+      repositoryMetadata?.git_provider ?? childMetadata?.git_provider ?? null,
+    selected_workspace: parentMetadata?.selected_workspace ?? null,
+    active_profile:
+      parentMetadata?.active_profile ?? childMetadata?.active_profile ?? null,
+  });
+}
+
+function getActionPrompt(action: CanvasConversationAction): string | null {
+  const prompt = action.prompt?.trim();
+  return prompt ? prompt : null;
+}
+
+async function getParentConversation(
+  parentConversationId: string,
+): Promise<AppConversation | null> {
+  const [parent] =
+    await AgentServerConversationService.batchGetAppConversations([
+      parentConversationId,
+    ]);
+  return parent ?? null;
+}
+
+export async function handleCanvasConversationAction(
+  action: CanvasConversationAction,
+  parentConversationId?: string,
+): Promise<void> {
+  if (action.command !== "create_child_conversation") {
+    return;
+  }
+
+  const prompt = getActionPrompt(action);
+  if (!prompt) {
+    console.warn(
+      "[canvas_conversation] Ignoring child conversation request without a prompt.",
+    );
+    return;
+  }
+
+  if (!parentConversationId) {
+    console.warn(
+      "[canvas_conversation] Ignoring child conversation request without a parent conversation id.",
+    );
+    return;
+  }
+
+  try {
+    const parent = await getParentConversation(parentConversationId);
+    if (!parent) {
+      throw new Error(`Conversation ${parentConversationId} was not found`);
+    }
+
+    const child = await AgentServerConversationService.createConversation(
+      prompt,
+      undefined,
+      undefined,
+      getRepositoryMetadata(parent),
+      parent.workspace?.working_dir ?? undefined,
+      undefined,
+      undefined,
+      parent.sandbox_id ?? undefined,
+    );
+
+    syncChildConversationMetadata(parentConversationId, child, parent);
+
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["user", "conversations"] }),
+      queryClient.invalidateQueries({ queryKey: ["start-tasks"] }),
+    ]);
+
+    displaySuccessToast(i18n.t(I18nKey.CONVERSATION$CLEAR_SUCCESS));
+  } catch (error) {
+    const message =
+      error instanceof AxiosError
+        ? retrieveAxiosErrorMessage(error)
+        : error instanceof Error
+          ? error.message
+          : null;
+    displayErrorToast(message ?? i18n.t(I18nKey.ERROR$GENERIC));
+  }
+}

--- a/src/types/agent-server/core/base/action.ts
+++ b/src/types/agent-server/core/base/action.ts
@@ -299,6 +299,17 @@ export interface CanvasUIAction extends ActionBase<"CanvasUIAction"> {
   tab?: string | null;
 }
 
+/**
+ * Frontend-injected custom tool for creating fresh child conversations.
+ * Emitted over the existing WebSocket as a regular ActionEvent; intercepted
+ * client-side by handleCanvasConversationAction. The Python definition lives
+ * in tools/canvas_conversation_tool.py.
+ */
+export interface CanvasConversationAction extends ActionBase<"CanvasConversationAction"> {
+  command: "create_child_conversation";
+  prompt: string;
+}
+
 export type Action =
   | MCPToolAction
   | FinishAction
@@ -323,4 +334,5 @@ export type Action =
   | GrepAction
   | InvokeSkillAction
   | SwitchLLMAction
-  | CanvasUIAction;
+  | CanvasUIAction
+  | CanvasConversationAction;

--- a/src/types/agent-server/core/base/base.ts
+++ b/src/types/agent-server/core/base/base.ts
@@ -22,10 +22,12 @@ type ActionOnlyType =
   | "BrowserListTabs"
   | "BrowserSwitchTab"
   | "BrowserCloseTab"
-  // Frontend-injected custom tool. Not part of the upstream SDK Action
-  // union but emitted as a regular ActionEvent over the WebSocket. See
-  // tools/canvas_ui_tool.py and src/services/canvas-ui.ts.
-  | "CanvasUI";
+  // Frontend-injected custom tools. Not part of the upstream SDK Action
+  // union but emitted as regular ActionEvents over the WebSocket. See
+  // tools/canvas_ui_tool.py / src/services/canvas-ui.ts and
+  // tools/canvas_conversation_tool.py / src/services/canvas-conversation.ts.
+  | "CanvasUI"
+  | "CanvasConversation";
 
 type ObservationOnlyType = "Browser";
 

--- a/src/types/agent-server/type-guards.ts
+++ b/src/types/agent-server/type-guards.ts
@@ -10,6 +10,7 @@ import {
   BrowserObservation,
   BrowserNavigateAction,
   SwitchLLMObservation,
+  CanvasConversationAction,
   CanvasUIAction,
 } from "./core";
 import { AgentErrorEvent } from "./core/events/observation-event";
@@ -177,6 +178,14 @@ export const isCanvasUIActionEvent = (
   event: OpenHandsEvent,
 ): event is ActionEvent<CanvasUIAction> =>
   isActionEvent(event) && event.tool_name === "canvas_ui";
+
+/**
+ * Type guard for the canvas_conversation custom tool's ActionEvent.
+ */
+export const isCanvasConversationActionEvent = (
+  event: OpenHandsEvent,
+): event is ActionEvent<CanvasConversationAction> =>
+  isActionEvent(event) && event.tool_name === "canvas_conversation";
 
 /**
  * Type guard function to check if an event is a system prompt event

--- a/tools/canvas_conversation_tool.py
+++ b/tools/canvas_conversation_tool.py
@@ -1,0 +1,101 @@
+"""Canvas conversation control tool.
+
+Shipped with Agent Canvas. Mounted into the agent-server container at
+``/canvas-tools`` and loaded via ``tool_module_qualnames`` so the agent can
+create fresh child conversations that share the current backend/runtime.
+
+The server-side executor is a no-op that returns an acknowledgment. The actual
+conversation creation happens client-side: the frontend watches the WebSocket
+stream for ``ActionEvent``s with ``tool_name == "canvas_conversation"`` and
+creates the child conversation using the current conversation as the source of
+workspace/runtime inheritance.
+"""
+
+from collections.abc import Sequence
+from typing import Literal
+
+from pydantic import Field
+
+from openhands.sdk import Action, Observation, ToolDefinition
+from openhands.sdk.tool import ToolAnnotations, ToolExecutor, register_tool
+
+
+CanvasConversationCommand = Literal["create_child_conversation"]
+
+
+class CanvasConversationAction(Action):
+    """Create a fresh child conversation in Agent Canvas."""
+
+    command: CanvasConversationCommand = Field(description="Conversation command to dispatch.")
+    prompt: str = Field(
+        description=(
+            "Full handoff prompt for the child conversation. The child starts with "
+            "fresh context, so include any relevant background, goals, and constraints."
+        )
+    )
+
+
+class CanvasConversationObservation(Observation):
+    """Acknowledgment that the conversation command was dispatched."""
+
+
+class CanvasConversationExecutor(
+    ToolExecutor[CanvasConversationAction, CanvasConversationObservation]
+):
+    def __call__(
+        self,
+        action: CanvasConversationAction,
+        conversation=None,  # noqa: ARG002
+    ) -> CanvasConversationObservation:
+        return CanvasConversationObservation.from_text(
+            f"Conversation command '{action.command}' dispatched to the Agent Canvas frontend."
+        )
+
+
+_CANVAS_CONVERSATION_DESCRIPTION = """The user is interacting with you inside Agent Canvas. This tool lets you ask the frontend to create a fresh child conversation that appears in the normal Conversations list.
+
+Use this when the user explicitly wants a separate thread/chat/conversation for follow-up work, or when you need a fresh-context child conversation that should share the current backend/runtime.
+
+Important semantics:
+- The child conversation is FRESH CONTEXT. It does NOT fork/copy this conversation's event history.
+- Because the child starts fresh, you must put all relevant context into `prompt`.
+- The child reuses the current backend/runtime:
+  - Local backend: same workspace/directory as the current conversation
+  - Cloud backend: same sandbox/backend as the current conversation
+- This is intentionally closer to `/new` semantics than to `fork()` semantics.
+- The new conversation should show up in the normal Conversations list.
+
+Parameters:
+- command="create_child_conversation"
+- prompt=<full handoff prompt for the child conversation>
+"""
+
+
+class CanvasConversationTool(
+    ToolDefinition[CanvasConversationAction, CanvasConversationObservation]
+):
+    """Tool for creating child conversations from Agent Canvas."""
+
+    @classmethod
+    def create(
+        cls,
+        conv_state=None,  # noqa: ARG003
+        **params,  # noqa: ARG003
+    ) -> Sequence["CanvasConversationTool"]:
+        return [
+            cls(
+                description=_CANVAS_CONVERSATION_DESCRIPTION,
+                action_type=CanvasConversationAction,
+                observation_type=CanvasConversationObservation,
+                executor=CanvasConversationExecutor(),
+                annotations=ToolAnnotations(
+                    readOnlyHint=False,
+                    destructiveHint=False,
+                    idempotentHint=False,
+                    openWorldHint=False,
+                ),
+            )
+        ]
+
+
+register_tool("canvas_conversation", CanvasConversationTool)


### PR DESCRIPTION
## Summary
- add a frontend-injected `canvas_conversation` tool that creates a fresh child conversation instead of using SDK `fork()`
- reuse the parent runtime context correctly (`workspace.working_dir` locally, `sandbox_id` in cloud) while requiring the parent to pass explicit handoff context
- wire the new ActionEvent through the websocket handler and cover the adapter/tool/service behavior with focused tests

## Verification
- `npm ci`
- `npm run typecheck`
- `npm run test -- __tests__/services/canvas-conversation.test.ts __tests__/api/agent-server-adapter.test.ts __tests__/tools/canvas-conversation-tool.test.ts`

cc @enyst

_This PR was created by an AI agent (OpenHands) on behalf of the user._