### PR TITLE
test(e2e): de-flake git control bar workspace pill assertion

### DIFF
--- a/tests/e2e/mock-llm/files/mock-llm-files-and-git.spec.ts
+++ b/tests/e2e/mock-llm/files/mock-llm-files-and-git.spec.ts
@@ -30,6 +30,10 @@ import {
 
 const USER_MESSAGE = "Hello, please respond.";
 const WORKSPACE_PATH = "/tmp/e2e-test-project/my-app";
+// The git remote the step-2 trajectory configures for the workspace. Kept as a
+// shared constant so the `git remote add` command and the control-bar pill
+// assertion below can never drift apart.
+const EXPECTED_REPO_SLUG = "test-org/test-repo";
 
 /**
  * Seed `selected_workspace` into the conversation metadata localStorage key.
@@ -115,7 +119,7 @@ test.describe("files tab, git control bar, and browser tab", () => {
       // Otherwise bootstrap a fresh repo with a GitHub remote (Docker path).
       // Must configure user.name/email — Docker containers may not have them.
       "|| (git init && git config user.email test@test.com && git config user.name test",
-      "&& git remote add origin https://github.com/test-org/test-repo.git",
+      `&& git remote add origin https://github.com/${EXPECTED_REPO_SLUG}.git`,
       "&& git commit --allow-empty -m init)",
     ].join(" ");
     await registerTrajectory(request, "files-and-git", [
@@ -202,12 +206,22 @@ test.describe("files tab, git control bar, and browser tab", () => {
 
     const workspaceName = WORKSPACE_PATH.replace(/\/+$/, "").split("/").pop()!;
 
-    // The git control bar renders below the chat input. The workspace
-    // metadata seeded above makes it show the folder basename as a pill.
-    await test.step("verify workspace pill is visible", async () => {
-      await expect(
-        page.getByText(workspaceName).first(),
-      ).toBeVisible({ timeout: 15_000 });
+    // The git control bar renders below the chat input and shows the
+    // conversation's workspace/repo identity. Either state is valid and the
+    // bar flips between them as the local `git remote get-url origin` probe
+    // resolves: it shows the folder basename ("my-app") until the remote
+    // (added by step 2) is detected, then the repo slug ("test-org/test-repo").
+    // Accept either so the assertion doesn't race that probe (the source of a
+    // pre-existing flake — see GitControlBarRepoButton: selectedRepository ||
+    // workspaceName).
+    const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pillText = new RegExp(
+      `${escapeRegExp(workspaceName)}|${escapeRegExp(EXPECTED_REPO_SLUG)}`,
+    );
+    await test.step("verify workspace/repo pill is visible", async () => {
+      await expect(page.getByText(pillText).first()).toBeVisible({
+        timeout: 15_000,
+      });
     });
 
     // When useLocalGitInfo detects a remote (trajectory ran git init +


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fix a flaky e2e test: the git control bar workspace pill assertion that raced git-remote detection.

- [x] A human has tested these changes.

AGENT:

Diagnosed from the CI failure artifact of another PR's mock-LLM e2e run. The `test-failed-1.png` screenshot shows a fully healthy app: the conversation ran (`MOCK_LLM_E2E_REPLY_OK`) and the git control bar renders `test-org/test-repo`, `master`, and Pull/Push/Pull Request — i.e. the git-remote probe had already resolved, so the bar showed the repo slug, not the `my-app` folder pill the test waited for. Confirmed the mechanism in `git-control-bar.tsx` (`effectiveRepository = ... || localGitInfo?.repository`) and `GitControlBarRepoButton` (`buttonText = selectedRepository || workspaceName`).

`npm run typecheck` → 0 errors. The fix touches only the spec; the PR's own mock-LLM e2e run is the end-to-end validation (the local `.mock-llm-venv` here lacks the `openhands` SDK, so the suite can't be run on my machine).

---

## Why

`mock-llm-files-and-git.spec.ts` step 3 asserted the git control bar shows the workspace folder basename (`my-app`). But the bar shows the **git remote slug** once the local `git remote get-url origin` probe detects the remote that step 2 adds — the folder name is only the pre-detection fallback. The assertion raced that probe and failed intermittently (seen failing on this workflow across unrelated PRs).

## Summary

- Accept either valid control-bar state — the folder basename **or** the configured remote slug — so the assertion no longer races git-remote detection.
- Share the remote slug via one `EXPECTED_REPO_SLUG` constant used by both the trajectory's `git remote add` and the assertion, so they can't drift.

## Issue Number

<!-- No issue; unblocks the flaky CI seen on #1474. -->

## How to Test

1. `npm run test:e2e:mock-llm -- tests/e2e/mock-llm/files/mock-llm-files-and-git.spec.ts`
2. Step 3 ("git control bar shows workspace/repo pill") passes regardless of whether the git-remote probe has resolved.

## Video/Screenshots

N/A — test-only change. Root-cause screenshot (bar showing `test-org/test-repo` instead of `my-app`) came from the failing CI artifact.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Unblocks the mock-LLM e2e check on #1474 (the streaming PR), which was red only due to this flake. The Docker-only `connection refused` failures on that PR were a separate infra cascade.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a10` |
| **Commit** | `f55e21dc495c2f891c736a5228eef0af169719a5` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f55e21d
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f55e21d
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f55e21d-amd64
ghcr.io/openhands/agent-canvas:vasco-fix-flaky-git-control-bar-pill-amd64
ghcr.io/openhands/agent-canvas:pr-1475-amd64
ghcr.io/openhands/agent-canvas:sha-f55e21d-arm64
ghcr.io/openhands/agent-canvas:vasco-fix-flaky-git-control-bar-pill-arm64
ghcr.io/openhands/agent-canvas:pr-1475-arm64
ghcr.io/openhands/agent-canvas:sha-f55e21d
ghcr.io/openhands/agent-canvas:vasco-fix-flaky-git-control-bar-pill
ghcr.io/openhands/agent-canvas:pr-1475
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f55e21d`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f55e21d-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->
