### PR TITLE
chore(deps): bump agent-server/openhands-sdk to 1.29.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,10 +517,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.28.1")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.29.0")
   - `OH_SECRET_KEY` — secret key for settings encryption; auto-generated and persisted to `~/.openhands/agent-canvas/secret-key.txt` on first run (same file Docker uses), ensuring dev mode and Docker share the same key when both mount the same `~/.openhands` directory. Override with the env var to pin a specific key.
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.28.1` for agent-server SDK libraries
+  - Default: released PyPI version `1.29.0` for agent-server SDK libraries
 
 - Security: `scripts/dev-safe.mjs` and `scripts/dev-with-automation.mjs` auto-generate random API keys when needed and persist the defaults so static builds, localStorage, and restarted services stay in sync:
   - `SESSION_API_KEY` — 64-character hex (256-bit) for agent-server API authentication; persisted at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden via env var

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -389,16 +389,16 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.28.1",
+      "openhands-agent-server==1.29.0",
       "--with",
-      "openhands-sdk==1.28.1",
+      "openhands-sdk==1.29.0",
       "--with",
-      "openhands-tools==1.28.1",
+      "openhands-tools==1.29.0",
       "--with",
-      "openhands-workspace==1.28.1",
+      "openhands-workspace==1.29.0",
       "agent-server",
     ]);
-    expect(cmd.source).toBe("PyPI (1.28.1, default)");
+    expect(cmd.source).toBe("PyPI (1.29.0, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -2,9 +2,9 @@
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
 
   "versions": {
-    "agentServer": "1.28.1",
+    "agentServer": "1.29.0",
     "agentCanvas": "1.0.0-rc.11",
-    "automation": "1.0.0a10"
+    "automation": "1.0.0a12"
   },
 
   "compatibility": {

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.28.1 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.29.0 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -78,7 +78,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/agent-canvas/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.28.1"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.29.0"}}'
 `);
   process.exit(0);
 }
@@ -260,9 +260,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.28.1,<2.0.0"
- *   "openhands-tools==1.28.1"
- *   "openhands-workspace (>=1.28.1)"
+ *   "openhands-sdk>=1.29.0,<2.0.0"
+ *   "openhands-tools==1.29.0"
+ *   "openhands-workspace (>=1.29.0)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -276,7 +276,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.28.1", "==1.28.1", "(>=1.28.1)", "~=1.28.1"
+      // ">=1.29.0", "==1.29.0", "(>=1.29.0)", "~=1.29.0"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -394,7 +394,7 @@ export function validateFrontendDependencies(
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.28.1")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.29.0")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a

--- a/src/mocks/settings-handlers.ts
+++ b/src/mocks/settings-handlers.ts
@@ -619,7 +619,7 @@ const MOCK_VERIFIED_MODELS_BY_PROVIDER = MOCK_MODELS.reduce<
   return acc;
 }, {});
 
-const MOCK_AGENT_SERVER_VERSION = "1.28.1";
+const MOCK_AGENT_SERVER_VERSION = "1.29.0";
 
 // --- Handlers for options/config/settings ---
 // Uses wildcard "*" prefix to match both relative paths and absolute URLs


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

Validated locally on this branch:

- `node scripts/check-sdk-version-sync.mjs` → **exit 0**, "All SDK versions are in sync!" — confirms the released `openhands-automation==1.0.0a12` resolves `openhands-sdk`/`openhands-workspace` to **1.29.0**, matching the new `versions.agentServer`.
- `npx vitest run __tests__/scripts/docs-version-sync.test.ts __tests__/scripts/dev-safe.test.ts` → **56 passed** (the two suites that enforce doc/JSDoc/command-builder references against `config/defaults.json`).
- `npm test` (full unit suite) → **3346 passed, 0 failed** (1 skipped, 9 todo), after restoring deps with `npm ci`.

## Why

`@openhands/typescript-client` 1.27.0 (see #1484) is built and integration-tested against **agent-server `1.29.0-python`**, but Canvas was pinning the spawned backend SDK train to **1.28.1**. This bumps agent-server / openhands-sdk to **1.29.0** so Canvas runs the exact agent-server version its client is validated against.

## Summary

- `config/defaults.json`: `versions.agentServer` **1.28.1 → 1.29.0**. This single pin drives the whole SDK release train (`openhands-sdk`, `openhands-tools`, `openhands-workspace`, `openhands-agent-server`) for both the uvx (`dev-safe.mjs`) and Docker (`docker.yml`) install paths.
- `config/defaults.json`: `versions.automation` **1.0.0a10 → 1.0.0a12** — required, because `check-sdk-version-sync` asserts the automation package's SDK deps equal `versions.agentServer`; `1.0.0a12` is the released automation whose deps resolve to 1.29.0.
- Synced the agent-server version examples in `AGENTS.md`, `scripts/dev-safe.mjs`, and `scripts/check-sdk-version-sync.mjs` (enforced by `docs-version-sync.test.ts`), the default-version assertions in `__tests__/scripts/dev-safe.test.ts`, and the mock `server_info` version in `src/mocks/settings-handlers.ts`.

## Issue Number

N/A

## How to Test

```bash
node scripts/check-sdk-version-sync.mjs                 # exit 0, "All SDK versions are in sync!"
npx vitest run __tests__/scripts/docs-version-sync.test.ts __tests__/scripts/dev-safe.test.ts
npm ci && npm test                                      # full suite green
```

## Video/Screenshots

N/A — version-pin/config change, no UI surface. Evidence is the passing sync check + unit suite above.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- **`minimumAgentServer` is intentionally left at `1.28.0`** — this bumps the *shipped/default* version, not the backward-compatibility floor, so existing backends on 1.28.x stay supported.
- The `openhands-automation` bump is a forced consequence of the version-sync coupling, not independent scope.
- Complements #1484 (the `@openhands/typescript-client` 1.25.0 → 1.27.0 bump): together they put the client and the agent-server it targets on the same 1.29.0 baseline.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.29.0-python` |
| **Automation** | `openhands-automation==1.0.0a12` |
| **Commit** | `f8c982344532a63f5d3da0a5381677dc6b9dafb2` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f8c9823
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f8c9823
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f8c9823-amd64
ghcr.io/openhands/agent-canvas:chore-bump-agent-server-sdk-1.29.0-amd64
ghcr.io/openhands/agent-canvas:pr-1485-amd64
ghcr.io/openhands/agent-canvas:sha-f8c9823-arm64
ghcr.io/openhands/agent-canvas:chore-bump-agent-server-sdk-1.29.0-arm64
ghcr.io/openhands/agent-canvas:pr-1485-arm64
ghcr.io/openhands/agent-canvas:sha-f8c9823
ghcr.io/openhands/agent-canvas:chore-bump-agent-server-sdk-1.29.0
ghcr.io/openhands/agent-canvas:pr-1485
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f8c9823`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f8c9823-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->