### PR TITLE
fix: remove inner overflow-y-auto from settings layout main column

### DIFF
--- a/src/utils/settings-like-page-layout-classes.ts
+++ b/src/utils/settings-like-page-layout-classes.ts
@@ -6,6 +6,14 @@
 export const settingsLikeMainScrollClassName =
   "flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto custom-scrollbar-always px-4 pt-8 pb-12 md:px-0 md:pr-[14px]";
 
-/** Same scroll shell as {@link settingsLikeMainScrollClassName} but desktop top padding comes from the outer `md:pt-8` wrapper ({@link SettingsLayout}). */
+/**
+ * Content column for {@link SettingsLayout} (all `/settings/*` sub-routes).
+ *
+ * Deliberately has no `overflow-y-auto` so the settings main area does not
+ * create an inner scroll container on desktop. Scrolling is handled by the
+ * outer `#root-outlet` in `root-layout.tsx`, which already has
+ * `overflow-auto` and keeps the settings sidebar sticky via
+ * `position: sticky` + `align-self: start`.
+ */
 export const settingsLayoutMainScrollClassName =
-  "flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto custom-scrollbar-always px-4 pt-8 pb-12 md:px-0 md:pt-0 md:pr-[14px]";
+  "flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden px-4 pt-8 pb-12 md:px-0 md:pt-0 md:pr-[14px]";


### PR DESCRIPTION
## Problem

On desktop, all `/settings/*` sub-routes (Secrets, LLM, Agent, etc.) had a nested inner scroll container created by `overflow-y-auto` on the `<main>` element inside `SettingsLayout`. This was particularly visible on the Secrets settings page, which is compact enough that the inner scroll layer was clearly redundant.

## Root cause

`settingsLayoutMainScrollClassName` (in `src/utils/settings-like-page-layout-classes.ts`) included `overflow-y-auto custom-scrollbar-always`, creating a second scroll container inside the outer `#root-outlet` (which already has `overflow-auto` in `root-layout.tsx`).

## Fix

Remove `overflow-y-auto` and `custom-scrollbar-always` from `settingsLayoutMainScrollClassName`. The outer `#root-outlet` handles all page scrolling. The `SettingsDesktopSidebar` uses `position: sticky` + `align-self: start`, so it continues to stay pinned correctly without the inner scroll.

## Scope

Only `settingsLayoutMainScrollClassName` is changed. All seven `/settings/*` sub-routes are affected:

| Route | Status |
|---|---|
| `/settings` (index) | ✅ no longer inner-scrolls |
| `/settings/llm` | ✅ outer scroll takes over when content is long |
| `/settings/agent` | ✅ |
| `/settings/condenser` | ✅ |
| `/settings/verification` | ✅ |
| `/settings/app` | ✅ |
| `/settings/secrets` | ✅ the reported case |

The `/skills`, `/plugins`, and `/mcp` routes use the separate `settingsLikeMainScrollClassName` and are **not affected**.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a9` |
| **Commit** | `dec98900981381724be32ecab280232fbddc2a90` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-dec9890
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-dec9890
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-dec9890-amd64
ghcr.io/openhands/agent-canvas:fix-settings-layout-inner-scroll-amd64
ghcr.io/openhands/agent-canvas:pr-1394-amd64
ghcr.io/openhands/agent-canvas:sha-dec9890-arm64
ghcr.io/openhands/agent-canvas:fix-settings-layout-inner-scroll-arm64
ghcr.io/openhands/agent-canvas:pr-1394-arm64
ghcr.io/openhands/agent-canvas:sha-dec9890
ghcr.io/openhands/agent-canvas:fix-settings-layout-inner-scroll
ghcr.io/openhands/agent-canvas:pr-1394
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-dec9890`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-dec9890-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->