### PR TITLE
chore(posthog): route through z.openhands.dev proxy and always create person profiles

### DIFF
--- a/.agents/skills/create-fork.md
+++ b/.agents/skills/create-fork.md
@@ -1,0 +1,482 @@
+---
+name: create-fork
+description: How to create and maintain a long-running *personal* fork of a GitHub project — the kind that intentionally diverges from upstream `main` to carry personal preferences and gets rebased onto upstream periodically. Default starting target is `OpenHands/agent-sdk`. Use when the user wants to fork a repo for sustained customizations, NOT for one-off "fork → branch → PR back upstream" contributions.
+triggers:
+- create fork
+- create-fork
+- long-running fork
+- personal fork
+- maintain a fork
+- diverging fork
+---
+
+# Creating and Maintaining a Long-Running Personal Fork
+
+This skill walks through setting up a *long-running personal fork* of an
+upstream repo, and the discipline that keeps it cheap to maintain
+indefinitely.
+
+**Use this skill when** the user wants to carry personal customizations
+(theming, layout tweaks, dev-loop helpers, default flips, …) on top of an
+active upstream codebase, and re-sync with upstream periodically. The
+fork's customized line lives on its **default branch** and intentionally
+diverges from upstream's default branch.
+
+**Do NOT use this skill** for normal "fork to make a PR" workflows. For
+those, just use `gh repo fork --remote` and open the PR.
+
+## Default starting target
+
+When the user invokes this skill without naming a specific upstream,
+default to **`OpenHands/agent-sdk`** as the upstream to fork. Confirm
+the user's GitHub login first (the fork will land in that account):
+
+```sh
+curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["login"])'
+```
+
+If the user names a different upstream, substitute that everywhere
+`OpenHands/agent-sdk` appears below. The procedure is identical.
+
+For reference, an existing fork built this way is
+[`rbren/agent-canvas`](https://github.com/rbren/agent-canvas) — its
+`.agents/skills/long-running-fork.md` is a fully fleshed-out example
+of the per-repo skill this guide tells you to create.
+
+## Fork model: divergent `main`, no separate branch
+
+The recommended structure is:
+
+- **The fork's default branch is `main`** (whatever upstream calls its
+  default — usually `main`, sometimes `master`).
+- **The fork's `main` intentionally diverges from upstream's `main`.** It
+  is *not* a mirror; it carries the personal customizations on top.
+- **There is no separate "my changes" branch on the fork.** The fork
+  *itself* plays that role. Keeping a parallel branch like `rbren` is
+  redundant — you'd just have to keep it in sync with `main`.
+- Worktrees branched off `main` naturally start on the customized line,
+  which is usually what you want.
+
+Reject any plan that involves "mirror upstream `main`, put customizations
+on a side branch on the fork" unless the user explicitly insists — it
+creates a permanent two-branch reconciliation tax.
+
+## Step 1 — Create the fork on GitHub
+
+Use the GitHub REST API (or `gh repo fork`). Do **not** set
+`default_branch_only: true` — let all branches come along, you can prune
+later if you want.
+
+```sh
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OpenHands/agent-sdk/forks \
+  -d '{"default_branch_only": false}'
+```
+
+Wait a few seconds for GitHub to copy branches. The fork's default
+branch will start out as a mirror of upstream's default branch tip.
+
+Verify:
+
+```sh
+curl -s -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/<your-login>/agent-sdk \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["default_branch"], d["fork"], d["parent"]["full_name"])'
+```
+
+## Step 2 — Clone locally with proper remotes
+
+Use **ssh:// URLs for both remotes**. Don't embed GitHub tokens in remote
+URLs (they leak into `git config`, shell history, error messages).
+
+```sh
+git clone ssh://git@github.com/<your-login>/agent-sdk.git
+cd agent-sdk
+
+# Origin is already the fork; just normalize the URL form if needed.
+git remote set-url origin ssh://git@github.com/<your-login>/agent-sdk.git
+
+# Add upstream as a second remote. Fetch-only in practice.
+git remote add upstream ssh://git@github.com/OpenHands/agent-sdk.git
+git fetch upstream
+```
+
+The convention: `origin` = the fork (the one you push to); `upstream` =
+the canonical project (read-only for your purposes). Never push to
+`upstream`.
+
+Confirm SSH auth works (`ssh -T git@github.com` should greet the user by
+their GitHub login). If they don't have SSH keys set up, stop and ask
+— don't fall back to HTTPS+token without explicit consent.
+
+## Step 3 — Add the `long-running-fork` skill to the fork
+
+Every long-running fork needs an in-repo skill at
+`.agents/skills/long-running-fork.md` so future agents working on the
+fork auto-load the maintenance discipline. **You write this file
+yourself, in the new fork, as your first fork-local commit.**
+
+The skill must include the following sections:
+
+### 3a. Frontmatter
+
+```yaml
+---
+name: long-running-fork
+description: Repo-specific guidance for the long-running personal fork `<your-login>/<repo>` of `<upstream-owner>/<repo>`. Auto-loaded for any task on the fork's `main` branch (which diverges from upstream `main`).
+triggers:
+- <your-login>
+- <your-login>/<repo>
+- long-running fork
+- merge upstream
+- rebase upstream
+---
+```
+
+### 3b. Intro + Remote setup
+
+Identifies the fork, names the maintainer, states the divergence-from-
+upstream-main model, and documents the two SSH remotes (`origin` = fork,
+`upstream` = canonical). Include a "fix-up" recipe (`git remote set-url
+origin ssh://…`) for clones made before the fork existed.
+
+### 3c. MODLOG — inventory of fork-local divergences
+
+This is the **canonical inventory of every divergence from upstream
+`main`** that currently exists on the fork. It is **NOT a timeline**
+— it is a grouped-by-topic list of the current final state.
+
+Rules:
+- One entry per piece of fork-local behavior. Don't merge conceptually
+  distinct edits even if they touch the same file.
+- Each entry describes the **current** state, lists touched files, and
+  records the *original* introducing commit as a historical anchor.
+- **Adjustments** to an existing fork-local change update the entry's
+  description; they do *not* add a new commit hash.
+- **Reverts** (fork-local change fully removed) → delete the entry.
+- **Adopted upstream** (upstream now provides what the fork used to
+  override) → delete the entry on the rebase commit that retires the
+  local code.
+- Group entries under `####` topic subheadings (Branding, Theming,
+  Sidebar, Dev meta, …). Re-group / re-title freely; the groups are a
+  navigation aid, not a contract.
+
+Entry format:
+
+```
+- **<area>** — <one-line description of the *current* final state>.
+  Files: `<path>`[, `<path>` …]
+  Introduced: <short commit hash>
+  Upstream proposal: <issue/PR url, if filed; omit otherwise>
+```
+
+Start the MODLOG empty. Populate it as customizations land — in the
+**same commit** as the change.
+
+### 3d. SYNCLOG — chronological upstream-sync record
+
+Unlike the MODLOG, the SYNCLOG **is** a timeline. Append-only,
+chronological, newest at the bottom. One entry per sync operation
+(merge or rebase from `upstream/main`), regardless of how many upstream
+commits it absorbed.
+
+The **first entry** is the upstream commit the fork was originally
+branched from (no sync happened — it's the starting point of all later
+diffs).
+
+Entry format:
+
+```
+- **YYYY-MM-DD** — synced upstream `main` at `<short hash>` ("<commit title>")
+  - Sync commit: `<short hash on the fork's main>` (omit for the initial branch point)
+  - Conflicts: <comma-separated files / paths>, or "None"
+  - Notes: <one-paragraph summary of breakages, fork-local fix-ups,
+            or behavior shifts that landed in the sync commit>. Use
+            "None" for clean merges.
+```
+
+Even clean syncs get an entry — that's the evidence the fork was
+up-to-date at that point in time. Don't retroactively edit historical
+entries; add new ones for follow-ups.
+
+### 3e. Marker convention
+
+Pick one literal token that every fork-local source edit carries as a
+comment, so they can be grepped trivially.
+
+A good token:
+- Is unique enough to not collide with anything upstream (`fork:` is too
+  generic; `<your-login>'s mod:` or `<your-login>-fork:` is fine).
+- Includes a `:` so it can be greped without false positives against the
+  word in prose.
+- Is documented as **the single canonical form** — don't allow variants
+  (`mything:`, `mything branch:`, `mything fork:`). Variants defeat the
+  grep.
+
+Document the rename procedure: if you ever need to change the token, do
+it as a coordinated sweep across the whole tree in one commit, and
+update this skill in the same commit.
+
+### 3f. Core principles
+
+Keep these short. The standard set:
+
+1. **Additive, not invasive.** Prefer new files / new entries / new
+   variants over editing shared files in place. New files never conflict
+   on merge; edits to shared files often do.
+2. **Smallest possible diff to shared files.** One-line edits at the
+   bottom of a file rebase cleanly; reorganizing the file doesn't.
+3. **Mark every fork-local edit clearly** with the marker comment
+   (Section 3e).
+4. **Quarantine fork-local code** in files that exist only on the fork
+   (e.g. under `.agents/skills/`, a new file under `src/themes/`, a new
+   script under `scripts/`).
+5. **Don't reformat shared files** (no drive-by prettier passes, import
+   reordering, comment cleanups). Every reformatted line is a future
+   conflict.
+6. **Don't rename or move shared files.** Renames are the worst-case
+   conflict — git often can't follow them across an upstream rebase.
+
+### 3g. Rebase recipe + force-push to origin
+
+Document the canonical sync command:
+
+```sh
+git fetch upstream
+git rebase upstream/main
+git grep -n "<marker>:" -- ':(exclude).agents/skills/long-running-fork.md'  # sanity check
+git push --force-with-lease origin main
+```
+
+Always `--force-with-lease`, never plain `--force` (long-running branches
+deserve the safety net). Never push to `upstream`.
+
+### 3h. Conflict-recurrence escalation
+
+Document the "open an upstream issue" trigger and template (see Step 7
+below).
+
+## Step 4 — Seed the MODLOG and SYNCLOG
+
+Even before any customizations exist, **commit the empty skill** with:
+
+- An empty MODLOG (just the section header + maintenance rules + empty
+  "Current entries").
+- A SYNCLOG with exactly **one entry**: the initial branch point.
+
+```
+### Entries
+
+- **YYYY-MM-DD** — branched from `<upstream-tip-hash>` ("<commit title>")
+  on upstream `main`.
+  - Conflicts: N/A (initial branch point, not a sync)
+  - Notes: starting commit of the long-running fork.
+```
+
+That commit becomes the historical anchor for the fork. After it lands,
+the MODLOG-self-entry can be added when the first real customization
+goes in.
+
+## Step 5 — Optional: rebrand the README header
+
+If the user wants the fork to feel like its own thing (UI title, sidebar
+wordmark, etc.), add a fork-local header section at the top of
+`README.md`:
+
+```md
+# <repo> — <fork-display-name>
+
+> [!NOTE]
+> **<fork-display-name>** is a **long-running personal fork** of
+> [`<upstream-owner>/<repo>`](https://github.com/<upstream-owner>/<repo>)
+> maintained by **<user-name>** at
+> [`<your-login>/<repo>`](https://github.com/<your-login>/<repo>).
+> The fork's default branch — this `main` — intentionally diverges from
+> upstream `main` to carry personal preferences. It is rebased onto
+> upstream periodically and is not guaranteed to be stable between
+> rebases. If you are looking for the canonical project, use
+> [`<upstream-owner>/<repo>`](https://github.com/<upstream-owner>/<repo>).
+
+> [!IMPORTANT]
+> **Maintainers and agents working on <fork-display-name>:** read
+> [`.agents/skills/long-running-fork.md`](.agents/skills/long-running-fork.md)
+> first. It documents the merge-friendly editing discipline, the remote
+> layout, the **MODLOG**, the **SYNCLOG**, and the marker convention.
+
+---
+
+## Upstream README
+
+<original README content preserved verbatim>
+```
+
+Add a MODLOG entry for the README divergence.
+
+## Step 6 — Periodic sync from upstream
+
+On a cadence the user chooses (weekly, on upstream release, "when
+something I want lands"), pull upstream changes into the fork's `main`:
+
+```sh
+cd <fork-checkout>
+git fetch upstream
+git --no-pager log --oneline HEAD..upstream/main   # preview what's coming
+git rebase upstream/main
+# Resolve conflicts. Use the marker comments to identify fork-local lines.
+git push --force-with-lease origin main
+```
+
+Then **append a SYNCLOG entry** in the same rebase commit (or a tiny
+follow-up commit) recording:
+- Upstream tip synced to.
+- Conflicts touched (or "None").
+- Any breakages and how they were fixed.
+
+If a rebase hits a conflict in a file that only contains marker comments,
+prefer re-applying the marker on top of the new upstream content rather
+than blindly keeping the fork-local version. The marker is the contract;
+the surrounding lines belong to upstream.
+
+## Step 7 — Pushing select fixes back to upstream
+
+When a fork-local commit turns out to be a genuine bug fix or a
+generally-useful improvement (not just a personal preference), port it
+upstream as a regular PR:
+
+1. Branch off `upstream/main` (**not** the fork's `main`):
+   ```sh
+   git fetch upstream
+   git checkout -b upstream-pr/<descriptive-name> upstream/main
+   ```
+2. Cherry-pick the relevant commit and scrub it of fork-local-only
+   context (drop the marker comments, drop MODLOG edits, etc.):
+   ```sh
+   git cherry-pick <fork-local-commit-sha>
+   # then edit to remove fork-local markers / MODLOG entries
+   ```
+3. Push to the fork on a non-`main` branch and open a PR against
+   `upstream/main`:
+   ```sh
+   git push origin upstream-pr/<descriptive-name>
+   gh pr create --repo <upstream-owner>/<repo> --base main \
+     --head <your-login>:upstream-pr/<descriptive-name> \
+     --title "<concise upstream-friendly title>" \
+     --body "<rationale — no fork-local framing>"
+   ```
+4. Once the PR merges upstream, **drop the equivalent fork-local commit
+   on the next rebase**. That is the win condition — the fork carries
+   one fewer commit and one fewer rebase risk.
+
+Always include an AI-disclosure line in PR descriptions (per the github
+skill's standard).
+
+## Step 8 — When conflicts recur, propose upstream extensibility hooks
+
+The cheapest fork-local change is the one you don't have to maintain. If
+the same upstream file (or small cluster of files) conflicts on the fork
+across **two or more** rebases, and the fork-local edit is structurally
+the same each time (a label swap, a default flip, a feature toggle, a
+color, a route entry, …), **open an upstream issue proposing an
+extensibility hook**.
+
+File one when **two or more** of these are true:
+
+- Same upstream file has conflicted on the fork ≥2 rebases.
+- The fork-local edit is structurally the same each time.
+- The change generalizes — other fork maintainers would plausibly want
+  it too. (Not "my idiosyncratic preference".)
+- You can describe a concrete hook that lets upstream keep its
+  opinionated defaults while letting forks override cleanly: a config
+  flag, a render slot, a registry entry, a theme key, an env var, a
+  prop with the current value as default, etc.
+
+If only one is true, just keep the local edit and move on.
+
+### Issue template
+
+Title: `Proposal: make <X> configurable to reduce fork-rebase friction`
+
+Body:
+
+```
+### Context
+This came up while maintaining the long-running `<your-login>/<repo>`
+fork of `<upstream-owner>/<repo>`, where a fork-local tweak to
+<FILE / FEATURE> has conflicted on <N> consecutive rebases of upstream
+`main` into the fork's `main`.
+
+### Current behavior
+<What upstream currently does — link the exact lines / file.>
+
+### Why this causes rebase friction on forks
+<Why the fork has to keep editing this same spot, e.g. hardcoded
+label / hardcoded default theme / hardcoded route list.>
+
+### Proposed extensibility hook
+<Concrete proposal, kept minimal. Examples:
+- a new optional prop / config field with the current value as default,
+- moving a hardcoded literal into a small registry/constants module,
+- exposing a render slot,
+- reading a value from a config / env var with current behavior as fallback.>
+
+### Backward compatibility
+<Confirm the proposal preserves current default behavior so it is a
+pure additive change for non-fork consumers.>
+
+### Out of scope
+<Explicitly state this issue is *not* asking upstream to adopt the
+fork-local value — only to expose the seam. Forks remain responsible
+for their own values.>
+```
+
+Always include the standard AI-disclosure line at the end of the body
+(per the github skill):
+
+> _This issue was opened by an AI agent (OpenHands) on behalf of
+> @<your-login> while maintaining the long-running `<your-login>/<repo>`
+> fork._
+
+After filing, drop the issue URL into a one-line comment alongside the
+fork-local edit:
+
+```ts
+label: "Code", /* <marker>: was "New"; upstream proposal: <upstream-owner>/<repo>#NNN */
+```
+
+If upstream lands the hook, your next rebase should **delete** the
+fork-local edit and switch to consuming the new hook. Win condition,
+documented retirement path.
+
+### What *not* to do
+
+- Don't file an issue asking upstream to adopt your preferred value
+  (theme color, label text, default route). Upstream owns defaults; the
+  fork owns overrides.
+- Don't open a PR against upstream with the fork-local change directly.
+  File the issue first; let maintainers decide on the seam shape before
+  any PR.
+- Don't bundle multiple unrelated proposals into one issue — one
+  extensibility hook per issue.
+
+## Final checklist
+
+After running this skill end-to-end the user should have:
+
+- [ ] A fork at `<your-login>/<upstream-repo>`, default branch `main`.
+- [ ] A local clone with `origin` = fork (ssh://) and `upstream` =
+      canonical (ssh://).
+- [ ] An initial fork-local commit on `main` containing
+      `.agents/skills/long-running-fork.md` with: intro, remote setup,
+      empty MODLOG (with maintenance rules), seeded SYNCLOG (one entry =
+      initial branch point), marker convention, core principles, rebase
+      recipe, escalation guidance.
+- [ ] (Optional) Rebranded README header + a MODLOG entry for it.
+- [ ] `origin/main` pushed.
+
+Future agents working on the fork will auto-load
+`long-running-fork.md` and follow its discipline. Your job in this skill
+is done as soon as the scaffolding is in place — the first real
+customization is its own task.

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -208,7 +208,7 @@ describes. Specifically:
   Defaults to `OpenHands/agent-sdk` as the upstream when no target is
   specified. Lives only on this fork — upstream has no notion of it.
   Files: `.agents/skills/create-fork.md`
-  Introduced: (this commit)
+  Introduced: 3489c8b
 
 ### Sanity-check the MODLOG against git
 

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -138,6 +138,102 @@ When pulling in upstream `main`:
    ```
    (Never plain `--force` against a long-running branch.)
 
+## Pushing Upstream When Conflicts Recur
+
+The cheapest fork-local change is the one you don't have to maintain. If you
+find yourself **repeatedly resolving conflicts in the same upstream code**
+because of a fork-local tweak — and you have an idea for how upstream could
+expose that surface as a configuration point — open an issue on the upstream
+repo proposing it. A small upstream extensibility hook usually beats indefinite
+rebase friction.
+
+### When to file an upstream issue
+
+File one when **two or more** of these are true:
+
+- The same upstream file (or small cluster of files) has conflicted on this
+  branch across multiple rebases.
+- The fork-local edit is structurally the same each time (a label swap,
+  a default value flip, a feature gated on / off, a different color, etc.).
+- The change is something other fork maintainers would plausibly also want
+  to make — i.e. it generalizes, not "rbren's idiosyncratic preference".
+- You can describe a concrete extensibility hook that would let upstream stay
+  opinionated about defaults while letting forks override cleanly (a config
+  flag, a slot/render-prop, a registry entry, a theme key, an env var, etc.).
+
+If only one of those is true it's probably not worth filing — just keep the
+local edit and move on.
+
+### Where to file
+
+Upstream is **`OpenHands/agent-canvas`**. Use the GitHub MCP tools (e.g.
+`github_create_issue` with `owner: "OpenHands"`, `repo: "agent-canvas"`).
+
+### Issue template
+
+Title: `Proposal: make <X> configurable to reduce fork-rebase friction`
+
+Body (fill in each section):
+
+```
+### Context
+This came up while maintaining the long-running `rbren` fork of
+agent-canvas, where a fork-local tweak to <FILE / FEATURE> has
+conflicted on <N> consecutive rebases of `main` into `rbren`.
+
+### Current behavior
+<What upstream currently does — link the exact lines / file.>
+
+### Why this causes rebase friction on forks
+<Why the fork has to keep editing this same spot, e.g. hardcoded
+label / hardcoded default theme / hardcoded route list.>
+
+### Proposed extensibility hook
+<Concrete proposal, kept minimal. Examples:
+- a new optional prop / config field with the current value as default,
+- moving a hardcoded literal into a small registry/constants module,
+- exposing a render slot,
+- reading a value from a config / env var with current behavior as
+  fallback.>
+
+### Backward compatibility
+<Confirm the proposal preserves current default behavior so it is a
+pure additive change for non-fork consumers.>
+
+### Out of scope
+<Explicitly state this issue is *not* asking upstream to adopt the
+fork-local value — only to expose the seam. Forks remain responsible
+for their own values.>
+```
+
+Always include the standard AI-disclosure line in the body, since the issue
+will be read by humans:
+
+> _This issue was opened by an AI agent (OpenHands) on behalf of @rbren while
+> maintaining the long-running `rbren` fork._
+
+### After filing
+
+- Drop the issue URL into a one-line comment alongside the fork-local edit:
+  ```ts
+  label: "Code", /* rbren branch: was "New"; upstream: OpenHands/agent-canvas#NNN */
+  ```
+  That way the next rebaser knows whether the upstream proposal landed and
+  the fork-local edit can be retired.
+- If upstream lands the hook, your next rebase should **delete** the fork-local
+  edit and switch to consuming the new hook. That is the win condition.
+
+### What *not* to do
+
+- Don't file an issue to ask upstream to adopt your preferred value
+  (theme color, label text, default route). Upstream owns defaults; the fork
+  owns overrides.
+- Don't open a PR against upstream with the fork-local change directly. File
+  the issue first; let maintainers decide on the seam shape before any PR.
+- Don't bundle multiple unrelated proposals into one issue — one
+  extensibility hook per issue keeps the discussion (and any subsequent PR)
+  focused.
+
 ## When in Doubt
 
 If a proposed change *cannot* be made additively and *must* edit a shared file,

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -200,6 +200,16 @@ describes. Specifically:
   Files: `.agents/skills/long-running-fork.md`
   Introduced: 82f2bc7
 
+- **`create-fork` skill** — meta-skill that teaches an agent how to set
+  up *another* long-running personal fork the same way this one is set
+  up (fork model, ssh:// remotes, MODLOG/SYNCLOG-bearing
+  `long-running-fork.md` in the new repo, upstream-sync recipe,
+  conflict-recurrence escalation, AI-disclosed upstream-issue template).
+  Defaults to `OpenHands/agent-sdk` as the upstream when no target is
+  specified. Lives only on this fork — upstream has no notion of it.
+  Files: `.agents/skills/create-fork.md`
+  Introduced: (this commit)
+
 ### Sanity-check the MODLOG against git
 
 Before any rebase, cross-check that the MODLOG matches reality:

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -21,6 +21,102 @@ Every change must be made with the question "how painful will this be to rebase
 when upstream evolves?" in mind. Optimize for low merge-conflict surface area,
 not for elegance in isolation.
 
+## MODLOG — Live Fork-Local Modifications
+
+This section is the **canonical inventory** of everything that diverges from
+upstream `main` on this branch. Treat it as authoritative: if a change isn't
+listed here, it isn't intentionally fork-local.
+
+Each entry describes the **current final state** of one piece of fork-local
+behavior plus the original introducing commit (as a historical anchor — full
+history lives in `git log`). One-line descriptions are best; this is a
+ledger, not a changelog.
+
+### Maintenance rules
+
+Update this MODLOG **in the same commit** as the fork-local code change it
+describes. Specifically:
+
+1. **New fork-local change** → add a new entry: one-line description of the
+   behavior + the introducing commit hash.
+2. **Adjustment to an existing fork-local change** → update that entry's
+   description to reflect the **new final state**. Do *not* add a new commit
+   hash — the entry only ever references the *original* introducing commit
+   as a historical anchor. The current state is documented in the
+   description; the full history is in `git log`.
+3. **Reverted fork-local change** (nothing of the original change survives,
+   upstream behavior fully restored) → **remove the entry entirely**. The
+   MODLOG only lists divergences that *currently* exist.
+4. **Change incorporated upstream** (the fork no longer needs to carry it
+   because upstream now does the same thing, or exposes a hook the fork now
+   consumes cleanly) → **remove the entry entirely** on the rebase commit
+   that retires the fork-local code. If the fork is now *consuming* an
+   upstream hook rather than overriding it, that consumption is no longer
+   a divergence and doesn't need a MODLOG entry.
+5. **Keep entries atomic.** One entry per piece of behavior, so each can be
+   retired independently. Don't merge conceptually distinct changes that
+   happen to touch the same file (e.g. a sidebar nav-label swap and a
+   hypothetical sidebar ordering change should be two separate entries).
+
+### Entry format
+
+```
+- **<area>** — <one-line description of the *current* final state>.
+  Files: `<path>`[, `<path>` …]
+  Introduced: <commit hash>
+  Upstream proposal: <issue/PR url, if filed; omit otherwise>
+```
+
+### Current entries
+
+- **README — fork-local header + dockerless-VM install instructions** — top of
+  the README declares this is a long-running fork maintained by Robert
+  Brennan and documents the dockerless-on-a-VM install path (uv + `npm run
+  dev:dangerously-dockerless`). Upstream README is preserved verbatim below
+  an `---` separator under an "Upstream README" heading.
+  Files: `README.md`
+  Introduced: 82f2bc7
+
+- **Monospace UI font on `<body>`** — body `font-family` swapped to a
+  monospace stack (IBM Plex Mono → JetBrains Mono → Fira Code → system mono
+  fallbacks). Applies regardless of selected color theme.
+  Files: `src/index.css`
+  Introduced: 82f2bc7
+
+- **`rbren-earth` color theme + default-theme flip** — new fork-local entry
+  appended to `COLOR_THEMES` (warm earth-tone dark palette: Sand / Palm Leaf
+  / Camel / Olive Wood / Stone Brown across the surface ramp; Toffee Brown
+  as the primary accent). `DEFAULT_COLOR_THEME` flipped to `"rbren-earth"`.
+  Upstream themes (`openhands-deepsea`, `openhands-neutral`) are untouched.
+  Files: `src/themes/color-themes.ts`
+  Introduced: 82f2bc7
+
+- **Sidebar nav-label rename** — three left-nav labels swapped: "New" →
+  **Code**, "Extensions" → **Customize**, "Automations" → **Automate** (the
+  third was previously a `t(I18nKey.SIDEBAR$AUTOMATIONS)` call). Each line
+  carries an `rbren branch:` marker comment.
+  Files: `src/components/features/sidebar/sidebar.tsx`
+  Introduced: 9d130c4
+
+- **`long-running-fork` skill** — this file. Fork-local skill documenting
+  maintenance discipline, upstream-issue escalation path, and this MODLOG.
+  Loaded automatically on every task for this branch.
+  Files: `.agents/skills/long-running-fork.md`
+  Introduced: 82f2bc7
+
+### Sanity-check the MODLOG against git
+
+Before any rebase, cross-check that the MODLOG matches reality:
+
+```sh
+git --no-pager log --oneline main..HEAD
+git grep -n "rbren branch:" -- ':(exclude).agents/skills/long-running-fork.md'
+```
+
+Every distinct piece of fork-local behavior visible in `git log` /
+`rbren branch:` markers should correspond to exactly one MODLOG entry. If
+something is missing on either side, fix the MODLOG before rebasing.
+
 ## Core Principles
 
 1. **Additive, not invasive.** Prefer adding *new* files, *new* entries, or *new*

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -171,13 +171,6 @@ describes. Specifically:
 
 #### Sidebar
 
-- **Sidebar nav-label rename** — three left-nav labels swapped: "New" →
-  **Code**, "Extensions" → **Customize**, "Automations" → **Automate** (the
-  third was previously a `t(I18nKey.SIDEBAR$AUTOMATIONS)` call). Each line
-  carries an `rbren's mod:` marker comment.
-  Files: `src/components/features/sidebar/sidebar.tsx`
-  Introduced: 9d130c4
-
 - **Workspace-/repo-picker dropdown on the conversations nav row** —
   new fork-local component `RbrenWorkspacePicker` renders a small
   outline-bordered chevron-down button on the right edge of the
@@ -402,6 +395,38 @@ is omitted.
     docker tooling (#634/#635/#666), ACP onboarding (#643), and assorted
     test fixes. No MODLOG entries were retired in this sync. Marker
     count unchanged at 18.
+
+- **2026-05-22** — synced upstream `main` at `27aea4bd` ("feat(ui):
+  modal polish — skills, hooks, tools, metrics, and conversation menu
+  (#721)").
+  - Sync commit: this commit (see `git log` for hash)
+  - Conflicts: `src/components/features/sidebar/sidebar.tsx`,
+    `.agents/skills/long-running-fork.md`
+  - Notes: Pulled in 24 upstream commits (`4f14ce10..27aea4bd`) via
+    `git rebase --empty=drop upstream/main`. The dominant churn this
+    cycle was PR #623 ("fix(ui): left navigation rail, mobile drawer,
+    and responsive chrome"), which **extracted the sidebar rail body
+    into a new `SidebarRailBody` component** in
+    `src/components/features/sidebar/sidebar-rail-body.tsx`, leaving
+    `sidebar.tsx` as a thin shell that just renders
+    `<SidebarRailBody ...>`. Every fork-local sidebar mod migrated from
+    `sidebar.tsx` onto the new file: (a) the `compact` prop on the
+    collapsed-rail `OpenHandsLogoButton`, (b) the workspace-/repo-picker
+    flex wrap around the conversations `SidebarNavLink`, and (c) the
+    expanded-mode logo-container width fix that drops upstream's
+    `w-[18px] justify-center` so the wordmark doesn't get clipped. The
+    fork-local "Sidebar nav-label rename" commit (`6774c377`) was
+    **retired** — upstream's `translation.json` now resolves
+    `SIDEBAR$AUTOMATIONS` to `"Automate"` in `en` (and every other
+    locale), matching the fork's prior hardcoded "Automate" override; the
+    rename commit was therefore `git rebase --skip`-ped and its MODLOG
+    entry removed. Two MODLOG entries had their `Files:` list updated
+    from `sidebar.tsx` → `sidebar-rail-body.tsx` ("Sidebar logo
+    tinted ..." and "Workspace-/repo-picker dropdown ..."), and the
+    latter's title was generalized from "Code nav row" to "conversations
+    nav row" since upstream is now relabeling that link
+    (`"Code"` → `"New Chat"` this cycle). Marker count dropped from 18 →
+    17 (one retired: the `label="Automate"` override marker).
 
 ## Core Principles
 

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -19,11 +19,11 @@ upstream `main`** — it carries personal preferences (theming, layout
 tweaks, dev-loop helpers, etc.) on top of upstream and is rebased onto
 upstream periodically.
 
-> **There is no `rbren` branch on this fork.** The fork itself plays the
-> role the old `rbren` branch used to play; `main` here is "rbren's main".
-> The literal token `rbren branch:` is still used in source comments as a
-> fixed marker for fork-local edits (see "Mark every fork-local edit" in
-> Core Principles) — it's a recognizable string, not a current branch name.
+> **The fork is informally called "rbren's mod"** (that's also the
+> browser-tab title and sidebar wordmark). There is no `rbren` branch
+> here — `main` is the customized line, and fork-local edits in source
+> are tagged with a `rbren's mod:` comment marker (see "Mark every
+> fork-local edit" in Core Principles).
 
 ### Remote setup
 
@@ -170,7 +170,7 @@ describes. Specifically:
 - **Sidebar nav-label rename** — three left-nav labels swapped: "New" →
   **Code**, "Extensions" → **Customize**, "Automations" → **Automate** (the
   third was previously a `t(I18nKey.SIDEBAR$AUTOMATIONS)` call). Each line
-  carries an `rbren branch:` marker comment.
+  carries an `rbren's mod:` marker comment.
   Files: `src/components/features/sidebar/sidebar.tsx`
   Introduced: 9d130c4
 
@@ -207,11 +207,11 @@ Before any rebase, cross-check that the MODLOG matches reality:
 ```sh
 git fetch upstream
 git --no-pager log --oneline upstream/main..HEAD
-git grep -n "rbren branch:" -- ':(exclude).agents/skills/long-running-fork.md'
+git grep -n "rbren's mod:" -- ':(exclude).agents/skills/long-running-fork.md'
 ```
 
 Every distinct piece of fork-local behavior visible in `git log` /
-`rbren branch:` markers should correspond to exactly one MODLOG entry. If
+`rbren's mod:` markers should correspond to exactly one MODLOG entry. If
 something is missing on either side, fix the MODLOG before rebasing.
 
 ## SYNCLOG — Upstream Sync History
@@ -299,13 +299,16 @@ is omitted.
    the file or sprinkling edits throughout it does not.
 
 3. **Mark every fork-local edit clearly.** Any line that exists only on the
-   fork must carry a `rbren branch:` (or `rbren:`) comment so future merges
-   can immediately identify what is local vs. upstream. This also makes it
-   trivial to grep for fork-local code: `git grep -n "rbren branch:"`. The
-   literal token `rbren branch:` is preserved as a fixed marker for grep /
-   tooling reasons — it predates the move to a dedicated fork and is *not*
-   a current git branch name. Don't rename it without a coordinated sweep
-   across the whole tree.
+   fork must carry a `rbren's mod:` comment so future merges can immediately
+   identify what is local vs. upstream. This also makes it trivial to grep
+   for fork-local code:
+   ```sh
+   git grep -n "rbren's mod:"
+   ```
+   `rbren's mod:` is the canonical marker token. Don't introduce variants
+   (`rbren:`, `rbren branch:`, `rbren fork:`, etc.) — they'll just defeat the
+   grep. If you ever need to rename the token, do it as a coordinated sweep
+   across the whole tree in a single commit and update this skill.
 
 4. **Quarantine fork-local code where possible.** Prefer putting fork-local code
    in a file that *only exists on the fork* (e.g. under `.agents/skills/`,
@@ -333,7 +336,7 @@ is omitted.
   `hero.ts` / `tailwind.config.js` color tokens in place. Those files are
   actively maintained upstream and will conflict on every rebase.
 - **Body / font-family overrides:** prefer a *new* CSS file imported once at
-  app entry (or a single localized edit clearly tagged `rbren branch:`) over
+  app entry (or a single localized edit clearly tagged `rbren's mod:`) over
   spreading font changes across many components.
 
 ### React components / TS modules
@@ -361,7 +364,7 @@ export const RBREN_USE_HACKERY_THEME_BY_DEFAULT = true;
 - Don't update upstream snapshot tests just because the theme looks different
   on the fork. Either:
   - Mark those snapshot tests skipped on the fork's `main` with a clear
-    `rbren branch:` comment, or
+    `rbren's mod:` comment, or
   - Maintain a parallel fork-local snapshot directory and switch on the
     fork-local flag.
 - New tests for fork-local behavior should live in fork-local test files so
@@ -400,12 +403,12 @@ When pulling in upstream `main` from `OpenHands/agent-canvas`:
    ```
 3. Before rebasing, run:
    ```sh
-   git grep -n "rbren branch:" -- ':(exclude).agents/skills/long-running-fork.md'
+   git grep -n "rbren's mod:" -- ':(exclude).agents/skills/long-running-fork.md'
    ```
    to remind yourself of every fork-local edit. If something on that list no
    longer needs to exist (because upstream now does the same thing), drop it
    during the rebase instead of carrying it forward.
-4. If a rebase hits a conflict in a file that *only* contains "rbren branch:"
+4. If a rebase hits a conflict in a file that *only* contains "rbren's mod:"
    markers, prefer resolving by re-applying the marker on top of the new
    upstream content rather than blindly keeping the fork-local version. The
    marker is the contract; the surrounding lines belong to upstream.
@@ -495,7 +498,7 @@ will be read by humans:
 
 - Drop the issue URL into a one-line comment alongside the fork-local edit:
   ```ts
-  label: "Code", /* rbren branch: was "New"; upstream: OpenHands/agent-canvas#NNN */
+  label: "Code", /* rbren's mod: was "New"; upstream: OpenHands/agent-canvas#NNN */
   ```
   That way the next rebaser knows whether the upstream proposal landed and
   the fork-local edit can be retired.

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -1,0 +1,153 @@
+---
+name: long-running-fork
+description: Repo-specific guidance for the `rbren` long-running fork of OpenHands/agent-canvas. Auto-loaded for any task on this branch so changes stay easy to merge from / into `main`.
+triggers:
+- rbren
+- long-running fork
+- merge upstream
+- rebase upstream
+- upstream merge
+---
+
+# Long-Running Fork — `rbren` Branch
+
+This branch (`rbren`) is a **long-running personal fork** of `OpenHands/agent-canvas`
+maintained by Robert Brennan. It carries personal preferences (theming, layout
+tweaks, dev-loop helpers, etc.) on top of `main` and is rebased / fast-forwarded
+onto upstream periodically.
+
+**The branch's #1 maintenance constraint is staying easy to merge with `main`.**
+Every change must be made with the question "how painful will this be to rebase
+when upstream evolves?" in mind. Optimize for low merge-conflict surface area,
+not for elegance in isolation.
+
+## Core Principles
+
+1. **Additive, not invasive.** Prefer adding *new* files, *new* entries, or *new*
+   variants over editing existing ones in place. Adding a new theme to a registry
+   is great; mutating the values of an existing theme is bad — the next upstream
+   change to that theme will conflict.
+
+2. **Smallest possible diff to shared files.** When you *must* edit a file that
+   is also maintained upstream, make the change as small and as localized as
+   possible. One-line edits at the bottom of a file rebase cleanly; reorganizing
+   the file or sprinkling edits throughout it does not.
+
+3. **Mark every fork-local edit clearly.** Any line that exists only on this
+   branch must carry a `rbren branch:` (or `rbren:`) comment so future merges
+   can immediately identify what is local vs. upstream. This also makes it
+   trivial to grep for fork-local code: `git grep -n "rbren branch:"`.
+
+4. **Quarantine fork-local code where possible.** Prefer putting fork-local code
+   in a file that *only exists on this branch* (e.g. under `.agents/skills/`,
+   a new file under `src/themes/`, a new script under `scripts/`). New files
+   never conflict on merge; edits to shared files often do.
+
+5. **Don't reformat shared files.** No drive-by formatting, import reordering,
+   prettier passes, or comment cleanups on files you didn't otherwise need to
+   touch. Every reformatted line is a future conflict.
+
+6. **Don't rename or move shared files.** Renames are the worst-case conflict —
+   git often can't follow them across an upstream rebase and the rebase has to
+   be resolved by hand.
+
+## Concrete Patterns
+
+### Theming / styling
+
+- **Good:** Add a new entry to `COLOR_THEMES` in `src/themes/color-themes.ts`
+  (e.g. `"rbren-hackery"`), and flip `DEFAULT_COLOR_THEME` to point at it. The
+  new entry is fork-local; the `DEFAULT_COLOR_THEME` flip is a one-line edit
+  that rebases cleanly.
+- **Bad:** Mutating the hex values inside `openhands-deepsea` or
+  `openhands-neutral`, editing `--cool-grey-*` in `index.css`, or rewriting
+  `hero.ts` / `tailwind.config.js` color tokens in place. Those files are
+  actively maintained upstream and will conflict on every rebase.
+- **Body / font-family overrides:** prefer a *new* CSS file imported once at
+  app entry (or a single localized edit clearly tagged `rbren branch:`) over
+  spreading font changes across many components.
+
+### React components / TS modules
+
+- **Good:** Add a new component file and import it from a single place. Add a
+  new hook in a new file. Add a new route module.
+- **Bad:** Editing a heavily-trafficked shared component to add a fork-local
+  flag, prop, or branch. If you really must, gate it behind a single
+  fork-local feature flag (see below) and keep the touched lines minimal.
+
+### Fork-local feature flags
+
+For behavior toggles that genuinely require editing a shared file, prefer
+threading them through a *single* fork-local constants module rather than
+sprinkling literals through the codebase. Then the only shared-file edit is
+"read the flag", and the flag itself lives in a fork-only file. Example:
+
+```ts
+// src/fork/rbren-flags.ts   (fork-local, new file, never conflicts)
+export const RBREN_USE_HACKERY_THEME_BY_DEFAULT = true;
+```
+
+### Tests
+
+- Don't update upstream snapshot tests just because the theme looks different
+  on this branch. Either:
+  - Mark those snapshot tests skipped on the `rbren` branch with a clear
+    `rbren branch:` comment, or
+  - Maintain a parallel fork-local snapshot directory and switch on the
+    fork-local flag.
+- New tests for fork-local behavior should live in fork-local test files so
+  they don't fight upstream test churn.
+
+### Scripts / tooling
+
+- New scripts go in `scripts/` with an `rbren-` prefix
+  (e.g. `scripts/rbren-deploy.mjs`). Don't extend `package.json` scripts
+  upstream maintains; add new `rbren:*` scripts instead so the diff to
+  `package.json` is purely additive lines at the end of the `scripts` object.
+
+### Documentation
+
+- The branch's `README.md` divergence from upstream is **expected and
+  documented** — the top of the README explains this is a long-running branch
+  and the rest of the file is "Upstream README". When rebasing onto upstream,
+  resolve `README.md` conflicts by keeping the `rbren` header section and
+  replacing the "Upstream README" body with the new upstream README content
+  verbatim.
+
+## Rebasing / Merging Upstream
+
+When pulling in upstream `main`:
+
+1. Prefer **rebase** over **merge** so the branch stays a clean linear set of
+   "rbren-only" commits on top of `main`. This keeps `git log main..rbren`
+   readable as exactly "what is fork-local".
+2. Before rebasing, run:
+   ```sh
+   git grep -n "rbren branch:" -- ':(exclude).agents/skills/long-running-fork.md'
+   ```
+   to remind yourself of every fork-local edit. If something on that list no
+   longer needs to exist (because upstream now does the same thing), drop it
+   during the rebase instead of carrying it forward.
+3. If a rebase hits a conflict in a file that *only* contains "rbren branch:"
+   markers, prefer resolving by re-applying the marker on top of the new
+   upstream content rather than blindly keeping the fork-local version. The
+   marker is the contract; the surrounding lines belong to upstream.
+4. After the rebase, force-push with lease:
+   ```sh
+   git push --force-with-lease origin rbren
+   ```
+   (Never plain `--force` against a long-running branch.)
+
+## When in Doubt
+
+If a proposed change *cannot* be made additively and *must* edit a shared file,
+stop and ask:
+
+- Could this live in a new file instead?
+- Could this be expressed as a single one-line toggle that reads a fork-local
+  flag?
+- If neither — is the benefit really worth re-resolving this conflict on every
+  upstream rebase for the foreseeable future?
+
+The default answer for invasive edits to shared files is **no**. The cost of
+this branch is rebase pain, and rebase pain compounds.

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -296,6 +296,32 @@ is omitted.
     the `main` branch of a dedicated fork at `rbren/agent-canvas` (no
     history rewrite — same commit graph, new home).
 
+- **2026-05-16** — synced upstream `main` at `56a3d8a4` ("fix: prevent LLM
+  profile actions menu from being clipped by scroll container (#523)").
+  - Sync commit: this commit (see `git log` for hash)
+  - Conflicts: `src/components/shared/buttons/openhands-logo-button.tsx`,
+    `src/components/features/sidebar/sidebar.tsx`
+  - Notes: Pulled in 10 upstream commits (`76a0e806..56a3d8a4`) via
+    `git rebase --empty=drop upstream/main`. The conversation-panel
+    filter-persistence work the fork had been carrying as a merge of
+    `feat/persist-conversation-panel-preferences` landed upstream as
+    PR #510 (`4a72f6bd`); the fork-local cherry (`cf13abc9`) was detected
+    by `git rebase` as already-applied and dropped automatically. Two
+    files conflicted, both because of upstream's chat-first home /
+    redesign work (PR #514 + #508): `openhands-logo-button.tsx` —
+    upstream refactored the component to accept optional
+    `className` / `logoClassName` / `logoWidth` / `logoHeight` props with
+    `cn()`-based class merging; resolution kept all upstream props *and*
+    layered the fork's `compact` prop, var(--oh-muted) tint, and wordmark
+    on top (additive — no upstream behavior overridden). `sidebar.tsx` —
+    upstream's redesigned collapsed-rail logo block now passes the new
+    width/height/className props; resolution kept those props and added
+    `compact` so the rail still suppresses the wordmark. All 18
+    fork-local `rbren's mod:` markers were preserved (re-grep clean).
+    The `enable-subagent-delegation` feature branch the fork had merged
+    in (`9ed13b24`) has *not* landed on upstream `main` yet and was
+    replayed onto the new base as a normal commit (`093f2ee6`).
+
 ## Core Principles
 
 1. **Additive, not invasive.** Prefer adding *new* files, *new* entries, or *new*

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -98,6 +98,24 @@ describes. Specifically:
   Files: `src/components/features/sidebar/sidebar.tsx`
   Introduced: 9d130c4
 
+- **Browser-tab title rebranded to "rbren's mod"** — `APP_TITLE` constant
+  swapped from `"OpenHands"` to `"rbren's mod"`. Carries through to all
+  `<title>` rendering (including conversation-title prefixes and agent-state
+  emoji prefixes) since the rest of `useAppTitle` is untouched.
+  Files: `src/hooks/use-app-title.ts`
+  Introduced: HEAD
+
+- **Sidebar logo tinted + tooltip rebranded** — the `OpenHandsLogo` SVG in
+  the top-left of the sidebar is tinted Toffee Brown (`#9D684B`, the
+  `rbren-earth` theme's primary accent) via a Tailwind arbitrary-selector
+  class that overrides the SVG's inline `fill="white"` paths only (the
+  transparent face cut-out stays transparent). The hover tooltip and aria
+  label are hardcoded to `"rbren's mod"` / `"rbren's mod logo"`, replacing
+  the upstream `t(I18nKey.BRANDING$OPENHANDS{,_LOGO})` calls; the unused
+  `useTranslation` / `I18nKey` imports are dropped.
+  Files: `src/components/shared/buttons/openhands-logo-button.tsx`
+  Introduced: HEAD
+
 - **`long-running-fork` skill** — this file. Fork-local skill documenting
   maintenance discipline, upstream-issue escalation path, and this MODLOG.
   Loaded automatically on every task for this branch.

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -103,18 +103,24 @@ describes. Specifically:
   `<title>` rendering (including conversation-title prefixes and agent-state
   emoji prefixes) since the rest of `useAppTitle` is untouched.
   Files: `src/hooks/use-app-title.ts`
-  Introduced: HEAD
+  Introduced: 6d894ef
 
-- **Sidebar logo tinted + tooltip rebranded** — the `OpenHandsLogo` SVG in
-  the top-left of the sidebar is tinted Toffee Brown (`#9D684B`, the
-  `rbren-earth` theme's primary accent) via a Tailwind arbitrary-selector
-  class that overrides the SVG's inline `fill="white"` paths only (the
-  transparent face cut-out stays transparent). The hover tooltip and aria
-  label are hardcoded to `"rbren's mod"` / `"rbren's mod logo"`, replacing
-  the upstream `t(I18nKey.BRANDING$OPENHANDS{,_LOGO})` calls; the unused
+- **Sidebar logo tinted, wordmark added, tooltip rebranded** — the
+  `OpenHandsLogo` SVG in the top-left of the sidebar is tinted with
+  `var(--oh-muted)` (matching the inactive color of the Code / Customize /
+  Automate nav icons) via a Tailwind arbitrary-selector class that
+  overrides the SVG's inline `fill="white"` paths only (the transparent
+  face cut-out stays transparent). A `"rbren's mod"` wordmark is rendered
+  next to the logo in expanded mode; the component now accepts an optional
+  `compact` prop that suppresses the wordmark in the collapsed 64px rail,
+  passed from `sidebar-rail-body.tsx` in the collapsed branch. The hover
+  tooltip and aria label are hardcoded to `"rbren's mod"` /
+  `"rbren's mod logo"`, replacing the upstream
+  `t(I18nKey.BRANDING$OPENHANDS{,_LOGO})` calls; the unused
   `useTranslation` / `I18nKey` imports are dropped.
-  Files: `src/components/shared/buttons/openhands-logo-button.tsx`
-  Introduced: HEAD
+  Files: `src/components/shared/buttons/openhands-logo-button.tsx`,
+  `src/components/features/sidebar/sidebar-rail-body.tsx`
+  Introduced: 6d894ef
 
 - **`long-running-fork` skill** — this file. Fork-local skill documenting
   maintenance discipline, upstream-issue escalation path, and this MODLOG.

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -160,7 +160,7 @@ describes. Specifically:
   plus the wrapping div.
   Files: `src/components/features/sidebar/rbren-workspace-picker.tsx`
   (new), `src/components/features/sidebar/sidebar-rail-body.tsx`
-  Introduced: HEAD
+  Introduced: 05572b2
 
 #### Dev meta / skills
 

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -361,6 +361,24 @@ is omitted.
     edge off-screen; the expanded-mode `OpenHandsLogoButton` className
     now drops the width / centering for natural content sizing.
 
+- **2026-05-19** — synced upstream `main` at `4f891ca5` ("fix(files-tab):
+  restore static fileserver for rich file preview (#632)").
+  - Sync commit: this commit (see `git log` for hash)
+  - Conflicts: None
+  - Notes: Pulled in 15 upstream commits (`cf1a8835..4f891ca5`) via
+    `git rebase --empty=drop upstream/main`. No conflicts on any of
+    the 19 fork-local commits: upstream's churn this cycle was
+    concentrated in surfaces the fork doesn't override (automations
+    UI, ACP onboarding / Settings → Agent route family, dev-docker
+    scripts, files-tab preview hook), so none of the rebased patches
+    overlapped with the divergence territory recorded in the MODLOG
+    (`README.md`, `src/hooks/use-app-title.ts`, `src/index.css`,
+    `src/themes/color-themes.ts`,
+    `src/components/shared/buttons/openhands-logo-button.tsx`,
+    `src/components/features/sidebar/sidebar.tsx`, and the two
+    fork-only `rbren-*-picker.tsx` widgets). No MODLOG entries were
+    retired in this sync. Marker count unchanged at 18.
+
 ## Core Principles
 
 1. **Additive, not invasive.** Prefer adding *new* files, *new* entries, or *new*

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -144,7 +144,11 @@ describes. Specifically:
   tooltip and aria label are hardcoded to `"rbren's mod"` /
   `"rbren's mod logo"`, replacing the upstream
   `t(I18nKey.BRANDING$OPENHANDS{,_LOGO})` calls; the unused
-  `useTranslation` / `I18nKey` imports are dropped.
+  `useTranslation` / `I18nKey` imports are dropped. The expanded-mode
+  `OpenHandsLogoButton` call in `sidebar-rail-body.tsx` drops the
+  upstream `w-[18px] justify-center` container (which would clip the
+  wordmark by centering the logo+wordmark block on an 18px slot) in
+  favor of natural content sizing from the icon column's left edge.
   Files: `src/components/shared/buttons/openhands-logo-button.tsx`,
   `src/components/features/sidebar/sidebar-rail-body.tsx`
   Introduced: 6d894ef
@@ -327,6 +331,35 @@ is omitted.
     The `enable-subagent-delegation` feature branch the fork had merged
     in (`9ed13b24`) has *not* landed on upstream `main` yet and was
     replayed onto the new base as a normal commit (`093f2ee6`).
+
+- **2026-05-18** — synced upstream `main` at `2505b08f` ("Better default
+  install instructions (#585)").
+  - Sync commit: this commit (see `git log` for hash)
+  - Conflicts: `src/components/features/sidebar/sidebar.tsx`
+  - Notes: Pulled in 28 upstream commits (`56a3d8a4..2505b08f`) via
+    `git rebase --empty=drop upstream/main`. Upstream PR #509 landed the
+    sub-agent delegation feature the fork had been carrying as
+    `093f2ee6` ("feat: enable sub-agent delegation via task_tool_set");
+    the two patches were functionally identical so the fork-local commit
+    was dropped via `git rebase --skip` (cherry-mark didn't catch it
+    because the trees diverged slightly on a blank line). Upstream PR
+    #578 (`f143199a`, "refactor: rename top-level nav labels for clearer
+    copy") performed the same "New" → "Code" and "Extensions" →
+    "Customize" renames the fork had been doing in `3bfd31a4`; the
+    fork-local marker comments on those two lines were dropped during
+    conflict resolution since there is no longer a divergence to mark
+    (upstream now matches). The "Automations" → "Automate" rename
+    remains fork-local and its `rbren's mod:` marker was preserved. The
+    `rbren branch:` → `rbren's mod:` marker sweep commit (`b1844cb5`)
+    re-applied cleanly over the dropped lines for the four remaining
+    sidebar-side markers. Marker count went from 19 → 17 in this sync
+    (two retired). Fork-local layout fix-up landed on top of the rebase:
+    upstream's expanded-sidebar logo container is `w-[18px]
+    justify-center` (designed to symmetrically overflow a lone glyph
+    around the 18px icon column), but the fork's wordmark made that
+    center the *whole* logo+wordmark block on 18px and clip its leading
+    edge off-screen; the expanded-mode `OpenHandsLogoButton` className
+    now drops the width / centering for natural content sizing.
 
 ## Core Principles
 

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -379,6 +379,30 @@ is omitted.
     fork-only `rbren-*-picker.tsx` widgets). No MODLOG entries were
     retired in this sync. Marker count unchanged at 18.
 
+- **2026-05-20** — synced upstream `main` at `4f14ce10` ("fix: remove
+  hardcoded /workspace/project fallbacks from useLocalGitInfo (#671)").
+  - Sync commit: this commit (see `git log` for hash)
+  - Conflicts: None
+  - Notes: Pulled in 15 upstream commits (`4f891ca5..4f14ce10`) via
+    `git rebase --empty=drop upstream/main`. Only one of the incoming
+    commits — `39974205` ("Remove Docker dependency from dev workflow
+    (#635)") — touched a fork-local file (`README.md`), and even that
+    one applied cleanly: upstream's README delta (swap
+    `npm run dev:dangerously-dockerless` → `npm run dev`, drop the
+    Docker-sandbox / Kubernetes-pod sections) landed inside the fork's
+    `## Upstream README` mirror section via 3-way merge without
+    touching the fork's header. None of the other 14 commits overlapped
+    with MODLOG territory (`src/hooks/use-app-title.ts`,
+    `src/index.css`, `src/themes/color-themes.ts`,
+    `src/components/shared/buttons/openhands-logo-button.tsx`,
+    `src/components/features/sidebar/sidebar.tsx`, or the two fork-only
+    `rbren-*-picker.tsx` widgets) — upstream's churn this cycle was
+    concentrated in agent-delegation settings (#483), the recommended-
+    automations + MCP-marketplace setup flow (#504), Docker CI / dev-
+    docker tooling (#634/#635/#666), ACP onboarding (#643), and assorted
+    test fixes. No MODLOG entries were retired in this sync. Marker
+    count unchanged at 18.
+
 ## Core Principles
 
 1. **Additive, not invasive.** Prefer adding *new* files, *new* entries, or *new*

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -145,6 +145,23 @@ describes. Specifically:
   Files: `src/components/features/sidebar/sidebar.tsx`
   Introduced: 9d130c4
 
+- **Workspace-picker dropdown on the conversations nav row** — new
+  fork-local component `RbrenWorkspacePicker` renders a small
+  outline-bordered chevron-down button on the right edge of the
+  conversations / "New Chat" nav row. Clicking it opens a popover
+  listing "No workspace" at the top followed by every workspace from
+  `useResolvedWorkspaces`; selecting any entry immediately starts a new
+  conversation in that workspace (via `useCreateConversation`) and
+  navigates to `/conversations/{id}`. The picker returns `null` when
+  the sidebar is collapsed. Wired into `sidebar-rail-body.tsx` via a
+  thin flex wrapper around the existing `SidebarNavLink` for the
+  conversations route; the upstream `SidebarNavLink` is **not**
+  modified, so the feature can be retired by deleting the picker file
+  plus the wrapping div.
+  Files: `src/components/features/sidebar/rbren-workspace-picker.tsx`
+  (new), `src/components/features/sidebar/sidebar-rail-body.tsx`
+  Introduced: HEAD
+
 #### Dev meta / skills
 
 - **`long-running-fork` skill** — this file. Fork-local skill documenting

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -174,21 +174,27 @@ describes. Specifically:
   Files: `src/components/features/sidebar/sidebar.tsx`
   Introduced: 9d130c4
 
-- **Workspace-picker dropdown on the conversations nav row** — new
-  fork-local component `RbrenWorkspacePicker` renders a small
+- **Workspace-/repo-picker dropdown on the conversations nav row** —
+  new fork-local component `RbrenWorkspacePicker` renders a small
   outline-bordered chevron-down button on the right edge of the
-  conversations / "New Chat" nav row. Clicking it opens a popover
-  listing "No workspace" at the top followed by every workspace from
-  `useResolvedWorkspaces`; selecting any entry immediately starts a new
-  conversation in that workspace (via `useCreateConversation`) and
-  navigates to `/conversations/{id}`. The picker returns `null` when
-  the sidebar is collapsed. Wired into `sidebar-rail-body.tsx` via a
-  thin flex wrapper around the existing `SidebarNavLink` for the
-  conversations route; the upstream `SidebarNavLink` is **not**
-  modified, so the feature can be retired by deleting the picker file
-  plus the wrapping div.
+  conversations / "New Chat" nav row. Clicking it opens a popover whose
+  content depends on the active backend: in **local** mode it lists
+  "No workspace" at the top followed by every workspace from
+  `useResolvedWorkspaces`; in **cloud** mode it delegates to a sibling
+  `RbrenRepoPicker` that lists git repositories (with provider tabs +
+  search + paginated loading via `useGitRepositories` /
+  `useSearchRepositories` / `useUserProviders`) with a "No repository"
+  entry at the top. Selecting any entry immediately starts a new
+  conversation (workspace path in local mode, repo + default branch in
+  cloud mode) via `useCreateConversation` and navigates to
+  `/conversations/{id}`. The picker returns `null` when the sidebar is
+  collapsed. Wired into `sidebar-rail-body.tsx` via a thin flex wrapper
+  around the existing `SidebarNavLink` for the conversations route; the
+  upstream `SidebarNavLink` is **not** modified, so the feature can be
+  retired by deleting both picker files plus the wrapping div.
   Files: `src/components/features/sidebar/rbren-workspace-picker.tsx`
-  (new), `src/components/features/sidebar/sidebar-rail-body.tsx`
+  (new), `src/components/features/sidebar/rbren-repo-picker.tsx` (new),
+  `src/components/features/sidebar/sidebar-rail-body.tsx`
   Introduced: 05572b2
 
 #### Dev meta / skills

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -1,22 +1,50 @@
 ---
 name: long-running-fork
-description: Repo-specific guidance for the `rbren` long-running fork of OpenHands/agent-canvas. Auto-loaded for any task on this branch so changes stay easy to merge from / into `main`.
+description: Repo-specific guidance for the long-running personal fork `rbren/agent-canvas` of `OpenHands/agent-canvas`. Auto-loaded for any task on the fork's `main` branch (which diverges from upstream `main`) so changes stay easy to merge from / into upstream.
 triggers:
 - rbren
+- rbren/agent-canvas
 - long-running fork
 - merge upstream
 - rebase upstream
 - upstream merge
 ---
 
-# Long-Running Fork — `rbren` Branch
+# Long-Running Fork — `rbren/agent-canvas`
 
-This branch (`rbren`) is a **long-running personal fork** of `OpenHands/agent-canvas`
-maintained by Robert Brennan. It carries personal preferences (theming, layout
-tweaks, dev-loop helpers, etc.) on top of `main` and is rebased / fast-forwarded
-onto upstream periodically.
+This repository is checked out from **`rbren/agent-canvas`**, a long-running
+personal fork of `OpenHands/agent-canvas` maintained by Robert Brennan. The
+fork's default branch is **`main`**, which intentionally **diverges from
+upstream `main`** — it carries personal preferences (theming, layout
+tweaks, dev-loop helpers, etc.) on top of upstream and is rebased onto
+upstream periodically.
 
-**The branch's #1 maintenance constraint is staying easy to merge with `main`.**
+> **There is no `rbren` branch on this fork.** The fork itself plays the
+> role the old `rbren` branch used to play; `main` here is "rbren's main".
+> The literal token `rbren branch:` is still used in source comments as a
+> fixed marker for fork-local edits (see "Mark every fork-local edit" in
+> Core Principles) — it's a recognizable string, not a current branch name.
+
+### Remote setup
+
+This repo is configured with two remotes, both over SSH:
+
+- `origin` → `ssh://git@github.com/rbren/agent-canvas.git` — the fork.
+  Default branch `main`. This is where the fork's `main` is pushed.
+- `upstream` → `ssh://git@github.com/OpenHands/agent-canvas.git` — the
+  canonical repo. Default branch `main`. Fetch from here to sync upstream
+  changes; never push to it directly.
+
+If you see `origin` pointed at `OpenHands/agent-canvas` (e.g. on a clone
+made before the fork existed), fix it before pushing:
+
+```sh
+git remote set-url origin ssh://git@github.com/rbren/agent-canvas.git
+git remote add upstream ssh://git@github.com/OpenHands/agent-canvas.git 2>/dev/null || \
+  git remote set-url upstream ssh://git@github.com/OpenHands/agent-canvas.git
+```
+
+**The fork's #1 maintenance constraint is staying easy to merge with upstream `main`.**
 Every change must be made with the question "how painful will this be to rebase
 when upstream evolves?" in mind. Optimize for low merge-conflict surface area,
 not for elegance in isolation.
@@ -24,8 +52,9 @@ not for elegance in isolation.
 ## MODLOG — Live Fork-Local Modifications
 
 This section is the **canonical inventory** of everything that diverges from
-upstream `main` on this branch. Treat it as authoritative: if a change isn't
-listed here, it isn't intentionally fork-local.
+upstream `main` (i.e. `upstream/main`) on the fork's `main`. Treat it as
+authoritative: if a change isn't listed here, it isn't intentionally
+fork-local.
 
 Each entry describes the **current final state** of one piece of fork-local
 behavior plus the original introducing commit (as a historical anchor — full
@@ -33,7 +62,7 @@ history lives in `git log`). One-line descriptions are best; this is a
 ledger, not a changelog.
 
 > **The MODLOG is NOT a timeline. It is an unsorted inventory of the
-> divergences that currently exist on this branch, grouped by topic for
+> divergences that currently exist on the fork, grouped by topic for
 > readability.** Don't read entry order as chronology. Entries are grouped
 > under category subheadings (`#### …`) and may be reordered or moved
 > between groups whenever it makes the inventory easier to navigate.
@@ -165,8 +194,9 @@ describes. Specifically:
 #### Dev meta / skills
 
 - **`long-running-fork` skill** — this file. Fork-local skill documenting
+  the `rbren/agent-canvas` ↔ `OpenHands/agent-canvas` remote setup,
   maintenance discipline, upstream-issue escalation path, the MODLOG, and
-  the SYNCLOG. Loaded automatically on every task for this branch.
+  the SYNCLOG. Loaded automatically on every task on the fork's `main`.
   Files: `.agents/skills/long-running-fork.md`
   Introduced: 82f2bc7
 
@@ -175,7 +205,8 @@ describes. Specifically:
 Before any rebase, cross-check that the MODLOG matches reality:
 
 ```sh
-git --no-pager log --oneline main..HEAD
+git fetch upstream
+git --no-pager log --oneline upstream/main..HEAD
 git grep -n "rbren branch:" -- ':(exclude).agents/skills/long-running-fork.md'
 ```
 
@@ -186,12 +217,12 @@ something is missing on either side, fix the MODLOG before rebasing.
 ## SYNCLOG — Upstream Sync History
 
 **Unlike the MODLOG, the SYNCLOG _is_ a timeline.** It is a chronological,
-append-only record of every time upstream `main` was synced into this
-branch (whether via merge or rebase). Newest entries go at the **bottom**.
+append-only record of every time upstream `main` was synced into the fork's
+`main` (whether via merge or rebase). Newest entries go at the **bottom**.
 
-The first entry is the commit on `main` that this branch was originally
-branched from (no merge happened — it's the starting point of all later
-diffs). Every subsequent entry records a merge / rebase and any
+The first entry is the commit on upstream `main` that the fork was
+originally branched from (no merge happened — it's the starting point of
+all later diffs). Every subsequent entry records a merge / rebase and any
 conflicts, breakages, or follow-up fixes that had to be addressed to make
 the sync stick.
 
@@ -212,16 +243,17 @@ the sync stick.
 
 ```
 - **YYYY-MM-DD** — synced upstream `main` at `<short hash>` ("<commit title>")
-  - Sync commit: `<short hash on rbren>` (omit for the initial branch point)
+  - Sync commit: `<short hash on the fork's main>` (omit for the initial branch point)
   - Conflicts: <comma-separated files / paths>, or "None"
   - Notes: <one-paragraph summary of any breakages, fork-local fix-ups,
             or behavior shifts that landed in the sync commit>. Use "None"
             for clean merges.
 ```
 
-The "Sync commit" is the rbren-branch commit that *applied* the merge /
-rebase (so the reader can `git show` it). For the very first entry — the
-initial branch point — there is no sync commit and the line is omitted.
+The "Sync commit" is the commit on the fork's `main` that *applied* the
+merge / rebase (so the reader can `git show` it). For the very first
+entry — the initial branch point — there is no sync commit and the line
+is omitted.
 
 ### Maintenance rules
 
@@ -246,10 +278,13 @@ initial branch point — there is no sync commit and the line is omitted.
 - **2026-05-16** — branched from `f7c7dbe` ("perf(snapshots): skip retries
   on comparison pass, suppress consent modal (#505)") on upstream `main`.
   - Conflicts: N/A (initial branch point, not a sync)
-  - Notes: starting commit of the `rbren` long-running branch. All
-    fork-local divergences listed in the MODLOG above were introduced on
-    top of this commit. The initial fork-local commit on `rbren` was
-    `82f2bc7` ("Initialize rbren long-running branch").
+  - Notes: starting commit of the long-running fork. All fork-local
+    divergences listed in the MODLOG above were introduced on top of this
+    commit. The initial fork-local commit was `82f2bc7` ("Initialize rbren
+    long-running branch"). This work originally lived on a branch called
+    `rbren` inside `OpenHands/agent-canvas`; it was subsequently moved to
+    the `main` branch of a dedicated fork at `rbren/agent-canvas` (no
+    history rewrite — same commit graph, new home).
 
 ## Core Principles
 
@@ -263,13 +298,17 @@ initial branch point — there is no sync commit and the line is omitted.
    possible. One-line edits at the bottom of a file rebase cleanly; reorganizing
    the file or sprinkling edits throughout it does not.
 
-3. **Mark every fork-local edit clearly.** Any line that exists only on this
-   branch must carry a `rbren branch:` (or `rbren:`) comment so future merges
+3. **Mark every fork-local edit clearly.** Any line that exists only on the
+   fork must carry a `rbren branch:` (or `rbren:`) comment so future merges
    can immediately identify what is local vs. upstream. This also makes it
-   trivial to grep for fork-local code: `git grep -n "rbren branch:"`.
+   trivial to grep for fork-local code: `git grep -n "rbren branch:"`. The
+   literal token `rbren branch:` is preserved as a fixed marker for grep /
+   tooling reasons — it predates the move to a dedicated fork and is *not*
+   a current git branch name. Don't rename it without a coordinated sweep
+   across the whole tree.
 
 4. **Quarantine fork-local code where possible.** Prefer putting fork-local code
-   in a file that *only exists on this branch* (e.g. under `.agents/skills/`,
+   in a file that *only exists on the fork* (e.g. under `.agents/skills/`,
    a new file under `src/themes/`, a new script under `scripts/`). New files
    never conflict on merge; edits to shared files often do.
 
@@ -320,8 +359,8 @@ export const RBREN_USE_HACKERY_THEME_BY_DEFAULT = true;
 ### Tests
 
 - Don't update upstream snapshot tests just because the theme looks different
-  on this branch. Either:
-  - Mark those snapshot tests skipped on the `rbren` branch with a clear
+  on the fork. Either:
+  - Mark those snapshot tests skipped on the fork's `main` with a clear
     `rbren branch:` comment, or
   - Maintain a parallel fork-local snapshot directory and switch on the
     fork-local flag.
@@ -337,8 +376,8 @@ export const RBREN_USE_HACKERY_THEME_BY_DEFAULT = true;
 
 ### Documentation
 
-- The branch's `README.md` divergence from upstream is **expected and
-  documented** — the top of the README explains this is a long-running branch
+- The fork's `README.md` divergence from upstream is **expected and
+  documented** — the top of the README explains this is a long-running fork
   and the rest of the file is "Upstream README". When rebasing onto upstream,
   resolve `README.md` conflicts by keeping the `rbren` header section and
   replacing the "Upstream README" body with the new upstream README content
@@ -346,27 +385,36 @@ export const RBREN_USE_HACKERY_THEME_BY_DEFAULT = true;
 
 ## Rebasing / Merging Upstream
 
-When pulling in upstream `main`:
+When pulling in upstream `main` from `OpenHands/agent-canvas`:
 
-1. Prefer **rebase** over **merge** so the branch stays a clean linear set of
-   "rbren-only" commits on top of `main`. This keeps `git log main..rbren`
-   readable as exactly "what is fork-local".
-2. Before rebasing, run:
+1. Fetch upstream first (it's a separate remote — see "Remote setup" above):
+   ```sh
+   git fetch upstream
+   ```
+2. Prefer **rebase** over **merge** so the fork's `main` stays a clean
+   linear set of "rbren-only" commits on top of upstream `main`. This keeps
+   `git log upstream/main..origin/main` readable as exactly "what is
+   fork-local".
+   ```sh
+   git rebase upstream/main
+   ```
+3. Before rebasing, run:
    ```sh
    git grep -n "rbren branch:" -- ':(exclude).agents/skills/long-running-fork.md'
    ```
    to remind yourself of every fork-local edit. If something on that list no
    longer needs to exist (because upstream now does the same thing), drop it
    during the rebase instead of carrying it forward.
-3. If a rebase hits a conflict in a file that *only* contains "rbren branch:"
+4. If a rebase hits a conflict in a file that *only* contains "rbren branch:"
    markers, prefer resolving by re-applying the marker on top of the new
    upstream content rather than blindly keeping the fork-local version. The
    marker is the contract; the surrounding lines belong to upstream.
-4. After the rebase, force-push with lease:
+5. After the rebase, force-push with lease to the **fork** (origin):
    ```sh
-   git push --force-with-lease origin rbren
+   git push --force-with-lease origin main
    ```
-   (Never plain `--force` against a long-running branch.)
+   (Never plain `--force` against a long-running branch. Never push to
+   `upstream`.)
 
 ## Pushing Upstream When Conflicts Recur
 
@@ -381,8 +429,8 @@ rebase friction.
 
 File one when **two or more** of these are true:
 
-- The same upstream file (or small cluster of files) has conflicted on this
-  branch across multiple rebases.
+- The same upstream file (or small cluster of files) has conflicted on the
+  fork across multiple rebases.
 - The fork-local edit is structurally the same each time (a label swap,
   a default value flip, a feature gated on / off, a different color, etc.).
 - The change is something other fork maintainers would plausibly also want
@@ -407,9 +455,10 @@ Body (fill in each section):
 
 ```
 ### Context
-This came up while maintaining the long-running `rbren` fork of
-agent-canvas, where a fork-local tweak to <FILE / FEATURE> has
-conflicted on <N> consecutive rebases of `main` into `rbren`.
+This came up while maintaining the long-running `rbren/agent-canvas` fork
+of `OpenHands/agent-canvas`, where a fork-local tweak to <FILE / FEATURE>
+has conflicted on <N> consecutive rebases of upstream `main` into the
+fork's `main`.
 
 ### Current behavior
 <What upstream currently does — link the exact lines / file.>
@@ -440,7 +489,7 @@ Always include the standard AI-disclosure line in the body, since the issue
 will be read by humans:
 
 > _This issue was opened by an AI agent (OpenHands) on behalf of @rbren while
-> maintaining the long-running `rbren` fork._
+> maintaining the long-running `rbren/agent-canvas` fork._
 
 ### After filing
 
@@ -476,4 +525,4 @@ stop and ask:
   upstream rebase for the foreseeable future?
 
 The default answer for invasive edits to shared files is **no**. The cost of
-this branch is rebase pain, and rebase pain compounds.
+this fork is rebase pain, and rebase pain compounds.

--- a/.agents/skills/long-running-fork.md
+++ b/.agents/skills/long-running-fork.md
@@ -32,6 +32,13 @@ behavior plus the original introducing commit (as a historical anchor — full
 history lives in `git log`). One-line descriptions are best; this is a
 ledger, not a changelog.
 
+> **The MODLOG is NOT a timeline. It is an unsorted inventory of the
+> divergences that currently exist on this branch, grouped by topic for
+> readability.** Don't read entry order as chronology. Entries are grouped
+> under category subheadings (`#### …`) and may be reordered or moved
+> between groups whenever it makes the inventory easier to navigate.
+> Chronology lives in `git log` and in the SYNCLOG below.
+
 ### Maintenance rules
 
 Update this MODLOG **in the same commit** as the fork-local code change it
@@ -57,6 +64,12 @@ describes. Specifically:
    retired independently. Don't merge conceptually distinct changes that
    happen to touch the same file (e.g. a sidebar nav-label swap and a
    hypothetical sidebar ordering change should be two separate entries).
+6. **Group related entries under topic subheadings.** When you add a new
+   entry, place it under the existing `####` subheading that best fits its
+   topic (Branding, Theming & Typography, Sidebar, Dev meta, etc.). If no
+   group fits, create a new `####` subheading. Feel free to re-group or
+   re-title subheadings whenever it improves clarity — the groups are a
+   navigation aid, not a contract.
 
 ### Entry format
 
@@ -69,34 +82,19 @@ describes. Specifically:
 
 ### Current entries
 
-- **README — fork-local header + dockerless-VM install instructions** — top of
-  the README declares this is a long-running fork maintained by Robert
-  Brennan and documents the dockerless-on-a-VM install path (uv + `npm run
-  dev:dangerously-dockerless`). Upstream README is preserved verbatim below
-  an `---` separator under an "Upstream README" heading.
+#### Branding & identity ("rbren's mod")
+
+- **README — fork-local header + dockerless-VM install + skill pointer** —
+  top of the README declares this is a long-running fork maintained by
+  Robert Brennan, documents the dockerless-on-a-VM install path (uv +
+  `npm run dev:dangerously-dockerless`), and carries an "IMPORTANT" GitHub
+  callout pointing maintainers and agents at the
+  `.agents/skills/long-running-fork.md` skill (the canonical source for
+  MODLOG / SYNCLOG / merge-friendly editing discipline). Upstream README is
+  preserved verbatim below an `---` separator under an "Upstream README"
+  heading.
   Files: `README.md`
   Introduced: 82f2bc7
-
-- **Monospace UI font on `<body>`** — body `font-family` swapped to a
-  monospace stack (IBM Plex Mono → JetBrains Mono → Fira Code → system mono
-  fallbacks). Applies regardless of selected color theme.
-  Files: `src/index.css`
-  Introduced: 82f2bc7
-
-- **`rbren-earth` color theme + default-theme flip** — new fork-local entry
-  appended to `COLOR_THEMES` (warm earth-tone dark palette: Sand / Palm Leaf
-  / Camel / Olive Wood / Stone Brown across the surface ramp; Toffee Brown
-  as the primary accent). `DEFAULT_COLOR_THEME` flipped to `"rbren-earth"`.
-  Upstream themes (`openhands-deepsea`, `openhands-neutral`) are untouched.
-  Files: `src/themes/color-themes.ts`
-  Introduced: 82f2bc7
-
-- **Sidebar nav-label rename** — three left-nav labels swapped: "New" →
-  **Code**, "Extensions" → **Customize**, "Automations" → **Automate** (the
-  third was previously a `t(I18nKey.SIDEBAR$AUTOMATIONS)` call). Each line
-  carries an `rbren branch:` marker comment.
-  Files: `src/components/features/sidebar/sidebar.tsx`
-  Introduced: 9d130c4
 
 - **Browser-tab title rebranded to "rbren's mod"** — `APP_TITLE` constant
   swapped from `"OpenHands"` to `"rbren's mod"`. Carries through to all
@@ -122,9 +120,36 @@ describes. Specifically:
   `src/components/features/sidebar/sidebar-rail-body.tsx`
   Introduced: 6d894ef
 
+#### Theming & typography
+
+- **`rbren-earth` color theme + default-theme flip** — new fork-local entry
+  appended to `COLOR_THEMES` (warm earth-tone dark palette: Sand / Palm Leaf
+  / Camel / Olive Wood / Stone Brown across the surface ramp; Toffee Brown
+  as the primary accent). `DEFAULT_COLOR_THEME` flipped to `"rbren-earth"`.
+  Upstream themes (`openhands-deepsea`, `openhands-neutral`) are untouched.
+  Files: `src/themes/color-themes.ts`
+  Introduced: 82f2bc7
+
+- **Monospace UI font on `<body>`** — body `font-family` swapped to a
+  monospace stack (IBM Plex Mono → JetBrains Mono → Fira Code → system mono
+  fallbacks). Applies regardless of selected color theme.
+  Files: `src/index.css`
+  Introduced: 82f2bc7
+
+#### Sidebar
+
+- **Sidebar nav-label rename** — three left-nav labels swapped: "New" →
+  **Code**, "Extensions" → **Customize**, "Automations" → **Automate** (the
+  third was previously a `t(I18nKey.SIDEBAR$AUTOMATIONS)` call). Each line
+  carries an `rbren branch:` marker comment.
+  Files: `src/components/features/sidebar/sidebar.tsx`
+  Introduced: 9d130c4
+
+#### Dev meta / skills
+
 - **`long-running-fork` skill** — this file. Fork-local skill documenting
-  maintenance discipline, upstream-issue escalation path, and this MODLOG.
-  Loaded automatically on every task for this branch.
+  maintenance discipline, upstream-issue escalation path, the MODLOG, and
+  the SYNCLOG. Loaded automatically on every task for this branch.
   Files: `.agents/skills/long-running-fork.md`
   Introduced: 82f2bc7
 
@@ -140,6 +165,74 @@ git grep -n "rbren branch:" -- ':(exclude).agents/skills/long-running-fork.md'
 Every distinct piece of fork-local behavior visible in `git log` /
 `rbren branch:` markers should correspond to exactly one MODLOG entry. If
 something is missing on either side, fix the MODLOG before rebasing.
+
+## SYNCLOG — Upstream Sync History
+
+**Unlike the MODLOG, the SYNCLOG _is_ a timeline.** It is a chronological,
+append-only record of every time upstream `main` was synced into this
+branch (whether via merge or rebase). Newest entries go at the **bottom**.
+
+The first entry is the commit on `main` that this branch was originally
+branched from (no merge happened — it's the starting point of all later
+diffs). Every subsequent entry records a merge / rebase and any
+conflicts, breakages, or follow-up fixes that had to be addressed to make
+the sync stick.
+
+### Why we keep this
+
+- Provides a quick "when was the last sync?" answer without trawling
+  `git log`.
+- Surfaces conflict hotspots over time: if the same file shows up in the
+  conflicts list across multiple sync entries, that's a strong signal to
+  open an upstream issue (see "Pushing Upstream When Conflicts Recur"
+  below) so the fork-local edit can be replaced with an upstream
+  extensibility hook.
+- Records merge-time bug fixes that aren't otherwise represented in the
+  MODLOG (because they don't add fork-local behavior — they patch
+  fork-local code to keep working against new upstream behavior).
+
+### Entry format
+
+```
+- **YYYY-MM-DD** — synced upstream `main` at `<short hash>` ("<commit title>")
+  - Sync commit: `<short hash on rbren>` (omit for the initial branch point)
+  - Conflicts: <comma-separated files / paths>, or "None"
+  - Notes: <one-paragraph summary of any breakages, fork-local fix-ups,
+            or behavior shifts that landed in the sync commit>. Use "None"
+            for clean merges.
+```
+
+The "Sync commit" is the rbren-branch commit that *applied* the merge /
+rebase (so the reader can `git show` it). For the very first entry — the
+initial branch point — there is no sync commit and the line is omitted.
+
+### Maintenance rules
+
+1. **Append, never reorder.** This is the one section where commit order
+   matters; entries are chronological.
+2. **One entry per sync operation,** regardless of how many upstream
+   commits it pulled in. Reference the *tip* of `main` at sync time, not
+   each individual upstream commit.
+3. **A "clean" sync still gets an entry.** Even if there are no
+   conflicts, record the sync — that's the evidence that the branch was
+   up-to-date at that point in time.
+4. **Don't retroactively edit historical entries** to "fix" descriptions
+   of past conflicts. If a follow-up fix landed later, add a new entry
+   for the follow-up rather than rewriting history. (Typo / formatting
+   fixes are obviously fine.)
+5. **Cross-link to upstream issues.** If a recurring conflict triggered
+   an upstream-issue proposal (per "Pushing Upstream When Conflicts
+   Recur"), drop the issue/PR URL in the Notes section.
+
+### Entries
+
+- **2026-05-16** — branched from `f7c7dbe` ("perf(snapshots): skip retries
+  on comparison pass, suppress consent modal (#505)") on upstream `main`.
+  - Conflicts: N/A (initial branch point, not a sync)
+  - Notes: starting commit of the `rbren` long-running branch. All
+    fork-local divergences listed in the MODLOG above were introduced on
+    top of this commit. The initial fork-local commit on `rbren` was
+    `82f2bc7` ("Initialize rbren long-running branch").
 
 ## Core Principles
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 > rbren's mod's `main`. Fork-local edits in source are tagged with a
 > `rbren's mod:` comment so they can be grepped easily.
 
+<img width="1511" height="827" alt="Screenshot 2026-05-16 at 1 36 07 PM" src="https://github.com/user-attachments/assets/d2cad58a-14f0-4337-88fe-c5ab3b8cdb20" />
+
+
 ## Robert's dockerless VM install
 
 These are the install steps Robert uses on a fresh Linux VM where Docker is not

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 > It is rebased / fast-forwarded onto `main` periodically and is not guaranteed to be stable
 > between rebases. If you are looking for the canonical project, use `main`.
 
+> [!IMPORTANT]
+> **Maintainers and agents working on this branch:** read
+> [`.agents/skills/long-running-fork.md`](.agents/skills/long-running-fork.md)
+> first. It documents the merge-friendly editing discipline, the **MODLOG**
+> (canonical inventory of every fork-local divergence from `main`), and the
+> **SYNCLOG** (chronological record of upstream syncs). The skill is also
+> auto-loaded by OpenHands for every task on this branch.
+
 ## Robert's dockerless VM install
 
 These are the install steps Robert uses on a fresh Linux VM where Docker is not

--- a/README.md
+++ b/README.md
@@ -1,4 +1,63 @@
-# agent-canvas
+# agent-canvas — `rbren` branch
+
+> [!NOTE]
+> This is a **long-running branch** maintained by **Robert Brennan** (`@rbren`).
+> It carries personal preferences (theming, layout tweaks, dev-loop helpers, etc.) on top of `main`.
+> It is rebased / fast-forwarded onto `main` periodically and is not guaranteed to be stable
+> between rebases. If you are looking for the canonical project, use `main`.
+
+## Robert's dockerless VM install
+
+These are the install steps Robert uses on a fresh Linux VM where Docker is not
+available (or not desired) and the VM is dedicated to running Agent Canvas.
+
+> [!WARNING]
+> The dockerless path runs the agent-server directly on the host — the agent has
+> full access to the VM's filesystem. Only do this on a VM you own and treat as
+> disposable. See [SELF_HOSTING.md](SELF_HOSTING.md) for hardening guidance.
+
+**Prerequisites**:
+
+- A Linux VM you control (Ubuntu 22.04+ / Debian 12+ tested)
+- Node.js **22.12.x or later** (`nvm install 22` works)
+- `npm`
+- [`uv`](https://docs.astral.sh/uv/) — used to launch the agent server via `uvx`
+- `git`
+
+```sh
+# 1. Install uv (one-liner from astral.sh)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 2. Clone this branch
+git clone -b rbren https://github.com/OpenHands/agent-canvas.git
+cd agent-canvas
+
+# 3. Install JS deps and run dockerless
+npm install
+npm run dev:dangerously-dockerless
+```
+
+Access the UI at [http://localhost:8000](http://localhost:8000).
+
+To expose it to the outside world, front it with nginx + Let's Encrypt + basic
+auth — do **not** publish the raw port. See [SELF_HOSTING.md](SELF_HOSTING.md)
+for a reference setup.
+
+If you want the static (non-hot-reloading) variant for stability:
+
+```sh
+npm run dev:dangerously-dockerless
+```
+
+If you are hacking on the frontend itself and want live reload:
+
+```sh
+npm run dev:dangerously-dockerless:dynamic
+```
+
+---
+
+## Upstream README
 
 > [!WARNING]
 > This project is in alpha phase. It may be vibecoded, untested, or out of date. [Learn more](https://github.com/OpenHands/incubator-program).

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-# agent-canvas — `rbren/agent-canvas` fork
+# agent-canvas — rbren's mod
 
 > [!NOTE]
-> This is a **long-running personal fork** of [`OpenHands/agent-canvas`](https://github.com/OpenHands/agent-canvas) maintained by **Robert Brennan** (`@rbren`).
+> **rbren's mod** is a **long-running personal fork** of [`OpenHands/agent-canvas`](https://github.com/OpenHands/agent-canvas) maintained by **Robert Brennan** (`@rbren`) at [`rbren/agent-canvas`](https://github.com/rbren/agent-canvas).
 > The fork's default branch — this `main` — intentionally **diverges from upstream `main`** to carry personal preferences (theming, layout tweaks, dev-loop helpers, etc.) on top of upstream.
 > It is rebased onto upstream periodically and is not guaranteed to be stable between rebases. If you are looking for the canonical project, use [`OpenHands/agent-canvas`](https://github.com/OpenHands/agent-canvas).
 
 > [!IMPORTANT]
-> **Maintainers and agents working on this fork:** read
+> **Maintainers and agents working on rbren's mod:** read
 > [`.agents/skills/long-running-fork.md`](.agents/skills/long-running-fork.md)
 > first. It documents the merge-friendly editing discipline, the remote
 > layout (`origin` = fork, `upstream` = `OpenHands/agent-canvas`), the
 > **MODLOG** (canonical inventory of every fork-local divergence from
 > upstream `main`), and the **SYNCLOG** (chronological record of upstream
 > syncs). The skill is also auto-loaded by OpenHands for every task on
-> this fork's `main`.
+> rbren's mod's `main`. Fork-local edits in source are tagged with a
+> `rbren's mod:` comment so they can be grepped easily.
 
 ## Robert's dockerless VM install
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-# agent-canvas — `rbren` branch
+# agent-canvas — `rbren/agent-canvas` fork
 
 > [!NOTE]
-> This is a **long-running branch** maintained by **Robert Brennan** (`@rbren`).
-> It carries personal preferences (theming, layout tweaks, dev-loop helpers, etc.) on top of `main`.
-> It is rebased / fast-forwarded onto `main` periodically and is not guaranteed to be stable
-> between rebases. If you are looking for the canonical project, use `main`.
+> This is a **long-running personal fork** of [`OpenHands/agent-canvas`](https://github.com/OpenHands/agent-canvas) maintained by **Robert Brennan** (`@rbren`).
+> The fork's default branch — this `main` — intentionally **diverges from upstream `main`** to carry personal preferences (theming, layout tweaks, dev-loop helpers, etc.) on top of upstream.
+> It is rebased onto upstream periodically and is not guaranteed to be stable between rebases. If you are looking for the canonical project, use [`OpenHands/agent-canvas`](https://github.com/OpenHands/agent-canvas).
 
 > [!IMPORTANT]
-> **Maintainers and agents working on this branch:** read
+> **Maintainers and agents working on this fork:** read
 > [`.agents/skills/long-running-fork.md`](.agents/skills/long-running-fork.md)
-> first. It documents the merge-friendly editing discipline, the **MODLOG**
-> (canonical inventory of every fork-local divergence from `main`), and the
-> **SYNCLOG** (chronological record of upstream syncs). The skill is also
-> auto-loaded by OpenHands for every task on this branch.
+> first. It documents the merge-friendly editing discipline, the remote
+> layout (`origin` = fork, `upstream` = `OpenHands/agent-canvas`), the
+> **MODLOG** (canonical inventory of every fork-local divergence from
+> upstream `main`), and the **SYNCLOG** (chronological record of upstream
+> syncs). The skill is also auto-loaded by OpenHands for every task on
+> this fork's `main`.
 
 ## Robert's dockerless VM install
 
@@ -36,8 +37,8 @@ available (or not desired) and the VM is dedicated to running Agent Canvas.
 # 1. Install uv (one-liner from astral.sh)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# 2. Clone this branch
-git clone -b rbren https://github.com/OpenHands/agent-canvas.git
+# 2. Clone this fork (default branch is `main`, which is the customized one)
+git clone https://github.com/rbren/agent-canvas.git
 cd agent-canvas
 
 # 3. Install JS deps and run dockerless

--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -431,7 +431,7 @@ export function ChatInterface() {
             maybeLoadOlder(e.currentTarget);
           }}
           onWheel={handleWheelForPagination}
-          className="custom-scrollbar-always flex grow flex-col gap-2 overflow-x-hidden overflow-y-auto px-0 pt-4 md:px-4"
+          className="custom-scrollbar-always flex grow flex-col gap-2 overflow-x-hidden overflow-y-auto px-0 pt-4 pb-8 md:px-4"
         >
           {isChatLoading && isReturningToConversation && (
             <ChatMessagesSkeleton />

--- a/src/components/features/sidebar/rbren-repo-picker.tsx
+++ b/src/components/features/sidebar/rbren-repo-picker.tsx
@@ -209,7 +209,12 @@ export function RbrenRepoPicker({ collapsed }: RbrenRepoPickerProps) {
           data-testid="rbren-repo-picker-popover"
           role="menu"
           className={cn(
-            "absolute z-30 top-full right-0 mt-1 p-1 min-w-[280px]",
+            // Anchor the popover's left edge to the chevron rather than its
+            // right edge — at min-w-[280px] the popover is wider than the
+            // sidebar, so anchoring with `right-0` would push it leftward
+            // and run it off the left side of the screen. `left-0` lets it
+            // float rightward over the main content area instead.
+            "absolute z-30 top-full left-0 mt-1 p-1 min-w-[280px]",
             "bg-[var(--oh-surface)] border border-[var(--oh-border-input)]",
             "rounded-lg shadow-xl",
             "flex flex-col",

--- a/src/components/features/sidebar/rbren-repo-picker.tsx
+++ b/src/components/features/sidebar/rbren-repo-picker.tsx
@@ -1,0 +1,347 @@
+/**
+ * rbren's mod: fork-local sidebar widget.
+ *
+ * Cloud-mode counterpart of `rbren-workspace-picker.tsx`. Renders the same
+ * outline-bordered chevron-down trigger button next to the "Code" nav link
+ * in the left sidebar, but opens a popover listing **git repositories**
+ * (filtered by provider + optional search query) instead of local
+ * workspaces. Selecting a repo immediately starts a new conversation
+ * against that repo's default branch and navigates to it.
+ *
+ * Composition pattern modeled after
+ * `components/features/conversation-panel/new-conversation-button-cloud.tsx`
+ * (same `useGitRepositories` + `useSearchRepositories` + `useUserProviders`
+ * + `useCreateConversation` + `useNavigation` set). This is intentionally
+ * separate so the fork-local sidebar tweak can be retired by deleting this
+ * file alongside `rbren-workspace-picker.tsx` and the wrapping div in
+ * `sidebar.tsx`.
+ */
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown } from "lucide-react";
+
+import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
+import { useNavigation } from "#/context/navigation-context";
+import { useIsCreatingConversation } from "#/hooks/use-is-creating-conversation";
+import { useGitRepositories } from "#/hooks/query/use-git-repositories";
+import { useSearchRepositories } from "#/hooks/query/use-search-repositories";
+import { useUserProviders } from "#/hooks/use-user-providers";
+import { useDebounce } from "#/hooks/use-debounce";
+import { useHomeStore } from "#/stores/home-store";
+import { I18nKey } from "#/i18n/declaration";
+import { cn } from "#/utils/utils";
+import { GitRepository } from "#/types/git";
+import { Provider } from "#/types/settings";
+import RepoIcon from "#/icons/repo.svg?react";
+import { GitProviderIcon } from "#/components/shared/git-provider-icon";
+
+interface RbrenRepoPickerProps {
+  /** Hide the picker entirely when the sidebar is collapsed to a 64px rail. */
+  collapsed: boolean;
+}
+
+export function RbrenRepoPicker({ collapsed }: RbrenRepoPickerProps) {
+  const { t } = useTranslation("openhands");
+  const { navigate } = useNavigation();
+
+  const { providers } = useUserProviders();
+  const { lastSelectedProvider, setLastSelectedProvider } = useHomeStore();
+
+  const [open, setOpen] = React.useState(false);
+  const wrapRef = React.useRef<HTMLDivElement>(null);
+  const [selectedProvider, setSelectedProvider] =
+    React.useState<Provider | null>(lastSelectedProvider ?? null);
+  const [query, setQuery] = React.useState("");
+  const debouncedQuery = useDebounce(query, 300);
+
+  // Auto-select a provider once `useUserProviders` resolves: prefer the
+  // previously chosen one if it's still connected, otherwise the first
+  // available provider.
+  React.useEffect(() => {
+    if (providers.length === 0) {
+      if (selectedProvider !== null) setSelectedProvider(null);
+      return;
+    }
+    if (selectedProvider && providers.includes(selectedProvider)) return;
+    const fallback =
+      lastSelectedProvider && providers.includes(lastSelectedProvider)
+        ? lastSelectedProvider
+        : providers[0];
+    setSelectedProvider(fallback);
+  }, [providers, selectedProvider, lastSelectedProvider]);
+
+  const {
+    data: repoPages,
+    isLoading,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useGitRepositories({ provider: selectedProvider });
+
+  const { data: searchResults, isLoading: isSearchLoading } =
+    useSearchRepositories(debouncedQuery, selectedProvider);
+
+  const allRepositories = React.useMemo(
+    () => repoPages?.pages.flatMap((page) => page.items) ?? [],
+    [repoPages],
+  );
+
+  const repositories = debouncedQuery ? (searchResults ?? []) : allRepositories;
+
+  const { mutate: createConversation, isPending } = useCreateConversation();
+  const isCreatingElsewhere = useIsCreatingConversation();
+  const isCreating = isPending || isCreatingElsewhere;
+
+  // Outside-click closes the popover.
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const onDown = (event: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // Escape also closes.
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  // When the popover is open and the active provider has very few repos
+  // available, auto-load the next page so users can scroll without
+  // explicitly clicking "Load more". Mirrors the cloud "+ New Conversation"
+  // popover behavior.
+  React.useEffect(() => {
+    if (!open) return;
+    if (debouncedQuery) return;
+    if (!hasNextPage || isFetchingNextPage || isLoading) return;
+    if (repositories.length === 0 || repositories.length >= 10) return;
+    fetchNextPage();
+  }, [
+    open,
+    debouncedQuery,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    repositories.length,
+    fetchNextPage,
+  ]);
+
+  if (collapsed) return null;
+
+  const launch = (repo?: GitRepository) => {
+    if (isCreating) return;
+    createConversation(
+      repo
+        ? {
+            repository: {
+              name: repo.full_name,
+              gitProvider: repo.git_provider,
+              branch: repo.main_branch ?? "main",
+            },
+          }
+        : {},
+      {
+        onSuccess: (data) => {
+          setOpen(false);
+          navigate(`/conversations/${data.conversation_id}`);
+        },
+      },
+    );
+  };
+
+  const handleProviderChange = (provider: Provider) => {
+    setSelectedProvider(provider);
+    setLastSelectedProvider(provider);
+    setQuery("");
+  };
+
+  const itemClass = cn(
+    "flex items-center gap-2 w-full px-2 py-1.5 rounded-md text-left text-sm",
+    "text-white hover:bg-[var(--oh-interactive-hover)] transition-colors",
+    "disabled:opacity-60 disabled:cursor-not-allowed",
+  );
+
+  const isListLoading = debouncedQuery ? isSearchLoading : isLoading;
+  const showLoadMore =
+    !debouncedQuery && hasNextPage && repositories.length > 0;
+
+  return (
+    <div ref={wrapRef} className="relative shrink-0">
+      <button
+        type="button"
+        data-testid="rbren-repo-picker-trigger"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Pick repository for new conversation"
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setOpen((o) => !o);
+        }}
+        className={cn(
+          "flex h-6 w-6 items-center justify-center rounded-md",
+          "border border-[var(--oh-border)]",
+          "text-[var(--oh-muted)] hover:text-white hover:bg-[var(--oh-surface-raised)]",
+          "transition-colors cursor-pointer",
+        )}
+      >
+        <ChevronDown
+          width={14}
+          height={14}
+          className={cn(
+            "transition-transform duration-150",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open && (
+        <div
+          data-testid="rbren-repo-picker-popover"
+          role="menu"
+          className={cn(
+            "absolute z-30 top-full right-0 mt-1 p-1 min-w-[280px]",
+            "bg-[var(--oh-surface)] border border-[var(--oh-border-input)]",
+            "rounded-lg shadow-xl",
+            "flex flex-col",
+          )}
+        >
+          {providers.length > 1 && (
+            <div
+              className="flex items-center gap-1 px-1 pt-1"
+              data-testid="rbren-repo-picker-provider-tabs"
+            >
+              {providers.map((provider) => {
+                const isActive = provider === selectedProvider;
+                return (
+                  <button
+                    key={provider}
+                    type="button"
+                    data-testid={`rbren-repo-picker-provider-tab-${provider}`}
+                    onClick={() => handleProviderChange(provider)}
+                    className={cn(
+                      "flex items-center gap-1 px-2 py-1 rounded text-xs",
+                      "border transition-colors",
+                      isActive
+                        ? "bg-[var(--oh-interactive-hover)] border-[var(--oh-border-input)] text-white"
+                        : "border-transparent text-[var(--oh-text-secondary)] hover:text-white",
+                    )}
+                  >
+                    <GitProviderIcon gitProvider={provider} />
+                    <span className="capitalize">{provider}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          <div className="px-1 pt-1">
+            <input
+              type="text"
+              data-testid="rbren-repo-picker-search-input"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t(I18nKey.COMMON$SEARCH_REPOSITORIES)}
+              disabled={!selectedProvider}
+              className={cn(
+                "w-full px-2 py-1.5 text-sm rounded-md",
+                "bg-[var(--oh-surface)] border border-[var(--oh-border)] text-white",
+                "placeholder:text-[var(--oh-muted)] outline-none",
+                "focus:border-[var(--oh-border-input)]",
+                "disabled:opacity-60 disabled:cursor-not-allowed",
+              )}
+            />
+          </div>
+
+          <ul className="flex flex-col max-h-[40vh] overflow-y-auto mt-1">
+            <li>
+              <button
+                type="button"
+                role="menuitem"
+                disabled={isCreating}
+                data-testid="rbren-repo-picker-launch-no-repo"
+                onClick={() => launch()}
+                className={itemClass}
+              >
+                <span className="italic text-[var(--oh-muted)]">
+                  No repository
+                </span>
+              </button>
+            </li>
+
+            {isListLoading && repositories.length === 0 && (
+              <li
+                className="px-2 py-1.5 text-sm text-[var(--oh-muted)] italic"
+                data-testid="rbren-repo-picker-loading"
+              >
+                {t(I18nKey.HOME$LOADING_REPOSITORIES)}
+              </li>
+            )}
+            {isError && (
+              <li
+                className="px-2 py-1.5 text-sm text-[#F87171]"
+                data-testid="rbren-repo-picker-error"
+              >
+                {t(I18nKey.HOME$FAILED_TO_LOAD_REPOSITORIES)}
+              </li>
+            )}
+            {!isListLoading &&
+              !isError &&
+              repositories.length === 0 &&
+              !!selectedProvider && (
+                <li
+                  className="px-2 py-1.5 text-sm text-[var(--oh-muted)] italic"
+                  data-testid="rbren-repo-picker-empty"
+                >
+                  {t(I18nKey.GITHUB$NO_RESULTS)}
+                </li>
+              )}
+            {repositories.map((repo) => (
+              <li key={`${repo.git_provider}:${repo.id}`}>
+                <button
+                  type="button"
+                  role="menuitem"
+                  disabled={isCreating}
+                  data-testid="rbren-repo-picker-launch-repo"
+                  data-repo-name={repo.full_name}
+                  title={repo.full_name}
+                  onClick={() => launch(repo)}
+                  className={itemClass}
+                >
+                  <RepoIcon width={14} height={14} className="shrink-0" />
+                  <span className="truncate">{repo.full_name}</span>
+                </button>
+              </li>
+            ))}
+            {showLoadMore && (
+              <li>
+                <button
+                  type="button"
+                  data-testid="rbren-repo-picker-load-more"
+                  disabled={isFetchingNextPage}
+                  onClick={() => fetchNextPage()}
+                  className={itemClass}
+                >
+                  <span className="text-[var(--oh-text-secondary)]">
+                    {isFetchingNextPage
+                      ? t(I18nKey.HOME$LOADING_MORE_REPOSITORIES)
+                      : t(I18nKey.CONVERSATION$LOAD_MORE)}
+                  </span>
+                </button>
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/sidebar/rbren-workspace-picker.tsx
+++ b/src/components/features/sidebar/rbren-workspace-picker.tsx
@@ -1,5 +1,5 @@
 /**
- * rbren branch: fork-local sidebar widget.
+ * rbren's mod: fork-local sidebar widget.
  *
  * Renders a small outline-bordered chevron-down button next to the "Code"
  * nav link in the left sidebar. Clicking it opens a popover listing

--- a/src/components/features/sidebar/rbren-workspace-picker.tsx
+++ b/src/components/features/sidebar/rbren-workspace-picker.tsx
@@ -1,0 +1,165 @@
+/**
+ * rbren branch: fork-local sidebar widget.
+ *
+ * Renders a small outline-bordered chevron-down button next to the "Code"
+ * nav link in the left sidebar. Clicking it opens a popover listing
+ * "No workspace" at the top followed by every workspace from
+ * `useResolvedWorkspaces`. Selecting any entry immediately starts a new
+ * conversation in that workspace (or with no workingDir for "No workspace")
+ * and navigates to it.
+ *
+ * Composition pattern modeled after
+ * `components/features/conversation-panel/new-conversation-button-local.tsx`
+ * (same `useResolvedWorkspaces` + `useCreateConversation` + `useNavigation`
+ * trio, same outside-click / Escape close behavior). This is intentionally
+ * separate so the fork-local sidebar tweak can be retired by deleting this
+ * file + the wrapping div in `sidebar.tsx`.
+ */
+import React from "react";
+import { ChevronDown } from "lucide-react";
+
+import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
+import { useNavigation } from "#/context/navigation-context";
+import { useIsCreatingConversation } from "#/hooks/use-is-creating-conversation";
+import { useResolvedWorkspaces } from "#/hooks/query/use-resolved-workspaces";
+import { cn } from "#/utils/utils";
+
+interface RbrenWorkspacePickerProps {
+  /** Hide the picker entirely when the sidebar is collapsed to a 64px rail. */
+  collapsed: boolean;
+}
+
+export function RbrenWorkspacePicker({ collapsed }: RbrenWorkspacePickerProps) {
+  const [open, setOpen] = React.useState(false);
+  const wrapRef = React.useRef<HTMLDivElement>(null);
+  const { navigate } = useNavigation();
+
+  const { workspaces, isLoading } = useResolvedWorkspaces();
+  const { mutate: createConversation, isPending } = useCreateConversation();
+  const isCreatingElsewhere = useIsCreatingConversation();
+  const isCreating = isPending || isCreatingElsewhere;
+
+  // Outside-click closes the popover.
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const onDown = (event: MouseEvent) => {
+      if (
+        wrapRef.current &&
+        !wrapRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // Escape also closes.
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  if (collapsed) return null;
+
+  const launch = (workingDir?: string) => {
+    if (isCreating) return;
+    createConversation(
+      { workingDir },
+      {
+        onSuccess: (data) => {
+          setOpen(false);
+          navigate(`/conversations/${data.conversation_id}`);
+        },
+      },
+    );
+  };
+
+  const itemClass = cn(
+    "flex items-center gap-2 w-full px-2 py-1.5 rounded-md text-left text-sm",
+    "text-white hover:bg-[var(--oh-interactive-hover)] transition-colors",
+    "disabled:opacity-60 disabled:cursor-not-allowed",
+  );
+
+  return (
+    <div ref={wrapRef} className="relative shrink-0">
+      <button
+        type="button"
+        data-testid="rbren-workspace-picker-trigger"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Pick workspace for new conversation"
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setOpen((o) => !o);
+        }}
+        className={cn(
+          "flex h-6 w-6 items-center justify-center rounded-md",
+          "border border-[var(--oh-border)]",
+          "text-[var(--oh-muted)] hover:text-white hover:bg-[var(--oh-surface-raised)]",
+          "transition-colors cursor-pointer",
+        )}
+      >
+        <ChevronDown
+          width={14}
+          height={14}
+          className={cn(
+            "transition-transform duration-150",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open && (
+        <div
+          data-testid="rbren-workspace-picker-popover"
+          role="menu"
+          className={cn(
+            "absolute z-30 top-full right-0 mt-1 p-1 min-w-[220px]",
+            "bg-[var(--oh-surface)] border border-[var(--oh-border-input)]",
+            "rounded-lg shadow-xl",
+            "flex flex-col max-h-[40vh] overflow-y-auto",
+          )}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            disabled={isCreating}
+            data-testid="rbren-launch-no-workspace"
+            onClick={() => launch()}
+            className={itemClass}
+          >
+            <span className="italic text-[var(--oh-muted)]">No workspace</span>
+          </button>
+
+          {workspaces.map((w) => (
+            <button
+              key={w.id}
+              type="button"
+              role="menuitem"
+              disabled={isCreating}
+              data-testid="rbren-launch-workspace"
+              data-workspace-path={w.path}
+              title={w.path}
+              onClick={() => launch(w.path)}
+              className={itemClass}
+            >
+              <span className="truncate">{w.name}</span>
+            </button>
+          ))}
+
+          {!isLoading && workspaces.length === 0 && (
+            <div className="px-2 py-1.5 text-xs text-[var(--oh-muted)]">
+              No workspaces configured
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/sidebar/rbren-workspace-picker.tsx
+++ b/src/components/features/sidebar/rbren-workspace-picker.tsx
@@ -14,6 +14,10 @@
  * trio, same outside-click / Escape close behavior). This is intentionally
  * separate so the fork-local sidebar tweak can be retired by deleting this
  * file + the wrapping div in `sidebar.tsx`.
+ *
+ * In cloud mode the local-workspace concept doesn't apply, so this
+ * component delegates to `RbrenRepoPicker` which renders the same trigger
+ * but lists git repositories instead.
  */
 import React from "react";
 import { ChevronDown } from "lucide-react";
@@ -22,7 +26,9 @@ import { useCreateConversation } from "#/hooks/mutation/use-create-conversation"
 import { useNavigation } from "#/context/navigation-context";
 import { useIsCreatingConversation } from "#/hooks/use-is-creating-conversation";
 import { useResolvedWorkspaces } from "#/hooks/query/use-resolved-workspaces";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { cn } from "#/utils/utils";
+import { RbrenRepoPicker } from "./rbren-repo-picker";
 
 interface RbrenWorkspacePickerProps {
   /** Hide the picker entirely when the sidebar is collapsed to a 64px rail. */
@@ -30,6 +36,13 @@ interface RbrenWorkspacePickerProps {
 }
 
 export function RbrenWorkspacePicker({ collapsed }: RbrenWorkspacePickerProps) {
+  const isCloud = useActiveBackend().backend.kind === "cloud";
+  if (isCloud) return <RbrenRepoPicker collapsed={collapsed} />;
+
+  return <LocalWorkspacePicker collapsed={collapsed} />;
+}
+
+function LocalWorkspacePicker({ collapsed }: RbrenWorkspacePickerProps) {
   const [open, setOpen] = React.useState(false);
   const wrapRef = React.useRef<HTMLDivElement>(null);
   const { navigate } = useNavigation();

--- a/src/components/features/sidebar/sidebar-rail-body.tsx
+++ b/src/components/features/sidebar/sidebar-rail-body.tsx
@@ -121,11 +121,20 @@ export function SidebarRailBody({
           </div>
         ) : (
           <>
+            {/* rbren's mod: upstream's SIDEBAR_ICON_SLOT_CLASS pins the
+                expanded-mode logo slot to w-[18px] + justify-center so the
+                lone logo glyph overflows symmetrically around the icon
+                column. The fork adds a "rbren's mod" wordmark next to the
+                logo, so a fixed 18px slot centers the whole (logo +
+                wordmark) block and pushes the leading edge off-screen left
+                of the sidebar padding. Drop the explicit width / centering
+                and let the row size to its content from the icon column's
+                left edge. */}
             <OpenHandsLogoButton
               logoWidth={SIDEBAR_LOGO_WIDTH}
               logoHeight={SIDEBAR_LOGO_HEIGHT}
               logoClassName="max-w-none"
-              className={cn(SIDEBAR_ICON_SLOT_CLASS, "overflow-visible")}
+              className="inline-flex h-10 shrink-0 items-center overflow-visible"
             />
             {showCollapseToggle ? (
               <button

--- a/src/components/features/sidebar/sidebar-rail-body.tsx
+++ b/src/components/features/sidebar/sidebar-rail-body.tsx
@@ -91,7 +91,10 @@ export function SidebarRailBody({
                 showCollapsedExpandButton && "opacity-0",
               )}
             >
+              {/* rbren's mod: pass compact so the wordmark is hidden in the
+                  collapsed 64px rail (the logo alone still fits there). */}
               <OpenHandsLogoButton
+                compact
                 logoWidth={SIDEBAR_LOGO_WIDTH}
                 logoHeight={SIDEBAR_LOGO_HEIGHT}
                 logoClassName="max-w-none"

--- a/src/components/features/sidebar/sidebar-rail-body.tsx
+++ b/src/components/features/sidebar/sidebar-rail-body.tsx
@@ -16,6 +16,8 @@ import { StyledTooltip } from "#/components/shared/buttons/styled-tooltip";
 import { BackendSelector } from "#/components/features/backends/backend-selector";
 import { BackendStatusDot } from "#/components/features/backends/backend-status-dot";
 import { SidebarConversationList } from "./sidebar-conversation-list";
+/* rbren's mod: workspace-picker dropdown on the conversations nav row. */
+import { RbrenWorkspacePicker } from "./rbren-workspace-picker";
 import AutomationsIcon from "#/icons/automations.svg?react";
 import {
   SIDEBAR_COLLAPSE_TOGGLE_OVERLAY_CLASS,
@@ -161,15 +163,27 @@ export function SidebarRailBody({
       </div>
 
       <nav className={sidebarNavListClassName(collapsed)}>
-        <SidebarNavLink
-          to="/conversations"
-          end
-          label="New Chat"
-          testId="sidebar-conversations-link"
-          disabled={linkDisabled}
-          collapsed={collapsed}
-          icon={<Plus width={ICON_SIZE} height={ICON_SIZE} />}
-        />
+        {/* rbren's mod: wrap the conversations nav row with a flex container
+            so a chevron-down workspace picker can sit on the right edge of
+            the row. The wrap is purely a layout aid — SidebarNavLink and
+            picker are independent siblings; SidebarNavLink stays unmodified
+            so the feature can be retired by deleting the wrap and the
+            picker file. In the collapsed (64px rail) layout the picker
+            renders nothing, so the wrapper degrades to a plain nav row. */}
+        <div className="flex items-center gap-1 w-full">
+          <div className="flex-1 min-w-0">
+            <SidebarNavLink
+              to="/conversations"
+              end
+              label="New Chat"
+              testId="sidebar-conversations-link"
+              disabled={linkDisabled}
+              collapsed={collapsed}
+              icon={<Plus width={ICON_SIZE} height={ICON_SIZE} />}
+            />
+          </div>
+          <RbrenWorkspacePicker collapsed={collapsed} />
+        </div>
         <SidebarNavLink
           to="/customize"
           label="Customize"

--- a/src/components/providers/posthog-wrapper.tsx
+++ b/src/components/providers/posthog-wrapper.tsx
@@ -73,8 +73,9 @@ export function PostHogWrapper({ children }: { children: React.ReactNode }) {
     <PostHogProvider
       apiKey={posthogClientKey}
       options={{
-        api_host: "https://us.i.posthog.com",
-        person_profiles: "identified_only",
+        api_host: "https://z.openhands.dev",
+        ui_host: "https://us.posthog.com",
+        person_profiles: "always",
         bootstrap: bootstrapIds,
       }}
     >

--- a/src/components/shared/buttons/openhands-logo-button.tsx
+++ b/src/components/shared/buttons/openhands-logo-button.tsx
@@ -1,9 +1,15 @@
-import { useTranslation } from "react-i18next";
 import OpenHandsLogo from "#/assets/branding/openhands-logo.svg?react";
 import { NavigationLink } from "#/components/shared/navigation-link";
-import { I18nKey } from "#/i18n/declaration";
 import { StyledTooltip } from "#/components/shared/buttons/styled-tooltip";
 import { cn } from "#/utils/utils";
+
+/* rbren branch: useTranslation / I18nKey imports dropped — brand tooltip
+   and aria label are now hardcoded to "rbren's mod" below. Original lines:
+   import { useTranslation } from "react-i18next";
+   import { I18nKey } from "#/i18n/declaration";
+   const { t } = useTranslation("openhands");
+   const tooltipText = t(I18nKey.BRANDING$OPENHANDS);
+   const ariaLabel = t(I18nKey.BRANDING$OPENHANDS_LOGO); */
 
 const DEFAULT_LOGO_WIDTH = 46;
 const DEFAULT_LOGO_HEIGHT = 30;
@@ -22,10 +28,8 @@ export function OpenHandsLogoButton({
   logoWidth = DEFAULT_LOGO_WIDTH,
   logoHeight = DEFAULT_LOGO_HEIGHT,
 }: OpenHandsLogoButtonProps = {}) {
-  const { t } = useTranslation("openhands");
-
-  const tooltipText = t(I18nKey.BRANDING$OPENHANDS);
-  const ariaLabel = t(I18nKey.BRANDING$OPENHANDS_LOGO);
+  const tooltipText = "rbren's mod";
+  const ariaLabel = "rbren's mod logo";
 
   return (
     <StyledTooltip content={tooltipText}>
@@ -34,10 +38,17 @@ export function OpenHandsLogoButton({
         aria-label={ariaLabel}
         className={cn(className)}
       >
+        {/* rbren branch: tint logo with Toffee Brown (#9D684B), the
+            rbren-earth theme's primary accent. Targets only the
+            originally-white SVG paths so the transparent face cut-out
+            stays transparent. */}
         <OpenHandsLogo
           width={logoWidth}
           height={logoHeight}
-          className={cn("shrink-0", logoClassName)}
+          className={cn(
+            "shrink-0 [&_path[fill='white']]:fill-[#9D684B]",
+            logoClassName,
+          )}
         />
       </NavigationLink>
     </StyledTooltip>

--- a/src/components/shared/buttons/openhands-logo-button.tsx
+++ b/src/components/shared/buttons/openhands-logo-button.tsx
@@ -20,6 +20,9 @@ export type OpenHandsLogoButtonProps = {
   logoClassName?: string;
   logoWidth?: number;
   logoHeight?: number;
+  /* rbren branch: compact mode skips the "rbren's mod" wordmark next to the
+     logo. Used by the collapsed 64px sidebar rail where there's no room. */
+  compact?: boolean;
 };
 
 export function OpenHandsLogoButton({
@@ -27,6 +30,7 @@ export function OpenHandsLogoButton({
   logoClassName,
   logoWidth = DEFAULT_LOGO_WIDTH,
   logoHeight = DEFAULT_LOGO_HEIGHT,
+  compact = false,
 }: OpenHandsLogoButtonProps = {}) {
   const tooltipText = "rbren's mod";
   const ariaLabel = "rbren's mod logo";
@@ -38,18 +42,26 @@ export function OpenHandsLogoButton({
         aria-label={ariaLabel}
         className={cn(className)}
       >
-        {/* rbren branch: tint logo with Toffee Brown (#9D684B), the
-            rbren-earth theme's primary accent. Targets only the
-            originally-white SVG paths so the transparent face cut-out
-            stays transparent. */}
-        <OpenHandsLogo
-          width={logoWidth}
-          height={logoHeight}
-          className={cn(
-            "shrink-0 [&_path[fill='white']]:fill-[#9D684B]",
-            logoClassName,
+        <span className="flex items-center gap-2">
+          {/* rbren branch: tint logo with var(--oh-muted), matching the
+              inactive color of the sidebar nav icons (Code / Customize /
+              Automate). Targets only originally-white SVG paths so the
+              transparent face cut-out stays transparent. */}
+          <OpenHandsLogo
+            width={logoWidth}
+            height={logoHeight}
+            className={cn(
+              "shrink-0 [&_path[fill='white']]:fill-[var(--oh-muted)]",
+              logoClassName,
+            )}
+          />
+          {/* rbren branch: wordmark shown next to the logo in expanded mode. */}
+          {!compact && (
+            <span className="text-sm font-medium text-[var(--oh-muted)] whitespace-nowrap">
+              rbren&apos;s mod
+            </span>
           )}
-        />
+        </span>
       </NavigationLink>
     </StyledTooltip>
   );

--- a/src/components/shared/buttons/openhands-logo-button.tsx
+++ b/src/components/shared/buttons/openhands-logo-button.tsx
@@ -3,7 +3,7 @@ import { NavigationLink } from "#/components/shared/navigation-link";
 import { StyledTooltip } from "#/components/shared/buttons/styled-tooltip";
 import { cn } from "#/utils/utils";
 
-/* rbren branch: useTranslation / I18nKey imports dropped — brand tooltip
+/* rbren's mod: useTranslation / I18nKey imports dropped — brand tooltip
    and aria label are now hardcoded to "rbren's mod" below. Original lines:
    import { useTranslation } from "react-i18next";
    import { I18nKey } from "#/i18n/declaration";
@@ -20,7 +20,7 @@ export type OpenHandsLogoButtonProps = {
   logoClassName?: string;
   logoWidth?: number;
   logoHeight?: number;
-  /* rbren branch: compact mode skips the "rbren's mod" wordmark next to the
+  /* rbren's mod: compact mode skips the "rbren's mod" wordmark next to the
      logo. Used by the collapsed 64px sidebar rail where there's no room. */
   compact?: boolean;
 };
@@ -43,7 +43,7 @@ export function OpenHandsLogoButton({
         className={cn(className)}
       >
         <span className="flex items-center gap-2">
-          {/* rbren branch: tint logo with var(--oh-muted), matching the
+          {/* rbren's mod: tint logo with var(--oh-muted), matching the
               inactive color of the sidebar nav icons (Code / Customize /
               Automate). Targets only originally-white SVG paths so the
               transparent face cut-out stays transparent. */}
@@ -55,7 +55,7 @@ export function OpenHandsLogoButton({
               logoClassName,
             )}
           />
-          {/* rbren branch: wordmark shown next to the logo in expanded mode. */}
+          {/* rbren's mod: wordmark shown next to the logo in expanded mode. */}
           {!compact && (
             <span className="text-sm font-medium text-[var(--oh-muted)] whitespace-nowrap">
               rbren&apos;s mod

--- a/src/hooks/use-app-title.ts
+++ b/src/hooks/use-app-title.ts
@@ -3,7 +3,7 @@ import { useUserConversation } from "#/hooks/query/use-user-conversation";
 import { useConversationStateStore } from "#/stores/conversation-state-store";
 import { getAgentStateEmoji } from "#/utils/agent-state-emoji";
 
-const APP_TITLE = "OpenHands";
+const APP_TITLE = "rbren's mod"; /* rbren branch: was "OpenHands" */
 
 export const useAppTitle = () => {
   const { conversationId } = useParams<{ conversationId: string }>();

--- a/src/hooks/use-app-title.ts
+++ b/src/hooks/use-app-title.ts
@@ -3,7 +3,7 @@ import { useUserConversation } from "#/hooks/query/use-user-conversation";
 import { useConversationStateStore } from "#/stores/conversation-state-store";
 import { getAgentStateEmoji } from "#/utils/agent-state-emoji";
 
-const APP_TITLE = "rbren's mod"; /* rbren branch: was "OpenHands" */
+const APP_TITLE = "rbren's mod"; /* rbren's mod: was "OpenHands" */
 
 export const useAppTitle = () => {
   const { conversationId } = useParams<{ conversationId: string }>();

--- a/src/index.css
+++ b/src/index.css
@@ -44,7 +44,7 @@
 body {
   margin: 0;
   background-color: var(--oh-color-base);
-  /* rbren branch: monospace UI for structured-text "hackery" feel. */
+  /* rbren's mod: monospace UI for structured-text "hackery" feel. */
   font-family:
     "IBM Plex Mono", "JetBrains Mono", "Fira Code", "SF Mono", Menlo, Monaco,
     Consolas, "Liberation Mono", "Courier New", monospace;

--- a/src/index.css
+++ b/src/index.css
@@ -44,10 +44,10 @@
 body {
   margin: 0;
   background-color: var(--oh-color-base);
+  /* rbren branch: monospace UI for structured-text "hackery" feel. */
   font-family:
-    -apple-system, "SF Pro", BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+    "IBM Plex Mono", "JetBrains Mono", "Fira Code", "SF Mono", Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -146,6 +146,8 @@ async function initializePostHog(
     api_host: POSTHOG_HOST,
     // UI host is required when using a reverse proxy so PostHog features work correctly
     ui_host: POSTHOG_UI_HOST,
+    // Create person profiles for all users (anonymous and identified)
+    person_profiles: "always",
     // Start with capturing disabled by default - we enable it explicitly when needed
     opt_out_capturing_by_default: !enableCapturing,
     // Don't auto-capture page views - we control when to track

--- a/src/themes/color-themes.ts
+++ b/src/themes/color-themes.ts
@@ -1,8 +1,8 @@
 export type ColorThemeKey =
   | "openhands-deepsea"
   | "openhands-neutral"
-  // rbren branch: long-running-fork-local theme (mild green hackery tint).
-  | "rbren-hackery";
+  // rbren branch: long-running-fork-local theme (warm earth-tone palette).
+  | "rbren-earth";
 
 export interface ColorThemeDefinition {
   label: string;
@@ -154,75 +154,96 @@ export const COLOR_THEMES: Record<ColorThemeKey, ColorThemeDefinition> = {
     },
   },
 
-  // rbren branch: long-running-fork-local theme. Two-tone dark mode:
-  //   • main app shell (positions 950 / 975) → dark slate, restrained cool-
-  //     blue-gray (hue ~220, low saturation).
-  //   • side panel / cards / inputs / elevated surfaces (positions 50–925) →
-  //     mild green "hackery" tint (hue ~130, low saturation) so the chrome
-  //     reads like a CRT phosphor terminal without going neon.
+  // rbren branch: long-running-fork-local theme — warm earth-tone palette.
+  // Anchored on six named tones:
+  //   Sand        #CBB874 → position 300 (foreground text)
+  //   Palm Leaf   #9D956C → position 400
+  //   Camel       #AE8853 → position 500 (mid surfaces / active states)
+  //   Olive Wood  #826A48 → position 600
+  //   Stone Brown #6C5D4E → position 700 (hover/selected tint)
+  //   Toffee Brown #9D684B → primary accent (replaces default blue)
+  // Positions 50–200 (cream highlights) and 800–975 (dark app shell) are
+  // derived from the same warm hue family (H≈30, low-to-medium saturation)
+  // so the whole UI reads as a single warm earth-tone dark theme.
   // Lives only on this branch; do not propagate upstream.
   // See .agents/skills/long-running-fork.md.
-  "rbren-hackery": {
-    label: "rbren — Hackery Green",
+  "rbren-earth": {
+    label: "rbren — Earth Tones",
     scale: {
-      "--cool-grey-50": "#F3FBF3",
-      "--cool-grey-100": "#E8F0E8",
-      "--cool-grey-200": "#D8E0D8",
-      "--cool-grey-300": "#B7C5B7",
-      "--cool-grey-400": "#909E90",
-      "--cool-grey-500": "#6E7A6E",
-      "--cool-grey-600": "#525C52",
-      "--cool-grey-700": "#3E443E",
-      "--cool-grey-800": "#2F352F",
-      "--cool-grey-900": "#262C26",
-      "--cool-grey-925": "#1E221E",
-      // Main page background — dark slate, NOT green.
-      "--cool-grey-950": "#161A22",
-      "--cool-grey-975": "#0E1218",
+      "--cool-grey-50": "#F5EEDD", // light cream
+      "--cool-grey-100": "#EBE1C7",
+      "--cool-grey-200": "#DDCFA8",
+      "--cool-grey-300": "#CBB874", // Sand
+      "--cool-grey-400": "#9D956C", // Palm Leaf
+      "--cool-grey-500": "#AE8853", // Camel
+      "--cool-grey-600": "#826A48", // Olive Wood
+      "--cool-grey-700": "#6C5D4E", // Stone Brown
+      "--cool-grey-800": "#534639",
+      "--cool-grey-900": "#2F2820",
+      "--cool-grey-925": "#241F19",
+      "--cool-grey-950": "#1A1612", // main app shell — dark warm brown
+      "--cool-grey-975": "#120F0C",
     },
     heroui: {
-      // App-shell positions (950 / 975) — dark slate.
-      "--heroui-background": "222 21% 11%", // ~#161A22
-      "--heroui-background-foreground": "130 8% 96.86%",
-      "--heroui-foreground-50": "216 26% 7%", // ~#0E1218
-      "--heroui-foreground-100": "222 21% 11%", // ~#161A22
-      "--heroui-default-50": "216 26% 7%", // ~#0E1218
-      "--heroui-default-100": "222 21% 11%", // ~#161A22
+      // App-shell + foreground/default ramp.
+      // Position → HSL (channel format used by heroui as "H S% L%").
+      "--heroui-background": "30 18% 8.63%", // ~#1A1612
+      "--heroui-background-foreground": "42 55% 91.37%", // ~#F5EEDD
 
-      // Side panel / cards / elevated surfaces — green-tinted.
-      "--heroui-foreground-200": "130 8% 12.55%",
-      "--heroui-foreground-300": "130 8% 15.69%",
-      "--heroui-foreground-400": "130 8% 19.22%",
-      "--heroui-foreground-500": "130 8% 25.1%",
-      "--heroui-foreground-600": "130 8% 33.73%",
-      "--heroui-foreground-700": "130 8% 45.1%",
-      "--heroui-foreground-800": "130 8% 59.22%",
-      "--heroui-foreground-900": "130 8% 74.51%",
-      "--heroui-foreground": "130 8% 74.51%",
-      "--heroui-content1": "130 8% 12.55%",
-      "--heroui-content1-foreground": "130 8% 92.55%",
-      "--heroui-content2": "130 8% 15.69%",
-      "--heroui-content2-foreground": "130 8% 86.27%",
-      "--heroui-content3": "130 8% 19.22%",
-      "--heroui-content3-foreground": "130 8% 74.51%",
-      "--heroui-content4": "130 8% 25.1%",
-      "--heroui-content4-foreground": "130 8% 59.22%",
-      "--heroui-default-200": "130 8% 12.55%",
-      "--heroui-default-300": "130 8% 15.69%",
-      "--heroui-default-400": "130 8% 19.22%",
-      "--heroui-default-500": "130 8% 25.1%",
-      "--heroui-default-600": "130 8% 33.73%",
-      "--heroui-default-700": "130 8% 45.1%",
-      "--heroui-default-800": "130 8% 59.22%",
-      "--heroui-default-900": "130 8% 74.51%",
-      "--heroui-default-foreground": "130 8% 96.86%",
-      "--heroui-default": "130 8% 19.22%",
+      "--heroui-foreground-50": "30 20% 5.88%", // ~#120F0C
+      "--heroui-foreground-100": "30 18% 8.63%", // ~#1A1612
+      "--heroui-foreground-200": "32 19% 15.49%", // ~#2F2820
+      "--heroui-foreground-300": "30 19% 20.78%", // ~#3F352B (mid-dark)
+      "--heroui-foreground-400": "30 19% 27.45%", // ~#534639
+      "--heroui-foreground-500": "30 16% 36.47%", // Stone Brown
+      "--heroui-foreground-600": "35 29% 39.61%", // Olive Wood
+      "--heroui-foreground-700": "35 35% 50.39%", // Camel
+      "--heroui-foreground-800": "50 21% 51.96%", // Palm Leaf
+      "--heroui-foreground-900": "47 47% 62.55%", // Sand
+      "--heroui-foreground": "47 47% 62.55%", // Sand — primary text
+
+      "--heroui-content1": "32 19% 15.49%", // ~#2F2820 (panel)
+      "--heroui-content1-foreground": "43 53% 85.10%", // cream
+      "--heroui-content2": "30 19% 20.78%", // ~#3F352B (card)
+      "--heroui-content2-foreground": "44 50% 76.27%",
+      "--heroui-content3": "30 19% 27.45%", // ~#534639 (inner card)
+      "--heroui-content3-foreground": "47 47% 62.55%", // Sand
+      "--heroui-content4": "30 16% 36.47%", // Stone Brown (inset)
+      "--heroui-content4-foreground": "50 21% 51.96%", // Palm Leaf
+
+      "--heroui-default-50": "30 20% 5.88%",
+      "--heroui-default-100": "30 18% 8.63%",
+      "--heroui-default-200": "32 19% 15.49%",
+      "--heroui-default-300": "30 19% 20.78%",
+      "--heroui-default-400": "30 19% 27.45%",
+      "--heroui-default-500": "30 16% 36.47%", // Stone Brown
+      "--heroui-default-600": "35 29% 39.61%", // Olive Wood
+      "--heroui-default-700": "35 35% 50.39%", // Camel
+      "--heroui-default-800": "50 21% 51.96%", // Palm Leaf
+      "--heroui-default-900": "47 47% 62.55%", // Sand
+      "--heroui-default-foreground": "42 55% 91.37%", // cream
+      "--heroui-default": "30 19% 27.45%", // hover/selected tint
+
+      // Primary accent ramp — Toffee Brown #9D684B (hsl(21, 35%, 45.5%))
+      // at primary-500, ramped symmetrically darker / lighter.
+      "--heroui-primary-50": "21 35% 6%",
+      "--heroui-primary-100": "21 35% 10%",
+      "--heroui-primary-200": "21 35% 16%",
+      "--heroui-primary-300": "21 35% 22%",
+      "--heroui-primary-400": "21 35% 34%",
+      "--heroui-primary-500": "21 35% 45.5%", // Toffee Brown
+      "--heroui-primary-600": "21 35% 56%",
+      "--heroui-primary-700": "21 35% 67%",
+      "--heroui-primary-800": "21 35% 78%",
+      "--heroui-primary-900": "21 35% 88%",
+      "--heroui-primary": "21 35% 45.5%", // Toffee Brown
+      "--heroui-primary-foreground": "42 55% 91.37%", // cream on toffee
     },
   },
 };
 
-// rbren branch: default to the fork-local hackery-green theme.
-export const DEFAULT_COLOR_THEME: ColorThemeKey = "rbren-hackery";
+// rbren branch: default to the fork-local earth-tones theme.
+export const DEFAULT_COLOR_THEME: ColorThemeKey = "rbren-earth";
 
 export const AVAILABLE_COLOR_THEMES = Object.entries(COLOR_THEMES).map(
   ([key, def]) => ({ key: key as ColorThemeKey, label: def.label }),

--- a/src/themes/color-themes.ts
+++ b/src/themes/color-themes.ts
@@ -1,4 +1,8 @@
-export type ColorThemeKey = "openhands-deepsea" | "openhands-neutral";
+export type ColorThemeKey =
+  | "openhands-deepsea"
+  | "openhands-neutral"
+  // rbren branch: long-running-fork-local theme (mild green hackery tint).
+  | "rbren-hackery";
 
 export interface ColorThemeDefinition {
   label: string;
@@ -149,9 +153,68 @@ export const COLOR_THEMES: Record<ColorThemeKey, ColorThemeDefinition> = {
       "--heroui-default": NEUTRAL_HSL[800],
     },
   },
+
+  // rbren branch: long-running-fork-local theme. Mild green "hackery" tint —
+  // hue ~130 with low saturation so the dark UI reads like a CRT phosphor
+  // terminal without going neon. Lives only on this branch; do not propagate
+  // upstream. See .agents/skills/long-running-fork.md.
+  "rbren-hackery": {
+    label: "rbren — Hackery Green",
+    scale: {
+      "--cool-grey-50": "#F3FBF3",
+      "--cool-grey-100": "#E8F0E8",
+      "--cool-grey-200": "#D8E0D8",
+      "--cool-grey-300": "#B7C5B7",
+      "--cool-grey-400": "#909E90",
+      "--cool-grey-500": "#6E7A6E",
+      "--cool-grey-600": "#525C52",
+      "--cool-grey-700": "#3E443E",
+      "--cool-grey-800": "#2F352F",
+      "--cool-grey-900": "#262C26",
+      "--cool-grey-925": "#1E221E",
+      "--cool-grey-950": "#161A16",
+      "--cool-grey-975": "#0E120E",
+    },
+    heroui: {
+      "--heroui-background": "130 8% 9.41%",
+      "--heroui-background-foreground": "130 8% 96.86%",
+      "--heroui-foreground-50": "130 8% 6.27%",
+      "--heroui-foreground-100": "130 8% 9.41%",
+      "--heroui-foreground-200": "130 8% 12.55%",
+      "--heroui-foreground-300": "130 8% 15.69%",
+      "--heroui-foreground-400": "130 8% 19.22%",
+      "--heroui-foreground-500": "130 8% 25.1%",
+      "--heroui-foreground-600": "130 8% 33.73%",
+      "--heroui-foreground-700": "130 8% 45.1%",
+      "--heroui-foreground-800": "130 8% 59.22%",
+      "--heroui-foreground-900": "130 8% 74.51%",
+      "--heroui-foreground": "130 8% 74.51%",
+      "--heroui-content1": "130 8% 12.55%",
+      "--heroui-content1-foreground": "130 8% 92.55%",
+      "--heroui-content2": "130 8% 15.69%",
+      "--heroui-content2-foreground": "130 8% 86.27%",
+      "--heroui-content3": "130 8% 19.22%",
+      "--heroui-content3-foreground": "130 8% 74.51%",
+      "--heroui-content4": "130 8% 25.1%",
+      "--heroui-content4-foreground": "130 8% 59.22%",
+      "--heroui-default-50": "130 8% 6.27%",
+      "--heroui-default-100": "130 8% 9.41%",
+      "--heroui-default-200": "130 8% 12.55%",
+      "--heroui-default-300": "130 8% 15.69%",
+      "--heroui-default-400": "130 8% 19.22%",
+      "--heroui-default-500": "130 8% 25.1%",
+      "--heroui-default-600": "130 8% 33.73%",
+      "--heroui-default-700": "130 8% 45.1%",
+      "--heroui-default-800": "130 8% 59.22%",
+      "--heroui-default-900": "130 8% 74.51%",
+      "--heroui-default-foreground": "130 8% 96.86%",
+      "--heroui-default": "130 8% 19.22%",
+    },
+  },
 };
 
-export const DEFAULT_COLOR_THEME: ColorThemeKey = "openhands-neutral";
+// rbren branch: default to the fork-local hackery-green theme.
+export const DEFAULT_COLOR_THEME: ColorThemeKey = "rbren-hackery";
 
 export const AVAILABLE_COLOR_THEMES = Object.entries(COLOR_THEMES).map(
   ([key, def]) => ({ key: key as ColorThemeKey, label: def.label }),

--- a/src/themes/color-themes.ts
+++ b/src/themes/color-themes.ts
@@ -1,7 +1,7 @@
 export type ColorThemeKey =
   | "openhands-deepsea"
   | "openhands-neutral"
-  // rbren branch: long-running-fork-local theme (warm earth-tone palette).
+  // rbren's mod: long-running-fork-local theme (warm earth-tone palette).
   | "rbren-earth";
 
 export interface ColorThemeDefinition {
@@ -154,7 +154,7 @@ export const COLOR_THEMES: Record<ColorThemeKey, ColorThemeDefinition> = {
     },
   },
 
-  // rbren branch: long-running-fork-local theme — warm earth-tone palette.
+  // rbren's mod: long-running-fork-local theme — warm earth-tone palette.
   // Anchored on six named tones:
   //   Sand        #CBB874 → position 300 (foreground text)
   //   Palm Leaf   #9D956C → position 400
@@ -242,7 +242,7 @@ export const COLOR_THEMES: Record<ColorThemeKey, ColorThemeDefinition> = {
   },
 };
 
-// rbren branch: default to the fork-local earth-tones theme.
+// rbren's mod: default to the fork-local earth-tones theme.
 export const DEFAULT_COLOR_THEME: ColorThemeKey = "rbren-earth";
 
 export const AVAILABLE_COLOR_THEMES = Object.entries(COLOR_THEMES).map(

--- a/src/themes/color-themes.ts
+++ b/src/themes/color-themes.ts
@@ -154,10 +154,14 @@ export const COLOR_THEMES: Record<ColorThemeKey, ColorThemeDefinition> = {
     },
   },
 
-  // rbren branch: long-running-fork-local theme. Mild green "hackery" tint —
-  // hue ~130 with low saturation so the dark UI reads like a CRT phosphor
-  // terminal without going neon. Lives only on this branch; do not propagate
-  // upstream. See .agents/skills/long-running-fork.md.
+  // rbren branch: long-running-fork-local theme. Two-tone dark mode:
+  //   • main app shell (positions 950 / 975) → dark slate, restrained cool-
+  //     blue-gray (hue ~220, low saturation).
+  //   • side panel / cards / inputs / elevated surfaces (positions 50–925) →
+  //     mild green "hackery" tint (hue ~130, low saturation) so the chrome
+  //     reads like a CRT phosphor terminal without going neon.
+  // Lives only on this branch; do not propagate upstream.
+  // See .agents/skills/long-running-fork.md.
   "rbren-hackery": {
     label: "rbren — Hackery Green",
     scale: {
@@ -172,14 +176,20 @@ export const COLOR_THEMES: Record<ColorThemeKey, ColorThemeDefinition> = {
       "--cool-grey-800": "#2F352F",
       "--cool-grey-900": "#262C26",
       "--cool-grey-925": "#1E221E",
-      "--cool-grey-950": "#161A16",
-      "--cool-grey-975": "#0E120E",
+      // Main page background — dark slate, NOT green.
+      "--cool-grey-950": "#161A22",
+      "--cool-grey-975": "#0E1218",
     },
     heroui: {
-      "--heroui-background": "130 8% 9.41%",
+      // App-shell positions (950 / 975) — dark slate.
+      "--heroui-background": "222 21% 11%", // ~#161A22
       "--heroui-background-foreground": "130 8% 96.86%",
-      "--heroui-foreground-50": "130 8% 6.27%",
-      "--heroui-foreground-100": "130 8% 9.41%",
+      "--heroui-foreground-50": "216 26% 7%", // ~#0E1218
+      "--heroui-foreground-100": "222 21% 11%", // ~#161A22
+      "--heroui-default-50": "216 26% 7%", // ~#0E1218
+      "--heroui-default-100": "222 21% 11%", // ~#161A22
+
+      // Side panel / cards / elevated surfaces — green-tinted.
       "--heroui-foreground-200": "130 8% 12.55%",
       "--heroui-foreground-300": "130 8% 15.69%",
       "--heroui-foreground-400": "130 8% 19.22%",
@@ -197,8 +207,6 @@ export const COLOR_THEMES: Record<ColorThemeKey, ColorThemeDefinition> = {
       "--heroui-content3-foreground": "130 8% 74.51%",
       "--heroui-content4": "130 8% 25.1%",
       "--heroui-content4-foreground": "130 8% 59.22%",
-      "--heroui-default-50": "130 8% 6.27%",
-      "--heroui-default-100": "130 8% 9.41%",
       "--heroui-default-200": "130 8% 12.55%",
       "--heroui-default-300": "130 8% 15.69%",
       "--heroui-default-400": "130 8% 19.22%",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

Aligns the PostHog client configuration with the recommended managed-reverse-proxy setup: send analytics traffic to `https://z.openhands.dev` (the proxy) while keeping `ui_host` pointed at `https://us.posthog.com` so in-PostHog links resolve correctly. Also switches `person_profiles` to `'always'` so anonymous traffic still creates profiles.

## Summary

- `src/components/providers/posthog-wrapper.tsx`: switch `api_host` from `https://us.i.posthog.com` to `https://z.openhands.dev`, add `ui_host: 'https://us.posthog.com'`, change `person_profiles` from `'identified_only'` to `'always'`.
- `src/services/telemetry.ts`: add `person_profiles: 'always'` to match. `api_host` / `ui_host` here already defaulted to the proxy via `VITE_POSTHOG_HOST` / `VITE_POSTHOG_UI_HOST`.

## Issue Number

N/A

## How to Test

1. `npm run typecheck` — passes.
2. `npm run dev` (or `npm run build` + serve), open the app with analytics enabled, and confirm in DevTools that PostHog requests go to `z.openhands.dev/*` instead of `us.i.posthog.com/*`.
3. Verify in the PostHog UI that links/redirects render against `us.posthog.com` (e.g. "View in PostHog" from feature flag toolbar) and that anonymous sessions create person profiles.

## Video/Screenshots

N/A — config-only change, no UI affected.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR was opened by an AI agent (OpenHands) on behalf of @rbren.