### PR TITLE
chore: update OpenHands dependency pins

### DIFF
--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -64,7 +64,7 @@ jobs:
             cancel-in-progress: false
         steps:
             - name: Run issue duplicate check
-              uses: OpenHands/extensions/plugins/issue-duplicate-checker@fb020c71eb8e7cd2678f0251ab24327d3738da7d
+              uses: OpenHands/extensions/plugins/issue-duplicate-checker@6e46834290cf90864361b6900061550377bd16b9
               with:
                   mode: issue-check
                   repository: ${{ github.repository }}
@@ -84,7 +84,7 @@ jobs:
             cancel-in-progress: false
         steps:
             - name: Auto-close aged duplicate candidates
-              uses: OpenHands/extensions/plugins/issue-duplicate-checker@fb020c71eb8e7cd2678f0251ab24327d3738da7d
+              uses: OpenHands/extensions/plugins/issue-duplicate-checker@6e46834290cf90864361b6900061550377bd16b9
               with:
                   mode: auto-close
                   repository: ${{ github.repository }}

--- a/.github/workflows/remove-duplicate-candidate-label.yml
+++ b/.github/workflows/remove-duplicate-candidate-label.yml
@@ -25,7 +25,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Remove duplicate-candidate label
-              uses: OpenHands/extensions/plugins/issue-duplicate-checker@fb020c71eb8e7cd2678f0251ab24327d3738da7d
+              uses: OpenHands/extensions/plugins/issue-duplicate-checker@6e46834290cf90864361b6900061550377bd16b9
               with:
                   mode: remove-label
                   github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,7 +532,7 @@ When adding code that needs a new string, decide up front which rule it falls un
   - `/api/automation/*` → automation backend (:18001)
   - `/api/*`, `/sockets`, etc. → agent server (:18000)
   - `/*` (default) → frontend server (:3001), either Vite or static depending on launcher mode
-  - Environment variables: `PORT` (ingress port, default: 8000), `OH_AUTOMATION_GIT_REF` (git ref, overrides default version), `OH_AUTOMATION_VERSION` (default: `1.0.0a3`), `AUTOMATION_LOCAL_API_KEY` (optional, use a fixed key; default: persisted generated key), `OH_AUTOMATION_API_KEY_PATH` (override the persisted default key path)
+  - Environment variables: `PORT` (ingress port, default: 8000), `OH_AUTOMATION_GIT_REF` (git ref, overrides default version), `OH_AUTOMATION_VERSION` (default: `1.1.0`), `AUTOMATION_LOCAL_API_KEY` (optional, use a fixed key; default: persisted generated key), `OH_AUTOMATION_API_KEY_PATH` (override the persisted default key path)
   - `scripts/check-sdk-version-sync.mjs` checks the released `openhands-automation` package against `versions.agentServer` in `config/defaults.json`; these must always match — if the automation package's SDK dependencies differ from `agentServer`, the check fails.
   - Access points: `http://localhost:8000/` (main UI), `http://localhost:8000/api/automation/docs` (API docs)
   - Security: `AUTOMATION_LOCAL_API_KEY` defaults to a generated key persisted across restarts because static frontend builds bake it into `VITE_AUTOMATION_API_KEY`. Set the env var explicitly to rotate or pin it. The cipher key (`OH_SECRET_KEY`) is persisted at `~/.openhands/agent-canvas/secret-key.txt` (same file used by `docker/entrypoint.sh`); both modes share the same key automatically when using the same `~/.openhands` directory.

--- a/__tests__/constants/extensions-catalogs.test.ts
+++ b/__tests__/constants/extensions-catalogs.test.ts
@@ -3,6 +3,7 @@ import { AUTOMATION_CATALOG } from "@openhands/extensions/automations";
 import { INTEGRATION_CATALOG } from "@openhands/extensions/integrations";
 import {
   getDefaultMcpTransport,
+  getInstallableMcpConnectionOption,
   getMcpMarketplaceCatalog,
 } from "#/utils/mcp-marketplace-utils";
 
@@ -40,13 +41,15 @@ describe("OpenHands extensions catalogs", () => {
     expect(getDefaultMcpTransport(linear)).toEqual({
       kind: "shttp",
       url: "https://mcp.linear.app/mcp",
-      apiKeyOptional: true,
     });
     expect(linear.docsUrl).toBe("https://linear.app/docs/mcp");
-    const mcpOption = linear.connectionOptions.find(
-      (option) => option.transport?.kind === "shttp",
-    );
+    const mcpOption = getInstallableMcpConnectionOption(linear);
     expect(mcpOption?.auth.strategy).toBe("bearer");
+    expect(mcpOption?.transport).toEqual({
+      kind: "shttp",
+      url: "https://mcp.linear.app/mcp",
+      apiKeyOptional: true,
+    });
     expect(
       linear.connectionOptions.some((option) => option.transport?.kind === "sse"),
     ).toBe(false);

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -4,7 +4,7 @@
   "versions": {
     "agentServer": "1.29.3",
     "agentCanvas": "1.1.0",
-    "automation": "1.0.0a13"
+    "automation": "1.1.0"
   },
 
   "compatibility": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/extensions": "0.7.0",
+        "@openhands/extensions": "0.7.2",
         "@openhands/typescript-client": "1.28.0",
         "@react-router/node": "7.17.0",
         "@react-router/serve": "7.17.0",
@@ -3467,9 +3467,10 @@
       "license": "MIT"
     },
     "node_modules/@openhands/extensions": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.7.0.tgz",
-      "integrity": "sha512-p0gY8bBR5Kmyu9I+/YYy0MlvO5D92KQYbocv3/W1Foy/fkcJv92iCultz66Vczpr42lzl+mc0FJ1/xO9/1+JSQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.7.2.tgz",
+      "integrity": "sha512-Rqk4y472Eug/QuBAkBaRSGCeZIX4noED5bsMg9MW+yVw1T99VMIGuR50T7Tesu5agtXxj5GLO15hSdF9HLmI9A==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/extensions": "0.7.0",
+    "@openhands/extensions": "0.7.2",
     "@openhands/typescript-client": "1.28.0",
     "@react-router/node": "7.17.0",
     "@react-router/serve": "7.17.0",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

E2E tests should suffice for this.

- [x] A human has tested these changes.

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

Validation performed:

```text
node scripts/check-sdk-version-sync.mjs
# Result: All SDK versions are in sync.

npm test -- __tests__/constants/extensions-catalogs.test.ts __tests__/scripts/check-sdk-version-sync.test.ts
# Result: 2 test files passed, 24 tests passed.

npm run typecheck
# Result: passed.

npm run build
# Result: passed.
```

---

## Why

Keep Agent Canvas aligned with the latest published OpenHands dependency versions and extension workflow refs currently used by the repository.

## Summary

- Bumped `@openhands/extensions` from `0.7.0` to `0.7.2` and refreshed the lockfile.
- Bumped the default `openhands-automation` version from `1.0.0a13` to `1.1.0`, keeping SDK dependency versions aligned with `openhands-agent-server` `1.29.3`.
- Updated pinned `OpenHands/extensions` issue-duplicate-checker workflow refs to the latest main SHA and adjusted the Linear catalog regression test for the new OAuth-first catalog shape.

## Issue Number

N/A

## How to Test

Run:

```bash
node scripts/check-sdk-version-sync.mjs
npm test -- __tests__/constants/extensions-catalogs.test.ts __tests__/scripts/check-sdk-version-sync.test.ts
npm run typecheck
npm run build
```

## Video/Screenshots

N/A — dependency/config/test-only update with no UI behavior change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

`@openhands/typescript-client` and the SDK/agent-server package pins were checked and were already at their latest published versions (`1.28.0` and `1.29.3`, respectively).

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/02a45a95-24f8-43aa-9c1f-92603d05f81e)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.29.3-python` |
| **Automation** | `openhands-automation==1.1.0` |
| **Commit** | `ea402bba2c09e0e7b0f0328141922b2ce2d6edaf` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-ea402bb
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-ea402bb
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-ea402bb-amd64
ghcr.io/openhands/agent-canvas:chore-update-openhands-dependencies-amd64
ghcr.io/openhands/agent-canvas:pr-1535-amd64
ghcr.io/openhands/agent-canvas:sha-ea402bb-arm64
ghcr.io/openhands/agent-canvas:chore-update-openhands-dependencies-arm64
ghcr.io/openhands/agent-canvas:pr-1535-arm64
ghcr.io/openhands/agent-canvas:sha-ea402bb
ghcr.io/openhands/agent-canvas:chore-update-openhands-dependencies
ghcr.io/openhands/agent-canvas:pr-1535
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-ea402bb`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-ea402bb-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->