### PR TITLE
refactor: extract FieldHelp and MenuItem settings sub-components

### DIFF
--- a/src/components/features/settings/llm-profiles/profile-actions-menu-item.tsx
+++ b/src/components/features/settings/llm-profiles/profile-actions-menu-item.tsx
@@ -1,0 +1,46 @@
+import { cn } from "#/utils/utils";
+import { ConversationNameContextMenuIconText } from "#/components/features/conversation/conversation-name-context-menu-icon-text";
+
+interface MenuItemProps {
+  index: number;
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  onKeyDown: (e: React.KeyboardEvent, index: number) => void;
+  menuItemsRef: React.MutableRefObject<(HTMLButtonElement | null)[]>;
+  disabled?: boolean;
+  testId: string;
+}
+
+export function MenuItem({
+  index,
+  icon,
+  label,
+  onClick,
+  onKeyDown,
+  menuItemsRef,
+  disabled,
+  testId,
+}: MenuItemProps) {
+  return (
+    <button
+      ref={(el) => {
+        // eslint-disable-next-line no-param-reassign
+        menuItemsRef.current[index] = el;
+      }}
+      type="button"
+      onClick={onClick}
+      onKeyDown={(e) => onKeyDown(e, index)}
+      disabled={disabled}
+      className={cn(
+        "group w-full cursor-pointer rounded px-2 py-2 text-start text-nowrap text-sm font-normal",
+        "text-[var(--oh-foreground)] hover:bg-[var(--oh-interactive-hover)]",
+        "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent",
+      )}
+      role="menuitem"
+      data-testid={testId}
+    >
+      <ConversationNameContextMenuIconText icon={icon} text={label} />
+    </button>
+  );
+}

--- a/src/components/features/settings/llm-profiles/profile-actions-menu.tsx
+++ b/src/components/features/settings/llm-profiles/profile-actions-menu.tsx
@@ -11,54 +11,10 @@ import { TextCursor, Copy } from "lucide-react";
 import { cn } from "#/utils/utils";
 import { dropdownMenuListClassName } from "#/utils/dropdown-classes";
 import { I18nKey } from "#/i18n/declaration";
-import { ConversationNameContextMenuIconText } from "#/components/features/conversation/conversation-name-context-menu-icon-text";
 import EditIcon from "#/icons/u-edit.svg?react";
 import CheckCircleIcon from "#/icons/u-check-circle.svg?react";
 import DeleteIcon from "#/icons/u-delete.svg?react";
-
-interface MenuItemProps {
-  index: number;
-  icon: React.ReactNode;
-  label: string;
-  onClick: () => void;
-  onKeyDown: (e: React.KeyboardEvent, index: number) => void;
-  menuItemsRef: React.MutableRefObject<(HTMLButtonElement | null)[]>;
-  disabled?: boolean;
-  testId: string;
-}
-
-function MenuItem({
-  index,
-  icon,
-  label,
-  onClick,
-  onKeyDown,
-  menuItemsRef,
-  disabled,
-  testId,
-}: MenuItemProps) {
-  return (
-    <button
-      ref={(el) => {
-        // eslint-disable-next-line no-param-reassign
-        menuItemsRef.current[index] = el;
-      }}
-      type="button"
-      onClick={onClick}
-      onKeyDown={(e) => onKeyDown(e, index)}
-      disabled={disabled}
-      className={cn(
-        "group w-full cursor-pointer rounded px-2 py-2 text-start text-nowrap text-sm font-normal",
-        "text-[var(--oh-foreground)] hover:bg-[var(--oh-interactive-hover)]",
-        "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent",
-      )}
-      role="menuitem"
-      data-testid={testId}
-    >
-      <ConversationNameContextMenuIconText icon={icon} text={label} />
-    </button>
-  );
-}
+import { MenuItem } from "./profile-actions-menu-item";
 
 interface ProfileActionsMenuProps {
   onEdit: () => void;

--- a/src/components/features/settings/sdk-settings/field-help.tsx
+++ b/src/components/features/settings/sdk-settings/field-help.tsx
@@ -1,0 +1,69 @@
+import { useTranslation } from "react-i18next";
+import { SettingsFieldSchema } from "#/types/settings";
+import { HelpLink } from "#/ui/help-link";
+import { Typography } from "#/ui/typography";
+import { resolveSchemaFieldDescription } from "#/utils/sdk-settings-field-metadata";
+
+// ---------------------------------------------------------------------------
+// Help links – UI-only mapping from field keys to user-facing guidance.
+// Keys use conventional i18n pattern: SCHEMA$<PATH>$HELP_TEXT / HELP_LINK_TEXT
+// ---------------------------------------------------------------------------
+export const FIELD_HELP_LINKS: Record<
+  string,
+  {
+    textKey: string;
+    linkTextKey: string;
+    href: string;
+    /** Skip rendering the schema description separately when the help text already includes it. */
+    hideDescription?: boolean;
+    /** Optional trailing copy rendered after the link (e.g. " tab of OpenHands Cloud."). */
+    suffixKey?: string;
+  }
+> = {
+  "llm.api_key": {
+    textKey: "SCHEMA$LLM$API_KEY$HELP_TEXT",
+    linkTextKey: "SCHEMA$LLM$API_KEY$HELP_LINK_TEXT",
+    href: "https://docs.openhands.dev/usage/local-setup#getting-an-api-key",
+  },
+  // Mirror the hint shown under the LLM provider's API key field when
+  // OpenHands is selected as the active provider; the SDK reuses that active
+  // LLM key when the critic key is empty.
+  "verification.critic_api_key": {
+    textKey: "SCHEMA$VERIFICATION$CRITIC_API_KEY$HELP_TEXT",
+    linkTextKey: "SETTINGS$NAV_API_KEYS",
+    suffixKey: "SCHEMA$VERIFICATION$CRITIC_API_KEY$HELP_SUFFIX",
+    href: "https://app.all-hands.dev/settings/api-keys",
+    hideDescription: true,
+  },
+};
+
+export function FieldHelp({ field }: { field: SettingsFieldSchema }) {
+  const { t } = useTranslation("openhands");
+  const helpLink = FIELD_HELP_LINKS[field.key];
+  const description = resolveSchemaFieldDescription(
+    t,
+    field.key,
+    field.description,
+  );
+
+  return (
+    <>
+      {description && !helpLink?.hideDescription ? (
+        <Typography.Paragraph className="text-tertiary-alt text-xs leading-5">
+          {description}
+        </Typography.Paragraph>
+      ) : null}
+      {helpLink ? (
+        <HelpLink
+          testId={`help-link-${field.key}`}
+          text={t(helpLink.textKey)}
+          linkText={t(helpLink.linkTextKey)}
+          href={helpLink.href}
+          suffix={helpLink.suffixKey ? ` ${t(helpLink.suffixKey)}` : undefined}
+          size="settings"
+          linkColor="white"
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/components/features/settings/sdk-settings/schema-field.tsx
+++ b/src/components/features/settings/sdk-settings/schema-field.tsx
@@ -5,12 +5,9 @@ import { SettingsDropdownInput } from "#/components/features/settings/settings-d
 import { SettingsInput } from "#/components/features/settings/settings-input";
 import { SettingsSwitch } from "#/components/features/settings/settings-switch";
 import { SettingsFieldSchema } from "#/types/settings";
-import { HelpLink } from "#/ui/help-link";
-import { Typography } from "#/ui/typography";
 import {
   getSettingsFieldConstraints,
   resolveSchemaChoiceLabel,
-  resolveSchemaFieldDescription,
   resolveSchemaFieldLabel,
 } from "#/utils/sdk-settings-field-metadata";
 import { cn } from "#/utils/utils";
@@ -18,39 +15,7 @@ import {
   formControlMultilineFieldClassName,
   formControlSwitchDescriptionClassName,
 } from "#/utils/form-control-classes";
-
-// ---------------------------------------------------------------------------
-// Help links – UI-only mapping from field keys to user-facing guidance.
-// Keys use conventional i18n pattern: SCHEMA$<PATH>$HELP_TEXT / HELP_LINK_TEXT
-// ---------------------------------------------------------------------------
-export const FIELD_HELP_LINKS: Record<
-  string,
-  {
-    textKey: string;
-    linkTextKey: string;
-    href: string;
-    /** Skip rendering the schema description separately when the help text already includes it. */
-    hideDescription?: boolean;
-    /** Optional trailing copy rendered after the link (e.g. " tab of OpenHands Cloud."). */
-    suffixKey?: string;
-  }
-> = {
-  "llm.api_key": {
-    textKey: "SCHEMA$LLM$API_KEY$HELP_TEXT",
-    linkTextKey: "SCHEMA$LLM$API_KEY$HELP_LINK_TEXT",
-    href: "https://docs.openhands.dev/usage/local-setup#getting-an-api-key",
-  },
-  // Mirror the hint shown under the LLM provider's API key field when
-  // OpenHands is selected as the active provider; the SDK reuses that active
-  // LLM key when the critic key is empty.
-  "verification.critic_api_key": {
-    textKey: "SCHEMA$VERIFICATION$CRITIC_API_KEY$HELP_TEXT",
-    linkTextKey: "SETTINGS$NAV_API_KEYS",
-    suffixKey: "SCHEMA$VERIFICATION$CRITIC_API_KEY$HELP_SUFFIX",
-    href: "https://app.all-hands.dev/settings/api-keys",
-    hideDescription: true,
-  },
-};
+import { FieldHelp } from "./field-help";
 
 /**
  * Field keys that should span the full settings grid (both columns on xl
@@ -61,37 +26,6 @@ export const FIELD_HELP_LINKS: Record<
 export const FIELD_FULL_WIDTH_KEYS: ReadonlySet<string> = new Set([
   "verification.critic_api_key",
 ]);
-
-function FieldHelp({ field }: { field: SettingsFieldSchema }) {
-  const { t } = useTranslation("openhands");
-  const helpLink = FIELD_HELP_LINKS[field.key];
-  const description = resolveSchemaFieldDescription(
-    t,
-    field.key,
-    field.description,
-  );
-
-  return (
-    <>
-      {description && !helpLink?.hideDescription ? (
-        <Typography.Paragraph className="text-tertiary-alt text-xs leading-5">
-          {description}
-        </Typography.Paragraph>
-      ) : null}
-      {helpLink ? (
-        <HelpLink
-          testId={`help-link-${field.key}`}
-          text={t(helpLink.textKey)}
-          linkText={t(helpLink.linkTextKey)}
-          href={helpLink.href}
-          suffix={helpLink.suffixKey ? ` ${t(helpLink.suffixKey)}` : undefined}
-          size="settings"
-          linkColor="white"
-        />
-      ) : null}
-    </>
-  );
-}
 
 function isSelectField(field: SettingsFieldSchema): boolean {
   return field.choices.length > 0;


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

Move two file-private sub-components out of their parents: FieldHelp
(plus its private FIELD_HELP_LINKS map) → sdk-settings/field-help.tsx,
and MenuItem → llm-profiles/profile-actions-menu-item.tsx. Each parent
imports its sub-component and drops the imports only it used (HelpLink /
Typography / resolveSchemaFieldDescription from schema-field;
ConversationNameContextMenuIconText from profile-actions-menu).
FIELD_FULL_WIDTH_KEYS (consumed elsewhere) stays in schema-field.

The sub-components are file-private, so no other module changes.
Behavior is unchanged — the existing schema-field and profile-actions-menu
test suites pass unmodified, so no new tests are added.

- [x] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

**Description**

Two settings components each define a file-private sub-component alongside their export:
`schema-field.tsx` (`FieldHelp`, the per-field description + help link) and
`profile-actions-menu.tsx` (`MenuItem`, a menu row). Split each into its own file.

**Scope (in)**

- Move `FieldHelp` (+ its private `FIELD_HELP_LINKS` map) → `field-help.tsx`.
- Move `MenuItem` → `profile-actions-menu-item.tsx`.
- Update each parent to import its sub-component; remove the imports only it used.

**Scope (out)**

- The sub-components are file-private → no consumer updates.
- `FIELD_FULL_WIDTH_KEYS` (consumed by `sdk-section-page.tsx`) stays in `schema-field.tsx`.
- `secret-list-item.tsx`'s exported `SecretListItemSkeleton` is deferred (needs a consumer update).

**Acceptance criteria**

- [x] Each sub-component lives in its own file with a named export.
- [x] `FIELD_HELP_LINKS` travels with `FieldHelp` (its only user); `FIELD_FULL_WIDTH_KEYS` stays.
- [x] No leftover unused imports.
- [x] `npm run typecheck` clean; eslint/prettier clean; full `npm test` green; both guards unmodified.

**Test plan**

- `schema-field.test.tsx` and `profile-actions-menu.test.tsx` are comprehensive guards that
  exercise `FieldHelp` and `MenuItem` through their parents — they must stay green unmodified.
  No new tests (would duplicate existing coverage).

**Rollback:** Revert the PR — file-private moves, no external consumers.

## Summary

<!-- 1-3 bullets describing what changed. -->
Batch of the settings sub-pages cluster for the "one component per file" refactor. Splits two
file-private sub-components out of their parents. **No functional or UX changes.**

### Why

`schema-field.tsx` and `profile-actions-menu.tsx` each bundle a small sub-component with their
exported component. Extracting them keeps each parent focused.

### Changes

- **New** `field-help.tsx` — `FieldHelp` (+ its private `FIELD_HELP_LINKS` map).
- **New** `profile-actions-menu-item.tsx` — `MenuItem`.
- **Slimmed** `schema-field.tsx` / `profile-actions-menu.tsx` → import their sub-component;
  dropped the imports only it used. `FIELD_FULL_WIDTH_KEYS` (external consumer) stays.

### Behavior preservation

- Both sub-components moved verbatim (markup, classes, ARIA, testids).
- `FIELD_HELP_LINKS` is used only by `FieldHelp`, so it travels with it; the dependency graph stays acyclic.
- The exported `SchemaField` / `ProfileActionsMenu` are unchanged.

### Testing

- `npm run typecheck` → **0 errors**; eslint + prettier clean.
- `npm test` → **3186 passed / 0 failed** (416 files).
- The existing `schema-field.test.tsx` + `profile-actions-menu.test.tsx` (**24 tests**) pass
  **unmodified** — they render the parents and exercise `FieldHelp` (help text/links) and
  `MenuItem` (the menu rows). No new tests are added (they would duplicate this coverage).

### Risk

Low — file-private moves, no external consumers, covered by the existing comprehensive guards.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/agent-canvas/issues/1401

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-server-gui` repository and start the development server by running the following command:

   ```bash
   npm run dev
   ```

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a9` |
| **Commit** | `dcffd5f81bc36fcc8ed1b4dbbe56f93c51d0b15b` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-dcffd5f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-dcffd5f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-dcffd5f-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2390-amd64
ghcr.io/openhands/agent-canvas:pr-1402-amd64
ghcr.io/openhands/agent-canvas:sha-dcffd5f-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2390-arm64
ghcr.io/openhands/agent-canvas:pr-1402-arm64
ghcr.io/openhands/agent-canvas:sha-dcffd5f
ghcr.io/openhands/agent-canvas:hieptl-app-2390
ghcr.io/openhands/agent-canvas:pr-1402
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-dcffd5f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-dcffd5f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->