### PR TITLE
fix: render literal angle-bracket text in user messages

### DIFF
--- a/__tests__/components/chat-message.test.tsx
+++ b/__tests__/components/chat-message.test.tsx
@@ -193,4 +193,41 @@ describe("ChatMessage", () => {
 
     expect(onStop).toHaveBeenCalledTimes(1);
   });
+
+  it("renders a literal angle-bracket user message as visible text", () => {
+    // Regression: user messages were rendered with raw-HTML parsing enabled,
+    // so a message like "<something>" was parsed as an unknown HTML tag and
+    // dropped by rehype-sanitize — leaving an empty bubble that looked like
+    // nothing was sent. User input must render literally.
+    const { container } = render(
+      <ChatMessage type="user" message="<something>" />,
+    );
+
+    expect(screen.getByTestId("user-message")).toBeInTheDocument();
+    // The angle-bracket text must survive verbatim...
+    expect(container.textContent).toContain("<something>");
+    // ...and must NOT have been parsed into an element.
+    expect(container.querySelector("something")).toBeNull();
+  });
+
+  it("renders literal angle-bracket text in a sending user message", () => {
+    // The pending/sending bubble renders through a different branch than the
+    // settled message, so it gets its own guard.
+    const { container } = render(
+      <ChatMessage type="user" message="<something>" pendingStatus="sending" />,
+    );
+
+    expect(container.textContent).toContain("<something>");
+    expect(container.querySelector("something")).toBeNull();
+  });
+
+  it("still parses inline HTML for agent messages", () => {
+    // The fix is scoped to user input: agent output keeps raw-HTML parsing so
+    // allowed inline tags (badges, <mark>, <details>, …) continue to render.
+    const { container } = render(
+      <ChatMessage type="agent" message="Hello <mark>world</mark>" />,
+    );
+
+    expect(container.querySelector("mark")?.textContent).toBe("world");
+  });
 });

--- a/src/components/features/chat/chat-message.tsx
+++ b/src/components/features/chat/chat-message.tsx
@@ -126,6 +126,7 @@ export function ChatMessage({
       <MarkdownRenderer
         includeStandard
         includeHeadings
+        allowHtml={type !== "user"}
         components={chatBubbleMarkdownComponents}
       >
         {message}

--- a/src/components/features/chat/user-message-body.tsx
+++ b/src/components/features/chat/user-message-body.tsx
@@ -80,6 +80,7 @@ export function UserMessageBody({
         <MarkdownRenderer
           includeStandard
           includeHeadings
+          allowHtml={false}
           components={chatBubbleMarkdownComponents}
         >
           {message}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fixing a small bug with user msg input.

- [x] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

**Agent verification (render-layer reproduction).** I reproduced the bug and confirmed the fix two ways: by running the app's exact react-markdown pipeline, and by rendering the real `ChatMessage` component in jsdom.

Library-layer pipeline (`remark-gfm` + `remark-breaks` + `rehype-raw` + `rehype-sanitize`), input → rendered HTML:

| Input | Before (`allowHtml=true`) | After (`allowHtml=false`) |
| --- | --- | --- |
| `<something>` | `""` (empty — the bug) | `&lt;something&gt;` (literal) |
| `hi <tag> there` | `<p>hi&nbsp;&nbsp;there</p>` | `<p>hi &lt;tag&gt; there</p>` |
| `<mark>kept</mark>` | `<p><mark>kept</mark></p>` | `<p>&lt;mark&gt;kept&lt;/mark&gt;</p>` |

Real `ChatMessage` DOM (current code, fix applied):

- user `"<something>"` → `&lt;something&gt;` (the literal text now renders)
- agent `"Hello <mark>world</mark>"` → `<p class="m-0 leading-6">Hello <mark>world</mark></p>` (agent HTML still parsed — scoping intact)

The local dev stack (`npm run dev`; ingress on :8000, agent-server on :18000) is running with the fix applied via Vite HMR and is ready for the human UI check described under **How to Test**.

---

## Why

In the chat, sending a message that looks like an HTML tag (e.g. `<something>`) rendered as an empty bubble, so it looked like nothing was sent. User messages are rendered through `MarkdownRenderer` with raw-HTML parsing enabled (`allowHtml` defaults to `true`): `rehype-raw` parses `<something>` as an unknown HTML element and `rehype-sanitize` strips it (it is not in the allow-list), leaving no visible content. A lone unclosed tag like `<something>` consumes the whole message, so the bubble is empty.

## Summary

- `src/components/features/chat/user-message-body.tsx`: render settled user messages with `allowHtml={false}` so typed text like `<something>` is shown literally.
- `src/components/features/chat/chat-message.tsx`: the pending/error branch (shared with agent messages) now passes `allowHtml={type !== "user"}` — raw HTML is disabled for user input only; agent output keeps it.
- `__tests__/components/chat-message.test.tsx`: 3 regression tests — settled user message, sending user message, and an agent-HTML scoping guard.

## Issue Number

N/A

## How to Test

Automated:

- `npm run test` — full unit suite (3349 passing, 0 failing); the new cases are in `__tests__/components/chat-message.test.tsx`.
- `npm run lint` — typecheck + eslint + prettier, all clean.

Manual (UI):

1. Run `npm run dev` and open http://localhost:8000/.
2. Start a conversation and send `<something>` as a message.
3. Without the fix the bubble is empty; with the fix it shows the literal text `<something>`. Confirm markdown (`**bold**`, lists, code) still renders, and that agent messages still render allowed inline HTML.

## Video/Screenshots

Before


https://github.com/user-attachments/assets/d28e419e-3161-4542-bc96-0fbbe6b1db37

after


https://github.com/user-attachments/assets/695976fc-2f83-4ed9-978c-dc12e42f8191


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Scope is intentionally limited to user-authored messages. Agent output keeps raw-HTML rendering (still sanitized), so existing rich content (badges, `<details>`, `<mark>`, etc.) is unaffected. No migrations or config changes.


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.28.1-python` |
| **Automation** | `openhands-automation==1.0.0a10` |
| **Commit** | `a7b66af13afdaa875b8b782eac8d1e6e15488a4e` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-a7b66af
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-a7b66af
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-a7b66af-amd64
ghcr.io/openhands/agent-canvas:fix-user-message-literal-angle-brackets-amd64
ghcr.io/openhands/agent-canvas:pr-1481-amd64
ghcr.io/openhands/agent-canvas:sha-a7b66af-arm64
ghcr.io/openhands/agent-canvas:fix-user-message-literal-angle-brackets-arm64
ghcr.io/openhands/agent-canvas:pr-1481-arm64
ghcr.io/openhands/agent-canvas:sha-a7b66af
ghcr.io/openhands/agent-canvas:fix-user-message-literal-angle-brackets
ghcr.io/openhands/agent-canvas:pr-1481
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-a7b66af`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-a7b66af-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->