### PR TITLE
fix(onboarding): stop next-slide flicker after Cloud login

### DIFF
--- a/__tests__/components/onboarding/onboarding-modal.test.tsx
+++ b/__tests__/components/onboarding/onboarding-modal.test.tsx
@@ -372,6 +372,45 @@ describe("OnboardingModal", () => {
     // click time, and the modal is now dismissing.
   });
 
+  it("does not flash the Choose Agent step after Cloud login in locked-to-Cloud mode", async () => {
+    // Regression for hieptl's follow-up flicker report on PR #1389
+    // (review 4543227064): even after `onClose` is wired up so the
+    // modal is *dismissed* on Cloud login, the modal stays mounted
+    // for one or more renders until the root first-run gate tears it
+    // down. During that teardown window the freshly-connected Cloud
+    // backend flips `skipBackendStep` true, which renumbers the slide
+    // rail and advances the visible slide from "backend" to "agent"
+    // (Choose Agent) — so the next screen flashes on screen before
+    // the modal finally disappears. Cloud login IS onboarding
+    // completion in locked mode, so the Choose Agent step must NEVER
+    // render after the Cloud login button is clicked.
+    window.localStorage.clear();
+    vi.stubEnv("VITE_BACKEND_BASE_URL", "");
+    vi.stubEnv("VITE_SESSION_API_KEY", "");
+    vi.stubEnv("VITE_LOCK_TO_CLOUD", "https://app.all-hands.dev");
+    delete (window as unknown as Record<string, unknown>)
+      .__AGENT_CANVAS_SESSION_API_KEY__;
+    __resetActiveStoreForTests();
+
+    const onClose = vi.fn();
+    renderModal(onClose);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("onboarding-backend-login-button"));
+
+    // Cloud login must dismiss the modal.
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // The Choose Agent slide ("the next window") must never appear at
+    // any point after Cloud login — not even briefly while the modal
+    // waits for the root gate to unmount it.
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      screen.queryByTestId("onboarding-step-choose-agent"),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps the backend step visible for a reachable stale Local backend in locked-to-Cloud mode", async () => {
     // Regression for PR #1389 review: in locked-to-Cloud mode a reachable
     // stale Local backend (one persisted from a previous non-locked

--- a/src/components/features/onboarding/onboarding-modal.tsx
+++ b/src/components/features/onboarding/onboarding-modal.tsx
@@ -160,14 +160,34 @@ export function OnboardingModal({
   const [selectedAgentId, setSelectedAgentId] =
     React.useState<OnboardingAgentId>("openhands");
 
+  // Once dismissal is requested (Cloud login in locked-to-Cloud mode, the
+  // skip button, or launching the final step) the modal must disappear
+  // immediately and never render another slide. The root first-run gate
+  // unmounts this modal asynchronously (it flips `showFirstRunOnboarding`
+  // inside a `useEffect`, so the unmount lags by a render). During that
+  // teardown window the freshly-connected Cloud backend can flip
+  // `skipBackendStep` true, which renumbers the slide rail and would
+  // otherwise advance the visible slide to Choose Agent — the "next window
+  // shows up, disappears, then shows up again" flicker reported on PR #1389
+  // (review 4543227064). Rendering nothing while `dismissing` is set guarantees
+  // no slide can flash before the gate tears the modal down.
+  const [dismissing, setDismissing] = React.useState(false);
+  const dismiss = React.useCallback(() => {
+    setDismissing(true);
+    onClose();
+  }, [onClose]);
+
   // When the backend slide drops out of the flow (skipBackendStep flips
   // true), a user still parked on "backend" must be moved forward to the
   // first remaining phase. Doing this with the *phase* rather than a numeric
   // step keeps every other phase pinned to itself, so the user never lands
-  // on the slide that used to live at the next index ("setup").
+  // on the slide that used to live at the next index ("setup"). Skipped
+  // while dismissing so a collapsing backend slide can't advance the phase
+  // (and flash the next slide) after Cloud login.
   React.useEffect(() => {
+    if (dismissing) return;
     if (!slideOrder.includes(phase)) setPhase(slideOrder[0]);
-  }, [phase, slideOrder]);
+  }, [phase, slideOrder, dismissing]);
 
   const totalSteps = slideOrder.length;
   const currentPhase = slideOrder.includes(phase) ? phase : slideOrder[0];
@@ -193,6 +213,11 @@ export function OnboardingModal({
       return order[Math.max(safeIdx - 1, 0)];
     });
   }, [slideOrder]);
+
+  // Dismissal requested: render nothing so no slide (in particular the
+  // Choose Agent step that a freshly-connected Cloud backend would
+  // otherwise advance to) can flash before the root gate unmounts us.
+  if (dismissing) return null;
 
   return (
     // No `onClose`: the flow must only be dismissed via explicit actions
@@ -232,7 +257,7 @@ export function OnboardingModal({
                   index={slideOrder.indexOf("backend")}
                   currentStep={currentStep}
                 >
-                  <CheckBackendStep onNext={goNext} onClose={onClose} />
+                  <CheckBackendStep onNext={goNext} onClose={dismiss} />
                 </Slide>
               )}
               <Slide
@@ -267,8 +292,8 @@ export function OnboardingModal({
               >
                 <SayHelloStep
                   onBack={goBack}
-                  onClose={onClose}
-                  onLaunched={onClose}
+                  onClose={dismiss}
+                  onLaunched={dismiss}
                 />
               </Slide>
             </div>
@@ -279,7 +304,7 @@ export function OnboardingModal({
           <button
             type="button"
             data-testid="onboarding-skip"
-            onClick={onClose}
+            onClick={dismiss}
             className="rounded-md px-3 py-2 text-sm text-[var(--oh-muted)] transition-colors hover:bg-white/5 hover:text-white cursor-pointer"
           >
             {t(I18nKey.ONBOARDING$SKIP)}


### PR DESCRIPTION
## Summary

Fixes the follow-up flicker reported by @hieptl on PR #1389 ([review 4543227064](https://github.com/OpenHands/agent-canvas/pull/1389#pullrequestreview-4543227064)):

> After logging into OpenHands Cloud, the onboarding modal appears to behave inconsistently. It repeatedly appears and disappears, resulting in a flickering effect.

After logging into OpenHands Cloud in locked-to-Cloud mode, the **Choose Agent** slide ("the next window") flashes on screen, disappears, then the modal is torn down by the root first-run gate.

## Root cause

`CheckBackendStep.handleConnected` already called `onClose` (`markCompleted`) instead of `onNext` (the original PR #1389 fix). But the modal stays mounted for a render or two until the root gate's `useEffect` flips `showFirstRunOnboarding` to `false`. During that teardown window the freshly-connected Cloud backend flips `skipBackendStep` to `true`, which renumbers the slide rail (`PHASE_ORDER_WITH_BACKEND` → `PHASE_ORDER_WITHOUT_BACKEND`) and advances the visible phase from `"backend"` to `"agent"` (Choose Agent) — so the next screen flashes before the modal is unmounted.

The existing regression test only asserted `onClose` was called once; it did not catch the slide advancement, so the flicker survived.

## Fix

In `OnboardingModal`:
- Wrap `onClose` in a `dismiss` callback that sets a local `dismissing` flag before calling `onClose`.
- **Render `null` while `dismissing`** so no slide (in particular Choose Agent) can flash during the teardown window.
- Skip the phase-renumber `useEffect` while `dismissing`, so a collapsing backend slide can't advance the phase after Cloud login.
- `dismiss` is passed to `CheckBackendStep`, `SayHelloStep`, and the skip button (all dismissal paths).

Result: when Cloud login succeeds, the onboarding modal **disappears immediately without showing the next screen**.

## Test

Adds a regression test `does not flash the Choose Agent step after Cloud login in locked-to-Cloud mode` that clicks the Cloud login button and asserts the Choose Agent step (`onboarding-step-choose-agent`) never renders. This test **fails before the fix** (the Choose Agent step renders) and passes after.

```
__tests__/components/onboarding/onboarding-modal.test.tsx
```

## Verification

- New test passes; full onboarding suite (77 tests), root + routes suites (273 tests) all green.
- `eslint`, `prettier --check`, and `tsc --noEmit` are clean.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/02a382e4-96a9-4edc-b507-f5180d7816cc)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a10` |
| **Commit** | `8f1c4c1e2673b00fa910f70757b0dee74d4a0b50` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-8f1c4c1
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-8f1c4c1
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-8f1c4c1-amd64
ghcr.io/openhands/agent-canvas:fix-onboarding-cloud-login-flicker-amd64
ghcr.io/openhands/agent-canvas:pr-1454-amd64
ghcr.io/openhands/agent-canvas:sha-8f1c4c1-arm64
ghcr.io/openhands/agent-canvas:fix-onboarding-cloud-login-flicker-arm64
ghcr.io/openhands/agent-canvas:pr-1454-arm64
ghcr.io/openhands/agent-canvas:sha-8f1c4c1
ghcr.io/openhands/agent-canvas:fix-onboarding-cloud-login-flicker
ghcr.io/openhands/agent-canvas:pr-1454
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-8f1c4c1`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-8f1c4c1-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->