### PR TITLE
fix: redact secrets in automation run logs

### DIFF
--- a/src/components/features/automations/detail/run-logs-modal.tsx
+++ b/src/components/features/automations/detail/run-logs-modal.tsx
@@ -9,6 +9,7 @@ import {
 import type { BashOutput } from "@openhands/typescript-client";
 import { cn } from "#/utils/utils";
 import { modalTitleLgMediumClassName } from "#/utils/modal-classes";
+import { redactShellSecrets } from "#/utils/redact-shell-secrets";
 
 /**
  * Localized empty-state message key for each `SandboxIssue` reason.
@@ -87,8 +88,8 @@ export function RunLogsModal({
   const { stdout, stderr } = useMemo(() => {
     if (!outputs) return { stdout: "", stderr: "" };
     return {
-      stdout: concatStream(outputs, "stdout"),
-      stderr: concatStream(outputs, "stderr"),
+      stdout: redactShellSecrets(concatStream(outputs, "stdout")),
+      stderr: redactShellSecrets(concatStream(outputs, "stderr")),
     };
   }, [outputs]);
 

--- a/src/utils/redact-shell-secrets.ts
+++ b/src/utils/redact-shell-secrets.ts
@@ -1,6 +1,5 @@
 const REDACTED = "<redacted>";
 
-// Mirrors openhands-sdk SECRET_KEY_PATTERNS (substring match, case-insensitive).
 const SECRET_KEY_PATTERNS = [
   "AUTHORIZATION",
   "COOKIE",
@@ -17,7 +16,6 @@ export function isSensitiveEnvVarName(name: string): boolean {
   return SECRET_KEY_PATTERNS.some((pattern) => upper.includes(pattern));
 }
 
-// export VAR='value', export VAR="value", or export VAR=unquoted
 const EXPORT_ASSIGNMENT =
   /export\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*('(?:\\'|[^'])*'|"(?:\\"|[^"])*"|[^\s&;|\\]+)/g;
 
@@ -31,11 +29,6 @@ function redactAssignment(
   return `${prefix}'${REDACTED}'`;
 }
 
-/**
- * Redact credential-bearing shell environment assignments before showing
- * automation run logs. Covers inline `export VAR=value` chains produced by
- * the automation backend when bootstrapping a run workspace.
- */
 export function redactShellSecrets(text: string): string {
   if (!text) return text;
 

--- a/src/utils/redact-shell-secrets.ts
+++ b/src/utils/redact-shell-secrets.ts
@@ -1,0 +1,43 @@
+const REDACTED = "<redacted>";
+
+// Mirrors openhands-sdk SECRET_KEY_PATTERNS (substring match, case-insensitive).
+const SECRET_KEY_PATTERNS = [
+  "AUTHORIZATION",
+  "COOKIE",
+  "CREDENTIAL",
+  "KEY",
+  "PASSWORD",
+  "SECRET",
+  "SESSION",
+  "TOKEN",
+] as const;
+
+export function isSensitiveEnvVarName(name: string): boolean {
+  const upper = name.toUpperCase();
+  return SECRET_KEY_PATTERNS.some((pattern) => upper.includes(pattern));
+}
+
+// export VAR='value', export VAR="value", or export VAR=unquoted
+const EXPORT_ASSIGNMENT =
+  /export\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*('(?:\\'|[^'])*'|"(?:\\"|[^"])*"|[^\s&;|\\]+)/g;
+
+function redactAssignment(
+  match: string,
+  name: string,
+  valuePart: string,
+): string {
+  if (!isSensitiveEnvVarName(name)) return match;
+  const prefix = match.slice(0, match.length - valuePart.length);
+  return `${prefix}'${REDACTED}'`;
+}
+
+/**
+ * Redact credential-bearing shell environment assignments before showing
+ * automation run logs. Covers inline `export VAR=value` chains produced by
+ * the automation backend when bootstrapping a run workspace.
+ */
+export function redactShellSecrets(text: string): string {
+  if (!text) return text;
+
+  return text.replace(EXPORT_ASSIGNMENT, redactAssignment);
+}


### PR DESCRIPTION
#### Summary
- Redact sensitive export values in automation run logs before they show in the UI.

#### Test plan
- npm test -- __tests__/utils/redact-shell-secrets.test.ts __tests__/components/automations/detail/run-logs-modal.test.tsx

#### Video/Screenshots
- N/A

#### Type
- Bug fix

fixes : #1470 (UI only)