### PR TITLE
Fix: upgrade typescript-client to v1.25.0 for pinned ACP versions

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1199,7 +1199,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
           schema_version: 1,
           agent_kind: "acp",
           acp_server: "claude-code",
-          acp_command: ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+          acp_command: [],
           acp_model: "claude-opus-4-5",
           // These fields are LLM-only and must NOT leak into ACP settings.
           // (mcp_config is handled separately — it IS forwarded for ACP; see
@@ -1460,7 +1460,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
       agent_settings: Record<string, unknown> & { acp_model?: unknown };
     };
 
-    expect(payload.agent_settings.acp_model).toBe("claude-opus-4-7");
+    expect(payload.agent_settings.acp_model).toBe("claude-opus-4-8");
   });
 
   it("omits acp_model for the custom preset when none is configured", () => {

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1224,7 +1224,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp",
+      "@agentclientprotocol/claude-agent-acp@0.30.0",
     ]);
     expect(payload.agent_settings.acp_model).toBe("claude-opus-4-5");
     // LLM-only fields must not leak into the ACP settings payload.
@@ -1373,7 +1373,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp",
+      "@agentclientprotocol/claude-agent-acp@0.30.0",
     ]);
   });
 
@@ -1395,7 +1395,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@zed-industries/codex-acp",
+      "@zed-industries/codex-acp@0.15.0",
     ]);
   });
 
@@ -1542,7 +1542,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(acpPayload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp",
+      "@agentclientprotocol/claude-agent-acp@0.30.0",
     ]);
     expect(acpPayload.agent_settings.acp_model).toBe("claude-opus-4-5");
     // acp_env is no longer a forwarded ACP setting — a stale value on saved

--- a/__tests__/components/features/chat/components/chat-input-model.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-model.test.tsx
@@ -216,10 +216,10 @@ describe("ChatInputModel", () => {
     renderWithProviders(<ChatInputModel />);
 
     const model = screen.getByTestId("chat-input-llm-model");
-    // Claude Code's registered default (``claude-opus-4-7``), shown as its
+    // Claude Code's registered default (``claude-opus-4-8``), shown as its
     // human label to match the conversation list chip. See CLAUDE_MODELS in
     // acp-providers.ts.
-    expect(model).toHaveAttribute("title", "Claude Opus 4.7");
+    expect(model).toHaveAttribute("title", "Claude Opus 4.8");
     fireEvent.click(model);
     expect(screen.getByRole("link")).toHaveAttribute("href", "/settings/agent");
   });
@@ -246,7 +246,7 @@ describe("ChatInputModel", () => {
     expect(selectedRow).toBeInTheDocument();
     expect(selectedRow).toHaveTextContent("Claude Sonnet 4.6");
     expect(
-      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-7"),
+      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-8"),
     ).toBeInTheDocument();
   });
 
@@ -264,14 +264,14 @@ describe("ChatInputModel", () => {
 
     fireEvent.click(screen.getByTestId("chat-input-llm-model"));
     fireEvent.click(
-      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-7"),
+      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-8"),
     );
 
     // Active conversation → live switch keyed by the conversation id from the
     // navigation context (test-conversation-id), default-write NOT used.
     expect(switchAcpModelMutate).toHaveBeenCalledWith({
       conversationId: "test-conversation-id",
-      model: "claude-opus-4-7",
+      model: "claude-opus-4-8",
     });
     // Popover closes after a selection.
     expect(
@@ -326,7 +326,7 @@ describe("ChatInputModel", () => {
     expect(selectedRow).toBeInTheDocument();
     expect(selectedRow).toHaveTextContent("Claude Sonnet 4.6");
     expect(
-      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-7"),
+      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-8"),
     ).toBeInTheDocument();
     const popover = screen.getByTestId("chat-input-llm-model-popover");
     expect(popover).toHaveTextContent("Claude Sonnet 4.6");

--- a/__tests__/components/features/conversation-panel/conversation-card.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-card.test.tsx
@@ -667,7 +667,7 @@ describe("ConversationCard", () => {
 
     it("shows the provider's picker label for a known model ID", () => {
       // When ``llm_model`` is a registry-known ID, the chip renders the
-      // human label ("Claude Opus 4.7") instead of the raw ID — matching
+      // human label ("Claude Opus 4.8") instead of the raw ID — matching
       // what the Settings → Agent picker shows for the same value.
       renderWithProviders(
         <ConversationCard
@@ -677,13 +677,13 @@ describe("ConversationCard", () => {
           showLlmProfiles
           agentKind="acp"
           acpServer="claude-code"
-          llmModel="claude-opus-4-7"
+          llmModel="claude-opus-4-8"
         />,
       );
 
       const chip = screen.getByTestId("conversation-card-agent-chip");
-      expect(chip).toHaveTextContent("Claude Opus 4.7");
-      expect(chip).toHaveAttribute("title", "Claude Code · Claude Opus 4.7");
+      expect(chip).toHaveTextContent("Claude Opus 4.8");
+      expect(chip).toHaveAttribute("title", "Claude Code · Claude Opus 4.8");
     });
 
     it("falls back to the provider display name for an ACP conversation with no model", () => {

--- a/__tests__/components/onboarding/choose-agent-step.test.tsx
+++ b/__tests__/components/onboarding/choose-agent-step.test.tsx
@@ -171,7 +171,7 @@ describe("ChooseAgentStep", () => {
       // ``acp_args`` can't survive and concatenate onto the spawn
       // command at conversation-create time.
       acp_args: [],
-      acp_model: "claude-opus-4-7",
+      acp_model: "claude-opus-4-8",
     });
   });
 

--- a/__tests__/routes/agent-settings.test.tsx
+++ b/__tests__/routes/agent-settings.test.tsx
@@ -231,7 +231,7 @@ describe("AgentSettingsScreen", () => {
 
     await screen.findByTestId("agent-command-input");
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.7",
+      "Claude Opus 4.8",
     );
   });
 
@@ -289,7 +289,7 @@ describe("AgentSettingsScreen", () => {
     await screen.findByTestId("agent-command-input");
     // Form loads with the Claude Code default visible.
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.7",
+      "Claude Opus 4.8",
     );
 
     // Switch to the Custom preset, then enter a different command — the
@@ -345,14 +345,14 @@ describe("AgentSettingsScreen", () => {
     renderAgentSettingsScreen();
     await screen.findByTestId("agent-command-input");
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.7",
+      "Claude Opus 4.8",
     );
 
     const commandInput = screen.getByTestId(
       "agent-command-input",
     ) as HTMLTextAreaElement;
     await user.clear(commandInput);
-    await user.type(commandInput, "npx -y @zed-industries/codex-acp");
+    await user.type(commandInput, "npx -y @zed-industries/codex-acp@0.15.0");
 
     // The model field now reflects the Codex default, not the stale Claude one.
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
@@ -397,10 +397,10 @@ describe("AgentSettingsScreen", () => {
       "agent-command-input",
     )) as HTMLTextAreaElement;
     expect(commandInput.value).toBe(
-      "npx -y @agentclientprotocol/claude-agent-acp",
+      "npx -y @agentclientprotocol/claude-agent-acp@0.30.0",
     );
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.7",
+      "Claude Opus 4.8",
     );
 
     await user.click(screen.getByTestId("agent-save-button"));
@@ -422,7 +422,7 @@ describe("AgentSettingsScreen", () => {
       // ``acp_args`` can't survive and concatenate onto the spawn
       // command at conversation-create time.
       acp_args: [],
-      acp_model: "claude-opus-4-7",
+      acp_model: "claude-opus-4-8",
     });
   });
 
@@ -589,7 +589,7 @@ describe("AgentSettingsScreen", () => {
       "agent-command-input",
     )) as HTMLTextAreaElement;
     expect(cmd.value).toBe(
-      "npx -y @agentclientprotocol/claude-agent-acp --extra-arg",
+      "npx -y @agentclientprotocol/claude-agent-acp@0.30.0 --extra-arg",
     );
 
     // Touch the form to mark it dirty (Save is disabled until isDirty),
@@ -611,7 +611,7 @@ describe("AgentSettingsScreen", () => {
     expect(call.agent_settings_diff?.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp",
+      "@agentclientprotocol/claude-agent-acp@0.30.0",
       "--extra-arg",
     ]);
     // ``acp_args: []`` resets the API-set args so they don't double up
@@ -783,7 +783,7 @@ describe("AgentSettingsScreen", () => {
           schema_version: 1,
           agent_kind: "acp",
           acp_server: "claude-code",
-          acp_command: ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+          acp_command: [],
         },
       }),
     );
@@ -822,7 +822,7 @@ describe("AgentSettingsScreen", () => {
           schema_version: 1,
           agent_kind: "acp",
           acp_server: "claude-code",
-          acp_command: ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+          acp_command: [],
         },
       }),
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
         "@openhands/extensions": "0.5.0",
-        "@openhands/typescript-client": "1.24.3",
+        "@openhands/typescript-client": "1.25.0",
         "@react-router/node": "7.17.0",
         "@react-router/serve": "7.17.0",
         "@tailwindcss/vite": "4.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3482,9 +3482,9 @@
       }
     },
     "node_modules/@openhands/typescript-client": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.24.3.tgz",
-      "integrity": "sha512-4w5rGbgXSnRKm6DZGedGRMWa4nIyl8/1+lEzinBIjZbdE0MD6+89EAItkk6FTvKU0jdVpoCAtmLWBP3Y/r8ORA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.25.0.tgz",
+      "integrity": "sha512-Xjqg3/aZi+20CYN7ZLzIiH4CqwThFIAvyp8vziu97UDaVIBrZgfXGlSI42/vNh8Dm1y33STMIKfYarMu17n9AQ==",
       "dependencies": {
         "@openrouter/sdk": "^0.12.35",
         "ws": "^8.20.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
     "@openhands/extensions": "0.5.0",
-    "@openhands/typescript-client": "1.24.3",
+    "@openhands/typescript-client": "1.25.0",
     "@react-router/node": "7.17.0",
     "@react-router/serve": "7.17.0",
     "@tailwindcss/vite": "4.2.4",


### PR DESCRIPTION
Upgrades typescript-client from v1.24.3 to v1.25.0 to resolve the codex-acp version incompatibility issue.

## Problem
Users installing agent-canvas fresh encounter 'Method not found' errors when starting Codex ACP sessions because:
- typescript-client v1.24.3 has unpinned: `["npx", "-y", "@zed-industries/codex-acp"]`
- npm resolves to latest (0.16.0), which lacks the `session/set_model` RPC method
- SDK calls this method during session init, causing the error

## Solution  
typescript-client v1.25.0 now includes PR #205 which pins ACP CLI versions:
- `codex-acp@0.15.0` (compatible with SDK)
- `claude-agent-acp@0.30.0`
- `gemini-cli@0.38.0`

## Changes
- `package.json`: Update `@openhands/typescript-client` from 1.24.3 → 1.25.0

## Verification
```bash
git show v1.25.0:src/models/acp-providers.json | grep 'codex-acp'
# Should show: "default_command": ["npx", "-y", "@zed-industries/codex-acp@0.15.0"]
```

Closes: codex ACP version incompatibility issue



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a9` |
| **Commit** | `10134fccd99a1bc04fa75aa1714abde9372b2f02` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-10134fc
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-10134fc
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-10134fc-amd64
ghcr.io/openhands/agent-canvas:fix-acp-version-pinning-amd64
ghcr.io/openhands/agent-canvas:pr-1369-amd64
ghcr.io/openhands/agent-canvas:sha-10134fc-arm64
ghcr.io/openhands/agent-canvas:fix-acp-version-pinning-arm64
ghcr.io/openhands/agent-canvas:pr-1369-arm64
ghcr.io/openhands/agent-canvas:sha-10134fc
ghcr.io/openhands/agent-canvas:fix-acp-version-pinning
ghcr.io/openhands/agent-canvas:pr-1369
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-10134fc`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-10134fc-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->