### PR TITLE
fix: set bundled skill source to real filesystem path

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -135,7 +135,10 @@ describe("buildStartConversationRequest", () => {
     for (const skill of skills) {
       expect(skill).toHaveProperty("name");
       expect(skill).toHaveProperty("content");
-      expect(skill).toHaveProperty("source", "public");
+      // source is an absolute path to SKILL.md in node_modules (app builds)
+      // or the fallback string "public" (library builds where path is unknown)
+      expect(typeof skill.source).toBe("string");
+      expect(skill.source).toBeTruthy();
       expect(skill).toHaveProperty("is_agentskills_format", true);
       // trigger is either null (always-active) or { type, keywords }
       if (skill.trigger !== null) {

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -135,10 +135,13 @@ describe("buildStartConversationRequest", () => {
     for (const skill of skills) {
       expect(skill).toHaveProperty("name");
       expect(skill).toHaveProperty("content");
-      // source is an absolute path to SKILL.md in node_modules (app builds)
-      // or the fallback string "public" (library builds where path is unknown)
-      expect(typeof skill.source).toBe("string");
-      expect(skill.source).toBeTruthy();
+      // source must be an absolute path to the skill's SKILL.md so the
+      // Python agent-server can resolve bundled resources (scripts/, references/).
+      const source = skill.source as string;
+      expect(source).toMatch(/^\//);
+      expect(source).toMatch(
+        new RegExp(`/${skill.name as string}/SKILL\\.md$`),
+      );
       expect(skill).toHaveProperty("is_agentskills_format", true);
       // trigger is either null (always-active) or { type, keywords }
       if (skill.trigger !== null) {

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -544,7 +544,7 @@ interface BundledSkill {
   name: string;
   content: string;
   trigger: { type: "keyword"; keywords: string[] } | null;
-  source: "public";
+  source: string;
   description: string | null;
   is_agentskills_format: true;
   license?: string;
@@ -566,11 +566,18 @@ function buildBundledSkills(): BundledSkill[] {
         ? { type: "keyword", keywords: entry.triggers }
         : null;
 
+    // Use the absolute path to the skill's SKILL.md so the Python
+    // agent-server can resolve bundled resources (scripts/, references/).
+    // Falls back to "public" in library builds where the path isn't known.
+    const source = __EXTENSIONS_SKILLS_DIR__
+      ? `${__EXTENSIONS_SKILLS_DIR__}/${entry.name}/SKILL.md`
+      : "public";
+
     return {
       name: entry.name,
       content: entry.content,
       trigger,
-      source: "public" as const,
+      source,
       description: entry.description ?? null,
       is_agentskills_format: true as const,
       ...(entry.license ? { license: entry.license } : {}),

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="react-scripts" />
 
+// Injected by vite.config.ts `define` — absolute path to the
+// @openhands/extensions skills directory in node_modules, or an
+// empty string in library builds.
+declare const __EXTENSIONS_SKILLS_DIR__: string;
+
 interface Window {
   posthog?: {
     capture: (event: string, properties?: Record<string, unknown>) => void;

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+/**
+ * Absolute filesystem path to the bundled extensions skills directory,
+ * injected by Vite at build time via `define` in vite.config.ts.
+ * Empty string in library builds; always a real path in app/dev builds.
+ */
+declare const __EXTENSIONS_SKILLS_DIR__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 /// <reference types="vitest" />
 /// <reference types="vite-plugin-svgr/client" />
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { resolve, dirname } from "node:path";
 import { defineConfig, loadEnv } from "vite";
 import svgr from "vite-plugin-svgr";
 import { reactRouter } from "@react-router/dev/vite";
@@ -21,6 +23,16 @@ const LIB_EXTERNALS = [
   "react-router",
 ];
 const APP_CHUNK_MAX_BYTES = 450 * 1024;
+
+// Absolute path to the bundled extensions skills directory in node_modules.
+// Injected as __EXTENSIONS_SKILLS_DIR__ so agent-server-adapter.ts can pass
+// real filesystem paths to the Python agent-server (which uses them to
+// resolve bundled skill resources like scripts/ and references/).
+const _require = createRequire(import.meta.url);
+const EXTENSIONS_SKILLS_DIR = resolve(
+  dirname(_require.resolve("@openhands/extensions/package.json")),
+  "skills",
+);
 
 const appBuildConfig = {
   rolldownOptions: {
@@ -59,6 +71,14 @@ export default defineConfig(({ mode }) => {
   const FE_PORT = Number.parseInt(VITE_FRONTEND_PORT, 10);
 
   return {
+    define: {
+      // Empty string for library builds so consumers aren't bound to this
+      // machine's node_modules path; agent-server-adapter falls back to
+      // "public" when the value is falsy.
+      __EXTENSIONS_SKILLS_DIR__: JSON.stringify(
+        isLibraryBuild ? "" : EXTENSIONS_SKILLS_DIR,
+      ),
+    },
     plugins: [
       {
         name: "suppress-chrome-devtools-well-known",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [x] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

Root cause confirmed via code inspection:
- Traced `source: "public"` in `buildBundledSkills()` → `location = skill.source` in the SDK → `Skill location: public` in EXTRA_INFO
- Verified `scripts/main.py` exists at the resolved node_modules path:
  ```
  EXTENSIONS_SKILLS_DIR: /Users/.../node_modules/@openhands/extensions/skills
  SKILL.md exists: true
  scripts/main.py exists: true
  ```
- All 70 unit tests in `__tests__/api/agent-server-adapter.test.ts` pass after the fix:
  ```
  ✓ __tests__/api/agent-server-adapter.test.ts (70 tests) 13ms
  Test Files  1 passed (1)
        Tests  70 passed (70)
  ```
- TypeScript compilation passes with no new errors (`npx tsc --noEmit --skipLibCheck`)

---

## Why

When the frontend migrated from git-clone-based skill loading to bundling skills from the `@openhands/extensions` npm package, `buildBundledSkills()` hardcoded `source: "public"` for every skill entry. The Python agent-server SDK sets `location = skill.source`, so every bundled skill ends up with `Skill location: public` in its EXTRA_INFO block.

Any skill whose SKILL.md references bundled resources (e.g. `scripts/main.py`, `references/state-schema.md`) is broken — the agent receives an unusable location string instead of a real filesystem path, so it cannot find the files.

## Summary

- Compute the absolute path to the `@openhands/extensions` skills directory at Vite build/serve time and inject it as `__EXTENSIONS_SKILLS_DIR__` via `define`
- Set each bundled skill's `source` to `${__EXTENSIONS_SKILLS_DIR__}/${name}/SKILL.md` so the agent-server receives a real path it can resolve
- Fall back to `"public"` in library builds where the local node_modules path is not meaningful

## Issue Number

<!-- No issue — discovered while investigating skill resource resolution for PR #325 in OpenHands/extensions -->

## How to Test

1. Point `@openhands/extensions` at a skill branch that includes bundled resources (e.g. `github:OpenHands/extensions#fix/pr-reviewer-deterministic-script`)
2. Start the dev server: `npm run dev:automation`
3. Open a new conversation and type `/pr-reviewer:setup`
4. The EXTRA_INFO block should show `Skill location: /abs/path/to/.../github-pr-reviewer/SKILL.md` instead of `Skill location: public`
5. The agent should be able to read `scripts/main.py` from that path without error

## Video/Screenshots

Automations now follow the pattern:
<img width="1511" height="858" alt="image" src="https://github.com/user-attachments/assets/20b3a42f-1eb0-4a0b-b5c6-ffc475d6fde0" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `__EXTENSIONS_SKILLS_DIR__` constant is evaluated once at Vite startup from the resolved `package.json` of `@openhands/extensions`, so it always reflects whatever version of the package is installed in node_modules — including local overrides via `npm install github:owner/repo#branch`.

_This PR was created by an AI agent (OpenHands) on behalf of @tofarr._


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.27.0-python` |
| **Automation** | `openhands-automation==1.0.0a7` |
| **Commit** | `160749f07ebd322850480d8c17db3bf6698d66b1` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-160749f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-160749f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-160749f-amd64
ghcr.io/openhands/agent-canvas:fix-bundled-skill-resource-path-amd64
ghcr.io/openhands/agent-canvas:pr-1310-amd64
ghcr.io/openhands/agent-canvas:sha-160749f-arm64
ghcr.io/openhands/agent-canvas:fix-bundled-skill-resource-path-arm64
ghcr.io/openhands/agent-canvas:pr-1310-arm64
ghcr.io/openhands/agent-canvas:sha-160749f
ghcr.io/openhands/agent-canvas:fix-bundled-skill-resource-path
ghcr.io/openhands/agent-canvas:pr-1310
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-160749f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-160749f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->