### PR TITLE
fix(config): surface model-ID-only providers (e.g. OpenRouter) in Basic LLM list

### DIFF
--- a/__tests__/api/config-service.test.ts
+++ b/__tests__/api/config-service.test.ts
@@ -58,4 +58,38 @@ describe("ConfigService", () => {
     const openhands = page.items.find((p) => p.name === "openhands");
     expect(openhands).toEqual({ name: "openhands", verified: true });
   });
+
+  it("surfaces providers discoverable only from model IDs (e.g. openrouter)", async () => {
+    // Arrange: mirror the real local agent-server, where OpenRouter ships
+    // namespaced model IDs (`openrouter/...`) but is absent from both
+    // /api/llm/providers and the verified map.
+    server.use(
+      http.get("*/api/llm/providers", () =>
+        HttpResponse.json({ providers: ["anthropic", "openai"] }),
+      ),
+      http.get("*/api/llm/models", () =>
+        HttpResponse.json({
+          models: [
+            "anthropic/claude-opus-4-5-20251101",
+            "openai/gpt-4o",
+            "openrouter/anthropic/claude-3.5-sonnet",
+            "openrouter/google/gemini-2.0-flash",
+          ],
+        }),
+      ),
+      http.get("*/api/llm/models/verified", () =>
+        HttpResponse.json({
+          models: { anthropic: ["claude-opus-4-5-20251101"] },
+        }),
+      ),
+    );
+
+    // Act
+    const page = await ConfigService.searchProviders({ limit: 20 });
+
+    // Assert: openrouter is present (unverified, derived from model IDs) and
+    // appears exactly once despite contributing multiple model entries.
+    const openrouter = page.items.filter((p) => p.name === "openrouter");
+    expect(openrouter).toEqual([{ name: "openrouter", verified: false }]);
+  });
 });

--- a/src/api/config-service/config-service.api.ts
+++ b/src/api/config-service/config-service.api.ts
@@ -161,13 +161,30 @@ class ConfigService {
       verifiedByProvider !== undefined
         ? Promise.resolve(verifiedByProvider)
         : llmClient.getVerifiedModels();
-    const [providers, verifiedMap] = await Promise.all([
+    const [providers, models, verifiedMap] = await Promise.all([
       llmClient.getProviders(),
+      llmClient.getModels(),
       verifiedFetch,
     ]);
 
     const verifiedProviders = new Set(Object.keys(verifiedMap ?? {}));
-    const names = new Set<string>([...verifiedProviders, ...(providers ?? [])]);
+
+    // Providers discoverable from model IDs (e.g. `openrouter/...`). Some
+    // providers — OpenRouter is the canonical example — are absent from
+    // `/api/llm/providers` and the verified map on local backends, yet they
+    // still ship namespaced model IDs. Surfacing their prefixes keeps the
+    // Basic provider picker in parity with what the model list can offer.
+    const modelDerivedProviders = (models ?? [])
+      .map((model) => model.split("/")[0])
+      .filter((name): name is string => Boolean(name));
+
+    // Verified providers come first so they survive `limitItems` when the
+    // result is capped; the Set then dedupes while preserving insertion order.
+    const names = new Set<string>([
+      ...verifiedProviders,
+      ...(providers ?? []),
+      ...modelDerivedProviders,
+    ]);
     const providerItems: LLMProvider[] = [...names].map((name) => ({
       name,
       verified: verifiedProviders.has(name),


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

---

## Why

OpenRouter is offered in the Basic LLM Providers list on OpenHands Cloud, but it is missing on a local backend in Agent Canvas (issue #1419).

Root cause: `ConfigService.searchProviders` (local path in `src/api/config-service/config-service.api.ts`) built the provider list from `/api/llm/providers` plus the keys of the verified-models map only. On a local agent-server, `/api/llm/providers` comes from litellm and the verified map does not include OpenRouter, yet OpenRouter still ships namespaced model IDs (`openrouter/...`) via `/api/llm/models`. Because nothing fed those model-ID prefixes into the provider derivation, the provider never appeared in the Basic picker.

## Summary

- `searchProviders` now also fetches `/api/llm/models` and derives provider names from model-ID prefixes (e.g. `openrouter/...` → `openrouter`), so providers discoverable only from model IDs are surfaced.
- Names are deduped via a `Set` that lists verified providers first, then `/api/llm/providers`, then model-derived providers, preserving existing ordering/`limitItems` behavior (verified providers still survive when the result is capped).
- Added a regression test that mocks the real local-backend shape (provider absent from `/api/llm/providers` and the verified map, present only in model IDs) and asserts `openrouter` appears exactly once and unverified.

## Issue Number

Fixes #1419

## How to Test

Automated (what I ran):

```
npm ci
npm run make-i18n
npm run typecheck        # react-router typegen && tsc — clean
npx vitest run __tests__/api/config-service.test.ts   # 4 passed
npx eslint src/api/config-service/config-service.api.ts          # clean
npx prettier --check src/api/config-service/config-service.api.ts # clean
```

Regression-test proof: with the fix reverted (`git stash` on the source file), the new test fails with `expected [] to deeply equal [ { name: 'openrouter', verified: false } ]`; with the fix applied it passes. The other three existing provider/model derivation tests stay green.

Manual end-to-end against a live local agent-server was not run in this environment (no running agent-server available here). The change is confined to the local provider-search derivation; to verify in the GUI: start a local backend that exposes `openrouter/...` entries from `/api/llm/models`, open Settings → LLMs → Basic, and confirm OpenRouter now appears in the provider list.

## Video/Screenshots

Not captured — no live local backend available in this environment. See the regression-test before/after output described under How to Test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fix is intentionally minimal and local to `searchProviders`; the cloud path is unchanged (it calls `/api/v1/config/providers/search` directly). No UI-layer change was needed — the picker renders whatever this derivation returns.
