### PR TITLE
fix: pickFallbackBackend ignores backend health and kind

### DIFF
--- a/__tests__/api/backend-registry/active-store.test.ts
+++ b/__tests__/api/backend-registry/active-store.test.ts
@@ -9,11 +9,17 @@ import {
   subscribeActiveBackend,
 } from "#/api/backend-registry/active-store";
 import { SEEDED_DEFAULT_BACKEND_ID } from "#/api/backend-registry/default-backend";
+import { MAX_CONSECUTIVE_FAILURES } from "#/api/backend-registry/health-storage";
+import {
+  __resetHealthStoreForTests,
+  recordBackendFailure,
+} from "#/api/backend-registry/health-store";
 import type { Backend } from "#/api/backend-registry/types";
 
 beforeEach(() => {
   window.localStorage.clear();
   window.sessionStorage.clear();
+  __resetHealthStoreForTests();
   __resetActiveStoreForTests();
 });
 
@@ -21,6 +27,7 @@ afterEach(() => {
   window.localStorage.clear();
   window.sessionStorage.clear();
   vi.unstubAllEnvs();
+  __resetHealthStoreForTests();
   __resetActiveStoreForTests();
 });
 
@@ -39,6 +46,20 @@ const localBackend: Backend = {
   apiKey: "k",
   kind: "local",
 };
+
+const secondLocalBackend: Backend = {
+  id: "local-2",
+  name: "Local 2",
+  host: "http://localhost:9001",
+  apiKey: "k2",
+  kind: "local",
+};
+
+function markBackendUnhealthy(id: string): void {
+  for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i += 1) {
+    recordBackendFailure(id, new Error("connection failed"));
+  }
+}
 
 describe("active-store", () => {
   it("uses the no-backend sentinel when no backend details are available", () => {
@@ -81,6 +102,41 @@ describe("active-store", () => {
     expect(getActiveBackend().orgId).toBeNull();
   });
 
+  it("falls back to a healthy local backend when a cloud backend is registered first", () => {
+    setRegisteredBackends([cloudBackend, localBackend]);
+    setActiveSelection(null);
+
+    expect(getActiveBackend().backend).toEqual(localBackend);
+  });
+
+  it("skips an unhealthy local backend in favor of a healthy one further down", () => {
+    markBackendUnhealthy(localBackend.id);
+    setRegisteredBackends([localBackend, secondLocalBackend]);
+    setActiveSelection(null);
+
+    expect(getActiveBackend().backend).toEqual(secondLocalBackend);
+  });
+
+  it("still selects a local backend when every local backend is unhealthy", () => {
+    markBackendUnhealthy(localBackend.id);
+    markBackendUnhealthy(secondLocalBackend.id);
+    setRegisteredBackends([cloudBackend, localBackend, secondLocalBackend]);
+    setActiveSelection(null);
+
+    const { backend } = getActiveBackend();
+    expect(backend.kind).toBe("local");
+    expect(backend.id).not.toBe(NO_BACKEND_ID);
+    // Deterministic: first local backend in insertion order.
+    expect(backend).toEqual(localBackend);
+  });
+
+  it("selects a single healthy local backend at the first registry position", () => {
+    setRegisteredBackends([localBackend]);
+    setActiveSelection(null);
+
+    expect(getActiveBackend().backend).toEqual(localBackend);
+  });
+
   it("falls back to the first registered backend when the registry has no local entry", () => {
     setRegisteredBackends([cloudBackend]);
     setActiveSelection(null);
@@ -100,6 +156,15 @@ describe("active-store", () => {
     setActiveSelection({ backendId: cloudBackend.id });
 
     expect(getEffectiveLocalBackend()).toBeNull();
+  });
+
+  it("keeps an explicit cloud selection even when a healthy local backend exists", () => {
+    setRegisteredBackends([localBackend, cloudBackend]);
+    setActiveSelection({ backendId: cloudBackend.id, orgId: "org-2" });
+
+    const { backend, orgId } = getActiveBackend();
+    expect(backend).toEqual(cloudBackend);
+    expect(orgId).toBe("org-2");
   });
 
   it("notifies subscribers when selection changes", () => {

--- a/src/api/backend-registry/active-store.ts
+++ b/src/api/backend-registry/active-store.ts
@@ -1,3 +1,4 @@
+import { getBackendHealthEntry } from "./health-store";
 import {
   readStoredActiveBackend,
   readStoredBackends,
@@ -33,8 +34,27 @@ export function isNoBackend(backend: Backend): boolean {
   return backend.id === NO_BACKEND_ID;
 }
 
+/**
+ * Choose an active backend when there is no valid explicit selection (fresh
+ * start, or the selected backend was removed). Most of the GUI speaks the
+ * local agent-server protocol, so a cloud or dead-local backend at index 0
+ * would leave `getEffectiveLocalBackend()` null and make every local-protocol
+ * call throw "No backend is configured" even when a healthy local backend is
+ * registered further down the list. Consult the synchronous, persisted health
+ * store and prefer a healthy local backend; fall back to any local backend so
+ * the effective-local resolver still resolves, then to the prior deterministic
+ * `backends[0]` behavior for the registry-has-no-local case.
+ */
 function pickFallbackBackend(backends: Backend[]): Backend {
-  return backends[0] ?? NO_BACKEND;
+  const healthyLocalBackend = backends.find(
+    (backend) =>
+      backend.kind === "local" &&
+      getBackendHealthEntry(backend.id)?.disabled !== true,
+  );
+  if (healthyLocalBackend) return healthyLocalBackend;
+
+  const localBackend = backends.find((backend) => backend.kind === "local");
+  return localBackend ?? backends[0] ?? NO_BACKEND;
 }
 
 function computeSnapshot(


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

This change is library-internal to the backend registry (`src/api/backend-registry/active-store.ts`). I verified it with the package's own vitest suite against the touched and adjacent modules; there is no standalone way to exercise this resolver end-to-end without a multi-backend agent-server setup, so the verification is the unit suite plus the reproduction notes under How to Test below.

---

## Why

When there is no valid active backend selection (a fresh start, or the previously selected backend was removed), `pickFallbackBackend()` returned `backends[0]` — the first registered backend in insertion order — ignoring both its `kind` and its recorded health.

If index 0 is a cloud backend, or a local backend that has already been marked `disabled` in the persisted health store, `getEffectiveLocalBackend()` resolves to null. Every local-protocol call (verified models, LLM profiles, conversation CRUD) then throws "No backend is configured" — the symptom reported in the issue: Settings -> LLMs shows "No backend is configured" even when a healthy local backend is registered further down the list. A synchronous health store (`health-store.ts`) already exists at this selection point but was not consulted.

## Summary

- `pickFallbackBackend()` now consults the synchronous, persisted health store (`getBackendHealthEntry`) when resolving the fallback, and prefers a healthy local backend over a cloud backend or a backend already marked unhealthy.
- Selection priority on the fallback path: (1) a `local` backend not marked `disabled`, then (2) any `local` backend (so the effective-local resolver still resolves when all locals are unhealthy), then (3) the prior deterministic `backends[0] ?? NO_BACKEND` for the registry-has-no-local case.
- Scope is limited to the fallback path: explicit selections, including cloud, are untouched. No new exported API surface; the health store is read-only at this call site.

## Issue Number

Fixes #1174

## How to Test

```
npm install
npx vitest run __tests__/api/backend-registry/active-store.test.ts
```

All tests pass. New cases cover: a cloud backend registered first with a healthy local later (picks the local), an unhealthy local backend skipped for a healthy one further down, all-local-unhealthy still resolving to a local backend (no crash, deterministic), a single local backend at index 0, the registry-has-no-local case still returning `backends[0]`, and an explicit cloud selection remaining untouched.

Manual reproduction of the original bug: register a cloud backend (or a local backend whose health has tripped the failure cap) at the first registry position and a healthy local backend after it, with no explicit active selection. Before this change, Settings -> LLMs reports "No backend is configured"; after it, the healthy local backend is selected.

## Video/Screenshots

Not applicable — this is an internal resolver change with no UI surface of its own; evidence is the unit suite above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fix reads health lazily at fallback-resolution time and intentionally does not subscribe `active-store` to live `health-store` changes — re-selecting a different backend mid-session would also need the provider's bootstrap/cache-invalidation flow, which is out of scope for this fix. The resolver picks up the correct backend on the next registry/selection write or reload, which is the path the reported symptom occurs on.
