### PR TITLE
test: add mock-LLM e2e coverage for recent PRs (2026-06-24)

### DIFF
--- a/tests/e2e/mock-llm/settings/mock-llm-agent-settings.spec.ts
+++ b/tests/e2e/mock-llm/settings/mock-llm-agent-settings.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import {
+  BACKEND_URL,
+  SESSION_API_KEY,
+  seedLocalStorage,
+  routeSessionApiKey,
+  dismissAnalyticsModal,
+  waitForTestId,
+  ensureMockLLMProfileViaAPI,
+} from "../utils/mock-llm-helpers";
+
+const AGENT_SETTINGS_PATH = "/settings/agent";
+const TOOL_CONCURRENCY_INPUT_TEST_ID = "sdk-settings-tool_concurrency_limit";
+const DEFAULT_TOOL_CONCURRENCY_LIMIT = 1;
+const UPDATED_TOOL_CONCURRENCY_LIMIT = 4;
+
+async function patchAgentSettings(
+  request: APIRequestContext,
+  agentSettingsDiff: Record<string, unknown>,
+) {
+  const resp = await request.patch(`${BACKEND_URL}/api/settings`, {
+    headers: {
+      "X-Session-API-Key": SESSION_API_KEY,
+      "Content-Type": "application/json",
+    },
+    data: { agent_settings_diff: agentSettingsDiff },
+  });
+  expect(resp.ok(), `PATCH /api/settings: ${resp.status()}`).toBe(true);
+}
+
+async function getAgentSettings(request: APIRequestContext) {
+  const resp = await request.get(`${BACKEND_URL}/api/settings`, {
+    headers: { "X-Session-API-Key": SESSION_API_KEY },
+  });
+  expect(resp.ok(), `GET /api/settings: ${resp.status()}`).toBe(true);
+  const settings = await resp.json();
+  return settings?.agent_settings as Record<string, unknown>;
+}
+
+async function resetOpenHandsAgentSettings(request: APIRequestContext) {
+  await patchAgentSettings(request, {
+    agent_kind: "openhands",
+    enable_sub_agents: false,
+    tool_concurrency_limit: DEFAULT_TOOL_CONCURRENCY_LIMIT,
+  });
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Agent Settings", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await seedLocalStorage(page);
+    await ensureMockLLMProfileViaAPI(request);
+    await resetOpenHandsAgentSettings(request);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await resetOpenHandsAgentSettings(request).catch(() => {});
+  });
+
+  test("saves the OpenHands parallel tool call limit", async ({
+    page,
+    request,
+  }) => {
+    await routeSessionApiKey(page);
+    await page.goto(AGENT_SETTINGS_PATH, { waitUntil: "domcontentloaded" });
+    await dismissAnalyticsModal(page);
+    await waitForTestId(page, "agent-settings-screen");
+
+    const input = page.getByTestId(TOOL_CONCURRENCY_INPUT_TEST_ID);
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await expect(input).toHaveValue(String(DEFAULT_TOOL_CONCURRENCY_LIMIT));
+
+    await input.fill(String(UPDATED_TOOL_CONCURRENCY_LIMIT));
+
+    const saveButton = page.getByTestId("agent-save-button");
+    await expect(saveButton).toBeEnabled({ timeout: 5_000 });
+    await saveButton.click();
+    await expect(saveButton).toBeDisabled({ timeout: 10_000 });
+
+    await expect
+      .poll(async () => {
+        const agentSettings = await getAgentSettings(request);
+        return agentSettings.tool_concurrency_limit;
+      })
+      .toBe(UPDATED_TOOL_CONCURRENCY_LIMIT);
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await waitForTestId(page, "agent-settings-screen");
+    await expect(page.getByTestId(TOOL_CONCURRENCY_INPUT_TEST_ID)).toHaveValue(
+      String(UPDATED_TOOL_CONCURRENCY_LIMIT),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds mock-LLM E2E coverage for a recent merged user-facing PR that did not add `tests/e2e/` coverage.

Covered PRs:
- #1312 — settings: add parallel tool calls (`tool_concurrency_limit`) to Agent Settings

## Verification

- `npm ci`
- `npm run typecheck` initially failed because generated i18n declarations were missing in the clean checkout.
- `npm run make-i18n && npm run typecheck`

This pull request was created by an AI agent (OpenHands) on behalf of the user.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a10` |
| **Commit** | `923b0b937b0078c22c21ab32e1c7ff26fb469a86` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-923b0b9
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-923b0b9
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-923b0b9-amd64
ghcr.io/openhands/agent-canvas:auto-e2e-coverage-2026-06-24-amd64
ghcr.io/openhands/agent-canvas:pr-1478-amd64
ghcr.io/openhands/agent-canvas:sha-923b0b9-arm64
ghcr.io/openhands/agent-canvas:auto-e2e-coverage-2026-06-24-arm64
ghcr.io/openhands/agent-canvas:pr-1478-arm64
ghcr.io/openhands/agent-canvas:sha-923b0b9
ghcr.io/openhands/agent-canvas:auto-e2e-coverage-2026-06-24
ghcr.io/openhands/agent-canvas:pr-1478
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-923b0b9`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-923b0b9-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->