### PR TITLE
Validate LLM settings before saving

### DIFF
--- a/__tests__/routes/llm-settings.test.tsx
+++ b/__tests__/routes/llm-settings.test.tsx
@@ -171,11 +171,66 @@ describe("LlmSettingsScreen", () => {
 
     await waitFor(() => expect(saveSettingsSpy).toHaveBeenCalled());
     const payload = saveSettingsSpy.mock.calls[0][0] as Record<string, unknown>;
-    const llmPayload = (
-      payload.agent_settings_diff as Record<string, unknown>
-    ).llm as Record<string, unknown>;
+    const llmPayload = (payload.agent_settings_diff as Record<string, unknown>)
+      .llm as Record<string, unknown>;
     expect(llmPayload.api_key).toBe("test-api-key");
     expect(llmPayload).not.toHaveProperty("base_url");
+  });
+
+  it("does not save an invalid LLM base URL", async () => {
+    const saveSettingsSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        llm_model: "openai/gpt-4o",
+        llm_base_url: "",
+        agent_settings: {
+          ...MOCK_DEFAULT_USER_SETTINGS.agent_settings,
+          llm: {
+            model: "openai/gpt-4o",
+            api_key: null,
+            base_url: "",
+          },
+        },
+      }),
+    );
+
+    renderLlmSettingsScreen();
+
+    await screen.findByTestId("llm-settings-screen");
+    fireEvent.click(screen.getByTestId("sdk-section-advanced-toggle"));
+    fireEvent.change(screen.getByTestId("base-url-input"), {
+      target: { value: "not a url" },
+    });
+    fireEvent.click(screen.getByTestId("save-button"));
+
+    expect(await screen.findByTestId("base-url-input-error")).toHaveTextContent(
+      "Enter a valid base URL.",
+    );
+    expect(saveSettingsSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not save an API key that is too short", async () => {
+    const saveSettingsSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({ llm_model: "openai/gpt-4o", llm_api_key_set: false }),
+    );
+
+    renderLlmSettingsScreen();
+
+    await screen.findByTestId("llm-settings-screen");
+    fireEvent.change(screen.getByTestId("llm-api-key-input"), {
+      target: { value: "short" },
+    });
+    fireEvent.click(screen.getByTestId("save-button"));
+
+    expect(
+      await screen.findByTestId("llm-api-key-input-error"),
+    ).toHaveTextContent("API key must be at least 8 characters.");
+    expect(saveSettingsSpy).not.toHaveBeenCalled();
   });
 
   it("does not show a 'key set' indicator for a brand-new embedded profile even when a global key exists (bug #640)", async () => {

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -85,6 +85,34 @@ const isProviderDefaultBaseUrl = (model: string, baseUrl: string) => {
   );
 };
 
+const validateBaseUrl = (baseUrl: string) => {
+  const trimmedBaseUrl = baseUrl.trim();
+  if (!trimmedBaseUrl) return null;
+
+  try {
+    const parsedUrl = new URL(trimmedBaseUrl);
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      return "Base URL must start with http:// or https://.";
+    }
+    if (parsedUrl.username || parsedUrl.password) {
+      return "Base URL must not include credentials.";
+    }
+  } catch {
+    return "Enter a valid base URL.";
+  }
+
+  return null;
+};
+
+const validateApiKey = (apiKey: string) => {
+  const trimmedApiKey = apiKey.trim();
+  if (trimmedApiKey.length > 0 && trimmedApiKey.length < 8) {
+    return "API key must be at least 8 characters.";
+  }
+
+  return null;
+};
+
 interface OpenHandsApiKeyHelpProps {
   testId: string;
 }
@@ -152,6 +180,10 @@ export function LlmSettingsScreen({
     (isSubscriptionModelsLoading || isSubscriptionModelsFetching);
   const lastApiKeyModelRef = React.useRef<string | null>(null);
   const lastSubscriptionModelRef = React.useRef<string | null>(null);
+  const [llmValidationErrors, setLlmValidationErrors] = React.useState<{
+    apiKey?: string;
+    baseUrl?: string;
+  }>({});
 
   React.useEffect(() => {
     if (initialAuthType === LLM_AUTH_TYPE_SUBSCRIPTION) {
@@ -221,11 +253,18 @@ export function LlmSettingsScreen({
             className="w-full"
             value={apiKeyValue}
             placeholder={apiKeyIsSet ? "<hidden>" : ""}
-            onChange={(value) => onChange("llm.api_key", value)}
+            onChange={(value) => {
+              setLlmValidationErrors((errors) => ({
+                ...errors,
+                apiKey: undefined,
+              }));
+              onChange("llm.api_key", value);
+            }}
             isDisabled={isDisabled}
             startContent={
               apiKeyIsSet ? <KeyStatusIcon isSet={apiKeyIsSet} /> : undefined
             }
+            error={llmValidationErrors.apiKey}
           />
 
           <HelpLink
@@ -395,8 +434,15 @@ export function LlmSettingsScreen({
                     className="w-full"
                     value={baseUrlValue}
                     placeholder="https://api.openai.com"
-                    onChange={(value) => onChange("llm.base_url", value)}
+                    onChange={(value) => {
+                      setLlmValidationErrors((errors) => ({
+                        ...errors,
+                        baseUrl: undefined,
+                      }));
+                      onChange("llm.base_url", value);
+                    }}
                     isDisabled={isDisabled}
+                    error={llmValidationErrors.baseUrl}
                   />
 
                   {renderApiKeyInput(
@@ -414,6 +460,8 @@ export function LlmSettingsScreen({
       defaultModel,
       embedded,
       isWaitingForSubscriptionModels,
+      llmValidationErrors.apiKey,
+      llmValidationErrors.baseUrl,
       settings?.llm_api_key_set,
       subscriptionModels,
       t,
@@ -439,6 +487,7 @@ export function LlmSettingsScreen({
       const authType = resolveLlmAuthType(context.values[LLM_AUTH_TYPE_KEY]);
 
       if (authType === LLM_AUTH_TYPE_SUBSCRIPTION) {
+        setLlmValidationErrors({});
         llm.auth_type = LLM_AUTH_TYPE_SUBSCRIPTION;
         llm.subscription_vendor = OPENAI_SUBSCRIPTION_VENDOR;
         const model =
@@ -462,6 +511,24 @@ export function LlmSettingsScreen({
           llm.auth_type = LLM_AUTH_TYPE_API_KEY;
           llm.subscription_vendor = null;
         }
+        const apiKeyValue =
+          typeof context.values["llm.api_key"] === "string"
+            ? context.values["llm.api_key"]
+            : "";
+        const baseUrlValue =
+          typeof context.values["llm.base_url"] === "string"
+            ? context.values["llm.base_url"]
+            : "";
+        const nextValidationErrors = {
+          apiKey: validateApiKey(apiKeyValue) ?? undefined,
+          baseUrl: validateBaseUrl(baseUrlValue) ?? undefined,
+        };
+        if (nextValidationErrors.apiKey || nextValidationErrors.baseUrl) {
+          setLlmValidationErrors(nextValidationErrors);
+          throw new Error("Fix the highlighted LLM settings before saving.");
+        }
+        setLlmValidationErrors({});
+
         if (context.view === "basic" && llm.model !== undefined) {
           llm.base_url = getSchemaFieldDefaultValue(schema, "llm.base_url");
         }


### PR DESCRIPTION
HUMAN:

I reviewed the settings validation behavior and confirmed the PR is ready for maintainer review.

- [x] A human has tested these changes.

AGENT:

---

## Why

The LLM settings form allowed invalid base URL values and very short API keys to be submitted, which could save unusable configuration and leave users without clear inline feedback.

## Summary

- add client-side validation for LLM base URL values before saving
- add API key length validation when a key is entered
- surface inline field errors and skip the save request when validation fails

## Issue Number

Fixes #911

## How to Test

Run the validation and type checks:

- npm run make-i18n
- npx vitest run __tests__/routes/llm-settings.test.tsx
- npm run typecheck
- npx prettier --check src/routes/llm-settings.tsx __tests__/routes/llm-settings.test.tsx
- npx eslint src/routes/llm-settings.tsx __tests__/routes/llm-settings.test.tsx

Then manually open the LLM settings form, enter an invalid base URL or too-short API key, and confirm the form shows inline validation errors without saving.

## Video/Screenshots

Not included.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Fork CI and preview deploys may still require maintainer approval before running.