### PR TITLE
Clarify unknown agent-server version errors

### DIFF
--- a/__tests__/api/agent-server-compatibility-bundled-pin.test.ts
+++ b/__tests__/api/agent-server-compatibility-bundled-pin.test.ts
@@ -8,6 +8,7 @@ import {
 import type { Backend } from "#/api/backend-registry/types";
 import {
   AgentServerUnavailableError,
+  AgentServerUnknownVersionError,
   AgentServerUnsupportedVersionError,
   loadAgentServerInfo,
   MINIMUM_COMPATIBLE_AGENT_SERVER_VERSION,
@@ -86,14 +87,14 @@ describe("loadAgentServerInfo", () => {
     });
   });
 
-  it("throws AgentServerUnsupportedVersionError when the local backend omits its version", async () => {
+  it("throws AgentServerUnknownVersionError when the local backend omits its version", async () => {
     setRegisteredBackends([localBackend]);
     setActiveSelection({ backendId: localBackend.id });
     getServerInfoMock.mockResolvedValue({});
 
     await expect(loadAgentServerInfo()).rejects.toMatchObject({
-      name: AgentServerUnsupportedVersionError.name,
-      actualVersion: "unknown",
+      name: AgentServerUnknownVersionError.name,
+      actualVersion: null,
       requiredVersion: MINIMUM_COMPATIBLE_AGENT_SERVER_VERSION,
     });
   });

--- a/__tests__/api/option-service.test.ts
+++ b/__tests__/api/option-service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import {
   AgentServerUnavailableError,
+  AgentServerUnknownVersionError,
   AgentServerUnsupportedVersionError,
   clearCachedAgentServerInfo,
   isAgentServerToolAvailable,
@@ -61,8 +62,8 @@ describe("OptionService", () => {
     );
 
     await expect(OptionService.getConfig()).rejects.toMatchObject({
-      name: AgentServerUnsupportedVersionError.name,
-      actualVersion: "unknown",
+      name: AgentServerUnknownVersionError.name,
+      actualVersion: null,
     });
   });
 

--- a/src/api/agent-server-compatibility.test.ts
+++ b/src/api/agent-server-compatibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentServerUnknownVersionError,
+  AgentServerUnsupportedVersionError,
+  assertAgentServerVersionIsSupported,
+  getDisplayAgentServerVersion,
+  type AgentServerInfo,
+} from "./agent-server-compatibility";
+
+const serverInfo = (version?: string): AgentServerInfo =>
+  ({ version }) as AgentServerInfo;
+
+describe("agent-server version compatibility", () => {
+  it("classifies missing and unknown versions separately from old versions", () => {
+    for (const version of [undefined, "", "unknown", " UNKNOWN "]) {
+      expect(() =>
+        assertAgentServerVersionIsSupported(serverInfo(version)),
+      ).toThrow(AgentServerUnknownVersionError);
+    }
+  });
+
+  it("classifies malformed versions separately from old versions", () => {
+    expect(() =>
+      assertAgentServerVersionIsSupported(serverInfo("dev-build")),
+    ).toThrow(AgentServerUnknownVersionError);
+  });
+
+  it("keeps valid but too-old versions on the unsupported-version path", () => {
+    expect(() =>
+      assertAgentServerVersionIsSupported(serverInfo("0.0.1")),
+    ).toThrow(AgentServerUnsupportedVersionError);
+  });
+
+  it("does not render unknown or malformed versions as backend badges", () => {
+    expect(getDisplayAgentServerVersion(serverInfo("unknown"))).toBeNull();
+    expect(getDisplayAgentServerVersion(serverInfo("dev-build"))).toBeNull();
+    expect(getDisplayAgentServerVersion(serverInfo("1.28.0"))).toBe("1.28.0");
+  });
+});

--- a/src/api/agent-server-compatibility.ts
+++ b/src/api/agent-server-compatibility.ts
@@ -19,6 +19,8 @@ export const MINIMUM_COMPATIBLE_AGENT_SERVER_VERSION =
   defaults.compatibility.minimumAgentServer;
 export const AGENT_SERVER_UNSUPPORTED_VERSION_ERROR_CODE =
   "AGENT_SERVER_UNSUPPORTED_VERSION";
+export const AGENT_SERVER_UNKNOWN_VERSION_ERROR_CODE =
+  "AGENT_SERVER_UNKNOWN_VERSION";
 
 export interface AgentServerInfo extends BaseServerInfo {
   usable_tools?: string[] | null;
@@ -76,6 +78,25 @@ export class AgentServerUnsupportedVersionError extends AgentServerUnavailableEr
   }
 }
 
+export class AgentServerUnknownVersionError extends AgentServerUnavailableError {
+  readonly code = AGENT_SERVER_UNKNOWN_VERSION_ERROR_CODE;
+  readonly actualVersion: string | null;
+  readonly requiredVersion = MINIMUM_COMPATIBLE_AGENT_SERVER_VERSION;
+
+  constructor(actualVersion: string | null) {
+    const reported = actualVersion ? ` It reported "${actualVersion}".` : "";
+    const message =
+      `Could not determine this backend's agent-server version.${reported} ` +
+      `Agent Canvas requires agent-server ${MINIMUM_COMPATIBLE_AGENT_SERVER_VERSION} ` +
+      "or newer, but this backend did not return a valid version from " +
+      "/server_info. Restart or rebuild the agent-server backend, then try again.";
+    super(message);
+    this.name = "AgentServerUnknownVersionError";
+    this.message = message;
+    this.actualVersion = actualVersion;
+  }
+}
+
 export const isAgentServerUnsupportedVersionError = (
   error: unknown,
 ): error is AgentServerUnsupportedVersionError =>
@@ -84,6 +105,15 @@ export const isAgentServerUnsupportedVersionError = (
     error !== null &&
     "code" in error &&
     error.code === AGENT_SERVER_UNSUPPORTED_VERSION_ERROR_CODE);
+
+export const isAgentServerUnknownVersionError = (
+  error: unknown,
+): error is AgentServerUnknownVersionError =>
+  error instanceof AgentServerUnknownVersionError ||
+  (typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === AGENT_SERVER_UNKNOWN_VERSION_ERROR_CODE);
 
 /**
  * Returns true when the agent-server probe failed with HTTP 401.
@@ -128,10 +158,30 @@ export function isSdkHttpStatusError(error: unknown, status: number): boolean {
   );
 }
 
-function getReportedAgentServerVersion(serverInfo: AgentServerInfo) {
-  return typeof serverInfo.version === "string" && serverInfo.version.trim()
-    ? serverInfo.version.trim()
-    : UNKNOWN_AGENT_SERVER_VERSION;
+function getRawAgentServerVersion(serverInfo: AgentServerInfo): string | null {
+  if (typeof serverInfo.version !== "string") return null;
+  const trimmed = serverInfo.version.trim();
+  return trimmed || null;
+}
+
+function getComparableAgentServerVersion(
+  serverInfo: AgentServerInfo,
+): string | null {
+  const version = getRawAgentServerVersion(serverInfo);
+  if (!version || version.toLowerCase() === UNKNOWN_AGENT_SERVER_VERSION) {
+    return null;
+  }
+  return version;
+}
+
+export function getDisplayAgentServerVersion(
+  serverInfo: AgentServerInfo,
+): string | null {
+  const version = getComparableAgentServerVersion(serverInfo);
+  if (!version || !parseAgentServerVersion(version)) {
+    return null;
+  }
+  return version;
 }
 
 function compareAgentServerVersions(actual: string, required: string) {
@@ -187,13 +237,25 @@ function parseAgentServerVersion(version: string) {
 export function assertAgentServerVersionIsSupported(
   serverInfo: AgentServerInfo,
 ) {
-  const actualVersion = getReportedAgentServerVersion(serverInfo);
+  const actualVersion = getComparableAgentServerVersion(serverInfo);
+  if (!actualVersion) {
+    clearCachedAgentServerInfo();
+    throw new AgentServerUnknownVersionError(
+      getRawAgentServerVersion(serverInfo),
+    );
+  }
+
   const comparison = compareAgentServerVersions(
     actualVersion,
     MINIMUM_COMPATIBLE_AGENT_SERVER_VERSION,
   );
 
-  if (comparison === null || comparison < 0) {
+  if (comparison === null) {
+    clearCachedAgentServerInfo();
+    throw new AgentServerUnknownVersionError(actualVersion);
+  }
+
+  if (comparison < 0) {
     clearCachedAgentServerInfo();
     throw new AgentServerUnsupportedVersionError(actualVersion);
   }

--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -15,7 +15,10 @@ import { useActiveBackendContext } from "#/contexts/active-backend-context";
 import { useNavigation } from "#/context/navigation-context";
 import { useBackendsHealth } from "#/hooks/query/use-backends-health";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
-import { assertAgentServerVersionIsSupported } from "#/api/agent-server-compatibility";
+import {
+  assertAgentServerVersionIsSupported,
+  getDisplayAgentServerVersion,
+} from "#/api/agent-server-compatibility";
 import ChevronDownSmallIcon from "#/icons/chevron-down-small.svg?react";
 import { I18nKey } from "#/i18n/declaration";
 import type { Backend, BackendKind } from "#/api/backend-registry/types";
@@ -187,7 +190,7 @@ function BackendStatusBadge({
           timeout: 5000,
         }),
       ).getServerInfo();
-      return info.version ?? null;
+      return getDisplayAgentServerVersion(info);
     },
     retry: false,
     staleTime: 60_000,

--- a/src/components/features/backends/backend-version.tsx
+++ b/src/components/features/backends/backend-version.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ServerClient } from "@openhands/typescript-client/clients";
 import { type Backend } from "#/api/backend-registry/types";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
+import { getDisplayAgentServerVersion } from "#/api/agent-server-compatibility";
 import { I18nKey } from "#/i18n/declaration";
 
 export function BackendVersion({ backend }: { backend: Backend }) {
@@ -18,7 +19,7 @@ export function BackendVersion({ backend }: { backend: Backend }) {
           timeout: 5000,
         }),
       ).getServerInfo();
-      return info.version ?? null;
+      return getDisplayAgentServerVersion(info);
     },
     retry: false,
     staleTime: 60_000,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

Live reproduction on June 16, 2026: the Orchard tunnel was reachable, but `/server_info` returned `version: "unknown"`, `sdk_version: "unknown"`, etc. The backend health path then displayed the backend as disconnected with the same upgrade wording used for genuinely old versions, and the backend row rendered `vunknown`.

I restarted the Orchard backend from a clean `uvx` environment after finding the old process was still running from a partially removed uv archive. The public Orchard tunnel now reports `version: "1.28.0"` via `https://statusquo-amd-ohorchard.ngrok-free.app/server_info`, and authenticated `/api/settings`, `/api/conversations/search?limit=1`, and CORS preflight checks return 200.

---

## Why

A backend that cannot report a valid version is different from a backend that reports a valid but too-old version. Treating `unknown` as “too old” points users at the wrong fix. In the Orchard case, the actual issue was a stale/deleted runtime install, not an incompatible agent-server version.

## Summary

- Add a separate `AgentServerUnknownVersionError` for missing, `unknown`, or malformed `/server_info.version` values.
- Keep valid semver values below the compatibility floor on the existing unsupported-version error path.
- Hide backend version badges for unknown/malformed versions so the Manage Backends modal does not render `vunknown`.
- Add unit coverage for unknown, malformed, unsupported, and displayable versions.

## Issue Number

N/A

## How to Test

- `npm test -- src/api/agent-server-compatibility.test.ts`
  - Result: `1 passed`, `4 passed` tests.
- Follow-up on June 16, 2026 after merging `origin/main` into `be7e3b10`: `npm run make-i18n && npx vitest run src/api/agent-server-compatibility.test.ts __tests__/api/agent-server-compatibility-bundled-pin.test.ts __tests__/api/option-service.test.ts`
  - Result: `3 passed` test files, `19 passed` tests.
- `npm run typecheck`
  - Result: passed.
- `npm run build`
  - Result: passed.
- `/home/gneubig/work/agent-canvas/node_modules/.bin/prettier --check src/api/agent-server-compatibility.ts src/api/agent-server-compatibility.test.ts src/components/features/backends/backend-version.tsx src/components/features/backends/backend-form-modal.tsx`
  - Result: `All matched files use Prettier code style!`.
- Live Orchard check after backend restart:
  - `curl https://statusquo-amd-ohorchard.ngrok-free.app/server_info` reports `version`, `sdk_version`, `tools_version`, and `workspace_version` as `1.28.0`.
  - Authenticated `GET /api/settings` and `GET /api/conversations/search?limit=1` return 200.
  - CORS `OPTIONS` for `/server_info`, `/api/settings`, and `/api/conversations` returns 200 with `access-control-allow-origin: https://statusquo-amd-oh.ngrok-free.app`.

## Video/Screenshots

No screenshot. This is a backend selection/error-message fix; live curl checks above cover the reproduced Orchard failure mode and recovery.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR changes only the client-side classification and display of unknown/malformed versions. It does not relax the compatibility floor for valid old versions.


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a9` |
| **Commit** | `be7e3b101a96033551247b041ab6581b3b583615` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-be7e3b1
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-be7e3b1
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-be7e3b1-amd64
ghcr.io/openhands/agent-canvas:codex-unknown-agent-server-version-message-amd64
ghcr.io/openhands/agent-canvas:pr-1382-amd64
ghcr.io/openhands/agent-canvas:sha-be7e3b1-arm64
ghcr.io/openhands/agent-canvas:codex-unknown-agent-server-version-message-arm64
ghcr.io/openhands/agent-canvas:pr-1382-arm64
ghcr.io/openhands/agent-canvas:sha-be7e3b1
ghcr.io/openhands/agent-canvas:codex-unknown-agent-server-version-message
ghcr.io/openhands/agent-canvas:pr-1382
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-be7e3b1`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-be7e3b1-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->

## Issue

Fixes #1393.