### PR TITLE
fix: send on Enter for touchscreen laptops

### DIFF
--- a/src/hooks/chat/use-chat-input-events.ts
+++ b/src/hooks/chat/use-chat-input-events.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { isMobileDevice } from "#/utils/utils";
+import { isMobileUserAgent } from "#/utils/utils";
 import {
   ensureCursorVisible,
   clearEmptyContent,
@@ -80,8 +80,11 @@ export const useChatInputEvents = (
         return;
       }
 
-      // Original submit logic - only for desktop without shift key
-      if (!isMobileDevice() && !e.shiftKey && !disabled) {
+      // Submit on Enter for everything except phones/tablets (where Enter
+      // inserts a newline and the user taps the send button). We gate on the
+      // user agent rather than touch capability so a desktop OS with a
+      // touchscreen (e.g. a Windows 2-in-1) still submits on Enter.
+      if (!isMobileUserAgent() && !e.shiftKey && !disabled) {
         e.preventDefault();
         handleSubmit();
       }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -62,18 +62,24 @@ export const setStyleHeightPx = (el: HTMLElement, height: number): void => {
 };
 
 /**
+ * Detect a phone/tablet user agent (Android, iPhone, iPad, …).
+ * Unlike isMobileDevice, this ignores touch capability, so a desktop OS with
+ * a touchscreen (e.g. a Windows 2-in-1) is NOT matched. Use this when the
+ * decision depends on having a physical keyboard rather than on touch input.
+ */
+export const isMobileUserAgent = (): boolean =>
+  /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent,
+  );
+
+/**
  * Detect if the user is on a mobile device.
  * Touch support alone is not sufficient — touchscreen laptops have touch
  * but use a mouse/trackpad as primary input. We check that the primary
  * pointing device is coarse (finger) to avoid false positives.
  */
 export const isMobileDevice = (): boolean => {
-  if (
-    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-      navigator.userAgent,
-    )
-  )
-    return true;
+  if (isMobileUserAgent()) return true;
 
   const hasTouch = "ontouchstart" in window || navigator.maxTouchPoints > 0;
   if (!hasTouch) return false;


### PR DESCRIPTION
HUMAN:

Fix a bug we had in SaaS

- [x] A human has tested these changes.

AGENT:

This is a 1:1 port of the already-merged OpenHands/OpenHands#14870 (full CI green, human-verified on a Windows touchscreen 2-in-1 by @jamiechicago312). agent-canvas carried the identical pre-fix code in `src/utils/utils.ts` and `src/hooks/chat/use-chat-input-events.ts`.

I did **not** run the app end-to-end (no Windows touchscreen available, and this is a non-visual logic change); verification is by code trace + relying on the upstream PR's human test and this repo's CI (lint/build/unit). The reporter's console values from OpenHands/OpenHands#14861 — `maxTouchPoints: 10`, `(pointer: fine) = false`, desktop Windows UA — trace through the new gate as: `isMobileUserAgent()` → `false` (UA has no mobile token) → Enter submits. Under the old `isMobileDevice()` gate the same values returned `true`, which is the bug.

---

## Why

On Windows touchscreen laptops / 2-in-1s, pressing Enter in the chat input inserts a newline instead of sending. Enter-to-send was gated by `!isMobileDevice()`, and `isMobileDevice()` returns `true` for touch devices whose primary pointer is coarse. On these machines the browser reports the touchscreen as the *primary* pointer, so `(pointer: fine)` is false, `isMobileDevice()` is `true`, and Enter no longer submits.

Pointer-based detection is unreliable for this on Windows, and the Enter-vs-newline decision doesn't need touch detection: a user pressing a physical Enter key wants send-on-Enter. The only devices where Enter should insert a newline are phones/tablets, which the user agent identifies reliably.

## Summary

- Add `isMobileUserAgent()` (user-agent only, ignores touch) to `src/utils/utils.ts`.
- Gate Enter-to-send on `!isMobileUserAgent()` instead of `!isMobileDevice()`, so any desktop OS with a touchscreen submits on Enter.
- `isMobileDevice()` is unchanged (it now reuses the same UA regex internally); its other callers — `remove-file-button` and `use-drag-resize` — keep their touch-aware behavior.

## Issue Number

No agent-canvas issue. Tracks upstream OpenHands/OpenHands#14861 and ports its fix OpenHands/OpenHands#14870.

## How to Test

On a Windows touchscreen laptop / 2-in-1 (or any device where `navigator.maxTouchPoints > 0` and `matchMedia("(pointer: fine)").matches` is false):

1. Open the chat input, type a message, press **Enter** → it now **sends** (previously inserted a newline).
2. Press **Shift+Enter** → still inserts a newline.
3. On a phone/tablet (mobile UA) → Enter still inserts a newline, unchanged.

## Video/Screenshots

N/A — non-visual logic change (no rendered UI changes). Same as upstream OpenHands/OpenHands#14870.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

`isMobileDevice()`'s touch+pointer heuristic is intentionally kept for the two touch-UX callers (`use-drag-resize`, `remove-file-button`) where "is touch the primary input" is the right question; only the Enter-to-send decision moves to the UA check.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a10` |
| **Commit** | `c71543ec89ef81cd322bd18b5208dc1c921a3605` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-c71543e
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-c71543e
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-c71543e-amd64
ghcr.io/openhands/agent-canvas:fix-enter-to-send-touchscreen-laptops-amd64
ghcr.io/openhands/agent-canvas:pr-1418-amd64
ghcr.io/openhands/agent-canvas:sha-c71543e-arm64
ghcr.io/openhands/agent-canvas:fix-enter-to-send-touchscreen-laptops-arm64
ghcr.io/openhands/agent-canvas:pr-1418-arm64
ghcr.io/openhands/agent-canvas:sha-c71543e
ghcr.io/openhands/agent-canvas:fix-enter-to-send-touchscreen-laptops
ghcr.io/openhands/agent-canvas:pr-1418
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-c71543e`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-c71543e-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->