### PR TITLE
docs: add Testing Rules section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,27 @@ npm run test:e2e:mock-llm -- --headed        # watch in browser
 npm run test:e2e:mock-llm -- -g "test name"  # run single test by name
 ```
 
+## Testing Rules
+
+<TESTING_RULES>
+Create TDD tests for your changes. Focus on user behavior and follow TDD best practices, including:
+
+- AAA structure (Arrange, Act, Assert)
+- Clear test focus
+- Proper test data management
+
+Before writing any test:
+
+- Avoid duplicating test cases or logic
+- Do not assert the same condition more than once
+- Do not mock the hook. Instead, mock the underlying service that the hook depends on
+- Prefer adding to or extending existing test files whenever possible. Create new test files only if no suitable ones exist
+- Do not include any tests that verify CSS, styling, or visual presentation. Focus only on functional behavior and logic
+- Keep the number of test cases to the minimum necessary while still fully covering the intended changes and behaviors
+
+Ensure each test is meaningful, concise, and covers a unique aspect of user interaction.
+</TESTING_RULES>
+
 ## Additional Notes
 
 - **Published binary auth fix**: When users install the npm package globally (`npm install -g @openhands/agent-canvas`) and run `agent-canvas`, the pre-built static frontend has NO `VITE_SESSION_API_KEY` baked in (npm publish runs `npm run build` with no such env var). The runtime session key is generated when the CLI launches and reaches the frontend via `scripts/static-server.mjs --session-api-key <key>`, which injects a `<head>` script that does two things: (a) sets `window.__AGENT_CANVAS_SESSION_API_KEY__ = <key>` — read by `getBakedSessionApiKey()` in `src/api/agent-server-config.ts` as a fallback when the env var is empty, symmetric with `__AGENT_CANVAS_AUTH_REQUIRED__` / `isAuthRequired()`; (b) writes the same key into `localStorage['openhands-agent-server-config'].sessionApiKey`, always overwriting when the value differs, so any code path that still reads the legacy storage key (e.g. e2e fixtures) sees the live key. The window-global path is the load-bearing one — without it, `makeDefaultLocalBackend()` returns null on a fresh install, the backend registry seeds empty, and `root.tsx` traps the user behind the Manage Backends modal instead of onboarding. `scripts/dev-with-automation.mjs` and `scripts/dev-static.mjs` both pass `--session-api-key ${config.sessionApiKey}` when starting the static server.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

Add a <TESTING_RULES> directive block establishing consistent TDD test-authoring standards for contributors and AI coding agents. AGENTS.md previously documented test infrastructure (E2E frameworks, debugging) but had no guidance on how to write tests.

The rules cover AAA structure, mocking the underlying service rather than the hook, extending existing test files, excluding CSS/visual assertions, and keeping coverage minimal but complete.

Placed at the end of the existing testing cluster (after "Debugging E2E Test Failures", before "Additional Notes") so all testing guidance stays in one contiguous region. Documentation-only change; pure insertion.

- [x] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

`AGENTS.md` is the operating guide that human engineers and their AI coding agents read before working in this repo. Today it documents test **infrastructure** (Live E2E, Mock-LLM E2E, debugging E2E failures) but offers no guidance on how to _author_ tests. Without a shared standard, contributors and agents write tests inconsistently — duplicated cases, mocked hooks, CSS/visual assertions, and redundant coverage.

Add a `<TESTING_RULES>` directive block that establishes consistent TDD authoring standards so everyone writing tests follows the same conventions.

### Acceptance Criteria

- [ ] A new `## Testing Rules` section exists in `AGENTS.md`.
- [ ] It contains the `<TESTING_RULES>...</TESTING_RULES>` block verbatim (AAA structure, mock the service not the hook, no CSS/visual tests, extend existing test files, minimal-but-complete coverage, no duplicated assertions).
- [ ] The section is placed within the existing testing cluster (after "Debugging E2E Test Failures", before "Additional Notes").
- [ ] The change is documentation-only — no source or test files modified.
- [ ] Diff is a pure insertion; no surrounding content altered.

### Out of Scope

- Enforcing these rules via lint/CI tooling.
- Rewriting or refactoring any existing tests.

## Summary

<!-- 1-3 bullets describing what changed. -->
Adds a new `## Testing Rules` section to `AGENTS.md` containing a `<TESTING_RULES>` directive block that establishes consistent TDD test-authoring standards for both human engineers and AI coding agents.

`AGENTS.md` already documents test **infrastructure** (Live E2E, Mock-LLM E2E, debugging E2E failures) but had no guidance on how to _author_ tests. This block fills that gap so tests are written consistently across contributors and agents.

### What the rules cover

- Create TDD tests focused on user behavior, using AAA (Arrange, Act, Assert) structure, clear test focus, and proper test data management.
- Avoid duplicating test cases/logic; don't assert the same condition twice.
- Don't mock the hook — mock the underlying service the hook depends on.
- Prefer extending existing test files; create new files only when none fit.
- No CSS / styling / visual-presentation tests — functional behavior only.
- Keep the number of test cases minimal while still fully covering the behavior.

### Placement & rationale

Inserted at the end of the existing testing cluster — after "Debugging E2E Test Failures" and before "Additional Notes" — so all testing guidance lives in one contiguous region (frameworks → debugging → authoring rules). The convention sections (`API Access Rules`, `No Magic Strings`) were not chosen because they govern production-code architecture, not test authoring. The provided `<TESTING_RULES>` block is kept verbatim under a `## Testing Rules` heading that matches the document's section convention.

### Changes

- `AGENTS.md` — +21 lines, pure insertion. No other files touched.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/agent-canvas/issues/1444

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

- Documentation-only change; no build or test impact.
- `git diff AGENTS.md` confirms a single added section with no deletions or modifications to surrounding content.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a10` |
| **Commit** | `8f24523e722f9b335f98a123c4f2e54ce6fb05cd` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-8f24523
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-8f24523
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-8f24523-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2442-amd64
ghcr.io/openhands/agent-canvas:pr-1445-amd64
ghcr.io/openhands/agent-canvas:sha-8f24523-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2442-arm64
ghcr.io/openhands/agent-canvas:pr-1445-arm64
ghcr.io/openhands/agent-canvas:sha-8f24523
ghcr.io/openhands/agent-canvas:hieptl-app-2442
ghcr.io/openhands/agent-canvas:pr-1445
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-8f24523`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-8f24523-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->