### PR TITLE
fix: allow trusted HTTP workspace preview cookies

### DIFF
--- a/__tests__/scripts/dev-static.test.ts
+++ b/__tests__/scripts/dev-static.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildAutomationBackendEnv } from "../../scripts/dev-static.mjs";
+import {
+  buildAutomationBackendEnv,
+  parseArgs,
+} from "../../scripts/dev-static.mjs";
 
 describe("dev-static", () => {
   it("uses the same session key for both agent-server and automation backend auth", () => {
@@ -16,6 +19,12 @@ describe("dev-static", () => {
       AUTOMATION_AGENT_SERVER_URL: "http://localhost:18000",
       AUTOMATION_AGENT_SERVER_API_KEY: "shared-session-key",
       AUTOMATION_LOCAL_API_KEY: "shared-session-key",
+    });
+  });
+
+  it("parses --disable-secure", () => {
+    expect(parseArgs(["--disable-secure"])).toMatchObject({
+      disableSecureWorkspaceSession: true,
     });
   });
 });

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -330,6 +330,21 @@ describe("buildConfig", () => {
 
     expect(config.sessionApiKey).toBe("my-api-key");
   });
+
+  it("keeps workspace-session cookie rewriting disabled by default", async () => {
+    const config = await buildConfig({}, envWithIsolatedKeyPath());
+
+    expect(config.disableSecureWorkspaceSession).toBe(false);
+  });
+
+  it("enables workspace-session cookie rewriting when requested", async () => {
+    const config = await buildConfig(
+      { disableSecureWorkspaceSession: true },
+      envWithIsolatedKeyPath(),
+    );
+
+    expect(config.disableSecureWorkspaceSession).toBe(true);
+  });
 });
 
 describe("stack mode routing", () => {
@@ -525,6 +540,7 @@ describe("dev-with-automation CLI", () => {
     expect(output).toContain("--dynamic");
     expect(output).toContain("--frontend-only");
     expect(output).toContain("--backend-only");
+    expect(output).toContain("--disable-secure");
     expect(output).toContain("OH_AUTOMATION_GIT_REF");
     expect(output).toContain("OH_AGENT_SERVER_LOCAL_PATH");
     expect(output).toContain("OPENHANDS_AUTOMATION_API_KEY");

--- a/__tests__/scripts/ingress.test.ts
+++ b/__tests__/scripts/ingress.test.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server } from "node:http";
+import { createServer, request as httpRequest, type Server } from "node:http";
 import { connect as netConnect, type AddressInfo, type Socket } from "node:net";
 import type { Duplex } from "node:stream";
 import { spawn, type ChildProcess } from "node:child_process";
@@ -116,6 +116,20 @@ async function stopChild(child?: ChildProcess) {
     child.kill("SIGKILL");
     await Promise.race([exited, delay(1000)]);
   }
+}
+
+async function requestSetCookieHeaders(url: string, method = "GET") {
+  return new Promise<string[]>((resolve, reject) => {
+    const req = httpRequest(url, { method }, (res) => {
+      res.resume();
+      res.on("end", () => {
+        const setCookie = res.headers["set-cookie"];
+        resolve(Array.isArray(setCookie) ? setCookie : [setCookie ?? ""]);
+      });
+    });
+    req.on("error", reject);
+    req.end();
+  });
 }
 
 describe("ingress.mjs CLI", () => {
@@ -412,6 +426,98 @@ describe("ingress route matching", () => {
   it("returns 503 for unmatched routes with no default", async () => {
     const response = await fetch(`${originForPort(ingressPort)}/unknown`);
     expect(response.status).toBe(503);
+  });
+});
+
+describe("ingress workspace-session cookie handling", () => {
+  let backend: Server;
+  let backendPort: number;
+
+  beforeAll(async () => {
+    backend = createServer((req, res) => {
+      if (req.url?.startsWith("/api/auth/workspace-session")) {
+        res.writeHead(204, {
+          "Set-Cookie":
+            "oh_workspace_session_key=abc; Path=/api/conversations; HttpOnly; Secure; SameSite=Lax",
+        });
+        res.end();
+        return;
+      }
+
+      res.writeHead(204, {
+        "Set-Cookie": "other=abc; Path=/; Secure; SameSite=Lax",
+      });
+      res.end();
+    });
+    backendPort = await listenOnLoopback(backend);
+  });
+
+  afterAll(async () => {
+    await closeServer(backend);
+  });
+
+  async function startIngressWithCookieMode(disableSecure: boolean) {
+    const ingressPort = await getFreePort();
+    const child = spawn(
+      process.execPath,
+      [
+        ingressScript,
+        "--port",
+        ingressPort.toString(),
+        "--default",
+        originForPort(backendPort),
+        ...(disableSecure ? ["--disable-secure"] : []),
+      ],
+      {
+        cwd: repoRoot,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    await waitForPort(ingressPort, child);
+    return { child, origin: originForPort(ingressPort) };
+  }
+
+  it("preserves Secure on workspace-session cookies by default", async () => {
+    const { child, origin } = await startIngressWithCookieMode(false);
+    try {
+      const cookies = await requestSetCookieHeaders(
+        `${origin}/api/auth/workspace-session`,
+        "POST",
+      );
+
+      expect(cookies.join("\n")).toContain("Secure");
+    } finally {
+      await stopChild(child);
+    }
+  });
+
+  it("strips Secure from workspace-session cookies when --disable-secure is set", async () => {
+    const { child, origin } = await startIngressWithCookieMode(true);
+    try {
+      const cookies = await requestSetCookieHeaders(
+        `${origin}/api/auth/workspace-session`,
+        "POST",
+      );
+
+      const cookieText = cookies.join("\n");
+      expect(cookieText).toContain("oh_workspace_session_key=abc");
+      expect(cookieText).not.toContain("Secure");
+    } finally {
+      await stopChild(child);
+    }
+  });
+
+  it("does not strip Secure from unrelated cookies when --disable-secure is set", async () => {
+    const { child, origin } = await startIngressWithCookieMode(true);
+    try {
+      const cookies = await requestSetCookieHeaders(`${origin}/api/settings`);
+
+      const cookieText = cookies.join("\n");
+      expect(cookieText).toContain("other=abc");
+      expect(cookieText).toContain("Secure");
+    } finally {
+      await stopChild(child);
+    }
   });
 });
 

--- a/__tests__/scripts/proxy-cookie-utils.test.ts
+++ b/__tests__/scripts/proxy-cookie-utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { maybeRewriteWorkspaceSessionCookieHeaders } from "../../scripts/proxy-cookie-utils.mjs";
+
+describe("proxy-cookie-utils", () => {
+  const workspaceCookie =
+    "oh_workspace_session_key=abc; Path=/api/conversations; HttpOnly; Secure; SameSite=Lax";
+
+  it("leaves workspace-session cookies secure by default", () => {
+    const headers = maybeRewriteWorkspaceSessionCookieHeaders(
+      { "set-cookie": [workspaceCookie] },
+      "/api/auth/workspace-session",
+      {},
+    );
+
+    expect(headers["set-cookie"]).toEqual([workspaceCookie]);
+  });
+
+  it("strips Secure from workspace-session cookies when explicitly enabled", () => {
+    const headers = maybeRewriteWorkspaceSessionCookieHeaders(
+      { "set-cookie": [workspaceCookie] },
+      "/api/auth/workspace-session",
+      { disableSecureWorkspaceSession: true },
+    );
+
+    expect(headers["set-cookie"]).toEqual([
+      "oh_workspace_session_key=abc; Path=/api/conversations; HttpOnly; SameSite=Lax",
+    ]);
+  });
+
+  it("does not strip Secure from unrelated cookies", () => {
+    const headers = maybeRewriteWorkspaceSessionCookieHeaders(
+      { "set-cookie": ["other=abc; Path=/; Secure; SameSite=Lax"] },
+      "/api/settings",
+      { disableSecureWorkspaceSession: true },
+    );
+
+    expect(headers["set-cookie"]).toEqual([
+      "other=abc; Path=/; Secure; SameSite=Lax",
+    ]);
+  });
+});

--- a/__tests__/scripts/static-server.test.ts
+++ b/__tests__/scripts/static-server.test.ts
@@ -1,4 +1,5 @@
 import type { Server } from "node:http";
+import { createServer, request as httpRequest } from "node:http";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -40,6 +41,39 @@ describe("static-server.mjs", () => {
     }
 
     return `http://127.0.0.1:${address.port}`;
+  }
+
+  async function listenOnLoopback(server: Server) {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        server.off("error", onError);
+        reject(error);
+      };
+      server.once("error", onError);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", onError);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected server to listen on a TCP port");
+    }
+    return `http://127.0.0.1:${address.port}`;
+  }
+
+  async function requestSetCookieHeaders(url: string, method = "GET") {
+    return new Promise<string[]>((resolve, reject) => {
+      const req = httpRequest(url, { method }, (res) => {
+        res.resume();
+        res.on("end", () => {
+          const setCookie = res.headers["set-cookie"];
+          resolve(Array.isArray(setCookie) ? setCookie : [setCookie ?? ""]);
+        });
+      });
+      req.on("error", reject);
+      req.end();
+    });
   }
 
   describe("parseArgs", () => {
@@ -90,6 +124,86 @@ describe("static-server.mjs", () => {
     it("treats empty string as null for runtime services info", () => {
       const config = parseArgs(["--runtime-services-info", ""]);
       expect(config.runtimeServicesInfo).toBeNull();
+    });
+
+    it("parses --disable-secure", () => {
+      const config = parseArgs(["--disable-secure"]);
+      expect(config.disableSecureWorkspaceSession).toBe(true);
+    });
+  });
+
+  describe("proxy workspace-session cookie handling", () => {
+    function createCookieBackend() {
+      return createServer((req, res) => {
+        if (req.url?.startsWith("/api/auth/workspace-session")) {
+          res.writeHead(204, {
+            "Set-Cookie":
+              "oh_workspace_session_key=abc; Path=/api/conversations; HttpOnly; Secure; SameSite=Lax",
+          });
+          res.end();
+          return;
+        }
+
+        res.writeHead(204, {
+          "Set-Cookie": "other=abc; Path=/; Secure; SameSite=Lax",
+        });
+        res.end();
+      });
+    }
+
+    async function startProxy(disableSecureWorkspaceSession: boolean) {
+      const backend = createCookieBackend();
+      const backendOrigin = await listenOnLoopback(backend);
+      servers.push(backend);
+
+      const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
+      tempDirs.push(buildDir);
+      writeFileSync(path.join(buildDir, "index.html"), "<main>app</main>");
+
+      const server = await startStaticServer({
+        port: 0,
+        host: "127.0.0.1",
+        dir: buildDir,
+        routes: {
+          "/api": backendOrigin,
+        },
+        disableSecureWorkspaceSession,
+      });
+      servers.push(server);
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("No port");
+      return `http://127.0.0.1:${address.port}`;
+    }
+
+    it("preserves Secure on workspace-session cookies by default", async () => {
+      const origin = await startProxy(false);
+      const cookies = await requestSetCookieHeaders(
+        `${origin}/api/auth/workspace-session`,
+        "POST",
+      );
+
+      expect(cookies.join("\n")).toContain("Secure");
+    });
+
+    it("strips Secure from workspace-session cookies when enabled", async () => {
+      const origin = await startProxy(true);
+      const cookies = await requestSetCookieHeaders(
+        `${origin}/api/auth/workspace-session`,
+        "POST",
+      );
+
+      const cookieText = cookies.join("\n");
+      expect(cookieText).toContain("oh_workspace_session_key=abc");
+      expect(cookieText).not.toContain("Secure");
+    });
+
+    it("does not strip Secure from unrelated cookies when enabled", async () => {
+      const origin = await startProxy(true);
+      const cookies = await requestSetCookieHeaders(`${origin}/api/settings`);
+
+      const cookieText = cookies.join("\n");
+      expect(cookieText).toContain("other=abc");
+      expect(cookieText).toContain("Secure");
     });
   });
 

--- a/bin/agent-canvas.mjs
+++ b/bin/agent-canvas.mjs
@@ -52,6 +52,7 @@ Override versions via environment variables:
   process.exit(0);
 }
 const isPublic = args.includes("--public");
+const isDisableSecure = args.includes("--disable-secure");
 const isFrontendOnly = args.includes("--frontend-only");
 const isBackendOnly = args.includes("--backend-only");
 
@@ -76,6 +77,8 @@ AUTH MODES:
 OPTIONS:
   -p, --port <port>     Ingress port (default: 8000)
   --public              Enable public mode (see above)
+  --disable-secure      Allow workspace file preview over plain HTTP by
+                        removing Secure from workspace session cookies
   --frontend-only       Start only the static frontend behind ingress
   --backend-only        Start only agent-server + automation behind ingress
   -v, --version         Show version number
@@ -103,6 +106,9 @@ EXAMPLES:
 
   # Public mode — users must enter the API key in the browser
   LOCAL_BACKEND_API_KEY=my-secret npx @openhands/agent-canvas --public
+
+  # Public mode on a trusted plain-HTTP LAN/lab host
+  LOCAL_BACKEND_API_KEY=my-secret npx @openhands/agent-canvas --public --disable-secure
 
   # Use a specific port
   npx @openhands/agent-canvas --port 3000
@@ -164,6 +170,7 @@ main({
   staticDir: BUILD_DIR,
   mode: "agent-canvas",
   isPublic,
+  disableSecureWorkspaceSession: isDisableSecure,
 }).catch((err) => {
   console.error(`Fatal error: ${err.message}`);
   if (err.stack) {

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -168,6 +168,17 @@ before they can use it. Without `--public`, the key is auto-injected into
 the frontend (convenient for local-only use, but unsafe for a
 publicly-reachable deployment).
 
+If you intentionally access a trusted LAN or lab host over plain HTTP instead
+of HTTPS, workspace file previews may need:
+
+```bash
+export LOCAL_BACKEND_API_KEY=<your-saved-key>
+npx @openhands/agent-canvas --public --disable-secure
+```
+
+Use this only for trusted non-HTTPS environments. Internet-facing deployments
+should keep the default cookie behavior and use TLS through step 4.
+
 ## 4. (Optional) Get a domain and put nginx + Let's Encrypt in front
 
 If you want to reach the UI from a browser without an SSH tunnel — for

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -109,6 +109,7 @@ export function parseArgs(argv = process.argv.slice(2)) {
     automationRepo: null,
     skipBuild: false,
     verbose: false,
+    disableSecureWorkspaceSession: false,
   };
 
   for (let i = 0; i < argv.length; i++) {
@@ -125,6 +126,9 @@ export function parseArgs(argv = process.argv.slice(2)) {
         break;
       case "--skip-build":
         config.skipBuild = true;
+        break;
+      case "--disable-secure":
+        config.disableSecureWorkspaceSession = true;
         break;
       case "-v":
       case "--verbose":
@@ -156,6 +160,8 @@ OPTIONS:
   --automation-ref <ref>      Git ref for automation backend (default: main)
   --automation-repo <url>     Git repo URL for automation
   --skip-build                Reuse existing build/ directory (faster restart)
+  --disable-secure            Allow workspace file preview over plain HTTP by
+                              removing Secure from workspace session cookies
   -v, --verbose               Show detailed output
   -h, --help                  Show this help
 
@@ -391,6 +397,7 @@ function startStaticServer(config) {
       ...(config.sessionApiKey
         ? ["--session-api-key", config.sessionApiKey]
         : []),
+      ...(config.disableSecureWorkspaceSession ? ["--disable-secure"] : []),
       "--route",
       `/api/automation=http://localhost:${config.autoBackendPort}`,
       "--route",
@@ -453,6 +460,7 @@ function startIngress(config) {
       `/openapi.json=http://localhost:${config.agentServerPort}`,
       "--default",
       `http://localhost:${config.vitePort}`,
+      ...(config.disableSecureWorkspaceSession ? ["--disable-secure"] : []),
     ],
     {
       cwd: projectRoot,

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -172,6 +172,7 @@ function parseArgs() {
     staticDir: null,
     skipBuild: false,
     public: false,
+    disableSecureWorkspaceSession: false,
     frontendOnly: false,
     backendOnly: false,
   };
@@ -206,6 +207,9 @@ function parseArgs() {
         break;
       case "--public":
         config.public = true;
+        break;
+      case "--disable-secure":
+        config.disableSecureWorkspaceSession = true;
         break;
       case "--frontend-only":
         config.frontendOnly = true;
@@ -243,6 +247,8 @@ OPTIONS:
   --dynamic                   Force Vite dev server when a wrapper defaults static
   --frontend-only             Start only the frontend behind ingress
   --backend-only              Start only agent-server + automation behind ingress
+  --disable-secure            Allow workspace file preview over plain HTTP by
+                              removing Secure from workspace session cookies
   -v, --verbose               Show detailed output
   -h, --help                  Show this help
 
@@ -446,6 +452,7 @@ async function buildConfig(args, env = process.env) {
 
     // Public mode — the session key should NOT be baked into the frontend
     isPublic,
+    disableSecureWorkspaceSession: Boolean(args.disableSecureWorkspaceSession),
 
     frontendOnly,
     backendOnly,
@@ -924,6 +931,7 @@ function startIngress(config) {
       config.ingressPort.toString(),
       ...buildRouteArgs(getLocalServiceRoutes(config)),
       ...(frontendBackend ? ["--default", frontendBackend] : []),
+      ...(config.disableSecureWorkspaceSession ? ["--disable-secure"] : []),
     ],
     {
       cwd: projectRoot,
@@ -987,6 +995,9 @@ function startVite(config) {
     viteEnv.VITE_AUTH_REQUIRED = "true";
   } else if (config.launchAgentServer) {
     viteEnv.VITE_SESSION_API_KEY = config.sessionApiKey;
+  }
+  if (config.disableSecureWorkspaceSession) {
+    viteEnv.VITE_DISABLE_SECURE_WORKSPACE_SESSION = "true";
   }
 
   spawnService("vite", frontendCommand.command, frontendCommand.args, {
@@ -1206,6 +1217,7 @@ async function main(options = {}) {
     // When true, enable public mode (require LOCAL_BACKEND_API_KEY,
     // don't bake session key into frontend).
     isPublic: isPublicOverride,
+    disableSecureWorkspaceSession: disableSecureWorkspaceSessionOverride,
   } = options;
 
   const args = parseArgs();
@@ -1213,6 +1225,9 @@ async function main(options = {}) {
   // Allow options to override CLI args for public mode
   if (isPublicOverride != null) {
     args.public = isPublicOverride;
+  }
+  if (disableSecureWorkspaceSessionOverride != null) {
+    args.disableSecureWorkspaceSession = disableSecureWorkspaceSessionOverride;
   }
 
   // Allow options to override CLI args (for bin/agent-canvas.mjs)
@@ -1387,6 +1402,7 @@ function startStaticFrontend(config, staticDir) {
         : []),
       // Proxy routes only to services that this launch mode started.
       ...buildRouteArgs(getLocalServiceRoutes(config)),
+      ...(config.disableSecureWorkspaceSession ? ["--disable-secure"] : []),
       // Reject known API prefixes that have no backend — returns 503
       // instead of SPA-fallbacking to index.html.
       ...buildRejectPrefixArgs(getRejectPrefixes(config)),

--- a/scripts/ingress.mjs
+++ b/scripts/ingress.mjs
@@ -22,6 +22,8 @@
 import { createServer, request as httpRequest } from "node:http";
 import process from "node:process";
 
+import { maybeRewriteWorkspaceSessionCookieHeaders } from "./proxy-cookie-utils.mjs";
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Configuration
 // ═══════════════════════════════════════════════════════════════════════════
@@ -32,6 +34,7 @@ function parseArgs() {
     port: 8000,
     routes: {},
     defaultBackend: null,
+    disableSecureWorkspaceSession: false,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -49,6 +52,9 @@ function parseArgs() {
       case "-d":
       case "--default":
         config.defaultBackend = args[++i];
+        break;
+      case "--disable-secure":
+        config.disableSecureWorkspaceSession = true;
         break;
       case "-h":
       case "--help":
@@ -73,6 +79,8 @@ OPTIONS:
   -p, --port <port>           Port to listen on (default: 8000)
   -r, --route <path=url>      Add a route (can be repeated)
   -d, --default <url>         Default backend for unmatched routes
+  --disable-secure            Remove the Secure attribute from workspace
+                              session cookies for plain-HTTP lab hosts
   -h, --help                  Show this help
 
 ENVIRONMENT VARIABLES:
@@ -118,6 +126,9 @@ function buildConfig(args, env = process.env) {
     port: args.port || parseInt(env.INGRESS_PORT, 10) || 8000,
     routes,
     defaultBackend: args.defaultBackend || env.INGRESS_DEFAULT || null,
+    disableSecureWorkspaceSession:
+      args.disableSecureWorkspaceSession ||
+      env.INGRESS_DISABLE_SECURE === "true",
   };
 }
 
@@ -128,12 +139,16 @@ function buildConfig(args, env = process.env) {
 function createRouter(routes, defaultBackend) {
   // Sort routes by path length (longest first) for most-specific matching
   const sortedRoutes = Object.entries(routes).sort(
-    ([a], [b]) => b.length - a.length
+    ([a], [b]) => b.length - a.length,
   );
 
   return function route(url) {
     for (const [prefix, backend] of sortedRoutes) {
-      if (url === prefix || url.startsWith(prefix + "/") || url.startsWith(prefix + "?")) {
+      if (
+        url === prefix ||
+        url.startsWith(prefix + "/") ||
+        url.startsWith(prefix + "?")
+      ) {
         return backend;
       }
     }
@@ -167,7 +182,7 @@ function isBenignSocketError(err) {
   return Boolean(err && BENIGN_SOCKET_ERRORS.has(err.code));
 }
 
-function proxyRequest(req, res, backendUrl) {
+function proxyRequest(req, res, backendUrl, proxyOptions = {}) {
   const backend = parseBackendUrl(backendUrl);
 
   const options = {
@@ -194,7 +209,12 @@ function proxyRequest(req, res, backendUrl) {
       }
     });
 
-    res.writeHead(proxyRes.statusCode, proxyRes.headers);
+    const headers = maybeRewriteWorkspaceSessionCookieHeaders(
+      proxyRes.headers,
+      req.url,
+      proxyOptions,
+    );
+    res.writeHead(proxyRes.statusCode, headers);
     proxyRes.pipe(res, { end: true });
   });
 
@@ -253,7 +273,10 @@ function proxyWebSocket(req, socket, head, backendUrl) {
   // TCP socket would crash the entire ingress process.
   socket.on("error", (err) => {
     if (!isBenignSocketError(err)) {
-      console.error(`WebSocket client socket error for ${req.url}:`, err.message);
+      console.error(
+        `WebSocket client socket error for ${req.url}:`,
+        err.message,
+      );
     }
     proxyReq.destroy();
   });
@@ -278,10 +301,12 @@ function proxyWebSocket(req, socket, head, backendUrl) {
     proxySocket.on("close", () => socket.destroy());
 
     socket.write(
-      `HTTP/${proxyRes.httpVersion} ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n`
+      `HTTP/${proxyRes.httpVersion} ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n`,
     );
     for (let i = 0; i < proxyRes.rawHeaders.length; i += 2) {
-      socket.write(`${proxyRes.rawHeaders[i]}: ${proxyRes.rawHeaders[i + 1]}\r\n`);
+      socket.write(
+        `${proxyRes.rawHeaders[i]}: ${proxyRes.rawHeaders[i + 1]}\r\n`,
+      );
     }
     socket.write("\r\n");
 
@@ -309,6 +334,9 @@ function proxyWebSocket(req, socket, head, backendUrl) {
 
 function startIngress(config) {
   const route = createRouter(config.routes, config.defaultBackend);
+  const proxyOptions = {
+    disableSecureWorkspaceSession: config.disableSecureWorkspaceSession,
+  };
 
   const server = createServer((req, res) => {
     const backend = route(req.url);
@@ -319,7 +347,7 @@ function startIngress(config) {
       return;
     }
 
-    proxyRequest(req, res, backend);
+    proxyRequest(req, res, backend, proxyOptions);
   });
 
   // Handle WebSocket upgrades
@@ -349,15 +377,27 @@ function startIngress(config) {
 
   server.listen(config.port, () => {
     console.log("");
-    console.log("╔═══════════════════════════════════════════════════════════════╗");
-    console.log("║  Ingress Proxy                                                ║");
-    console.log("╠═══════════════════════════════════════════════════════════════╣");
-    console.log(`║  Listening on: http://localhost:${config.port}/`.padEnd(66) + "║");
-    console.log("╠═══════════════════════════════════════════════════════════════╣");
-    console.log("║  Routes:                                                      ║");
+    console.log(
+      "╔═══════════════════════════════════════════════════════════════╗",
+    );
+    console.log(
+      "║  Ingress Proxy                                                ║",
+    );
+    console.log(
+      "╠═══════════════════════════════════════════════════════════════╣",
+    );
+    console.log(
+      `║  Listening on: http://localhost:${config.port}/`.padEnd(66) + "║",
+    );
+    console.log(
+      "╠═══════════════════════════════════════════════════════════════╣",
+    );
+    console.log(
+      "║  Routes:                                                      ║",
+    );
 
     const sortedRoutes = Object.entries(config.routes).sort(
-      ([a], [b]) => b.length - a.length
+      ([a], [b]) => b.length - a.length,
     );
     for (const [path, backend] of sortedRoutes) {
       const line = `    ${path} → ${backend}`;
@@ -369,8 +409,12 @@ function startIngress(config) {
       console.log(`║  ${line.padEnd(61)}║`);
     }
 
-    console.log("║                                                               ║");
-    console.log("╚═══════════════════════════════════════════════════════════════╝");
+    console.log(
+      "║                                                               ║",
+    );
+    console.log(
+      "╚═══════════════════════════════════════════════════════════════╝",
+    );
     console.log("");
   });
 
@@ -385,7 +429,9 @@ const args = parseArgs();
 const config = buildConfig(args);
 
 if (Object.keys(config.routes).length === 0 && !config.defaultBackend) {
-  console.error("Error: No routes configured. Use --route or --default options.");
+  console.error(
+    "Error: No routes configured. Use --route or --default options.",
+  );
   console.error("Run with --help for usage information.");
   process.exit(1);
 }

--- a/scripts/proxy-cookie-utils.mjs
+++ b/scripts/proxy-cookie-utils.mjs
@@ -1,0 +1,36 @@
+const WORKSPACE_SESSION_PATH = "/api/auth/workspace-session";
+
+function isWorkspaceSessionRequest(url) {
+  return (
+    url === WORKSPACE_SESSION_PATH ||
+    url.startsWith(`${WORKSPACE_SESSION_PATH}?`)
+  );
+}
+
+function stripSecureAttribute(cookie) {
+  return cookie.replace(/;\s*Secure(?=;|$)/gi, "");
+}
+
+export function maybeRewriteWorkspaceSessionCookieHeaders(
+  headers,
+  reqUrl,
+  opts,
+) {
+  if (
+    !opts?.disableSecureWorkspaceSession ||
+    !isWorkspaceSessionRequest(reqUrl)
+  ) {
+    return headers;
+  }
+
+  const nextHeaders = { ...headers };
+  const setCookie = nextHeaders["set-cookie"];
+  if (!setCookie) {
+    return nextHeaders;
+  }
+
+  nextHeaders["set-cookie"] = Array.isArray(setCookie)
+    ? setCookie.map(stripSecureAttribute)
+    : stripSecureAttribute(setCookie);
+  return nextHeaders;
+}

--- a/scripts/static-server.mjs
+++ b/scripts/static-server.mjs
@@ -34,6 +34,8 @@ import { extname, isAbsolute, normalize, relative, resolve } from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 
+import { maybeRewriteWorkspaceSessionCookieHeaders } from "./proxy-cookie-utils.mjs";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // MIME types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -77,6 +79,7 @@ export function parseArgs(argv = process.argv.slice(2)) {
     authRequired: false,
     runtimeServicesInfo: null,
     lockToCloud: null,
+    disableSecureWorkspaceSession: false,
   };
 
   for (let i = 0; i < argv.length; i++) {
@@ -117,6 +120,9 @@ export function parseArgs(argv = process.argv.slice(2)) {
         break;
       case "--lock-to-cloud":
         config.lockToCloud = argv[++i] || null;
+        break;
+      case "--disable-secure":
+        config.disableSecureWorkspaceSession = true;
         break;
 
       case "--auth-required":
@@ -185,6 +191,8 @@ OPTIONS:
   --lock-to-cloud <cloud-url>  Lock backend setup to a single OpenHands Cloud
                                URL. Hides manual/local backend setup and the
                                custom Cloud URL field in the pre-built frontend.
+  --disable-secure             Remove the Secure attribute from workspace
+                               session cookies for plain-HTTP lab hosts.
   --reject-prefix <prefix>     Return 503 for requests matching <prefix>
                                instead of SPA-fallbacking to index.html;
                                may be repeated. Useful in --frontend-only
@@ -366,7 +374,7 @@ function parseBackendUrl(backendUrl) {
   };
 }
 
-function proxyRequest(req, res, backendUrl) {
+function proxyRequest(req, res, backendUrl, proxyOptions = {}) {
   const backend = parseBackendUrl(backendUrl);
 
   const proxyReq = httpRequest(
@@ -381,7 +389,12 @@ function proxyRequest(req, res, backendUrl) {
       },
     },
     (proxyRes) => {
-      res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+      const headers = maybeRewriteWorkspaceSessionCookieHeaders(
+        proxyRes.headers,
+        req.url,
+        proxyOptions,
+      );
+      res.writeHead(proxyRes.statusCode ?? 502, headers);
       proxyRes.pipe(res, { end: true });
     },
   );
@@ -633,11 +646,15 @@ export function startStaticServer(config) {
     lockToCloud: config.lockToCloud || null,
   };
   const rejectPrefixes = config.rejectPrefixes ?? [];
+  const proxyOptions = {
+    disableSecureWorkspaceSession:
+      config.disableSecureWorkspaceSession || false,
+  };
 
   const server = createServer((req, res) => {
     const backend = route(req.url);
     if (backend) {
-      proxyRequest(req, res, backend);
+      proxyRequest(req, res, backend, proxyOptions);
       return;
     }
     handleStatic(req, res, dirAbs, injectionOpts, rejectPrefixes).catch(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,17 +60,49 @@ export default defineConfig(({ mode }) => {
     VITE_USE_TLS = "false",
     VITE_FRONTEND_PORT = "3001",
     VITE_INSECURE_SKIP_VERIFY = "false",
+    VITE_DISABLE_SECURE_WORKSPACE_SESSION = "false",
   } = loadEnv(mode, process.cwd());
 
   const isLibraryBuild = process.env.BUILD_LIB === "true";
   const USE_TLS = VITE_USE_TLS === "true";
   const INSECURE_SKIP_VERIFY = VITE_INSECURE_SKIP_VERIFY === "true";
+  const DISABLE_SECURE_WORKSPACE_SESSION =
+    VITE_DISABLE_SECURE_WORKSPACE_SESSION === "true";
   const PROTOCOL = USE_TLS ? "https" : "http";
   const WS_PROTOCOL = USE_TLS ? "wss" : "ws";
 
   const API_URL = `${PROTOCOL}://${VITE_BACKEND_HOST}/`;
   const WS_URL = `${WS_PROTOCOL}://${VITE_BACKEND_HOST}/`;
   const FE_PORT = Number.parseInt(VITE_FRONTEND_PORT, 10);
+  const configureWorkspaceSessionProxy = (proxy: {
+    on: (
+      event: "proxyRes",
+      listener: (
+        proxyRes: { headers: Record<string, string | string[] | undefined> },
+        req: { url?: string },
+      ) => void,
+    ) => void;
+  }) => {
+    if (!DISABLE_SECURE_WORKSPACE_SESSION) return;
+
+    proxy.on("proxyRes", (proxyRes, req) => {
+      if (
+        req.url !== "/api/auth/workspace-session" &&
+        !req.url?.startsWith("/api/auth/workspace-session?")
+      ) {
+        return;
+      }
+
+      const setCookie = proxyRes.headers["set-cookie"];
+      if (!setCookie) return;
+
+      const stripSecure = (cookie: string) =>
+        cookie.replace(/;\s*Secure(?=;|$)/gi, "");
+      proxyRes.headers["set-cookie"] = Array.isArray(setCookie)
+        ? setCookie.map(stripSecure)
+        : stripSecure(setCookie);
+    });
+  };
 
   return {
     define: {
@@ -352,6 +384,7 @@ export default defineConfig(({ mode }) => {
           target: API_URL,
           changeOrigin: true,
           secure: !INSECURE_SKIP_VERIFY,
+          configure: configureWorkspaceSessionProxy,
         },
         "/server_info": {
           target: API_URL,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

AI-assisted change. I reviewed the diff and verification output before opening this PR.

---

## Why

Closes #1437.

When Agent Canvas is accessed over plain HTTP on a trusted non-loopback LAN/lab host, the agent-server can return `oh_workspace_session_key` with the `Secure` attribute from `POST /api/auth/workspace-session`. Browsers then withhold that cookie from follow-up HTTP workspace file-preview requests, so previews can fail with 401 even though the rest of the authenticated UI works.

## Summary

- Added an explicit `--disable-secure` launcher option that preserves the default secure behavior unless users opt in for trusted plain-HTTP environments.
- Rewrites `Set-Cookie` only for `/api/auth/workspace-session`, stripping only the `Secure` attribute from that workspace-session cookie path in ingress/static/Vite proxy flows.
- Added regression coverage for default behavior, enabled behavior, unrelated cookies, launcher parsing, and a self-hosting note for the trusted HTTP case.

## Issue Number

Closes #1437

## How to Test

I ran:

```bash
npm test -- --run __tests__/scripts/proxy-cookie-utils.test.ts __tests__/scripts/ingress.test.ts __tests__/scripts/static-server.test.ts __tests__/scripts/dev-with-automation.test.ts __tests__/scripts/dev-static.test.ts
npm run typecheck && npm run build
npm run lint
npx prettier --check __tests__/scripts/proxy-cookie-utils.test.ts __tests__/scripts/ingress.test.ts __tests__/scripts/static-server.test.ts __tests__/scripts/dev-with-automation.test.ts __tests__/scripts/dev-static.test.ts scripts/proxy-cookie-utils.mjs scripts/ingress.mjs scripts/static-server.mjs scripts/dev-with-automation.mjs scripts/dev-static.mjs bin/agent-canvas.mjs docs/SELF_HOSTING.md vite.config.ts
git diff --check
```

The focused test run passed 90 tests across 5 files. Typecheck, production build, lint, Prettier check, and whitespace check all passed.

## Video/Screenshots

Not applicable; this is launcher/proxy cookie handling. The regression tests verify the emitted `Set-Cookie` headers through the proxy paths.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The new option is intentionally opt-in. Default TLS and internet-facing deployments keep the original `Secure` cookie behavior. The rewrite is scoped to `/api/auth/workspace-session`; unrelated `Set-Cookie` headers still keep `Secure` even when `--disable-secure` is enabled.
