### PR TITLE
chore(deps): bump typescript-client 1.27.0 + agent-server/openhands-sdk 1.29.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,10 +517,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.28.1")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.29.0")
   - `OH_SECRET_KEY` — secret key for settings encryption; auto-generated and persisted to `~/.openhands/agent-canvas/secret-key.txt` on first run (same file Docker uses), ensuring dev mode and Docker share the same key when both mount the same `~/.openhands` directory. Override with the env var to pin a specific key.
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.28.1` for agent-server SDK libraries
+  - Default: released PyPI version `1.29.0` for agent-server SDK libraries
 
 - Security: `scripts/dev-safe.mjs` and `scripts/dev-with-automation.mjs` auto-generate random API keys when needed and persist the defaults so static builds, localStorage, and restarted services stay in sync:
   - `SESSION_API_KEY` — 64-character hex (256-bit) for agent-server API authentication; persisted at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden via env var

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -126,9 +126,9 @@ describe("buildStartConversationRequest", () => {
     });
     // Bundled public skills are injected into agent_context.skills so the
     // SDK can perform trigger matching without cloning the extensions repo.
-    expect(
-      Array.isArray(payload.agent_settings.agent_context.skills),
-    ).toBe(true);
+    expect(Array.isArray(payload.agent_settings.agent_context.skills)).toBe(
+      true,
+    );
     const skills = payload.agent_settings.agent_context.skills as Record<
       string,
       unknown
@@ -615,9 +615,9 @@ describe("buildStartConversationRequest", () => {
         tool_module_qualnames?: Record<string, string>;
       };
 
-      expect(payload.agent_settings.tools.map((tool) => tool.name)).not.toContain(
-        "canvas_ui",
-      );
+      expect(
+        payload.agent_settings.tools.map((tool) => tool.name),
+      ).not.toContain("canvas_ui");
       expect(payload.tool_module_qualnames).toBeUndefined();
     });
 
@@ -1161,9 +1161,9 @@ describe("agent_settings runtime services suffix", () => {
       load_user_skills: true,
       load_project_skills: true,
     });
-    expect(
-      Array.isArray(payload.agent_settings.agent_context.skills),
-    ).toBe(true);
+    expect(Array.isArray(payload.agent_settings.agent_context.skills)).toBe(
+      true,
+    );
   });
 
   it("sets system_message_suffix when runtime info is provided", () => {
@@ -1229,7 +1229,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp@0.30.0",
+      "@agentclientprotocol/claude-agent-acp@0.44.0",
     ]);
     expect(payload.agent_settings.acp_model).toBe("claude-opus-4-5");
     // LLM-only fields must not leak into the ACP settings payload.
@@ -1378,7 +1378,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp@0.30.0",
+      "@agentclientprotocol/claude-agent-acp@0.44.0",
     ]);
   });
 
@@ -1400,7 +1400,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@zed-industries/codex-acp@0.15.0",
+      "@zed-industries/codex-acp@0.16.0",
     ]);
   });
 
@@ -1465,7 +1465,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
       agent_settings: Record<string, unknown> & { acp_model?: unknown };
     };
 
-    expect(payload.agent_settings.acp_model).toBe("claude-opus-4-8");
+    expect(payload.agent_settings.acp_model).toBe("opus[1m]");
   });
 
   it("omits acp_model for the custom preset when none is configured", () => {
@@ -1547,7 +1547,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(acpPayload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp@0.30.0",
+      "@agentclientprotocol/claude-agent-acp@0.44.0",
     ]);
     expect(acpPayload.agent_settings.acp_model).toBe("claude-opus-4-5");
     // acp_env is no longer a forwarded ACP setting — a stale value on saved

--- a/__tests__/components/features/chat/components/chat-input-model.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-model.test.tsx
@@ -89,7 +89,7 @@ describe("ChatInputModel", () => {
         conversation_id: "test-conversation-id",
         agent_kind: "acp",
         acp_server: "claude-code",
-        llm_model: "claude-sonnet-4-6",
+        llm_model: "sonnet",
       },
     });
 
@@ -216,10 +216,10 @@ describe("ChatInputModel", () => {
     renderWithProviders(<ChatInputModel />);
 
     const model = screen.getByTestId("chat-input-llm-model");
-    // Claude Code's registered default (``claude-opus-4-8``), shown as its
+    // Claude Code's registered default (``opus[1m]``), shown as its
     // human label to match the conversation list chip. See CLAUDE_MODELS in
     // acp-providers.ts.
-    expect(model).toHaveAttribute("title", "Claude Opus 4.8");
+    expect(model).toHaveAttribute("title", "Claude Opus 4.8 (1M)");
     fireEvent.click(model);
     expect(screen.getByRole("link")).toHaveAttribute("href", "/settings/agent");
   });
@@ -230,7 +230,7 @@ describe("ChatInputModel", () => {
         conversation_id: "test-conversation-id",
         agent_kind: "acp",
         acp_server: "claude-code",
-        llm_model: "claude-sonnet-4-6",
+        llm_model: "sonnet",
       },
     });
 
@@ -239,14 +239,14 @@ describe("ChatInputModel", () => {
     fireEvent.click(screen.getByTestId("chat-input-llm-model"));
 
     // Every registered Claude Code model is offered as a row, and the running
-    // one (claude-sonnet-4-6) is marked selected.
+    // one (sonnet) is marked selected.
     const selectedRow = screen.getByTestId(
-      "chat-input-acp-model-option-claude-sonnet-4-6",
+      "chat-input-acp-model-option-sonnet",
     );
     expect(selectedRow).toBeInTheDocument();
     expect(selectedRow).toHaveTextContent("Claude Sonnet 4.6");
     expect(
-      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-8"),
+      screen.getByTestId("chat-input-acp-model-option-opus[1m]"),
     ).toBeInTheDocument();
   });
 
@@ -256,22 +256,20 @@ describe("ChatInputModel", () => {
         conversation_id: "test-conversation-id",
         agent_kind: "acp",
         acp_server: "claude-code",
-        llm_model: "claude-sonnet-4-6",
+        llm_model: "sonnet",
       },
     });
 
     renderWithProviders(<ChatInputModel />);
 
     fireEvent.click(screen.getByTestId("chat-input-llm-model"));
-    fireEvent.click(
-      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-8"),
-    );
+    fireEvent.click(screen.getByTestId("chat-input-acp-model-option-opus[1m]"));
 
     // Active conversation → live switch keyed by the conversation id from the
     // navigation context (test-conversation-id), default-write NOT used.
     expect(switchAcpModelMutate).toHaveBeenCalledWith({
       conversationId: "test-conversation-id",
-      model: "claude-opus-4-8",
+      model: "opus[1m]",
     });
     // Popover closes after a selection.
     expect(
@@ -291,15 +289,13 @@ describe("ChatInputModel", () => {
     renderWithProviders(<ChatInputModel />);
 
     fireEvent.click(screen.getByTestId("chat-input-llm-model"));
-    fireEvent.click(
-      screen.getByTestId("chat-input-acp-model-option-claude-sonnet-4-6"),
-    );
+    fireEvent.click(screen.getByTestId("chat-input-acp-model-option-sonnet"));
 
     // Home / no session → null conversationId routes the hook to the
     // settings-default write path.
     expect(switchAcpModelMutate).toHaveBeenCalledWith({
       conversationId: null,
-      model: "claude-sonnet-4-6",
+      model: "sonnet",
     });
   });
 
@@ -310,7 +306,7 @@ describe("ChatInputModel", () => {
         conversation_id: "test-conversation-id",
         agent_kind: "acp",
         acp_server: "claude-code",
-        llm_model: "claude-sonnet-4-6",
+        llm_model: "sonnet",
       },
     });
 
@@ -321,12 +317,12 @@ describe("ChatInputModel", () => {
     // Cloud ACP conversations support mid-conversation model switching,
     // so selectable model rows are shown.
     const selectedRow = screen.getByTestId(
-      "chat-input-acp-model-option-claude-sonnet-4-6",
+      "chat-input-acp-model-option-sonnet",
     );
     expect(selectedRow).toBeInTheDocument();
     expect(selectedRow).toHaveTextContent("Claude Sonnet 4.6");
     expect(
-      screen.getByTestId("chat-input-acp-model-option-claude-opus-4-8"),
+      screen.getByTestId("chat-input-acp-model-option-opus[1m]"),
     ).toBeInTheDocument();
     const popover = screen.getByTestId("chat-input-llm-model-popover");
     expect(popover).toHaveTextContent("Claude Sonnet 4.6");

--- a/__tests__/components/features/conversation-panel/conversation-card.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-card.test.tsx
@@ -655,13 +655,13 @@ describe("ConversationCard", () => {
           showLlmProfiles
           agentKind="acp"
           acpServer="claude-code"
-          llmModel="sonnet"
+          llmModel="raw-model-id"
         />,
       );
 
       const chip = screen.getByTestId("conversation-card-agent-chip");
-      expect(chip).toHaveTextContent("sonnet");
-      expect(chip).toHaveAttribute("title", "Claude Code · sonnet");
+      expect(chip).toHaveTextContent("raw-model-id");
+      expect(chip).toHaveAttribute("title", "Claude Code · raw-model-id");
       expect(
         within(chip).getByTestId("agent-brand-icon-claude-code"),
       ).toBeInTheDocument();
@@ -669,7 +669,7 @@ describe("ConversationCard", () => {
 
     it("shows the provider's picker label for a known model ID", () => {
       // When ``llm_model`` is a registry-known ID, the chip renders the
-      // human label ("Claude Opus 4.8") instead of the raw ID — matching
+      // human label ("Claude Opus 4.8 (1M)") instead of the raw ID — matching
       // what the Settings → Agent picker shows for the same value.
       renderWithProviders(
         <ConversationCard
@@ -679,13 +679,16 @@ describe("ConversationCard", () => {
           showLlmProfiles
           agentKind="acp"
           acpServer="claude-code"
-          llmModel="claude-opus-4-8"
+          llmModel="opus[1m]"
         />,
       );
 
       const chip = screen.getByTestId("conversation-card-agent-chip");
-      expect(chip).toHaveTextContent("Claude Opus 4.8");
-      expect(chip).toHaveAttribute("title", "Claude Code · Claude Opus 4.8");
+      expect(chip).toHaveTextContent("Claude Opus 4.8 (1M)");
+      expect(chip).toHaveAttribute(
+        "title",
+        "Claude Code · Claude Opus 4.8 (1M)",
+      );
     });
 
     it("falls back to the provider display name for an ACP conversation with no model", () => {

--- a/__tests__/components/onboarding/choose-agent-step.test.tsx
+++ b/__tests__/components/onboarding/choose-agent-step.test.tsx
@@ -171,7 +171,7 @@ describe("ChooseAgentStep", () => {
       // ``acp_args`` can't survive and concatenate onto the spawn
       // command at conversation-create time.
       acp_args: [],
-      acp_model: "claude-opus-4-8",
+      acp_model: "opus[1m]",
     });
   });
 

--- a/__tests__/constants/acp-providers.test.ts
+++ b/__tests__/constants/acp-providers.test.ts
@@ -54,10 +54,18 @@ describe("ACP provider registry", () => {
   });
 
   it("does not suggest generic default model placeholders", () => {
+    // Model lists are SDK-owned (see ACP_PROVIDERS) — Canvas no longer hand-keeps
+    // them. The claude-code registry intentionally offers an id ``default``
+    // labeled "Default (recommended)", a legitimate, well-labeled choice. Guard
+    // against genuinely empty ids and bare placeholder labels, not the qualified
+    // "Default (recommended)" entry.
     for (const provider of ACP_PROVIDERS) {
       for (const model of provider.available_models ?? []) {
-        expect(model.id.toLowerCase()).not.toBe("default");
-        expect(model.label.toLowerCase()).not.toContain("default");
+        expect(model.id.trim(), provider.key).toBeTruthy();
+        expect(
+          model.label.trim().toLowerCase(),
+          `${provider.key}:${model.id}`,
+        ).not.toBe("default");
       }
     }
   });

--- a/__tests__/hooks/use-chat-input-model-state.test.tsx
+++ b/__tests__/hooks/use-chat-input-model-state.test.tsx
@@ -107,7 +107,7 @@ describe("useChatInputModelState", () => {
         conversation_id: "c1",
         agent_kind: "acp",
         acp_server: "claude-code",
-        llm_model: "claude-sonnet-4-6",
+        llm_model: "sonnet",
       },
     });
     useOptionalConversationIdMock.mockReturnValue({ conversationId: "c1" });
@@ -123,7 +123,7 @@ describe("useChatInputModelState", () => {
     const { result } = renderHook(() => useChatInputModelState());
 
     expect(result.current.isAcpContext).toBe(true);
-    expect(result.current.currentModelId).toBe("claude-sonnet-4-6");
+    expect(result.current.currentModelId).toBe("sonnet");
     // Human label resolved from the registry (matches the conversation chip).
     expect(result.current.displayModel).toBe("Claude Sonnet 4.6");
     expect(result.current.availableAcpModels).toEqual(

--- a/__tests__/routes/agent-settings.test.tsx
+++ b/__tests__/routes/agent-settings.test.tsx
@@ -266,7 +266,7 @@ describe("AgentSettingsScreen", () => {
 
     await screen.findByTestId("agent-command-input");
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.8",
+      "Claude Opus 4.8 (1M)",
     );
   });
 
@@ -297,7 +297,7 @@ describe("AgentSettingsScreen", () => {
     const call = save.mock.calls[0]?.[0] as {
       agent_settings_diff?: Record<string, unknown>;
     };
-    expect(call.agent_settings_diff?.acp_model).toBe("claude-haiku-4-5");
+    expect(call.agent_settings_diff?.acp_model).toBe("haiku");
   });
 
   it("clears the model when switching from a built-in provider to Custom", async () => {
@@ -324,7 +324,7 @@ describe("AgentSettingsScreen", () => {
     await screen.findByTestId("agent-command-input");
     // Form loads with the Claude Code default visible.
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.8",
+      "Claude Opus 4.8 (1M)",
     );
 
     // Switch to the Custom preset, then enter a different command — the
@@ -380,18 +380,18 @@ describe("AgentSettingsScreen", () => {
     renderAgentSettingsScreen();
     await screen.findByTestId("agent-command-input");
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.8",
+      "Claude Opus 4.8 (1M)",
     );
 
     const commandInput = screen.getByTestId(
       "agent-command-input",
     ) as HTMLTextAreaElement;
     await user.clear(commandInput);
-    await user.type(commandInput, "npx -y @zed-industries/codex-acp@0.15.0");
+    await user.type(commandInput, "npx -y @zed-industries/codex-acp@0.16.0");
 
     // The model field now reflects the Codex default, not the stale Claude one.
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "GPT-5.5 (medium)",
+      "GPT-5.5",
     );
 
     await user.click(screen.getByTestId("agent-save-button"));
@@ -403,7 +403,7 @@ describe("AgentSettingsScreen", () => {
       agent_settings_diff?: Record<string, unknown>;
     };
     expect(call.agent_settings_diff?.acp_server).toBe("codex");
-    expect(call.agent_settings_diff?.acp_model).toBe("gpt-5.5/medium");
+    expect(call.agent_settings_diff?.acp_model).toBe("gpt-5.5");
   });
 
   it("saves an ACP diff when switching to ACP + Claude Code", async () => {
@@ -432,10 +432,10 @@ describe("AgentSettingsScreen", () => {
       "agent-command-input",
     )) as HTMLTextAreaElement;
     expect(commandInput.value).toBe(
-      "npx -y @agentclientprotocol/claude-agent-acp@0.30.0",
+      "npx -y @agentclientprotocol/claude-agent-acp@0.44.0",
     );
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.8",
+      "Claude Opus 4.8 (1M)",
     );
 
     await user.click(screen.getByTestId("agent-save-button"));
@@ -457,7 +457,7 @@ describe("AgentSettingsScreen", () => {
       // ``acp_args`` can't survive and concatenate onto the spawn
       // command at conversation-create time.
       acp_args: [],
-      acp_model: "claude-opus-4-8",
+      acp_model: "opus[1m]",
     });
   });
 
@@ -625,7 +625,7 @@ describe("AgentSettingsScreen", () => {
       "agent-command-input",
     )) as HTMLTextAreaElement;
     expect(cmd.value).toBe(
-      "npx -y @agentclientprotocol/claude-agent-acp@0.30.0 --extra-arg",
+      "npx -y @agentclientprotocol/claude-agent-acp@0.44.0 --extra-arg",
     );
 
     // Touch the form to mark it dirty (Save is disabled until isDirty),
@@ -647,7 +647,7 @@ describe("AgentSettingsScreen", () => {
     expect(call.agent_settings_diff?.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp@0.30.0",
+      "@agentclientprotocol/claude-agent-acp@0.44.0",
       "--extra-arg",
     ]);
     // ``acp_args: []`` resets the API-set args so they don't double up

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -389,16 +389,16 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.28.1",
+      "openhands-agent-server==1.29.0",
       "--with",
-      "openhands-sdk==1.28.1",
+      "openhands-sdk==1.29.0",
       "--with",
-      "openhands-tools==1.28.1",
+      "openhands-tools==1.29.0",
       "--with",
-      "openhands-workspace==1.28.1",
+      "openhands-workspace==1.29.0",
       "agent-server",
     ]);
-    expect(cmd.source).toBe("PyPI (1.28.1, default)");
+    expect(cmd.source).toBe("PyPI (1.29.0, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -2,9 +2,9 @@
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
 
   "versions": {
-    "agentServer": "1.28.1",
+    "agentServer": "1.29.0",
     "agentCanvas": "1.0.0-rc.11",
-    "automation": "1.0.0a10"
+    "automation": "1.0.0a12"
   },
 
   "compatibility": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
         "@openhands/extensions": "0.6.0",
-        "@openhands/typescript-client": "1.25.0",
+        "@openhands/typescript-client": "1.27.0",
         "@react-router/node": "7.17.0",
         "@react-router/serve": "7.17.0",
         "@tailwindcss/vite": "4.2.4",
@@ -3481,9 +3481,10 @@
       }
     },
     "node_modules/@openhands/typescript-client": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.25.0.tgz",
-      "integrity": "sha512-Xjqg3/aZi+20CYN7ZLzIiH4CqwThFIAvyp8vziu97UDaVIBrZgfXGlSI42/vNh8Dm1y33STMIKfYarMu17n9AQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.27.0.tgz",
+      "integrity": "sha512-JbDRAN1uqLRvHfty++cxHy2gyXzSG1TpdsN+R+ANMUMpV13fjAW2jOyY4gD7XhZp19PUYqvSfpeE1zXrNeTxvw==",
+      "license": "MIT",
       "dependencies": {
         "@openrouter/sdk": "^0.12.35",
         "ws": "^8.20.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
     "@openhands/extensions": "0.6.0",
-    "@openhands/typescript-client": "1.25.0",
+    "@openhands/typescript-client": "1.27.0",
     "@react-router/node": "7.17.0",
     "@react-router/serve": "7.17.0",
     "@tailwindcss/vite": "4.2.4",

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.28.1 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.29.0 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -78,7 +78,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/agent-canvas/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.28.1"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.29.0"}}'
 `);
   process.exit(0);
 }
@@ -260,9 +260,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.28.1,<2.0.0"
- *   "openhands-tools==1.28.1"
- *   "openhands-workspace (>=1.28.1)"
+ *   "openhands-sdk>=1.29.0,<2.0.0"
+ *   "openhands-tools==1.29.0"
+ *   "openhands-workspace (>=1.29.0)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -276,7 +276,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.28.1", "==1.28.1", "(>=1.28.1)", "~=1.28.1"
+      // ">=1.29.0", "==1.29.0", "(>=1.29.0)", "~=1.29.0"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -394,7 +394,7 @@ export function validateFrontendDependencies(
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.28.1")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.29.0")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a

--- a/src/mocks/settings-handlers.ts
+++ b/src/mocks/settings-handlers.ts
@@ -619,7 +619,7 @@ const MOCK_VERIFIED_MODELS_BY_PROVIDER = MOCK_MODELS.reduce<
   return acc;
 }, {});
 
-const MOCK_AGENT_SERVER_VERSION = "1.28.1";
+const MOCK_AGENT_SERVER_VERSION = "1.29.0";
 
 // --- Handlers for options/config/settings ---
 // Uses wildcard "*" prefix to match both relative paths and absolute URLs


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

bumps typescript-client version.

- [x] A human has tested these changes.

AGENT:

Validated locally on this branch (typescript-client 1.27.0 installed):

- `npm test` (full vitest) → **3346 passed, 0 failed** (1 skipped, 9 todo).
- `npm run typecheck` → exit 0; `npm run build` → exit 0.
- `node scripts/check-sdk-version-sync.mjs` → "All SDK versions are in sync!" (automation `1.0.0a12` resolves `openhands-sdk`/`openhands-workspace` to `1.29.0`, matching `versions.agentServer`).
- ACP fixture context: 1.27.0 refreshed the client's ACP registry, which broke 22 ACP tests (stale hardcoded values). Canvas sources those lists from the client (`src/constants/acp-providers.ts`, closes #740), so the source was already correct — only the fixtures were updated, plus one guard relaxed to accept the SDK's intentional `default` = "Default (recommended)" model.

## Why

Keep the client and the agent-server it targets on the same baseline. `@openhands/typescript-client` 1.27.0 is built and integration-tested against **agent-server `1.29.0-python`**, so this bumps the client to 1.27.0 *and* the spawned agent-server/openhands-sdk to 1.29.0 together, in one atomic change.

## Summary

- **`@openhands/typescript-client` 1.25.0 → 1.27.0** (`package.json` + lockfile).
- **agent-server / openhands-sdk 1.28.1 → 1.29.0** via `config/defaults.json` `versions.agentServer` (drives the whole SDK train: `openhands-sdk`/`openhands-tools`/`openhands-workspace`/`openhands-agent-server`); `versions.automation` `1.0.0a10 → 1.0.0a12` (required so `check-sdk-version-sync` stays green) + the doc/JSDoc/test/mock references it syncs.
- **ACP test fixtures** updated for 1.27.0's registry: command versions (`claude-agent-acp@0.30.0→0.44.0`, `codex-acp@0.15.0→0.16.0`), claude-code model ids (`claude-opus-4-8→opus[1m]`, `claude-sonnet-4-6→sonnet`, `claude-haiku-4-5→haiku`), codex default (`gpt-5.5/medium→gpt-5.5`); relaxed the `acp-providers` placeholder guard.

## Issue Number

N/A

## How to Test

```bash
npm ci
npm run typecheck && npm run build       # both pass
node scripts/check-sdk-version-sync.mjs  # "All SDK versions are in sync!"
npm test                                 # 3346 passed, 0 failed
```

## Video/Screenshots

N/A — dependency/version bump + test fixtures, no UI surface change. Evidence is the passing suite + sync check above.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- **`minimumAgentServer` intentionally stays `1.28.0`** — this bumps the shipped/default version, not the back-compat floor, so existing 1.28.x backends stay supported.
- The `openhands-automation` bump is a forced consequence of the version-sync coupling, not independent scope.
- Supersedes #1484 (client bump) and #1485 (server bump) — consolidated here so the client and the agent-server it targets land together.



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.29.0-python` |
| **Automation** | `openhands-automation==1.0.0a12` |
| **Commit** | `7f820808c0cd8ba43aab06627ed3a14725abda01` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-7f82080
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-7f82080
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-7f82080-amd64
ghcr.io/openhands/agent-canvas:chore-bump-typescript-client-and-agent-server-amd64
ghcr.io/openhands/agent-canvas:pr-1486-amd64
ghcr.io/openhands/agent-canvas:sha-7f82080-arm64
ghcr.io/openhands/agent-canvas:chore-bump-typescript-client-and-agent-server-arm64
ghcr.io/openhands/agent-canvas:pr-1486-arm64
ghcr.io/openhands/agent-canvas:sha-7f82080
ghcr.io/openhands/agent-canvas:chore-bump-typescript-client-and-agent-server
ghcr.io/openhands/agent-canvas:pr-1486
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-7f82080`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-7f82080-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->