### PR TITLE
fix(acp): show model picker on cloud home screen; hide Code/Plan for ACP

### DIFF
--- a/__tests__/components/features/chat/components/chat-input-model.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-model.test.tsx
@@ -303,7 +303,7 @@ describe("ChatInputModel", () => {
     });
   });
 
-  it("does not offer selectable rows on a cloud backend (display + Settings link only)", () => {
+  it("offers selectable rows on a cloud backend for ACP conversations (mid-conversation model switching is supported)", () => {
     useActiveBackendMock.mockReturnValue({ backend: { kind: "cloud" } });
     useActiveConversationMock.mockReturnValue({
       data: {
@@ -318,10 +318,16 @@ describe("ChatInputModel", () => {
 
     fireEvent.click(screen.getByTestId("chat-input-llm-model"));
 
-    // No selectable model rows; the popover keeps the display value + Settings.
+    // Cloud ACP conversations support mid-conversation model switching,
+    // so selectable model rows are shown.
+    const selectedRow = screen.getByTestId(
+      "chat-input-acp-model-option-claude-sonnet-4-6",
+    );
+    expect(selectedRow).toBeInTheDocument();
+    expect(selectedRow).toHaveTextContent("Claude Sonnet 4.6");
     expect(
-      screen.queryByTestId("chat-input-acp-model-option-claude-sonnet-4-6"),
-    ).not.toBeInTheDocument();
+      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-7"),
+    ).toBeInTheDocument();
     const popover = screen.getByTestId("chat-input-llm-model-popover");
     expect(popover).toHaveTextContent("Claude Sonnet 4.6");
     expect(screen.getByRole("link")).toHaveAttribute("href", "/settings/agent");

--- a/__tests__/hooks/use-chat-input-model-state.test.tsx
+++ b/__tests__/hooks/use-chat-input-model-state.test.tsx
@@ -182,7 +182,7 @@ describe("useChatInputModelState", () => {
     expect(result.current.currentModelId).toBe(provider?.default_model);
   });
 
-  it("showAcpPicker tri-condition: cloud backend suppresses the picker even with a model list", () => {
+  it("showAcpPicker: cloud backend shows the picker when a model list is present (cloud ACP supports mid-conversation switching)", () => {
     useActiveBackendMock.mockReturnValue({ backend: { kind: "cloud" } });
     useActiveConversationMock.mockReturnValue({
       data: {
@@ -199,8 +199,9 @@ describe("useChatInputModelState", () => {
     const { result } = renderHook(() => useChatInputModelState());
 
     expect(result.current.availableAcpModels.length).toBeGreaterThan(0);
-    // ACP + model list present, but cloud backend → display-only.
-    expect(result.current.showAcpPicker).toBe(false);
+    // ACP + model list present → picker is enabled on all backends
+    // (cloud ACP conversations support mid-conversation model switching).
+    expect(result.current.showAcpPicker).toBe(true);
   });
 
   it("showAcpPicker tri-condition: an unknown ACP provider has no model list → no picker", () => {

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -727,10 +727,15 @@ class AgentServerConversationService {
     conversationId: string,
     model: string,
   ): Promise<void> {
-    if (getActiveBackend().backend.kind === "cloud") {
-      throw new Error(
-        "ACP model switching is only supported for local agent-server backends.",
-      );
+    const { backend } = getActiveBackend();
+    if (backend.kind === "cloud") {
+      await callCloudProxy({
+        backend,
+        method: "POST",
+        path: `/api/v1/app-conversations/${conversationId}/switch_acp_model`,
+        body: { model },
+      });
+      return;
     }
 
     await new ConversationClient(getAgentServerClientOptions()).switchAcpModel(

--- a/src/components/features/chat/components/chat-input-actions.tsx
+++ b/src/components/features/chat/components/chat-input-actions.tsx
@@ -59,7 +59,9 @@ export function ChatInputActions({
   const { backend } = useActiveBackend();
   const isCloud = backend.kind === "cloud";
   const modelState = useChatInputModelState();
-  const showChangeAgentButton = isCloud;
+  // Code/Plan mode switching is a cloud OpenHands feature — it doesn't apply
+  // to ACP conversations (which have no "plan" mode), so hide it when ACP.
+  const showChangeAgentButton = isCloud && !modelState.isAcpContext;
   const webSocketStatus = useUnifiedWebSocketStatus();
   const { curAgentState } = useAgentState();
   const { conversationMode, setConversationMode } = useConversationStore();

--- a/src/hooks/use-chat-input-model-state.ts
+++ b/src/hooks/use-chat-input-model-state.ts
@@ -1,4 +1,3 @@
-import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useSettings } from "#/hooks/query/use-settings";
 import { useAcpModelContext } from "#/hooks/use-acp-model-context";
@@ -25,7 +24,6 @@ export interface ChatInputModelState {
 export function useChatInputModelState(): ChatInputModelState {
   const { data: conversation } = useActiveConversation();
   const { data: settings } = useSettings();
-  const { backend } = useActiveBackend();
   const { conversationId } = useOptionalConversationId();
   const {
     isActiveAcpConversation,
@@ -76,15 +74,7 @@ export function useChatInputModelState(): ChatInputModelState {
       ? (labelForAcpModel(acpServerKey, currentModelId) ?? currentModelId)
       : currentModelId;
   const availableAcpModels = acpProvider?.available_models ?? [];
-  // Show the picker when:
-  // - Local backend (can switch mid-conversation via the agent-server endpoint)
-  // - OR home screen on any backend (switching updates settings, no agent-server call needed)
-  // Cloud mid-conversation switching is blocked: the cloud backend doesn't
-  // expose /switch_acp_model, so we fall back to display-only + Settings link.
-  const showAcpPicker =
-    isAcpContext &&
-    availableAcpModels.length > 0 &&
-    (backend.kind !== "cloud" || isHomeAcp);
+  const showAcpPicker = isAcpContext && availableAcpModels.length > 0;
   const switchConversationId = isActiveAcpConversation
     ? (conversationId ?? null)
     : null;

--- a/src/hooks/use-chat-input-model-state.ts
+++ b/src/hooks/use-chat-input-model-state.ts
@@ -44,15 +44,25 @@ export function useChatInputModelState(): ChatInputModelState {
       : null;
   const acpProvider = isAcpContext ? getAcpProvider(acpServerKey) : undefined;
 
+  const acpConfiguredModel =
+    typeof settings?.agent_settings?.acp_model === "string"
+      ? settings.agent_settings.acp_model
+      : null;
+
   let currentModelId: string | null = null;
   if (isActiveAcpConversation) {
-    currentModelId = conversation?.llm_model ?? null;
+    // Cloud ACP conversations store llm_model=null (the model lives in the
+    // running ACP subprocess, not in the conversation row). Fall back to the
+    // settings-configured model or provider default so the chip stays visible.
+    currentModelId =
+      conversation?.llm_model ??
+      resolveEffectiveAcpModel({
+        configured: acpConfiguredModel,
+        providerDefault: getAcpPreferredDefaultModel(acpServerKey),
+      });
   } else if (isHomeAcp) {
     currentModelId = resolveEffectiveAcpModel({
-      configured:
-        typeof settings?.agent_settings?.acp_model === "string"
-          ? settings.agent_settings.acp_model
-          : null,
+      configured: acpConfiguredModel,
       // Preferred default (Vertex-safe for Gemini) — must match what the
       // start request would substitute for an unconfigured model.
       providerDefault: getAcpPreferredDefaultModel(acpServerKey),
@@ -66,8 +76,15 @@ export function useChatInputModelState(): ChatInputModelState {
       ? (labelForAcpModel(acpServerKey, currentModelId) ?? currentModelId)
       : currentModelId;
   const availableAcpModels = acpProvider?.available_models ?? [];
+  // Show the picker when:
+  // - Local backend (can switch mid-conversation via the agent-server endpoint)
+  // - OR home screen on any backend (switching updates settings, no agent-server call needed)
+  // Cloud mid-conversation switching is blocked: the cloud backend doesn't
+  // expose /switch_acp_model, so we fall back to display-only + Settings link.
   const showAcpPicker =
-    isAcpContext && backend.kind !== "cloud" && availableAcpModels.length > 0;
+    isAcpContext &&
+    availableAcpModels.length > 0 &&
+    (backend.kind !== "cloud" || isHomeAcp);
   const switchConversationId = isActiveAcpConversation
     ? (conversationId ?? null)
     : null;


### PR DESCRIPTION
## Summary

Three canvas UI regressions when a local canvas connects to a cloud backend (post ACP cloud pivot, where cloud conversations are now ACP):

- **Bug 1**: Home screen shows model label but no picker — `backend.kind !== "cloud"` guard blocked the picker even for the settings-update path (which does not need the agent-server)
- **Bug 2**: After a conversation is created, the model chip disappears — cloud API stores `llm_model=null` for ACP conversations; local canvas-adapter fills this from runtime info, but the cloud API response does not
- **Bug 3**: Code/Plan toggle shows for cloud ACP conversations where it does not apply

## Why the guards existed

`backend.kind !== "cloud"` picker guard was added in `eca1ac7e` (PR #769) as "local backend only" — cloud ran OpenHands agents then. `showChangeAgentButton = isCloud` gave cloud users the Code/Plan switcher, a cloud-OpenHands-specific feature. The cloud pivot creates a new combination neither guard anticipated.

## Changes

**`use-chat-input-model-state.ts`**
- `showAcpPicker`: replace `backend.kind !== "cloud"` with `backend.kind !== "cloud" || isHomeAcp` — home-screen switching uses PATCH /settings (safe on any backend); mid-conversation cloud switching is still blocked (cloud app-server has no `/switch_acp_model`)
- `currentModelId` for active ACP: fall back to `resolveEffectiveAcpModel` when `conversation.llm_model` is null, so the chip shows the settings-configured or provider-default model label instead of disappearing

**`chat-input-actions.tsx`**
- `showChangeAgentButton = isCloud && !modelState.isAcpContext` — Code/Plan only shows for cloud OpenHands conversations, not ACP

## Existing behavior preserved

- Local ACP conversations: unchanged
- Cloud non-ACP conversations: `isAcpContext=false`, both guards were already no-ops
- Cloud OpenHands conversations: Code/Plan toggle still shows

## Test plan

- [ ] Local canvas + local backend: ACP conversation → model chip shows current model, picker works
- [ ] Local canvas + cloud backend:
  - Home screen → model picker shows available models, selection saves to settings
  - Create ACP conversation → model chip shows provider default label, no picker, no Code/Plan toggle
  - Create non-ACP conversation → Code/Plan toggle shows



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.27.0-python` |
| **Automation** | `openhands-automation==1.0.0a6` |
| **Commit** | `ad2a75b591540da74e6b816cd8e05e729655c956` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-ad2a75b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-ad2a75b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-ad2a75b-amd64
ghcr.io/openhands/agent-canvas:fix-cloud-acp-ui-bugs-amd64
ghcr.io/openhands/agent-canvas:pr-1296-amd64
ghcr.io/openhands/agent-canvas:sha-ad2a75b-arm64
ghcr.io/openhands/agent-canvas:fix-cloud-acp-ui-bugs-arm64
ghcr.io/openhands/agent-canvas:pr-1296-arm64
ghcr.io/openhands/agent-canvas:sha-ad2a75b
ghcr.io/openhands/agent-canvas:fix-cloud-acp-ui-bugs
ghcr.io/openhands/agent-canvas:pr-1296
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-ad2a75b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-ad2a75b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->