### PR TITLE
fix: resolve OpenHands model alias against the API key when saving an LLM profile (#1111)

### DIFF
--- a/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
+++ b/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
+import { http, HttpResponse } from "msw";
 import { AxiosError } from "axios";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "test-utils";
+import { server } from "#/mocks/node";
 import {
   LlmSettingsLocalView,
   shouldReapplyProfileAfterSave,
@@ -631,6 +633,122 @@ describe("LlmSettingsLocalView", () => {
       expect(savedLlm.temperature).toBe(0.7);
       expect(savedLlm.model).toBe("anthropic/claude-opus-4-5-20251101");
       expect(savedLlm.api_key).toBe("gAAAA_encrypted_key");
+    });
+  });
+
+  describe("model resolution on save", () => {
+    it("resolves an OpenHands alias to a callable catalog id when a key is entered", async () => {
+      // Arrange — a profile whose model is the bare OpenHands alias that the
+      // proxy rejects at runtime (issue #1111). The proxy's /v1/models lists the
+      // underlying-provider-prefixed id instead. When the user enters a usable
+      // API key, the save flow should resolve the alias to that callable id.
+      const user = userEvent.setup();
+      vi.mocked(ProfilesService.getProfile).mockResolvedValue({
+        name: "gpt-4-profile",
+        api_key_set: true,
+        config: {
+          model: "openhands/claude-sonnet-4-5",
+          api_key: "gAAAA_encrypted_key",
+          base_url: OPENHANDS_LLM_PROXY_BASE_URL,
+        },
+      });
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      let modelsCalls = 0;
+      let capturedAuth: string | null = null;
+      server.use(
+        http.get(
+          "https://llm-proxy.app.all-hands.dev/v1/models",
+          ({ request }) => {
+            modelsCalls += 1;
+            capturedAuth = request.headers.get("authorization");
+            return HttpResponse.json({
+              data: [
+                { id: "anthropic/claude-sonnet-4-5" },
+                { id: "anthropic/claude-haiku-4-5" },
+              ],
+            });
+          },
+        ),
+      );
+
+      renderWithProviders(<LlmSettingsLocalView />);
+
+      // Act — open the profile, force the Basic tab, type a fresh API key, save.
+      await user.click(screen.getAllByTestId("profile-menu-trigger")[0]);
+      await user.click(screen.getByTestId("profile-edit"));
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-name-input")).toHaveValue(
+          "gpt-4-profile",
+        );
+      });
+      await user.click(await screen.findByTestId("sdk-section-basic-toggle"));
+      const apiKeyInput = await screen.findByTestId("llm-api-key-input");
+      await user.clear(apiKeyInput);
+      await user.type(apiKeyInput, "sk-fresh-key");
+      await waitFor(() => {
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled();
+      });
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      // Assert — the key's /v1/models was queried with the typed bearer token,
+      // and the persisted model is the resolved, callable catalog id.
+      await waitFor(() => expect(mockSaveMutateAsync).toHaveBeenCalled());
+      expect(modelsCalls).toBe(1);
+      expect(capturedAuth).toBe("Bearer sk-fresh-key");
+
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.model).toBe("openhands/anthropic/claude-sonnet-4-5");
+    });
+
+    it("does not query /v1/models when no fresh API key is entered", async () => {
+      // Arrange — edit a profile and change only a non-key field. With no usable
+      // raw credential, resolution must be skipped (the preserved key is the
+      // encrypted token) and the model persisted unchanged.
+      const user = userEvent.setup();
+      vi.mocked(ProfilesService.getProfile).mockResolvedValue({
+        name: "gpt-4-profile",
+        api_key_set: true,
+        config: {
+          model: "openhands/claude-sonnet-4-5",
+          api_key: "gAAAA_encrypted_key",
+          base_url: OPENHANDS_LLM_PROXY_BASE_URL,
+        },
+      });
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      let modelsCalls = 0;
+      server.use(
+        http.get("https://llm-proxy.app.all-hands.dev/v1/models", () => {
+          modelsCalls += 1;
+          return HttpResponse.json({ data: [] });
+        }),
+      );
+
+      renderWithProviders(<LlmSettingsLocalView />);
+
+      await user.click(screen.getAllByTestId("profile-menu-trigger")[0]);
+      await user.click(screen.getByTestId("profile-edit"));
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-name-input")).toHaveValue(
+          "gpt-4-profile",
+        );
+      });
+      await user.click(await screen.findByTestId("sdk-section-all-toggle"));
+      const temperatureInput = await screen.findByTestId(
+        "sdk-settings-llm.temperature",
+      );
+      await user.clear(temperatureInput);
+      await user.type(temperatureInput, "0.5");
+      await waitFor(() => {
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled();
+      });
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      await waitFor(() => expect(mockSaveMutateAsync).toHaveBeenCalled());
+      expect(modelsCalls).toBe(0);
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.model).toBe("openhands/claude-sonnet-4-5");
     });
   });
 });

--- a/__tests__/utils/resolve-openhands-model.test.ts
+++ b/__tests__/utils/resolve-openhands-model.test.ts
@@ -62,4 +62,37 @@ describe("chooseOpenHandsFallbackModel", () => {
 
     expect(chooseOpenHandsFallbackModel("gpt-4o", available)).toBe("GPT-4O");
   });
+
+  it("resolves a bare alias to a provider-prefixed catalog id", () => {
+    // The proxy's /v1/models lists underlying-provider-prefixed ids while the
+    // dropdown offers the bare verified name. See issue #1111.
+    const available = [
+      "anthropic/claude-sonnet-4-5",
+      "anthropic/claude-haiku-4-5",
+    ];
+
+    expect(chooseOpenHandsFallbackModel("claude-sonnet-4-5", available)).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+  });
+
+  it("resolves a bare alias to the latest dated provider-prefixed id", () => {
+    const available = [
+      "anthropic/claude-sonnet-4-5-20250101",
+      "anthropic/claude-sonnet-4-5-20250929",
+      "anthropic/claude-opus-4-5-20251101",
+    ];
+
+    expect(chooseOpenHandsFallbackModel("claude-sonnet-4-5", available)).toBe(
+      "anthropic/claude-sonnet-4-5-20250929",
+    );
+  });
+
+  it("prefers an exact bare id over a provider-prefixed variant", () => {
+    const available = ["claude-sonnet-4-5", "anthropic/claude-sonnet-4-5"];
+
+    expect(chooseOpenHandsFallbackModel("claude-sonnet-4-5", available)).toBe(
+      "claude-sonnet-4-5",
+    );
+  });
 });

--- a/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
+++ b/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
@@ -39,6 +39,8 @@ import {
   OPENHANDS_LLM_PROXY_BASE_URL,
   isOpenHandsProviderModel,
 } from "#/utils/openhands-llm";
+import { extractModelAndProvider } from "#/utils/extract-model-and-provider";
+import { resolveOpenHandsModelForApiKey } from "#/utils/resolve-openhands-model";
 
 type ViewMode = "list" | "create" | "edit";
 
@@ -287,6 +289,38 @@ export function LlmSettingsLocalView() {
     if (!model) {
       displayErrorToast(t(I18nKey.SETTINGS$MODEL_REQUIRED));
       return;
+    }
+
+    // Resolve the chosen model against the API key before persisting, so we
+    // don't save an OpenHands alias the key isn't entitled to call — otherwise
+    // the first conversation fails at runtime with a LiteLLM
+    // "Invalid model name" error (see issue #1111). Mirrors the onboarding
+    // flow's `persistAsProfile`.
+    //
+    // We only resolve with a freshly entered key (a new profile, or a replaced
+    // key). Resolution calls the provider's `/v1/models` with that key as a
+    // bearer token, which only works with a usable raw credential — in edit mode
+    // the preserved `api_key` is the agent-server's encrypted token, so we skip
+    // resolution when the key is unchanged. Resolution is best-effort:
+    // `resolveOpenHandsModelForApiKey` returns the requested model unchanged on
+    // any failure.
+    const existingApiKey =
+      typeof baseConfig.api_key === "string" ? baseConfig.api_key : "";
+    const candidateApiKey =
+      typeof llmConfig.api_key === "string" ? llmConfig.api_key.trim() : "";
+    const hasFreshApiKey =
+      candidateApiKey !== "" && candidateApiKey !== existingApiKey;
+    const { provider, model: providerModel } = extractModelAndProvider(model);
+    if (hasFreshApiKey && provider && providerModel) {
+      const baseUrlForResolve =
+        typeof llmConfig.base_url === "string" ? llmConfig.base_url : undefined;
+      const resolvedModelId = await resolveOpenHandsModelForApiKey({
+        provider,
+        requestedModel: providerModel,
+        apiKey: candidateApiKey,
+        baseUrl: baseUrlForResolve,
+      });
+      llmConfig.model = `${provider}/${resolvedModelId}`;
     }
 
     const trimmedName = profileName.trim();

--- a/src/utils/resolve-openhands-model.ts
+++ b/src/utils/resolve-openhands-model.ts
@@ -44,14 +44,19 @@ export const parseModelIdsFromModelsResponse = (payload: unknown): string[] => {
   return Array.from(unique);
 };
 
+const lastModelSegment = (model: string): string =>
+  model.split("/").pop() ?? model;
+
 export const chooseOpenHandsFallbackModel = (
   requestedModel: string,
   availableModels: string[],
 ): string | null => {
+  // 1. Exact id match.
   if (availableModels.includes(requestedModel)) {
     return requestedModel;
   }
 
+  // 2. Case-insensitive id match.
   const caseInsensitiveMatch = availableModels.find(
     (model) => model.toLowerCase() === requestedModel.toLowerCase(),
   );
@@ -59,8 +64,32 @@ export const chooseOpenHandsFallbackModel = (
     return caseInsensitiveMatch;
   }
 
+  // 3. Provider-prefixed match. A key's `/v1/models` catalog frequently lists
+  //    ids with an underlying-provider prefix (e.g. `anthropic/claude-sonnet-4-5`)
+  //    while the verified OpenHands list / dropdown offers the bare name
+  //    (`claude-sonnet-4-5`). Compare the trailing path segment so the bare
+  //    request still resolves to the callable prefixed id instead of falling
+  //    through and persisting the unusable alias.
+  const requestedSegment = lastModelSegment(requestedModel).toLowerCase();
+  const segmentMatch = availableModels.find(
+    (model) => lastModelSegment(model).toLowerCase() === requestedSegment,
+  );
+  if (segmentMatch) {
+    return segmentMatch;
+  }
+
+  // 4. Dated variants — match either the full id or the trailing segment
+  //    (e.g. request `claude-sonnet-4-5` -> `claude-sonnet-4-5-20250929` or
+  //    `anthropic/claude-sonnet-4-5-20250929`). Prefer the newest by descending
+  //    sort.
+  const datedPrefix = `${requestedModel}-`;
+  const datedSegmentPrefix = `${lastModelSegment(requestedModel)}-`;
   const datedMatches = availableModels
-    .filter((model) => model.startsWith(`${requestedModel}-`))
+    .filter(
+      (model) =>
+        model.startsWith(datedPrefix) ||
+        lastModelSegment(model).startsWith(datedSegmentPrefix),
+    )
     .sort((a, b) => b.localeCompare(a));
 
   return datedMatches[0] ?? null;


### PR DESCRIPTION
## Summary

This is a **follow-up stacked on top of #1139** (base: `fix/onboarding-model-validation`) that closes the remaining gap for issue **#1111**.

#1139 fixes the **first-run onboarding** path. But the same `Invalid model name` failure happens on the **manual LLM-profile path** — Settings → LLM Profiles → create/edit a profile, pick the **OpenHands** provider + a verified model (e.g. Sonnet 4.5). That flow (`llm-settings-local-view.tsx::handleSave`) persisted the bare alias verbatim, so the first conversation failed at runtime with:

```
litellm.BadRequestError: Litellm_proxyException - /chat/completions: Invalid model name passed in model=claude-sonnet-4-5. Call `/v1/models` to view available models for your key.
```

Root-cause trace and reproduction are documented in the issue: https://github.com/OpenHands/agent-canvas/issues/1111#issuecomment-4821426244

## What this PR adds (the delta on top of #1139)

1. **Apply resolution to the manual profile-save path.** `handleSave` now runs `resolveOpenHandsModelForApiKey` (the helper #1139 introduced for onboarding) before persisting, so a model that the key can't call is resolved to a callable catalog id instead of being saved as-is.
   - Resolution runs **only when a fresh API key is entered** (new profile, or the key is replaced). In edit mode the preserved `api_key` is the agent-server's encrypted token, which can't be used as a bearer credential — so we skip resolution when the key is unchanged (no wasted `/v1/models` round-trip).

2. **Harden `chooseOpenHandsFallbackModel` for provider-prefixed catalog ids.** The previous matcher only handled exact / case-insensitive / date-suffixed (`<model>-<date>`) variants. A key's `/v1/models` commonly lists **underlying-provider-prefixed** ids (e.g. `anthropic/claude-sonnet-4-5`) while the dropdown offers the bare name (`claude-sonnet-4-5`); none of the old branches matched those, so the resolver would fall through and persist the unusable alias. The matcher now also matches on the trailing path segment (exact and date-suffixed), e.g. `claude-sonnet-4-5` → `anthropic/claude-sonnet-4-5`.

   > ⚠️ @chuckbutkus / @FraterCCCLXIII — worth confirming the **public** proxy's `/v1/models` id shape. On a real LiteLLM proxy I inspected, the catalog is `anthropic/…`-prefixed, which the original matcher in #1139 would not resolve. This hardening covers both bare and prefixed shapes.

## Tests

- `__tests__/utils/resolve-openhands-model.test.ts` — new cases for provider-prefixed resolution (exact, latest-dated, and "prefer exact bare over prefixed").
- `__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx` — a real end-to-end (MSW) test that entering a key on a profile with a bare OpenHands alias queries `/v1/models` with the typed bearer token and persists the resolved `openhands/anthropic/claude-sonnet-4-5`; plus a negative test that no `/v1/models` call happens when the key is unchanged.

All 24 tests in the touched component suite pass; `npm run typecheck` is clean. (Note: the test file has 3 pre-existing `prettier/prettier` lint errors inherited from the base branch, unrelated to this change.)

## Suggested handling

Since this is stacked on your branch, the cleanest path is to **merge/cherry-pick these commits into #1139** so #1111 is fully fixed in one PR. Happy to adjust the approach (e.g. retarget to `main`, or fold the matcher hardening directly into your `resolve-openhands-model.ts`) — whatever's easiest for you.

Refs #1111. Complements #1139.

---
_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6f29e4de-4dcb-4163-a8b5-50cb51b06d6e)