### PR TITLE
feat: instrument PostHog analytics for the onboarding funnel

### DIFF
--- a/__tests__/components/onboarding/onboarding-modal.test.tsx
+++ b/__tests__/components/onboarding/onboarding-modal.test.tsx
@@ -20,6 +20,13 @@ import { DEFAULT_SETTINGS } from "#/services/settings";
 
 const llmSettingsScreenMock = vi.hoisted(() => vi.fn());
 const getServerInfoMock = vi.hoisted(() => vi.fn());
+const captureMock = vi.hoisted(() => vi.fn());
+
+// useTracking depends on PostHog's `usePostHog`. Mock that underlying service
+// (not useTracking itself) so the onboarding analytics events can be asserted.
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}));
 
 // Both the backend status badge in the embedded edit form and the
 // step-1 health probe ride on `useBackendsHealth`, which resolves
@@ -194,6 +201,7 @@ function renderModal(onClose = vi.fn()) {
 
 beforeEach(() => {
   window.localStorage.clear();
+  window.sessionStorage.clear();
   vi.stubEnv("VITE_BACKEND_BASE_URL", "http://localhost:9000");
   vi.stubEnv("VITE_SESSION_API_KEY", "session-key");
   __resetActiveStoreForTests();
@@ -228,6 +236,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   window.localStorage.clear();
+  window.sessionStorage.clear();
   vi.unstubAllEnvs();
   __resetActiveStoreForTests();
 });
@@ -973,5 +982,152 @@ describe("OnboardingModal", () => {
       }),
     );
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe("analytics events", () => {
+    // Surface only the captures for a given event; a session emits several.
+    const eventCalls = (event: string) =>
+      captureMock.mock.calls.filter(([name]) => name === event);
+
+    beforeEach(() => {
+      // Grant analytics consent so events pass useTracking's consent gate;
+      // the outer beforeEach seeds settings with consent withheld.
+      vi.spyOn(SettingsService, "getSettings").mockResolvedValue({
+        ...DEFAULT_SETTINGS,
+        agent_settings: { ...DEFAULT_SETTINGS.agent_settings, llm: {} },
+        user_consents_to_analytics: true,
+      });
+    });
+
+    it("captures onboarding_started once per session even across a remount", async () => {
+      // Arrange + act: open onboarding and let the first mount settle (a Step
+      // Viewed capture confirms consent resolved and backend health settled).
+      const firstMount = renderModal();
+      await waitFor(() =>
+        expect(
+          eventCalls("onboarding_step_viewed").length,
+        ).toBeGreaterThanOrEqual(1),
+      );
+
+      // Act: tear the modal down and mount it again in the same session. The
+      // remounted modal re-emits Step Viewed from a fresh ref, so waiting for
+      // the second one proves the Started effect had its chance to re-fire.
+      firstMount.unmount();
+      renderModal();
+      await waitFor(() =>
+        expect(
+          eventCalls("onboarding_step_viewed").length,
+        ).toBeGreaterThanOrEqual(2),
+      );
+
+      // Assert: the sessionStorage guard kept Started at a single capture.
+      expect(eventCalls("onboarding_started")).toHaveLength(1);
+    });
+
+    it("captures no onboarding events while analytics consent is not granted", async () => {
+      // Arrange: withhold consent.
+      vi.spyOn(SettingsService, "getSettings").mockResolvedValue({
+        ...DEFAULT_SETTINGS,
+        agent_settings: { ...DEFAULT_SETTINGS.agent_settings, llm: {} },
+        user_consents_to_analytics: false,
+      });
+
+      // Act: open onboarding and let it settle on the first step.
+      renderModal();
+      await waitForConfiguredBackendToBeSkipped();
+
+      // Assert: nothing reached PostHog.
+      expect(captureMock).not.toHaveBeenCalled();
+    });
+
+    it("captures onboarding_step_viewed for each step as the user advances", async () => {
+      // Arrange: the healthy backend is skipped, so the user lands on the
+      // agent step (index 0 of the 3-step flow).
+      renderModal();
+      const user = userEvent.setup();
+      await waitForConfiguredBackendToBeSkipped();
+
+      // Assert: the entry step carries the full funnel identity.
+      await waitFor(() =>
+        expect(captureMock).toHaveBeenCalledWith(
+          "onboarding_step_viewed",
+          expect.objectContaining({
+            step: "agent",
+            step_index: 0,
+            total_steps: 3,
+            agent: "openhands",
+          }),
+        ),
+      );
+
+      // Act: advance to the next step.
+      await completeAgentStep(user);
+
+      // Assert: the new step is captured too — tracking follows transitions,
+      // not just the initial mount.
+      await waitFor(() =>
+        expect(captureMock).toHaveBeenCalledWith(
+          "onboarding_step_viewed",
+          expect.objectContaining({
+            step: "setup",
+            step_index: 1,
+            total_steps: 3,
+          }),
+        ),
+      );
+    });
+
+    it("captures onboarding_completed when a conversation is launched from the final step", async () => {
+      // Arrange: walk through to the final Say Hello step.
+      renderModal();
+      const user = userEvent.setup();
+      await waitForConfiguredBackendToBeSkipped();
+      await completeAgentStep(user);
+      await user.click(screen.getByTestId("onboarding-llm-next"));
+      await waitFor(() =>
+        expect(screen.getByTestId("onboarding-slide-2")).toHaveAttribute(
+          "data-active",
+          "true",
+        ),
+      );
+
+      // Act: launch from the final step. The stubbed recommended-automation
+      // launcher invokes the same onLaunched completion callback as Say Hello.
+      const recommendations = screen.getByTestId(
+        "onboarding-recommended-automations",
+      );
+      await user.click(
+        within(recommendations).getByRole("button", {
+          name: "launch recommended automation",
+        }),
+      );
+
+      // Assert.
+      expect(captureMock).toHaveBeenCalledWith(
+        "onboarding_completed",
+        expect.objectContaining({ agent: "openhands" }),
+      );
+    });
+
+    it("captures onboarding_skipped with the current step when the user skips", async () => {
+      // Arrange: healthy backend skipped → user is on the agent step (0 of 3).
+      renderModal();
+      const user = userEvent.setup();
+      await waitForConfiguredBackendToBeSkipped();
+
+      // Act: skip out of onboarding.
+      await user.click(screen.getByTestId("onboarding-skip"));
+
+      // Assert.
+      expect(captureMock).toHaveBeenCalledWith(
+        "onboarding_skipped",
+        expect.objectContaining({
+          step: "agent",
+          step_index: 0,
+          total_steps: 3,
+          agent: "openhands",
+        }),
+      );
+    });
   });
 });

--- a/src/components/features/onboarding/onboarding-modal.tsx
+++ b/src/components/features/onboarding/onboarding-modal.tsx
@@ -11,6 +11,8 @@ import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";
 import { useActiveBackendContext } from "#/contexts/active-backend-context";
 import { useBackendsHealth } from "#/hooks/query/use-backends-health";
+import { useSettings } from "#/hooks/query/use-settings";
+import { useTracking } from "#/hooks/use-tracking";
 import { OnboardingProgressBar } from "./onboarding-progress-bar";
 import {
   ChooseAgentStep,
@@ -44,6 +46,14 @@ const PHASE_ORDER_WITHOUT_BACKEND: readonly OnboardingPhase[] = [
   "setup",
   "hello",
 ];
+
+/**
+ * sessionStorage flag marking that the one-time "onboarding started" analytics
+ * event has already been captured for this browser session. It survives
+ * rerenders, remounts and the lazy/Suspense flip so the event fires at most
+ * once per onboarding session.
+ */
+const ONBOARDING_STARTED_TRACKED_KEY = "openhands-onboarding-started";
 
 interface SlideProps {
   /** Index of this slide in the step sequence. */
@@ -124,6 +134,14 @@ export function OnboardingModal({
   isPreview = false,
 }: OnboardingModalProps) {
   const { t } = useTranslation("openhands");
+  const { data: settings } = useSettings();
+  const analyticsEnabled = settings?.user_consents_to_analytics === true;
+  const {
+    trackOnboardingStarted,
+    trackOnboardingStepViewed,
+    trackOnboardingCompleted,
+    trackOnboardingSkipped,
+  } = useTracking();
   const { active } = useActiveBackendContext();
   const { backend } = active;
   const noBackendSelected = isNoBackend(backend);
@@ -173,6 +191,15 @@ export function OnboardingModal({
   const currentPhase = slideOrder.includes(phase) ? phase : slideOrder[0];
   const currentStep = slideOrder.indexOf(currentPhase);
 
+  // Backend connectivity is "settled" once we know whether the active backend
+  // is reachable (or no backend is selected). Until then `skipBackendStep` may
+  // still flip true and renumber the slides, briefly showing the backend slide
+  // for an already-healthy backend. Gate Step Viewed on this so we never emit a
+  // phantom "backend" view that immediately auto-skips to "agent".
+  const backendHealthSettled =
+    noBackendSelected ||
+    healthByBackendId[backend.id]?.isConnected !== undefined;
+
   const isOpenHands = selectedAgentId === "openhands";
   const hideSkip = currentStep === 0 && getLockedCloudHost() !== null;
   const goNext = React.useCallback(() => {
@@ -193,6 +220,72 @@ export function OnboardingModal({
       return order[Math.max(safeIdx - 1, 0)];
     });
   }, [slideOrder]);
+
+  // --- Onboarding analytics -------------------------------------------------
+  // Every event is routed through `useTracking`, which drops captures unless
+  // the user has consented; the design-preview harness (`isPreview`) emits
+  // nothing.
+
+  // Onboarding Started — fire at most once per browser session. The
+  // sessionStorage flag survives rerenders, remounts and the lazy/Suspense
+  // flip; the consent gate means we only arm the guard once a capture can
+  // actually happen, so a user who consents partway through onboarding still
+  // gets the event instead of having it latched away during the no-consent
+  // window.
+  const startedTrackedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (isPreview || !analyticsEnabled || startedTrackedRef.current) return;
+    if (window.sessionStorage.getItem(ONBOARDING_STARTED_TRACKED_KEY)) return;
+    startedTrackedRef.current = true;
+    window.sessionStorage.setItem(ONBOARDING_STARTED_TRACKED_KEY, "1");
+    trackOnboardingStarted();
+  }, [isPreview, analyticsEnabled]);
+
+  // Onboarding Step Viewed — fire once per phase entry. The phase string is the
+  // stable identity (slide indices renumber), so dedupe on it: this absorbs
+  // StrictMode's double-invoke and the index renumber, while re-entering a step
+  // via Back counts as a genuine new view.
+  const lastViewedPhaseRef = React.useRef<OnboardingPhase | null>(null);
+  React.useEffect(() => {
+    if (isPreview || !analyticsEnabled || !backendHealthSettled) return;
+    if (lastViewedPhaseRef.current === currentPhase) return;
+    lastViewedPhaseRef.current = currentPhase;
+    trackOnboardingStepViewed({
+      step: currentPhase,
+      stepIndex: currentStep,
+      totalSteps,
+      agent: selectedAgentId,
+    });
+  }, [
+    isPreview,
+    analyticsEnabled,
+    backendHealthSettled,
+    currentPhase,
+    currentStep,
+    totalSteps,
+    selectedAgentId,
+  ]);
+
+  // Onboarding Completed — `onLaunched` runs only after a conversation is
+  // successfully created (the hello message or a recommended automation), so
+  // wrapping it captures completion exactly once before the modal closes.
+  const handleCompleted = () => {
+    trackOnboardingCompleted({ agent: selectedAgentId });
+    onClose();
+  };
+
+  // Onboarding Skipped/Dismissed — the user exited before completing, via the
+  // skip button (non-final steps) or the final-step Close button. `currentPhase`
+  // records where they left, which also distinguishes the two affordances.
+  const handleSkipOrDismiss = () => {
+    trackOnboardingSkipped({
+      step: currentPhase,
+      stepIndex: currentStep,
+      totalSteps,
+      agent: selectedAgentId,
+    });
+    onClose();
+  };
 
   return (
     // No `onClose`: the flow must only be dismissed via explicit actions
@@ -267,8 +360,8 @@ export function OnboardingModal({
               >
                 <SayHelloStep
                   onBack={goBack}
-                  onClose={onClose}
-                  onLaunched={onClose}
+                  onClose={handleSkipOrDismiss}
+                  onLaunched={handleCompleted}
                 />
               </Slide>
             </div>
@@ -279,7 +372,7 @@ export function OnboardingModal({
           <button
             type="button"
             data-testid="onboarding-skip"
-            onClick={onClose}
+            onClick={handleSkipOrDismiss}
             className="rounded-md px-3 py-2 text-sm text-[var(--oh-muted)] transition-colors hover:bg-white/5 hover:text-white cursor-pointer"
           >
             {t(I18nKey.ONBOARDING$SKIP)}

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -146,6 +146,52 @@ export const useTracking = () => {
     track("download_trajectory_button_clicked");
   };
 
+  const trackOnboardingStarted = () => {
+    track("onboarding_started");
+  };
+
+  const trackOnboardingStepViewed = ({
+    step,
+    stepIndex,
+    totalSteps,
+    agent,
+  }: {
+    step: string;
+    stepIndex: number;
+    totalSteps: number;
+    agent: string;
+  }) => {
+    track("onboarding_step_viewed", {
+      step,
+      step_index: stepIndex,
+      total_steps: totalSteps,
+      agent,
+    });
+  };
+
+  const trackOnboardingCompleted = ({ agent }: { agent: string }) => {
+    track("onboarding_completed", { agent });
+  };
+
+  const trackOnboardingSkipped = ({
+    step,
+    stepIndex,
+    totalSteps,
+    agent,
+  }: {
+    step: string;
+    stepIndex: number;
+    totalSteps: number;
+    agent: string;
+  }) => {
+    track("onboarding_skipped", {
+      step,
+      step_index: stepIndex,
+      total_steps: totalSteps,
+      agent,
+    });
+  };
+
   return {
     trackLoginButtonClick,
     trackConversationCreated,
@@ -160,5 +206,9 @@ export const useTracking = () => {
     trackSettingsSaved,
     trackMcpConfigUpdated,
     trackDownloadTrajectoryButtonClicked,
+    trackOnboardingStarted,
+    trackOnboardingStepViewed,
+    trackOnboardingCompleted,
+    trackOnboardingSkipped,
   };
 };


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

Add four product-analytics events to the Agent Canvas onboarding flow so funnels can measure where users start, progress, complete, or abandon onboarding: onboarding_started, onboarding_step_viewed, onboarding_completed, and onboarding_skipped.

- Add typed helpers to useTracking (src/hooks/use-tracking.ts), routed through the existing consent + PostHog gate. Only onboarding-specific properties are passed from the call site; common properties are added automatically.
- Instrument OnboardingModal as the single chokepoint covering both mount paths. Started fires once per session (sessionStorage-guarded, consent-aware so a mid-onboarding consent still captures it). Step Viewed dedupes on the stable phase string and waits for backend health to settle, so an already-healthy backend never emits a phantom "backend" view. Completed wraps onLaunched; Skipped/Dismissed wraps the skip button and the final-step Close, carrying the current step.
- Respect existing analytics consent, emit nothing in the design-preview harness, and preserve existing behavior (onClose still called exactly once per exit).

Tests: extend onboarding-modal.test.tsx by mocking the underlying posthog-js/react service (not useTracking), covering all four events plus remount-dedup and the consent gate.

- [x] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

The Agent Canvas onboarding flow had no product-analytics instrumentation, so we couldn't build onboarding funnels — there was no way to see where users start, advance, complete, or drop off. The only related signal, `trackConversationCreated`, can't distinguish an onboarding launch from any other conversation. This PR adds four dedicated, consent-respecting events captured through the application-level `useTracking` hook.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add four typed helpers to `useTracking` — `trackOnboardingStarted`, `trackOnboardingStepViewed`, `trackOnboardingCompleted`, `trackOnboardingSkipped` — using stable snake_case event names and routed through the existing consent + PostHog gate (common props auto-added).
- Instrument `OnboardingModal` as the single chokepoint: **Started** fires once per session (sessionStorage-guarded + consent-aware), **Step Viewed** dedupes on the stable phase string and waits for backend health to settle, **Completed** wraps `onLaunched`, **Skipped/Dismissed** wraps the skip button and final-step Close with the current step.
- Preserve all existing onboarding behavior (no direct `posthog.capture()` in components, no preview-mode events, `onClose` still called exactly once per exit).

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

**Automated checks (run in this environment):**

1. Static analysis — `npm run lint` (runs `typecheck` → `eslint src` → `prettier --check`):

```
> react-router typegen && tsc          # passed, no errors
> eslint src                            # passed
> prettier --check src/**/*.{ts,tsx}    # All matched files use Prettier code style!

```

2. Tests — `npx vitest run __tests__/components/onboarding/onboarding-modal.test.tsx __tests__/hooks/use-tracking.test.ts`:

```
Test Files  2 passed (2)
     Tests  51 passed (51)

```

The onboarding tests render the **real** `OnboardingModal` through React Testing Library and drive it with `userEvent`, mocking the **underlying** `posthog-js/react` service (not `useTracking`) and asserting the actual `posthog.capture(...)` calls. They cover: Started fires exactly once across a remount, no events without consent, Step Viewed per step with funnel identity, Completed on launch, and Skipped with the current step.

**Manual verification (recommended human step — not run in this environment):**

1. Run the app with a PostHog client key configured (or spy on `posthog.capture`) and set `user_consents_to_analytics = true`.
2. Open first-run onboarding and confirm in the PostHog debugger / network tab:

- `onboarding_started` fires once and does **not** refire on rerender/remount.
- `onboarding_step_viewed` fires once per step as you advance (with `step` / `step_index` / `total_steps` / `agent`); no phantom `"backend"` view for a healthy backend.
- Sending the hello message fires `onboarding_completed`.
- Clicking Skip (mid-flow) or Close (final step) fires `onboarding_skipped` with the correct `step`.
- With consent off, none of the four fire.

> Note: a live browser end-to-end run was not performed in this environment. Verification here is via component-level tests (real modal + real capture assertions) and static checks; the manual steps above are the recommended human confirmation.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- **No data-migration or config changes.** Events flow only when a PostHog key is configured and `user_consents_to_analytics === true` — same gates as existing events.
- **Known limitations (intentional):** locked-to-Cloud login completion is untracked (non-hello path), and pre-consent step views are not back-filled. Both are documented and safe follow-ups.
- **Event names are snake_case** to match the existing 13 events in `use-tracking.ts`.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.29.3-python` |
| **Automation** | `openhands-automation==1.0.0a13` |
| **Commit** | `1b9615e672ffab2b874cd56eacb8eabc7004b845` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-1b9615e
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-1b9615e
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-1b9615e-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2503-amd64
ghcr.io/openhands/agent-canvas:pr-1547-amd64
ghcr.io/openhands/agent-canvas:sha-1b9615e-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2503-arm64
ghcr.io/openhands/agent-canvas:pr-1547-arm64
ghcr.io/openhands/agent-canvas:sha-1b9615e
ghcr.io/openhands/agent-canvas:hieptl-app-2503
ghcr.io/openhands/agent-canvas:pr-1547
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-1b9615e`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-1b9615e-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->