### PR TITLE
fix: show full workspace list when dropdown reopens after selection

### DIFF
--- a/src/components/features/home/workspace-dropdown/workspace-dropdown.tsx
+++ b/src/components/features/home/workspace-dropdown/workspace-dropdown.tsx
@@ -196,7 +196,7 @@ export function WorkspaceDropdown({
             placeholder:
               isOpen && value
                 ? value.name
-               : (placeholder ?? t(I18nKey.HOME$WORKSPACE_PLACEHOLDER)),
+                : (placeholder ?? t(I18nKey.HOME$WORKSPACE_PLACEHOLDER)),
             className: cn(
               formControlFieldClassName,
               "text-inherit shadow-none pl-7 pr-16 text-sm font-normal leading-5",

--- a/src/components/features/home/workspace-dropdown/workspace-dropdown.tsx
+++ b/src/components/features/home/workspace-dropdown/workspace-dropdown.tsx
@@ -96,6 +96,16 @@ export function WorkspaceDropdown({
       handleSelectionChange(newSelectedItem ?? null);
     },
     inputValue,
+    onIsOpenChange: ({
+      isOpen: newIsOpen,
+      selectedItem: currentSelectedItem,
+    }) => {
+      if (newIsOpen) {
+        setInputValue("");
+      } else {
+        setInputValue(currentSelectedItem?.name ?? "");
+      }
+    },
     stateReducer: (state, actionAndChanges) =>
       actionAndChanges.type === useCombobox.stateChangeTypes.InputClick &&
       state.isOpen
@@ -183,7 +193,10 @@ export function WorkspaceDropdown({
         <input
           {...getInputProps({
             disabled,
-            placeholder: placeholder ?? t(I18nKey.HOME$WORKSPACE_PLACEHOLDER),
+            placeholder:
+              isOpen && value
+                ? value.name
+               : (placeholder ?? t(I18nKey.HOME$WORKSPACE_PLACEHOLDER)),
             className: cn(
               formControlFieldClassName,
               "text-inherit shadow-none pl-7 pr-16 text-sm font-normal leading-5",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I fixed this because it was annoying me.

- [x] A human has tested these changes.

AGENT:

No E2E or browser test run was possible in this environment (missing ARM64 rollup binary prevents the full dev stack from starting). TypeScript compiled cleanly via `npx tsc --noEmit`. The change is a two-line addition applying the same `onIsOpenChange` pattern that already exists verbatim in `src/ui/dropdown/dropdown.tsx`.

---

## Why

When a workspace was already selected, clicking the dropdown toggle a second time only showed the single item that matched the selected workspace name — because `inputValue` held the selection's name, filtering the list down to just that one entry. The user had to manually clear the field to see all options.

## Summary

- Add `onIsOpenChange` to `useCombobox` in `WorkspaceDropdown`: on open, clear `inputValue` to `""` so the full list always renders; on close, restore `inputValue` to the current selection's name.
- When the menu is open and a workspace is already selected, show that workspace's name as the input placeholder so the user retains a visual reminder of their current choice while browsing.

## Issue Number

## How to Test

1. `npm run dev` against a local agent-server.
2. Go to the `/conversations` home page and click **Open Workspace**.
3. Select any workspace — the dropdown closes and shows that workspace name.
4. Click the toggle again — the **full** workspace list must appear (not filtered to just the selected one). The selected name should appear greyed-out as placeholder text.
5. Press Escape or click outside — the selected workspace name is restored in the input field.
6. Type characters — filtering still works as expected.

## Video/Screenshots


https://github.com/user-attachments/assets/91af42c6-65fa-48db-bc26-55f25f7cdd6b


## Type

- [x] Bug fix

## Notes

Identical fix to the one already in `src/ui/dropdown/dropdown.tsx` (the shared generic `Dropdown` component). `WorkspaceDropdown` was simply missing the `onIsOpenChange` hook.

`git-branch-dropdown.tsx` has the same underlying issue (a `useEffect` repopulates `inputValue` with the selected branch name when the menu closes, causing the same filtering problem on reopen). That can be addressed in a follow-up.

_This PR was created by an AI agent (OpenHands) on behalf of the user._



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a9` |
| **Commit** | `01704e6c647e922a56c692208e4b2f3282a62363` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-01704e6
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-01704e6
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-01704e6-amd64
ghcr.io/openhands/agent-canvas:fix-workspace-dropdown-show-all-on-open-amd64
ghcr.io/openhands/agent-canvas:pr-1325-amd64
ghcr.io/openhands/agent-canvas:sha-01704e6-arm64
ghcr.io/openhands/agent-canvas:fix-workspace-dropdown-show-all-on-open-arm64
ghcr.io/openhands/agent-canvas:pr-1325-arm64
ghcr.io/openhands/agent-canvas:sha-01704e6
ghcr.io/openhands/agent-canvas:fix-workspace-dropdown-show-all-on-open
ghcr.io/openhands/agent-canvas:pr-1325
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-01704e6`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-01704e6-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->