### PR TITLE
feat: stream OpenHands agent responses

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -106,6 +106,8 @@ describe("buildStartConversationRequest", () => {
       model: "nested-model",
       api_key: "nested-key",
       base_url: "https://nested.example.com",
+      // Streaming is enabled so the OpenHands agent emits StreamingDeltaEvents.
+      stream: true,
     });
     expect(payload.agent_settings.condenser).toEqual({
       enabled: true,
@@ -183,6 +185,7 @@ describe("buildStartConversationRequest", () => {
 
     expect(payload.agent_settings.llm).toEqual({
       model: "gpt-5.2-codex",
+      stream: true,
       auth_type: LLM_AUTH_TYPE_SUBSCRIPTION,
       subscription_vendor: OPENAI_SUBSCRIPTION_VENDOR,
     });

--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -775,6 +775,8 @@ describe("AgentServerConversationService", () => {
         expect.objectContaining({
           model: "openhands/claude-haiku-4-5",
           api_key: "encrypted-key",
+          // Streaming must stay enabled after a mid-conversation switch.
+          stream: true,
           usage_id: expect.stringMatching(/^profile:haiku:/),
         }),
       );

--- a/__tests__/components/conversation-events/chat/event-thought-helpers.test.ts
+++ b/__tests__/components/conversation-events/chat/event-thought-helpers.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { splitInlineThink } from "#/components/conversation-events/chat/event-thought-helpers";
+
+describe("splitInlineThink", () => {
+  it("returns content unchanged when there is no <think> block", () => {
+    expect(splitInlineThink("Hello! How can I help?")).toEqual({
+      reasoning: "",
+      message: "Hello! How can I help?",
+    });
+  });
+
+  it("extracts a leading <think> block and keeps the trailing message", () => {
+    const content =
+      "<think>The user wants a greeting. Simple.</think>\n\n\nHello!";
+    expect(splitInlineThink(content)).toEqual({
+      reasoning: "The user wants a greeting. Simple.",
+      message: "Hello!",
+    });
+  });
+
+  it("treats an unclosed <think> (mid-stream) as reasoning so it never leaks", () => {
+    expect(splitInlineThink("<think>The user is asking me to")).toEqual({
+      reasoning: "The user is asking me to",
+      message: "",
+    });
+  });
+
+  it("joins multiple <think> blocks and keeps interleaved message text", () => {
+    const content = "<think>a</think>Hello <think>b</think>world";
+    expect(splitInlineThink(content)).toEqual({
+      reasoning: "a\n\nb",
+      message: "Hello world",
+    });
+  });
+
+  it("returns an empty message when the content is reasoning only", () => {
+    expect(splitInlineThink("<think>just thinking</think>")).toEqual({
+      reasoning: "just thinking",
+      message: "",
+    });
+  });
+});

--- a/__tests__/components/conversation-events/chat/event-thought-helpers.test.ts
+++ b/__tests__/components/conversation-events/chat/event-thought-helpers.test.ts
@@ -9,7 +9,7 @@ describe("splitInlineThink", () => {
     });
   });
 
-  it("extracts a leading <think> block and keeps the trailing message", () => {
+  it("extracts a leading closed <think> block and keeps the trailing message", () => {
     const content =
       "<think>The user wants a greeting. Simple.</think>\n\n\nHello!";
     expect(splitInlineThink(content)).toEqual({
@@ -18,18 +18,10 @@ describe("splitInlineThink", () => {
     });
   });
 
-  it("treats an unclosed <think> (mid-stream) as reasoning so it never leaks", () => {
-    expect(splitInlineThink("<think>The user is asking me to")).toEqual({
-      reasoning: "The user is asking me to",
-      message: "",
-    });
-  });
-
-  it("joins multiple <think> blocks and keeps interleaved message text", () => {
-    const content = "<think>a</think>Hello <think>b</think>world";
-    expect(splitInlineThink(content)).toEqual({
-      reasoning: "a\n\nb",
-      message: "Hello world",
+  it("handles leading whitespace before the <think> block", () => {
+    expect(splitInlineThink("\n  <think>thinking</think>\n\nHi")).toEqual({
+      reasoning: "thinking",
+      message: "Hi",
     });
   });
 
@@ -37,6 +29,58 @@ describe("splitInlineThink", () => {
     expect(splitInlineThink("<think>just thinking</think>")).toEqual({
       reasoning: "just thinking",
       message: "",
+    });
+  });
+
+  // Regression: an agent that literally emits "<think>" as its finalized
+  // answer (no closing tag) must render verbatim, not vanish into Thinking.
+  it("renders a finalized unclosed leading <think> verbatim", () => {
+    expect(splitInlineThink("<think>")).toEqual({
+      reasoning: "",
+      message: "<think>",
+    });
+  });
+
+  // Mid-stream, an unclosed leading <think> is reasoning still arriving, so
+  // it is hidden until </think> shows up.
+  it("treats an unclosed leading <think> as reasoning while streaming", () => {
+    expect(
+      splitInlineThink("<think>The user is asking me to", { streaming: true }),
+    ).toEqual({ reasoning: "The user is asking me to", message: "" });
+  });
+
+  // Only the first block is peeled; a <think> that is part of the answer
+  // (after </think>) is preserved verbatim.
+  it("preserves a <think> that appears after the reasoning block", () => {
+    expect(splitInlineThink("<think>reasoning</think>\n\n<think>")).toEqual({
+      reasoning: "reasoning",
+      message: "<think>",
+    });
+  });
+
+  // Regression (reviewer): a <think> that is NOT at the start must be
+  // preserved verbatim — only litellm's leading reasoning block is extracted.
+  it("leaves a mid-message <think> reference untouched", () => {
+    const content = "You can wrap reasoning in <think> and </think> tags.";
+    expect(splitInlineThink(content)).toEqual({
+      reasoning: "",
+      message: content,
+    });
+  });
+
+  it("leaves an unclosed mid-message <think> untouched", () => {
+    const content = "See the <think> tag for details.";
+    expect(splitInlineThink(content)).toEqual({
+      reasoning: "",
+      message: content,
+    });
+  });
+
+  it("does not extract a <think> block that follows real message text", () => {
+    const content = "Here is an example: <think>not reasoning</think> done.";
+    expect(splitInlineThink(content)).toEqual({
+      reasoning: "",
+      message: content,
     });
   });
 });

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -750,6 +750,12 @@ function buildConfiguredOpenHandsAgentSettings(
       ? llm.model
       : DEFAULT_SETTINGS.llm_model;
 
+  // Stream assistant tokens so the OpenHands agent matches the ACP agents'
+  // live-typing experience. The agent-server only emits StreamingDeltaEvent
+  // for SDK LLM agents when at least one LLM has stream=True (ACP agents
+  // stream unconditionally); the UI already renders those deltas.
+  llm.stream = true;
+
   const apiKey = normalizeSecretString(llm.api_key);
   if (apiKey) {
     llm.api_key = apiKey;

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -750,10 +750,8 @@ function buildConfiguredOpenHandsAgentSettings(
       ? llm.model
       : DEFAULT_SETTINGS.llm_model;
 
-  // Stream assistant tokens so the OpenHands agent matches the ACP agents'
-  // live-typing experience. The agent-server only emits StreamingDeltaEvent
-  // for SDK LLM agents when at least one LLM has stream=True (ACP agents
-  // stream unconditionally); the UI already renders those deltas.
+  // Stream assistant tokens (parity with ACP agents). The agent-server only
+  // emits StreamingDeltaEvents for SDK LLM agents when an LLM has stream=True.
   llm.stream = true;
 
   const apiKey = normalizeSecretString(llm.api_key);

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -715,10 +715,8 @@ class AgentServerConversationService {
     await conversationClient.switchLLM(conversationId, {
       ...profile.config,
       model,
-      // Keep token streaming on after a mid-conversation switch, matching the
-      // conversation-start payload (buildConfiguredOpenHandsAgentSettings).
-      // The agent-server only streams when an LLM has stream=True, so without
-      // this the new LLM defaults to stream=False and streaming silently stops.
+      // Keep streaming on after a switch (parity with conversation start);
+      // the profile config would otherwise default it to stream=False.
       stream: true,
       // Avoid stale first-write-wins entries in the backend LLM registry.
       usage_id: `profile:${profileName}:${uuidv4()}`,

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -715,6 +715,11 @@ class AgentServerConversationService {
     await conversationClient.switchLLM(conversationId, {
       ...profile.config,
       model,
+      // Keep token streaming on after a mid-conversation switch, matching the
+      // conversation-start payload (buildConfiguredOpenHandsAgentSettings).
+      // The agent-server only streams when an LLM has stream=True, so without
+      // this the new LLM defaults to stream=False and streaming silently stops.
+      stream: true,
       // Avoid stale first-write-wins entries in the backend LLM registry.
       usage_id: `profile:${profileName}:${uuidv4()}`,
     } as LLMConfig);

--- a/src/components/conversation-events/chat/event-message-components/user-assistant-event-message.tsx
+++ b/src/components/conversation-events/chat/event-message-components/user-assistant-event-message.tsx
@@ -5,6 +5,8 @@ import { ImageCarousel } from "../../../features/images/image-carousel";
 import { ConversationConfirmationButtons } from "#/components/shared/buttons/conversation-confirmation-buttons";
 import { parseMessageFromEvent } from "../event-content-helpers/parse-message-from-event";
 import { CriticResultDisplay } from "./critic-result-display";
+import { CollapsibleThinking } from "./collapsible-thinking";
+import { splitInlineThink } from "../event-thought-helpers";
 
 interface UserAssistantEventMessageProps {
   event: MessageEvent;
@@ -17,7 +19,14 @@ export function UserAssistantEventMessage({
   isLastMessage,
   isFromPlanningAgent,
 }: UserAssistantEventMessageProps) {
-  const message = parseMessageFromEvent(event);
+  const parsed = parseMessageFromEvent(event);
+  // Agent messages may carry inline <think> reasoning (e.g. when the response
+  // was streamed); route it to the collapsible thinking section instead of the
+  // bubble so reloaded conversations match the live streamed rendering.
+  const { reasoning, message } =
+    event.source === "agent"
+      ? splitInlineThink(parsed)
+      : { reasoning: "", message: parsed };
 
   const imageUrls: string[] = [];
   if (Array.isArray(event.llm_message.content)) {
@@ -30,6 +39,7 @@ export function UserAssistantEventMessage({
 
   return (
     <>
+      {reasoning && <CollapsibleThinking content={reasoning} />}
       <ChatMessage
         type={event.source}
         message={message}

--- a/src/components/conversation-events/chat/event-message-components/user-assistant-event-message.tsx
+++ b/src/components/conversation-events/chat/event-message-components/user-assistant-event-message.tsx
@@ -20,9 +20,8 @@ export function UserAssistantEventMessage({
   isFromPlanningAgent,
 }: UserAssistantEventMessageProps) {
   const parsed = parseMessageFromEvent(event);
-  // Agent messages may carry inline <think> reasoning (e.g. when the response
-  // was streamed); route it to the collapsible thinking section instead of the
-  // bubble so reloaded conversations match the live streamed rendering.
+  // Route an inline <think> block (e.g. from a streamed reply) to the thinking
+  // section so reloaded conversations match the live rendering.
   const { reasoning, message } =
     event.source === "agent"
       ? splitInlineThink(parsed)

--- a/src/components/conversation-events/chat/event-message.tsx
+++ b/src/components/conversation-events/chat/event-message.tsx
@@ -179,11 +179,10 @@ export function EventMessage({
   }
 
   if (isStreamingDeltaEvent(event)) {
-    // Some models stream chain-of-thought as an inline <think> block inside
-    // `content`; split it out so it renders in the collapsible thinking
-    // section instead of leaking into the message bubble.
+    // Route an inline <think> block to the thinking section, not the bubble.
     const { reasoning: inlineThink, message } = splitInlineThink(
       event.content ?? "",
+      { streaming: true },
     );
     const reasoningContent = [event.reasoning_content ?? "", inlineThink]
       .filter(Boolean)

--- a/src/components/conversation-events/chat/event-message.tsx
+++ b/src/components/conversation-events/chat/event-message.tsx
@@ -33,7 +33,7 @@ import { CollapsibleThinking } from "./event-message-components/collapsible-thin
 import { HookExecutionEventMessage } from "./event-message-components/hook-execution-event-message";
 import { createSkillReadyEvent } from "./event-content-helpers/create-skill-ready-event";
 import { shouldShowPlanPreview } from "./hooks/use-plan-preview-events";
-import { getReasoningContent } from "./event-thought-helpers";
+import { getReasoningContent, splitInlineThink } from "./event-thought-helpers";
 
 interface EventMessageProps {
   event: OpenHandsEvent & { isFromPlanningAgent?: boolean };
@@ -179,15 +179,22 @@ export function EventMessage({
   }
 
   if (isStreamingDeltaEvent(event)) {
-    const content = event.content ?? "";
-    const reasoningContent = event.reasoning_content ?? "";
+    // Some models stream chain-of-thought as an inline <think> block inside
+    // `content`; split it out so it renders in the collapsible thinking
+    // section instead of leaking into the message bubble.
+    const { reasoning: inlineThink, message } = splitInlineThink(
+      event.content ?? "",
+    );
+    const reasoningContent = [event.reasoning_content ?? "", inlineThink]
+      .filter(Boolean)
+      .join("\n\n");
     return (
       <>
         {reasoningContent && <CollapsibleThinking content={reasoningContent} />}
-        {content && (
+        {message && (
           <ChatMessage
             type="agent"
-            message={content}
+            message={message}
             isFromPlanningAgent={isFromPlanningAgent}
           />
         )}

--- a/src/components/conversation-events/chat/event-thought-helpers.ts
+++ b/src/components/conversation-events/chat/event-thought-helpers.ts
@@ -44,57 +44,41 @@ export const hasNonEmptyThought = (action: ActionEvent): boolean =>
   getActionThoughtText(action).trim().length > 0;
 
 /**
- * Splits an inline `<think>…</think>` reasoning block out of assistant
- * message content.
+ * Splits a leading `<think>…</think>` reasoning block out of assistant content
+ * so it renders in the collapsible thinking section, not the message bubble.
+ * Some models stream reasoning inline instead of via `reasoning_content`.
  *
- * Some models stream their chain-of-thought as an inline `<think>` block
- * inside the regular `content` instead of the dedicated `reasoning_content`
- * field. litellm extracts that block when a completion is NOT streamed, but
- * raw streamed deltas keep it inline — so a streamed OpenHands message would
- * otherwise render the reasoning as visible message text. This routes the
- * reasoning to the same collapsible "thinking" section used for
- * `reasoning_content`.
- *
- * Returns the extracted `reasoning` (joined across blocks) and the remaining
- * `message`. When there is no `<think>` block the content is returned
- * unchanged as `message`, so this is a safe no-op for normal messages. An
- * unclosed `<think>` (mid-stream) is treated as reasoning in full, so partial
- * thinking never leaks into the message bubble.
+ * Conservative to avoid mangling normal messages: only a `<think>` at the very
+ * start is touched (later occurrences, e.g. quoted in docs, stay verbatim),
+ * only the first block is peeled, and an unclosed leading `<think>` is reasoning
+ * only while `streaming` — in a finalized message it's literal output.
  */
 export const splitInlineThink = (
   content: string,
+  options?: { streaming?: boolean },
 ): { reasoning: string; message: string } => {
   const OPEN = "<think>";
   const CLOSE = "</think>";
-  if (!content.includes(OPEN)) {
+
+  // Only a <think> at the very start is reasoning.
+  const leading = content.replace(/^\s+/, "");
+  if (!leading.startsWith(OPEN)) {
     return { reasoning: "", message: content };
   }
 
-  const reasoning: string[] = [];
-  let message = "";
-  let rest = content;
+  const afterOpen = leading.slice(OPEN.length);
+  const close = afterOpen.indexOf(CLOSE);
 
-  while (rest.length > 0) {
-    const open = rest.indexOf(OPEN);
-    if (open === -1) {
-      message += rest;
-      break;
-    }
-    message += rest.slice(0, open);
-    const afterOpen = rest.slice(open + OPEN.length);
-    const close = afterOpen.indexOf(CLOSE);
-    if (close === -1) {
-      // Unclosed block: still streaming — everything left is reasoning.
-      reasoning.push(afterOpen);
-      break;
-    }
-    reasoning.push(afterOpen.slice(0, close));
-    rest = afterOpen.slice(close + CLOSE.length);
+  if (close === -1) {
+    // Unclosed: reasoning-in-progress while streaming, else literal output.
+    return options?.streaming
+      ? { reasoning: afterOpen.trim(), message: "" }
+      : { reasoning: "", message: content };
   }
 
   return {
-    reasoning: reasoning.join("\n\n").trim(),
-    message: message.trim(),
+    reasoning: afterOpen.slice(0, close).trim(),
+    message: afterOpen.slice(close + CLOSE.length).trim(),
   };
 };
 

--- a/src/components/conversation-events/chat/event-thought-helpers.ts
+++ b/src/components/conversation-events/chat/event-thought-helpers.ts
@@ -44,6 +44,61 @@ export const hasNonEmptyThought = (action: ActionEvent): boolean =>
   getActionThoughtText(action).trim().length > 0;
 
 /**
+ * Splits an inline `<think>…</think>` reasoning block out of assistant
+ * message content.
+ *
+ * Some models stream their chain-of-thought as an inline `<think>` block
+ * inside the regular `content` instead of the dedicated `reasoning_content`
+ * field. litellm extracts that block when a completion is NOT streamed, but
+ * raw streamed deltas keep it inline — so a streamed OpenHands message would
+ * otherwise render the reasoning as visible message text. This routes the
+ * reasoning to the same collapsible "thinking" section used for
+ * `reasoning_content`.
+ *
+ * Returns the extracted `reasoning` (joined across blocks) and the remaining
+ * `message`. When there is no `<think>` block the content is returned
+ * unchanged as `message`, so this is a safe no-op for normal messages. An
+ * unclosed `<think>` (mid-stream) is treated as reasoning in full, so partial
+ * thinking never leaks into the message bubble.
+ */
+export const splitInlineThink = (
+  content: string,
+): { reasoning: string; message: string } => {
+  const OPEN = "<think>";
+  const CLOSE = "</think>";
+  if (!content.includes(OPEN)) {
+    return { reasoning: "", message: content };
+  }
+
+  const reasoning: string[] = [];
+  let message = "";
+  let rest = content;
+
+  while (rest.length > 0) {
+    const open = rest.indexOf(OPEN);
+    if (open === -1) {
+      message += rest;
+      break;
+    }
+    message += rest.slice(0, open);
+    const afterOpen = rest.slice(open + OPEN.length);
+    const close = afterOpen.indexOf(CLOSE);
+    if (close === -1) {
+      // Unclosed block: still streaming — everything left is reasoning.
+      reasoning.push(afterOpen);
+      break;
+    }
+    reasoning.push(afterOpen.slice(0, close));
+    rest = afterOpen.slice(close + CLOSE.length);
+  }
+
+  return {
+    reasoning: reasoning.join("\n\n").trim(),
+    message: message.trim(),
+  };
+};
+
+/**
  * Find the `ActionEvent` whose thought should be rendered alongside the
  * given UI event. For an `ActionEvent` the thought belongs to itself; for
  * an `ObservationEvent` we look up the matching action in `allEvents`.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Add streaming for OH agent.

- [x] A human has tested these changes.

AGENT:

End-to-end verification was done against a real local stack, not just unit tests.

**Stack:** `npm run dev` (ingress `http://localhost:8000`, Vite frontend, OpenHands Agent Server `openhands-sdk v1.28.1` from PyPI), real LLM profile `openhands/gpt-5.5`. The UI was driven with Playwright (create conversation, dismiss onboarding/consent, send messages) while capturing the conversation websocket frames.

**1. Streaming works at conversation start.** Sending "Say hello in one short sentence." produced `StreamingDeltaEvent` frames token-by-token over `/sockets/events/<id>`, e.g.:
```
StreamingDeltaEvent content="<think>The"
StreamingDeltaEvent content=" user is"
... (tokens) ...
StreamingDeltaEvent content="Hello! I'm"
MessageEvent source=agent text="<think>…</think>…Hello! I'm here to help…"
```
The streamed deltas reconcile to a single bubble (existing `finalizeStreamingDeltasInPlace`); the duplicate `MessageEvent` seen on the wire shares the same `id` and is deduped by the store.

**2. A/B confirming the root cause of the "message shown twice" report.** Same prompt, `stream` toggled:
- `stream` omitted/false → bubble: `Hello! How can I help you today?` (litellm separates reasoning when not streaming).
- `stream: true` without the fix → bubble: `The user is asking me to say hello… [reasoning] … Hello! I'm here to help…` (the model emits inline `<think>` reasoning, which leaked into the message text).
- With the `splitInlineThink` fix → bubble: `Hello! I'm here to help you with any tasks you need.` and the reasoning is rendered in the collapsed **Thinking** section. Verified identical after a page reload (persisted message path).

**3. Streaming survives a mid-conversation model switch.** Initial message streamed (2 deltas) → switched model with the `/model gpt-5.5` command (routes through `switchProfile` → `POST /api/conversations/{id}/switch_llm`) → next message still streamed (3 deltas). Before the fix this dropped to 0 deltas because the switch payload defaulted to `stream=false`.

**CI checks run locally** (after syncing `node_modules` to the lockfile):
- `npm run typecheck` → 0 errors
- `npm run build` → success
- `npx vitest run` on affected suites → 298 passed (incl. new `splitInlineThink` tests and updated start/switch payload tests)
- pre-commit hook (eslint --fix, prettier, staged tsc, translation completeness) passed on commit

---

## Why

The ACP agents stream their responses token-by-token, but the OpenHands agent did not — it rendered each reply only once it was complete. This is an inconsistent conversation experience across agent types (issue #1471).

While enabling streaming, two correctness issues surfaced and are fixed here:
- Models that emit chain-of-thought as an inline `<think>…</think>` block (e.g. `openhands/gpt-5.5`) had that reasoning leak into the visible message — it reads like the message is shown twice.
- Switching the model mid-conversation silently turned streaming back off.

## Summary

- Enable LLM token streaming for the OpenHands (non-ACP) agent by setting `stream: true` on the LLM config — in both the conversation-start payload (`buildConfiguredOpenHandsAgentSettings`) and the mid-conversation `switch_llm` payload (`switchProfile`). The agent-server only emits `StreamingDeltaEvent`s when an LLM has `stream=True`; the frontend already renders them.
- Add `splitInlineThink` and route inline `<think>…</think>` reasoning into the existing collapsible "Thinking" section instead of the message bubble — applied to both the streamed-delta renderer and the persisted agent-message renderer so live and reloaded views match. Safe no-op when there is no `<think>` block.

## Issue Number

Closes #1471

## How to Test

1. `npm install && npm run dev`, open `http://localhost:8000/`.
2. Configure an LLM (a reasoning model such as `openhands/gpt-5.5` best demonstrates the `<think>` handling).
3. Start a New Chat with the **OpenHands** agent and send a message — the reply should stream in token-by-token (live typing), with any model reasoning collapsed under **Thinking** and only the answer in the bubble.
4. Mid-conversation, switch the model (model pill in the chat input, or the `/model <profile>` command) and send another message — it should still stream.
5. Reload the page — the message stays clean (no `<think>` text in the bubble).

## Video/Screenshots


https://github.com/user-attachments/assets/a7f93ce7-e658-4eaa-906d-c270d1887c03



## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This is the display-side fix for inline reasoning: the frontend parses `<think>` out at render time, but the block is still written into the **persisted** message content by the backend when streaming. Making the saved message clean too would be a `software-agent-sdk` change (separating reasoning during streaming) — out of scope here.
- ACP agents are unaffected: they stream unconditionally on the backend and their config/switch paths build no `llm` object.




<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a10` |
| **Commit** | `77d4aed9e3f7f177f81f8ce47326d9b5330a9ec6` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-77d4aed
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-77d4aed
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-77d4aed-amd64
ghcr.io/openhands/agent-canvas:vasco-streaming-amd64
ghcr.io/openhands/agent-canvas:pr-1474-amd64
ghcr.io/openhands/agent-canvas:sha-77d4aed-arm64
ghcr.io/openhands/agent-canvas:vasco-streaming-arm64
ghcr.io/openhands/agent-canvas:pr-1474-arm64
ghcr.io/openhands/agent-canvas:sha-77d4aed
ghcr.io/openhands/agent-canvas:vasco-streaming
ghcr.io/openhands/agent-canvas:pr-1474
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-77d4aed`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-77d4aed-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->