### PR TITLE
Fix dev server locale file serving

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,8 @@
 /// <reference types="vite-plugin-svgr/client" />
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
-import { resolve, dirname } from "node:path";
+import { readFile } from "node:fs/promises";
+import { resolve, dirname, relative, isAbsolute } from "node:path";
 import { defineConfig, loadEnv } from "vite";
 import svgr from "vite-plugin-svgr";
 import { reactRouter } from "@react-router/dev/vite";
@@ -33,6 +34,7 @@ const EXTENSIONS_SKILLS_DIR = resolve(
   dirname(_require.resolve("@openhands/extensions/package.json")),
   "skills",
 );
+const PUBLIC_LOCALES_DIR = resolve(process.cwd(), "public", "locales");
 
 const appBuildConfig = {
   rolldownOptions: {
@@ -87,10 +89,55 @@ export default defineConfig(({ mode }) => {
           server.middlewares.use(
             "/.well-known/appspecific/com.chrome.devtools.json",
             (_req, res) => {
-              res.statusCode = 204;
+              res.writeHead(204);
               res.end();
             },
           );
+        },
+      },
+      {
+        name: "serve-generated-i18n-locales",
+        apply: "serve",
+        configureServer(server) {
+          server.middlewares.use(async (req, res, next) => {
+            const method = req.method ?? "GET";
+            if (method !== "GET" && method !== "HEAD") {
+              next();
+              return;
+            }
+
+            const pathname = new URL(req.url ?? "", "http://localhost")
+              .pathname;
+            if (
+              !pathname.startsWith("/locales/") ||
+              !pathname.endsWith(".json")
+            ) {
+              next();
+              return;
+            }
+
+            const requestedPath = decodeURIComponent(
+              pathname.slice("/locales/".length),
+            );
+            const filePath = resolve(PUBLIC_LOCALES_DIR, requestedPath);
+            const relativePath = relative(PUBLIC_LOCALES_DIR, filePath);
+            if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+              res.writeHead(403);
+              res.end();
+              return;
+            }
+
+            try {
+              const content = await readFile(filePath);
+              res.writeHead(200, {
+                "Content-Type": "application/json; charset=utf-8",
+                "Cache-Control": "no-cache",
+              });
+              res.end(method === "HEAD" ? "" : content);
+            } catch {
+              next();
+            }
+          });
         },
       },
       !process.env.VITEST && !isLibraryBuild && reactRouter(),


### PR DESCRIPTION
HUMAN:
Graham tested this locally by switching between Japanese and English and confirmed localized UI text loads instead of raw localization keys.

- [x] A human has tested these changes.

AGENT:

## Why
This was working recently because the app previously had a different i18n failure mode: translated strings were effectively available from the app bundle path. Current `main` initializes i18next with `i18next-http-backend` and loads app translations from `/locales/{{lng}}/openhands.json` at runtime.

On the affected local dev server, the generated locale files existed on disk and contained valid English/Japanese translations, but `react-router dev` returned `404` HTML for both `/locales/en/openhands.json` and `/locales/ja/openhands.json`. When those runtime JSON fetches fail, i18next has no resources and the UI falls back to keys like `BUTTON$SAVE`.

So this PR fixes the dev-server serving path, not the translation data or language-switching settings.

## Summary
- add a dev-only Vite middleware that serves generated `/locales/*.json` files from `public/locales`
- keep the middleware narrow to locale JSON requests and validate paths stay inside the generated locales directory
- switch the existing Chrome DevTools suppression response to `writeHead` so `vite.config.ts` passes standalone ESLint

Closes #1329.

## How to Test
- before this fix, `curl -i http://127.0.0.1:3001/locales/en/openhands.json` returned `404` HTML from the running local dev server
- before this fix, `curl -i http://127.0.0.1:3001/locales/ja/openhands.json` returned `404` HTML from the running local dev server
- after this fix on a second dev server, `curl -i http://127.0.0.1:3101/locales/en/openhands.json` returns `200 OK` JSON
- after this fix on a second dev server, `curl -i http://127.0.0.1:3101/locales/ja/openhands.json` returns `200 OK` JSON
- fetched JSON resolves `BUTTON$SAVE` / `SETTINGS$SAVED` for English and Japanese
- Graham tested locally by switching between Japanese and English and confirmed localized UI text loads instead of raw localization keys
- `npx eslint vite.config.ts`
- `npx prettier --check vite.config.ts`
- `npm run typecheck`
- `git diff --check`


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a9` |
| **Commit** | `9e7fd3cb94ad6e97ac92b3bf89b7df3f8764343e` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-9e7fd3c
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-9e7fd3c
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-9e7fd3c-amd64
ghcr.io/openhands/agent-canvas:fix-dev-serve-locales-amd64
ghcr.io/openhands/agent-canvas:pr-1330-amd64
ghcr.io/openhands/agent-canvas:sha-9e7fd3c-arm64
ghcr.io/openhands/agent-canvas:fix-dev-serve-locales-arm64
ghcr.io/openhands/agent-canvas:pr-1330-arm64
ghcr.io/openhands/agent-canvas:sha-9e7fd3c
ghcr.io/openhands/agent-canvas:fix-dev-serve-locales
ghcr.io/openhands/agent-canvas:pr-1330
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-9e7fd3c`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-9e7fd3c-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->