### PR TITLE
Warn on Claude OAuth token + ANTHROPIC_API_KEY conflict (match SDK strip)

### DIFF
--- a/__tests__/constants/acp-providers.test.ts
+++ b/__tests__/constants/acp-providers.test.ts
@@ -208,6 +208,33 @@ describe("getAcpCredentialConflicts", () => {
     ).toEqual([["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL"]]);
   });
 
+  it("flags the Claude OAuth token + API key pair when both are set", () => {
+    // The SDK strips ANTHROPIC_API_KEY when the OAuth token is active
+    // (software-agent-sdk#3588), so the key would be silently ignored.
+    expect(
+      getAcpCredentialConflicts(
+        "claude-code",
+        has("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
+      ),
+    ).toEqual([["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]]);
+  });
+
+  it("flags both pairs when the token, API key, and base URL are all set", () => {
+    expect(
+      getAcpCredentialConflicts(
+        "claude-code",
+        has(
+          "CLAUDE_CODE_OAUTH_TOKEN",
+          "ANTHROPIC_API_KEY",
+          "ANTHROPIC_BASE_URL",
+        ),
+      ),
+    ).toEqual([
+      ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
+      ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL"],
+    ]);
+  });
+
   it("stays quiet when only one side is set", () => {
     expect(
       getAcpCredentialConflicts("claude-code", has("CLAUDE_CODE_OAUTH_TOKEN")),

--- a/src/constants/acp-providers.ts
+++ b/src/constants/acp-providers.ts
@@ -269,13 +269,21 @@ const ACP_RESERVED_CREDENTIALS: Record<string, ACPProviderSecretField[]> = {
 };
 
 /**
- * Credential pairs that break each other at runtime, keyed by provider.
- * Claude's OAuth token authenticates against Anthropic directly; an
- * ``ANTHROPIC_BASE_URL`` set alongside it silently routes requests elsewhere
- * and breaks the token's bearer auth (see docs/ACP_AGENTS.md).
+ * Credential pairs that break each other at runtime, keyed by provider —
+ * mirrors the SDK's ``_ENV_CONFLICT_MAP`` (software-agent-sdk#3588). Claude's
+ * OAuth token (``CLAUDE_CODE_OAUTH_TOKEN``) authenticates against Anthropic
+ * directly, so when it is set the SDK strips:
+ *   - ``ANTHROPIC_API_KEY``  — otherwise it takes precedence and silently
+ *     bypasses the subscription;
+ *   - ``ANTHROPIC_BASE_URL`` — otherwise it proxies the bearer to an endpoint
+ *     that rejects it (see docs/ACP_AGENTS.md).
+ * Either one set alongside the token is silently ignored at runtime, so warn.
  */
 const ACP_CREDENTIAL_CONFLICTS: Record<string, Array<[string, string]>> = {
-  "claude-code": [["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL"]],
+  "claude-code": [
+    ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
+    ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL"],
+  ],
 };
 
 /**


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

`ACP_CREDENTIAL_CONFLICTS` for Claude Code only listed `[CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_BASE_URL]`. But the SDK's `_ENV_CONFLICT_MAP` strips **both** `ANTHROPIC_API_KEY` *and* `ANTHROPIC_BASE_URL` when the OAuth token is active (software-agent-sdk#3588) — the API key would otherwise take precedence and silently bypass the subscription. So a user who sets the OAuth token alongside an API key gets the key silently ignored at runtime, with no warning. The canvas conflict list was incomplete vs the SDK's actual behavior.

## Summary

- Add `[CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY]` to `ACP_CREDENTIAL_CONFLICTS` so the onboarding and Settings → Agent credential forms warn about it too (the warning component + i18n string are already generic over the pair — no new keys).
- Update the comment to document both conflicts and point at the SDK `_ENV_CONFLICT_MAP` as the source of truth.
- Tests: add coverage for the OAuth-token + API-key pair and for the all-three-set case (both pairs flagged).

## Issue Number

Follow-up to OpenHands/agent-canvas#988 and software-agent-sdk#3588.

## How to Test

`npm run typecheck` — clean. `npx vitest run __tests__/constants/acp-providers.test.ts __tests__/components/onboarding/setup-acp-secrets-step.test.tsx __tests__/components/settings/acp-credentials-section.test.tsx` — 53 pass (incl. the new `getAcpCredentialConflicts` cases). `npx eslint` + `npx prettier --check` on the changed files — clean.

Manual: in onboarding or Settings → Agent for Claude Code, set the OAuth token and an `ANTHROPIC_API_KEY` (or `ANTHROPIC_BASE_URL`) → an amber "leave one of them blank" warning appears for each conflicting credential.

## Video/Screenshots

N/A (one-line constant + tests); warning uses the existing `SETTINGS$ACP_CREDENTIAL_CONFLICT_WARNING` rendering.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.26.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `5448f35c525041a7097e610b9885ae7e93d4736b` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-5448f35
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-5448f35
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-5448f35-amd64
ghcr.io/openhands/agent-canvas:acp-claude-oauth-apikey-conflict-amd64
ghcr.io/openhands/agent-canvas:pr-1279-amd64
ghcr.io/openhands/agent-canvas:sha-5448f35-arm64
ghcr.io/openhands/agent-canvas:acp-claude-oauth-apikey-conflict-arm64
ghcr.io/openhands/agent-canvas:pr-1279-arm64
ghcr.io/openhands/agent-canvas:sha-5448f35
ghcr.io/openhands/agent-canvas:acp-claude-oauth-apikey-conflict
ghcr.io/openhands/agent-canvas:pr-1279
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-5448f35`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-5448f35-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->