### PR TITLE
Externalize library dependencies to remove dist/node_modules

### DIFF
--- a/__tests__/vite-config.test.ts
+++ b/__tests__/vite-config.test.ts
@@ -54,7 +54,9 @@ describe("vite app build", () => {
       };
     };
 
-    expect(appBuild.build?.rolldownOptions?.output?.codeSplitting?.groups).toEqual(
+    expect(
+      appBuild.build?.rolldownOptions?.output?.codeSplitting?.groups,
+    ).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           name: "vendor",
@@ -76,9 +78,20 @@ describe("vite library build", () => {
     expect(config.build?.lib).toMatchObject({
       formats: ["es"],
     });
-    expect(config.build?.rollupOptions?.external).toEqual(
-      expect.arrayContaining(["react", "react-dom", "react-router"]),
+    const external = config.build?.rollupOptions?.external;
+    expect(typeof external).toBe("function");
+    if (typeof external !== "function") {
+      throw new Error("Expected library external matcher to be a function");
+    }
+    expect(external("react", undefined, false)).toBe(true);
+    expect(external("react-dom", undefined, false)).toBe(true);
+    expect(external("react-router", undefined, false)).toBe(true);
+    expect(external("@openhands/extensions/skills", undefined, false)).toBe(
+      true,
     );
+    expect(external("react-icons/fa6", undefined, false)).toBe(true);
+    expect(external("#/i18n/declaration", undefined, false)).toBe(false);
+    expect(external("./local-module", undefined, false)).toBe(false);
     expect(config.build?.rollupOptions?.output).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,20 +16,45 @@ import {
 } from "./src/styles/agent-server-ui-style-scope";
 
 const LIB_ENTRY = fileURLToPath(new URL("./src/index.ts", import.meta.url));
-const LIB_EXTERNALS = [
-  "react",
-  "react-dom",
-  "react/jsx-runtime",
-  "react/jsx-dev-runtime",
-  "react-router",
+const _require = createRequire(import.meta.url);
+const PACKAGE_JSON = _require("./package.json") as {
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+const LIB_EXTERNAL_PACKAGE_NAMES = [
+  ...new Set([
+    ...Object.keys(PACKAGE_JSON.dependencies ?? {}),
+    ...Object.keys(PACKAGE_JSON.optionalDependencies ?? {}),
+    ...Object.keys(PACKAGE_JSON.peerDependencies ?? {}),
+    "react/jsx-runtime",
+    "react/jsx-dev-runtime",
+  ]),
 ];
+const POSTHOG_REACT_IMPORT_ID = "posthog-js/react";
+const POSTHOG_REACT_ESM_ENTRY = "posthog-js/react/dist/esm/index.js";
+
+function isLibraryExternal(id: string) {
+  if (
+    id.startsWith("\0") ||
+    id.startsWith(".") ||
+    id.startsWith("/") ||
+    id.startsWith("#/")
+  ) {
+    return false;
+  }
+
+  return LIB_EXTERNAL_PACKAGE_NAMES.some(
+    (packageName) => id === packageName || id.startsWith(`${packageName}/`),
+  );
+}
+
 const APP_CHUNK_MAX_BYTES = 450 * 1024;
 
 // Absolute path to the bundled extensions skills directory in node_modules.
 // Injected as __EXTENSIONS_SKILLS_DIR__ so agent-server-adapter.ts can pass
 // real filesystem paths to the Python agent-server (which uses them to
 // resolve bundled skill resources like scripts/ and references/).
-const _require = createRequire(import.meta.url);
 const EXTENSIONS_SKILLS_DIR = resolve(
   dirname(_require.resolve("@openhands/extensions/package.json")),
   "skills",
@@ -177,7 +202,7 @@ export default defineConfig(({ mode }) => {
             formats: ["es"],
           },
           rollupOptions: {
-            external: LIB_EXTERNALS,
+            external: isLibraryExternal,
             output: [
               {
                 format: "es",
@@ -186,6 +211,8 @@ export default defineConfig(({ mode }) => {
                 entryFileNames: "[name].js",
                 chunkFileNames: "chunks/[name]-[hash].js",
                 assetFileNames: "assets/[name]-[hash][extname]",
+                paths: (id) =>
+                  id === POSTHOG_REACT_IMPORT_ID ? POSTHOG_REACT_ESM_ENTRY : id,
               },
               {
                 format: "cjs",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

Evidence from local testing:

- `npm ci` completed successfully.
- `npm run build:lib` completed successfully.
- `find dist -path '*node_modules*'` returned no paths after the library build.
- `npm run build` completed successfully.
- `npm run typecheck` completed successfully.
- `npx prettier --check vite.config.ts __tests__/vite-config.test.ts` completed successfully.
- `npm test -- __tests__/vite-config.test.ts` completed successfully after updating the config test for function-based externalization.
- `npm pack --json` reported `has_dist_node_modules: false`, with package size `6.23 MB`, unpacked size `23.3 MB`, and `4,066` entries.
- Installed the generated tarball into a clean temp project, verified `./node_modules/.bin/agent-canvas --version`, verified `@openhands/extensions/package.json` resolves from the normal dependency location, and built a minimal Vite consumer importing `@openhands/agent-canvas`, `@openhands/agent-canvas/terminal`, and `@openhands/agent-canvas/i18n`.

---

## Why

The library build was preserving modules while only externalizing React and React Router. As a result, dependency modules such as `react-icons`, `@openhands/extensions`, HeroUI-related packages, and others were emitted into `dist/node_modules`, duplicating the normal npm dependency tree and increasing install/package size.

## Summary

- Externalize library build imports using package names derived from `dependencies`, `optionalDependencies`, and `peerDependencies`.
- Preserve subpath imports such as `@openhands/extensions/skills` and `react-icons/fa6` instead of emitting them under `dist/node_modules`.
- Map the ESM output for `posthog-js/react` to its concrete ESM entry so minimal Vite consumers can bundle the library after externalization.

## Package size / disk footprint impact

Measured with `npm pack --json` and clean temp installs:

| Metric | Before (published `@openhands/agent-canvas@1.0.0-rc.11`) | After (this branch local pack) | Difference |
|---|---:|---:|---:|
| Tarball size | 16.67 MB | 6.23 MB | -10.44 MB (~63% smaller) |
| Unpacked package size | 61.98 MB | 23.3 MB | -38.68 MB (~62% smaller) |
| Package file count | 8,974 | 4,066 | -4,908 files (~55% fewer) |
| Installed `node_modules/@openhands/agent-canvas` directory | ~90 MB | ~35 MB | ~55 MB smaller |
| `dist/node_modules` contents | present (~55 MB in prior install) | absent | removed duplicate dependency tree |

Note: the before numbers are from the currently published npm package available during profiling; the branch version is `1.0.0-rc.6`, so the exact numbers may shift slightly by release, but the removed `dist/node_modules` duplicate is the meaningful delta.

## Install timing note

Measured in this sandbox with `npm install` into fresh temp projects. The before numbers are from the published npm package profile; the after numbers use a locally packed tarball from this branch, so they are directionally useful but not a perfect registry-to-registry comparison.

| Scenario | Before | After | Notes |
|---|---:|---:|---|
| Cold cache, default install | ~39.2s | not measured with audit | Default install includes audit; the first run before this PR was about 39s. |
| Cold cache, `--no-audit` | ~40.0s | ~44.4s | No clear wall-clock win in this sandbox; dependency resolution/download dominates and varied by run/version. |
| Warm cache, default install | ~22.4s | not measured with audit | Warm cache removes most download variance. |
| Warm cache, `--no-audit` | ~21.0s | ~23.3s | Also no clear wall-clock win; package extraction itself is smaller, but total install remains dominated by the dependency tree. |

The meaningful end-user improvement from this PR is package payload/disk footprint: the tarball is about 10.44 MB smaller, unpacked package payload is about 38.68 MB smaller, and the installed `@openhands/agent-canvas` package directory is about 55 MB smaller. Install time may improve on slower networks/disks, but the current dependency graph still dominates total `npm install` time.

## Issue Number

N/A

## How to Test

Run:

```bash
npm ci
npm run build:lib
find dist -path '*node_modules*'
npm run build
npm run typecheck
npx prettier --check vite.config.ts
npm pack --json
```

Expected result: `find dist -path '*node_modules*'` should produce no output, and the package metadata from `npm pack --json` should not include any files under `dist/node_modules/`.

Optional consumer smoke test:

```bash
rm -rf /tmp/agent-canvas-pack-smoke
mkdir -p /tmp/agent-canvas-pack-smoke
cd /tmp/agent-canvas-pack-smoke
npm init -y
npm install /path/to/openhands-agent-canvas-*.tgz --no-audit --loglevel=error
./node_modules/.bin/agent-canvas --version
node -e "console.log(require.resolve('@openhands/extensions/package.json'))"
mkdir -p src
printf '<div id="root"></div><script type="module" src="/src/main.js"></script>\n' > index.html
printf 'import * as canvas from "@openhands/agent-canvas";\nimport * as terminal from "@openhands/agent-canvas/terminal";\nimport { OPENHANDS_I18N_NAMESPACE } from "@openhands/agent-canvas/i18n";\nconsole.log(Object.keys(canvas).length, Object.keys(terminal).length, OPENHANDS_I18N_NAMESPACE);\n' > src/main.js
npx vite build --logLevel warn
```

## Video/Screenshots

Not applicable; this is a package/build configuration change. The validation is command-line build and package output listed above.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The raw public skill files still come from the normal `@openhands/extensions` dependency (for example `node_modules/@openhands/extensions/skills/...`), not from `@openhands/agent-canvas/dist/node_modules`. This change removes the duplicated build output only.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7dd2af3f-1e46-4b0d-bac5-acb3352afc3f)

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a9` |
| **Commit** | `114d7679f302faaefca8f391bdb71a5d3731f916` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-114d767
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-114d767
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-114d767-amd64
ghcr.io/openhands/agent-canvas:fix-library-dist-node-modules-amd64
ghcr.io/openhands/agent-canvas:pr-1348-amd64
ghcr.io/openhands/agent-canvas:sha-114d767-arm64
ghcr.io/openhands/agent-canvas:fix-library-dist-node-modules-arm64
ghcr.io/openhands/agent-canvas:pr-1348-arm64
ghcr.io/openhands/agent-canvas:sha-114d767
ghcr.io/openhands/agent-canvas:fix-library-dist-node-modules
ghcr.io/openhands/agent-canvas:pr-1348
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-114d767`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-114d767-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->

