### PR TITLE
Show automation run error detail

### DIFF
--- a/src/components/features/automations/detail/activity-log-item.tsx
+++ b/src/components/features/automations/detail/activity-log-item.tsx
@@ -37,6 +37,8 @@ export function ActivityLogItem({ run }: ActivityLogItemProps) {
   const { t, i18n } = useTranslation("openhands");
   const hasConversation = !!run.conversation_id;
   const hasBashCommand = !!run.bash_command_id;
+  const hasErrorDetail = !!run.error_detail?.trim();
+  const hasDebugInfo = hasBashCommand || hasErrorDetail;
   // Only surface "Conversation not created" when the run has reached a
   // terminal status without a conversation — i.e. the conversation truly
   // will not be created (e.g. sandbox provisioning failed). While
@@ -73,7 +75,7 @@ export function ActivityLogItem({ run }: ActivityLogItemProps) {
     setLogsOpen(true);
   };
 
-  const logsButton = hasBashCommand ? (
+  const logsButton = hasDebugInfo ? (
     <button
       type="button"
       onClick={handleLogsClick}
@@ -120,10 +122,11 @@ export function ActivityLogItem({ run }: ActivityLogItemProps) {
         </div>
       )}
 
-      {hasBashCommand && (
+      {hasDebugInfo && (
         <RunLogsModal
           conversationId={run.conversation_id}
           bashCommandId={run.bash_command_id}
+          errorDetail={run.error_detail}
           isOpen={logsOpen}
           onClose={() => setLogsOpen(false)}
         />

--- a/src/components/features/automations/detail/run-logs-modal.test.tsx
+++ b/src/components/features/automations/detail/run-logs-modal.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RunLogsModal } from "./run-logs-modal";
+import { useBashCommandLogs } from "#/hooks/query/use-bash-command-logs";
+
+vi.mock("#/hooks/query/use-bash-command-logs", () => ({
+  useBashCommandLogs: vi.fn(),
+}));
+
+const mockUseBashCommandLogs = vi.mocked(useBashCommandLogs);
+
+describe("RunLogsModal", () => {
+  it("appends automation error detail without replacing fetched output", () => {
+    mockUseBashCommandLogs.mockReturnValue({
+      data: [
+        {
+          id: "output-1",
+          command_id: "cmd-1",
+          bash_command_id: "cmd-1",
+          order: 0,
+          stdout: "existing stdout\n",
+          stderr: "",
+          timestamp: "2026-06-15T17:00:34.000Z",
+        },
+      ],
+      error: null,
+      isFetching: false,
+      isPending: false,
+      isResolvingConversation: false,
+      conversationMissing: false,
+      sandboxIssue: null,
+    });
+
+    render(
+      <RunLogsModal
+        conversationId="conv-1"
+        bashCommandId="cmd-1"
+        errorDetail={"Timed out: command timed out or was killed\nstderr log"}
+        isOpen
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("run-logs-output-stdout")).toHaveTextContent(
+      "existing stdout",
+    );
+    expect(screen.getByTestId("run-logs-error-detail")).toHaveTextContent(
+      "AUTOMATIONS$DETAIL$LOGS_ERROR_DETAIL",
+    );
+    expect(screen.getByTestId("run-logs-error-detail")).toHaveTextContent(
+      "Timed out: command timed out or was killed",
+    );
+    expect(screen.getByTestId("run-logs-error-detail")).toHaveTextContent(
+      "stderr log",
+    );
+  });
+});

--- a/src/components/features/automations/detail/run-logs-modal.tsx
+++ b/src/components/features/automations/detail/run-logs-modal.tsx
@@ -29,6 +29,8 @@ interface RunLogsModalProps {
   conversationId: string | null;
   /** Bash command id to fetch logs for. */
   bashCommandId: string | null;
+  /** Error detail recorded on the automation run by the automation backend. */
+  errorDetail?: string | null;
   isOpen: boolean;
   onClose: () => void;
 }
@@ -50,6 +52,7 @@ function concatStream(outputs: BashOutput[], key: "stdout" | "stderr"): string {
 export function RunLogsModal({
   conversationId,
   bashCommandId,
+  errorDetail,
   isOpen,
   onClose,
 }: RunLogsModalProps) {
@@ -97,6 +100,8 @@ export function RunLogsModal({
   const loading = isResolvingConversation || (isFetching && !outputs);
   const noBashCommand = !bashCommandId;
   const activeBody = activeTab === "stdout" ? stdout : stderr;
+  const normalizedErrorDetail = errorDetail?.trim() ?? "";
+  const hasErrorDetail = normalizedErrorDetail.length > 0;
 
   const tabBaseClass =
     "border-b-2 px-3 py-2 text-sm font-normal transition-colors focus:outline-none";
@@ -229,6 +234,20 @@ export function RunLogsModal({
                 </span>
               )}
             </pre>
+          )}
+
+          {hasErrorDetail && (
+            <section
+              data-testid="run-logs-error-detail"
+              className="mt-4 border-t border-[var(--oh-border)] pt-4"
+            >
+              <h3 className="mb-2 text-xs font-medium uppercase text-muted">
+                {t(I18nKey.AUTOMATIONS$DETAIL$LOGS_ERROR_DETAIL)}
+              </h3>
+              <pre className="whitespace-pre-wrap break-words text-danger">
+                {normalizedErrorDetail}
+              </pre>
+            </section>
           )}
         </div>
       </div>

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -13565,6 +13565,23 @@
     "uk": "Пісочниця недоступна — її могли зупинити або зменшити масштаб.",
     "ca": "El sandbox no és accessible — pot haver-se aturat o reduït."
   },
+  "AUTOMATIONS$DETAIL$LOGS_ERROR_DETAIL": {
+    "en": "Automation error detail",
+    "ja": "自動化エラー詳細",
+    "zh-CN": "自动化错误详情",
+    "zh-TW": "自動化錯誤詳細",
+    "ko-KR": "자동화 오류 세부 정보",
+    "no": "Feildetaljer for automatisering",
+    "it": "Dettagli errore automazione",
+    "pt": "Detalhes do erro da automação",
+    "es": "Detalle del error de automatización",
+    "ar": "تفاصيل خطأ الأتمتة",
+    "fr": "Détail de l’erreur d’automatisation",
+    "tr": "Otomasyon hata ayrıntısı",
+    "de": "Details zum Automatisierungsfehler",
+    "uk": "Деталі помилки автоматизації",
+    "ca": "Detall de l'error d'automatització"
+  },
   "AUTOMATIONS$DETAIL$TIME_JUST_NOW": {
     "en": "Just now",
     "ja": "たった今",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->
I stumbled into this error detail being available from the automations server and wanted to help get it surfaced.

- [x] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->
I want to surface the errror_detail content if available without getting rid of the other bits. I didn't dig into what is already showing and why.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Surface error_detail in automation run logs alongside fetched bash output
- Keep the logs button available when a run has debug info from either a bash command or an error detail
- Add coverage for rendering error details without replacing existing stdout
- Add the localized label for the new error detail section

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->
https://github.com/OpenHands/agent-canvas/issues/1037 related although it doesn't "fix" this.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->


## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
