### PR TITLE
refactor: extract ConversationMobilePanelPage from conversation-main

### DIFF
--- a/__tests__/components/features/conversation/conversation-mobile-panel-page.test.tsx
+++ b/__tests__/components/features/conversation/conversation-mobile-panel-page.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useConversationStore } from "#/stores/conversation-store";
+
+// Stub the heavy tab subtree so the test focuses on this page's own behavior.
+vi.mock(
+  "#/components/features/conversation/conversation-tabs/conversation-tabs",
+  () => ({ ConversationTabs: () => <div data-testid="conversation-tabs" /> }),
+);
+vi.mock(
+  "#/components/features/conversation/conversation-tabs/conversation-tab-content/conversation-tab-content",
+  () => ({ ConversationTabContent: () => <div data-testid="tab-content" /> }),
+);
+
+import { ConversationMobilePanelPage } from "#/components/features/conversation/conversation-main/conversation-mobile-panel-page";
+
+describe("ConversationMobilePanelPage", () => {
+  it("opens the right panel on mount", () => {
+    render(<ConversationMobilePanelPage onNavigateBack={vi.fn()} />);
+
+    expect(useConversationStore.getState().isRightPanelShown).toBe(true);
+  });
+
+  it("calls onNavigateBack when the back button is clicked", () => {
+    const onNavigateBack = vi.fn();
+    render(<ConversationMobilePanelPage onNavigateBack={onNavigateBack} />);
+
+    fireEvent.click(screen.getByTestId("conversation-mobile-panel-back"));
+
+    expect(onNavigateBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/routes/conversation-backend-switch.test.tsx
+++ b/__tests__/routes/conversation-backend-switch.test.tsx
@@ -30,6 +30,11 @@ vi.mock(
   "#/components/features/conversation/conversation-main/conversation-main",
   () => ({
     ConversationMain: () => <div data-testid="conversation-main" />,
+  }),
+);
+vi.mock(
+  "#/components/features/conversation/conversation-main/conversation-mobile-panel-page",
+  () => ({
     ConversationMobilePanelPage: () => <div data-testid="conversation-panel" />,
   }),
 );

--- a/src/components/features/conversation/conversation-main/conversation-main.tsx
+++ b/src/components/features/conversation/conversation-main/conversation-main.tsx
@@ -1,12 +1,4 @@
-import React from "react";
-import { ChevronLeft } from "lucide-react";
-import { useTranslation } from "react-i18next";
-import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";
-import {
-  mobileTopBarIconButtonClassName,
-  mobileTopBarIconClassName,
-} from "#/utils/mobile-top-bar-icon-button-classes";
 import { ChatInterfaceWrapper } from "./chat-interface-wrapper";
 import { ConversationTabContent } from "../conversation-tabs/conversation-tab-content/conversation-tab-content";
 import { ConversationNameWithStatus } from "../conversation-name-with-status";
@@ -129,68 +121,6 @@ export function ConversationMain() {
             </div>
           </div>
         )}
-      </div>
-    </div>
-  );
-}
-
-export function ConversationMobilePanelPage({
-  onNavigateBack,
-}: {
-  onNavigateBack: () => void;
-}) {
-  const { t } = useTranslation("openhands");
-  const { setIsRightPanelShown, setHasRightPanelToggled, setSelectedTab } =
-    useConversationStore();
-
-  React.useLayoutEffect(() => {
-    setIsRightPanelShown(true);
-    setHasRightPanelToggled(true);
-    const st = useConversationStore.getState();
-    if (!st.selectedTab) {
-      setSelectedTab("files");
-    }
-    return () => {
-      setIsRightPanelShown(false);
-      setHasRightPanelToggled(false);
-    };
-  }, [setIsRightPanelShown, setHasRightPanelToggled, setSelectedTab]);
-
-  const handleBack = () => {
-    onNavigateBack();
-  };
-
-  return (
-    <div className="flex h-full min-h-0 flex-col bg-[var(--oh-surface)]">
-      <div
-        data-testid="conversation-mobile-panel-top"
-        className="flex h-10 min-h-10 shrink-0 items-center gap-1.5 border-b border-[var(--oh-border)] pl-2.5"
-      >
-        <button
-          type="button"
-          data-testid="conversation-mobile-panel-back"
-          onClick={handleBack}
-          aria-label={t(I18nKey.COMMON$BACK)}
-          className={mobileTopBarIconButtonClassName}
-        >
-          <ChevronLeft
-            size={20}
-            className={mobileTopBarIconClassName}
-            aria-hidden
-            strokeWidth={2}
-          />
-        </button>
-        <div className="flex min-h-0 min-w-0 flex-1 items-center self-stretch">
-          <div
-            data-testid="tabs-pane-header"
-            className="flex h-full min-h-0 w-full min-w-0 flex-col justify-center"
-          >
-            <ConversationTabs variant="compact" />
-          </div>
-        </div>
-      </div>
-      <div className="flex min-h-0 flex-1 flex-col bg-[var(--oh-surface)]">
-        <ConversationTabContent />
       </div>
     </div>
   );

--- a/src/components/features/conversation/conversation-main/conversation-mobile-panel-page.tsx
+++ b/src/components/features/conversation/conversation-main/conversation-mobile-panel-page.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { ChevronLeft } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { I18nKey } from "#/i18n/declaration";
+import {
+  mobileTopBarIconButtonClassName,
+  mobileTopBarIconClassName,
+} from "#/utils/mobile-top-bar-icon-button-classes";
+import { useConversationStore } from "#/stores/conversation-store";
+import { ConversationTabContent } from "../conversation-tabs/conversation-tab-content/conversation-tab-content";
+import { ConversationTabs } from "../conversation-tabs/conversation-tabs";
+
+export function ConversationMobilePanelPage({
+  onNavigateBack,
+}: {
+  onNavigateBack: () => void;
+}) {
+  const { t } = useTranslation("openhands");
+  const { setIsRightPanelShown, setHasRightPanelToggled, setSelectedTab } =
+    useConversationStore();
+
+  React.useLayoutEffect(() => {
+    setIsRightPanelShown(true);
+    setHasRightPanelToggled(true);
+    const st = useConversationStore.getState();
+    if (!st.selectedTab) {
+      setSelectedTab("files");
+    }
+    return () => {
+      setIsRightPanelShown(false);
+      setHasRightPanelToggled(false);
+    };
+  }, [setIsRightPanelShown, setHasRightPanelToggled, setSelectedTab]);
+
+  const handleBack = () => {
+    onNavigateBack();
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-[var(--oh-surface)]">
+      <div
+        data-testid="conversation-mobile-panel-top"
+        className="flex h-10 min-h-10 shrink-0 items-center gap-1.5 border-b border-[var(--oh-border)] pl-2.5"
+      >
+        <button
+          type="button"
+          data-testid="conversation-mobile-panel-back"
+          onClick={handleBack}
+          aria-label={t(I18nKey.COMMON$BACK)}
+          className={mobileTopBarIconButtonClassName}
+        >
+          <ChevronLeft
+            size={20}
+            className={mobileTopBarIconClassName}
+            aria-hidden
+            strokeWidth={2}
+          />
+        </button>
+        <div className="flex min-h-0 min-w-0 flex-1 items-center self-stretch">
+          <div
+            data-testid="tabs-pane-header"
+            className="flex h-full min-h-0 w-full min-w-0 flex-col justify-center"
+          >
+            <ConversationTabs variant="compact" />
+          </div>
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col bg-[var(--oh-surface)]">
+        <ConversationTabContent />
+      </div>
+    </div>
+  );
+}

--- a/src/routes/conversation.tsx
+++ b/src/routes/conversation.tsx
@@ -21,10 +21,8 @@ import { useTaskPolling } from "#/hooks/query/use-task-polling";
 
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { useIsAuthed } from "#/hooks/query/use-is-authed";
-import {
-  ConversationMain,
-  ConversationMobilePanelPage,
-} from "#/components/features/conversation/conversation-main/conversation-main";
+import { ConversationMain } from "#/components/features/conversation/conversation-main/conversation-main";
+import { ConversationMobilePanelPage } from "#/components/features/conversation/conversation-main/conversation-mobile-panel-page";
 
 import { WebSocketProviderWrapper } from "#/contexts/websocket-provider-wrapper";
 import { useErrorMessageStore } from "#/stores/error-message-store";


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

Move ConversationMobilePanelPage (the mobile Files/Tools panel route
view) into its own file, conversation-mobile-panel-page.tsx, keeping
ConversationMain in conversation-main.tsx (which drops the imports only
the moved component used: React, ChevronLeft, useTranslation, I18nKey,
the mobileTopBar\* classes).

The component is exported and consumed by routes/conversation.tsx, and
mocked by name in conversation-backend-switch.test.tsx — both are
repointed at the new module (no re-export shim). Behavior is unchanged.
Adds a focused test for the extracted page (opens the right panel on
mount; back button navigates).

- [x] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

**Description**

`src/components/features/conversation/conversation-main/conversation-main.tsx` defined two
exported components: `ConversationMain` (the desktop/mobile split layout) and
`ConversationMobilePanelPage` (the mobile Files/Tools panel route view). Split the latter
into its own file. It shares no local symbol with `ConversationMain` (the only local
helper, `getDesktopTabPanelClass`, is used by `ConversationMain` only).

**Scope (in)**

- Move `ConversationMobilePanelPage` → `conversation-mobile-panel-page.tsx`.
- Update the consumer (`routes/conversation.tsx`) import.
- Update the `vi.mock(".../conversation-main")` in `conversation-backend-switch.test.tsx` —
  move the `ConversationMobilePanelPage` stub to a new mock for the new module path.

**Scope (out)**

- No behavior, markup, store-effect, or ARIA changes.
- `ConversationMain` (kept export; consumers in `routes/conversation.tsx`, the `conversation` barrel, and its own test) is unchanged.

**Acceptance criteria**

- [x] `ConversationMobilePanelPage` lives in its own file with a named export.
- [x] `conversation-main.tsx` keeps only `ConversationMain` + `getDesktopTabPanelClass`; no unused imports.
- [x] The consumer import and the route-test mock point at the new module.
- [x] `npm run typecheck` clean; full `npm test` green; `conversation-main.test.tsx` passes unmodified.

**Test plan**

- `conversation-main.test.tsx` (layout-stability) is the guard for `ConversationMain`.
- `conversation-backend-switch.test.tsx` guards the route wiring (mock relocated).
- Add a focused test for the now-isolated `ConversationMobilePanelPage`: it opens the right
  panel on mount and calls `onNavigateBack` on the back button (uses the real store; mocks
  only the heavy tab children).

**Rollback:** Revert the PR — change is contained to `conversation-main/` + one consumer import + one test mock.

## Summary

<!-- 1-3 bullets describing what changed. -->
Seventh phase of the "one component per file" refactor. Splits `ConversationMobilePanelPage`
out of `conversation-main.tsx`. **No functional or UX changes.**

### Why

The file held two exported components — the main split layout and the mobile panel route
view. Separating them keeps each file focused; the mobile page has its own route-driven
store effects that read better standalone.

### Changes

- **New** `conversation-mobile-panel-page.tsx` — `ConversationMobilePanelPage`.
- **Slimmed** `conversation-main.tsx` (−70 lines) → `ConversationMain` + `getDesktopTabPanelClass`;
  dropped the imports only the moved component used.
- **Consumer** — `routes/conversation.tsx` imports `ConversationMobilePanelPage` from the new path.
- **Route test** — `conversation-backend-switch.test.tsx` moves the `ConversationMobilePanelPage`
  `vi.mock` to the new module path (it stubs the component by name).
- **Tests** — new `conversation-mobile-panel-page.test.tsx`.

### Behavior preservation

- The component is moved verbatim (markup, testids, the layout-effect that opens the panel + sets the files tab, ARIA).
- Acyclic: `conversation-main` and `conversation-mobile-panel-page` are independent siblings.
- `ConversationMain` is unchanged, so its other consumers + its layout-stability test are untouched.

### Testing

- `npm run typecheck` → **0 errors**; eslint + prettier clean.
- `npm test` → **3188 passed / 0 failed** (417 files).
- `conversation-main.test.tsx` passes **unmodified**; `conversation-backend-switch.test.tsx`
  passes with the relocated mock.
- Added (previously uncovered — the route test mocks the component out): the page opens the
  right panel on mount and calls `onNavigateBack` when the back button is clicked
  (real store; only the heavy `ConversationTabs` / `ConversationTabContent` children mocked).

### Risk

Low — verbatim move, one consumer import + one test-mock relocation, covered by the existing
route/layout guards + a new focused test.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/agent-canvas/issues/1375

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository and start the development server by running the following command:

   ```bash
   npm run dev
   ```

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a9` |
| **Commit** | `2e1b77d63f8967a064e55eb04844e8cb1b90cdd8` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-2e1b77d
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-2e1b77d
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-2e1b77d-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2368-amd64
ghcr.io/openhands/agent-canvas:pr-1376-amd64
ghcr.io/openhands/agent-canvas:sha-2e1b77d-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2368-arm64
ghcr.io/openhands/agent-canvas:pr-1376-arm64
ghcr.io/openhands/agent-canvas:sha-2e1b77d
ghcr.io/openhands/agent-canvas:hieptl-app-2368
ghcr.io/openhands/agent-canvas:pr-1376
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-2e1b77d`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-2e1b77d-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->