### PR TITLE
Hide OAuth-only MCP marketplace entries

### DIFF
--- a/__tests__/routes/mcp-page.test.tsx
+++ b/__tests__/routes/mcp-page.test.tsx
@@ -128,6 +128,22 @@ describe("MCPPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("does not show OAuth-only Atlassian/Jira MCP entries in the local install marketplace", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(buildSettings());
+
+    renderPage();
+
+    const search = await screen.findByTestId("mcp-search-input");
+    fireEvent.change(search, { target: { value: "jira" } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mcp-marketplace-empty")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("mcp-marketplace-card-atlassian"),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps installed custom servers visible and searchable even when they are not in the marketplace catalog", async () => {
     vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
       buildSettings({

--- a/__tests__/utils/mcp-marketplace-utils.test.ts
+++ b/__tests__/utils/mcp-marketplace-utils.test.ts
@@ -3,6 +3,7 @@ import {
   findCatalogEntryForServer,
   findInstalledMatch,
   getDefaultMcpTransport,
+  getInstallableMcpMarketplaceCatalog,
   getInstallableMcpConnectionOption,
   getMcpMarketplaceCatalog,
   installedServerMatchesQuery,
@@ -132,7 +133,7 @@ describe("getInstallableMcpConnectionOption", () => {
 });
 
 describe("getMcpMarketplaceCatalog", () => {
-  it("excludes OAuth-only MCP entries that the local install modal cannot install", () => {
+  it("keeps OAuth-only MCP entries for installed-server metadata", () => {
     const oauthOnlyEntry: Parameters<
       typeof getMcpMarketplaceCatalog
     >[0][number] = {
@@ -151,6 +152,34 @@ describe("getMcpMarketplaceCatalog", () => {
     };
 
     const catalog = getMcpMarketplaceCatalog([oauthOnlyEntry, slackEntry]);
+
+    expect(catalog.map((entry) => entry.id)).toEqual(["oauth-only", "slack"]);
+  });
+});
+
+describe("getInstallableMcpMarketplaceCatalog", () => {
+  it("excludes OAuth-only MCP entries that the local install modal cannot install", () => {
+    const oauthOnlyEntry: Parameters<
+      typeof getInstallableMcpMarketplaceCatalog
+    >[0][number] = {
+      ...slackEntry,
+      id: "oauth-only",
+      connectionOptions: [
+        {
+          id: "oauth",
+          provider: "mcp",
+          auth: { strategy: "oauth2" },
+          transport: { kind: "shttp", url: "https://example.com/mcp" },
+        } as Parameters<
+          typeof getInstallableMcpMarketplaceCatalog
+        >[0][number]["connectionOptions"][number],
+      ],
+    };
+
+    const catalog = getInstallableMcpMarketplaceCatalog([
+      oauthOnlyEntry,
+      slackEntry,
+    ]);
 
     expect(catalog.map((entry) => entry.id)).toEqual(["slack"]);
   });

--- a/__tests__/utils/mcp-marketplace-utils.test.ts
+++ b/__tests__/utils/mcp-marketplace-utils.test.ts
@@ -131,6 +131,31 @@ describe("getInstallableMcpConnectionOption", () => {
   });
 });
 
+describe("getMcpMarketplaceCatalog", () => {
+  it("excludes OAuth-only MCP entries that the local install modal cannot install", () => {
+    const oauthOnlyEntry: Parameters<
+      typeof getMcpMarketplaceCatalog
+    >[0][number] = {
+      ...slackEntry,
+      id: "oauth-only",
+      connectionOptions: [
+        {
+          id: "oauth",
+          provider: "mcp",
+          auth: { strategy: "oauth2" },
+          transport: { kind: "shttp", url: "https://example.com/mcp" },
+        } as Parameters<
+          typeof getMcpMarketplaceCatalog
+        >[0][number]["connectionOptions"][number],
+      ],
+    };
+
+    const catalog = getMcpMarketplaceCatalog([oauthOnlyEntry, slackEntry]);
+
+    expect(catalog.map((entry) => entry.id)).toEqual(["slack"]);
+  });
+});
+
 describe("marketplaceEntryMatchesQuery", () => {
   it("matches by name (case-insensitive)", () => {
     expect(marketplaceEntryMatchesQuery(slackEntry, "slack")).toBe(true);

--- a/src/components/features/mcp-page/marketplace-section.tsx
+++ b/src/components/features/mcp-page/marketplace-section.tsx
@@ -5,8 +5,8 @@ import {
   type IntegrationCatalogEntry as MarketplaceEntry,
 } from "@openhands/extensions/integrations";
 import {
+  getInstallableMcpMarketplaceCatalog,
   getMarketplaceEntriesByPopularity,
-  getMcpMarketplaceCatalog,
   marketplaceEntryMatchesQuery,
 } from "#/utils/mcp-marketplace-utils";
 import { MarketplaceCard } from "./marketplace-card";
@@ -30,7 +30,7 @@ export function MarketplaceSection({
   const { t } = useTranslation("openhands");
 
   const visibleEntries = getMarketplaceEntriesByPopularity(
-    getMcpMarketplaceCatalog(MCP_MARKETPLACE),
+    getInstallableMcpMarketplaceCatalog(MCP_MARKETPLACE),
   ).filter((entry) => marketplaceEntryMatchesQuery(entry, query));
 
   return (

--- a/src/utils/mcp-marketplace-utils.ts
+++ b/src/utils/mcp-marketplace-utils.ts
@@ -61,7 +61,7 @@ export function getDefaultMcpTransport(
 export function getMcpMarketplaceCatalog(
   catalog: MarketplaceEntry[],
 ): MarketplaceEntry[] {
-  return catalog.filter((entry) => !!getDefaultMcpConnectionOption(entry));
+  return catalog.filter((entry) => !!getInstallableMcpConnectionOption(entry));
 }
 
 const tryUrl = (raw: string): URL | null => {

--- a/src/utils/mcp-marketplace-utils.ts
+++ b/src/utils/mcp-marketplace-utils.ts
@@ -61,6 +61,12 @@ export function getDefaultMcpTransport(
 export function getMcpMarketplaceCatalog(
   catalog: MarketplaceEntry[],
 ): MarketplaceEntry[] {
+  return catalog.filter((entry) => !!getDefaultMcpConnectionOption(entry));
+}
+
+export function getInstallableMcpMarketplaceCatalog(
+  catalog: MarketplaceEntry[],
+): MarketplaceEntry[] {
   return catalog.filter((entry) => !!getInstallableMcpConnectionOption(entry));
 }
 


### PR DESCRIPTION
HUMAN:

The Jira MCP connector doesn't work in Agent Canvas, this PR helps to deal with that. The issue is around OAuth that Agent Canvas doesn't support.

- [x] A human has tested these changes.

AGENT:

## Summary
- Hide OAuth-only MCP catalog entries from the local MCP install marketplace.
- Add utility coverage proving OAuth-only MCP entries are excluded from the installable catalog.
- Add route-level coverage for the Jira/Atlassian search case so the dead install tile does not reappear.

## Why

The Atlassian/Jira marketplace entry points at the hosted Atlassian MCP server, which requires OAuth. Agent Canvas currently supports static local MCP installs, but does not have the OAuth connector install flow wired up for that entry. Showing it as installable leaves users at a no-op install path.

This keeps the local marketplace limited to entries the install modal can actually configure until OAuth-backed MCP installation is supported.

## Issue Number

Related to #1255.

## How to Test

- npm exec vitest run __tests__/utils/mcp-marketplace-utils.test.ts __tests__/constants/extensions-catalogs.test.ts __tests__/routes/mcp-page.test.tsx
- npm exec prettier -- --check src/utils/mcp-marketplace-utils.ts __tests__/utils/mcp-marketplace-utils.test.ts __tests__/routes/mcp-page.test.tsx
- Pre-commit hook also ran eslint, staged typecheck, translation completeness, and prettier for the staged files.