### PR TITLE
feat: emit backend_added PostHog event on user-initiated backend adds

### DIFF
--- a/__tests__/components/backends/add-backend-modal.test.tsx
+++ b/__tests__/components/backends/add-backend-modal.test.tsx
@@ -21,6 +21,21 @@ vi.mock("@openhands/typescript-client/clients", () => ({
   }),
 }));
 
+// Mock the services useTracking depends on (PostHog client + settings) so the
+// consent gate is open and captured events are observable. useTracking itself
+// is never mocked.
+const captureMock = vi.hoisted(() => vi.fn());
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => ({
+    data: { user_consents_to_analytics: true, email: "user@example.com" },
+  }),
+}));
+
 function renderWithProviders(
   ui: React.ReactElement,
   navigation?: NavigationContextValue,
@@ -45,6 +60,7 @@ beforeEach(() => {
   window.localStorage.clear();
   getServerInfoMock.mockReset();
   getServerInfoMock.mockResolvedValue({ version: "1.28.0" });
+  captureMock.mockClear();
   __resetActiveStoreForTests();
 });
 
@@ -313,5 +329,41 @@ describe("AddBackendModal – redirect after adding a backend", () => {
 
     // Assert
     expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("AddBackendModal – analytics", () => {
+  it("captures backend_added once with manual connection metadata", async () => {
+    // Arrange
+    renderWithProviders(<AddBackendModal onClose={vi.fn()} />);
+    const user = userEvent.setup();
+
+    // Act — connect a local backend through the manual form
+    await user.type(screen.getByTestId("add-backend-name"), "Local Extra");
+    await user.type(
+      screen.getByTestId("add-backend-host"),
+      "http://localhost:8000",
+    );
+    await user.type(screen.getByTestId("add-backend-api-key"), "sk-local");
+    await user.click(screen.getByTestId("add-backend-submit"));
+
+    // Assert — emitted exactly once with coarse, non-sensitive properties
+    await waitFor(() =>
+      expect(captureMock).toHaveBeenCalledWith(
+        "backend_added",
+        expect.objectContaining({
+          backend_kind: "local",
+          connection_method: "manual",
+          is_openhands_cloud: false,
+          is_custom_host: true,
+          has_api_key: true,
+          source: "add_backend_modal",
+        }),
+      ),
+    );
+    const backendAddedCalls = captureMock.mock.calls.filter(
+      ([event]) => event === "backend_added",
+    );
+    expect(backendAddedCalls).toHaveLength(1);
   });
 });

--- a/__tests__/components/backends/manage-backends-modal.test.tsx
+++ b/__tests__/components/backends/manage-backends-modal.test.tsx
@@ -62,6 +62,21 @@ vi.mock("#/api/device-flow-client", () => ({
   },
 }));
 
+// Mock the services useTracking depends on (PostHog client + settings) so the
+// consent gate is open and captured events are observable. useTracking itself
+// is never mocked.
+const captureMock = vi.hoisted(() => vi.fn());
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => ({
+    data: { user_consents_to_analytics: true, email: "user@example.com" },
+  }),
+}));
+
 function renderWithProviders(ui: React.ReactElement) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -121,6 +136,7 @@ beforeEach(() => {
   });
   deviceFlowMocks.pollForToken.mockReset();
   deviceFlowMocks.pollForToken.mockImplementation(() => new Promise(() => {}));
+  captureMock.mockClear();
   __resetActiveStoreForTests();
   __resetHealthStoreForTests();
 });
@@ -463,6 +479,66 @@ describe("ManageBackendsModal", () => {
     expect(
       screen.queryByTestId("manage-backends-org-Acme Local"),
     ).not.toBeInTheDocument();
+  });
+
+  it("captures backend_added with source manage_backends_modal when adding from here", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ManageBackendsModal onClose={vi.fn()} />);
+
+    await user.click(await screen.findByTestId("manage-backends-add"));
+    await screen.findByTestId("add-backend-modal");
+
+    await user.type(screen.getByTestId("add-backend-name"), "Local Extra");
+    await user.type(
+      screen.getByTestId("add-backend-host"),
+      "http://localhost:8000",
+    );
+    await user.type(screen.getByTestId("add-backend-api-key"), "sk-local");
+    await user.click(screen.getByTestId("add-backend-submit"));
+
+    await waitFor(() =>
+      expect(captureMock).toHaveBeenCalledWith(
+        "backend_added",
+        expect.objectContaining({ source: "manage_backends_modal" }),
+      ),
+    );
+  });
+
+  it("does not capture backend_added when editing an existing backend", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <TestSeed
+        onMount={(ctx) => {
+          ctx.addBackend({
+            name: "Acme Local",
+            host: "http://localhost:9000",
+            apiKey: "old-key",
+            kind: "local",
+          });
+        }}
+      >
+        <ManageBackendsModal onClose={vi.fn()} />
+      </TestSeed>,
+    );
+
+    await user.click(
+      await screen.findByTestId("manage-backends-edit-Acme Local"),
+    );
+    await screen.findByTestId("edit-backend-modal");
+    const hostInput = screen.getByTestId("edit-backend-host");
+    await user.clear(hostInput);
+    await user.type(hostInput, "http://localhost:9999");
+    await user.click(screen.getByTestId("edit-backend-submit"));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("edit-backend-modal"),
+      ).not.toBeInTheDocument(),
+    );
+    expect(captureMock).not.toHaveBeenCalledWith(
+      "backend_added",
+      expect.anything(),
+    );
   });
 });
 

--- a/__tests__/hooks/use-tracking.test.ts
+++ b/__tests__/hooks/use-tracking.test.ts
@@ -239,6 +239,29 @@ describe("useTracking", () => {
     });
   });
 
+  describe("trackBackendAdded", () => {
+    it("captures backend_added with coarse, non-sensitive backend metadata", () => {
+      getTracking().trackBackendAdded({
+        backendKind: "cloud",
+        connectionMethod: "cloud_login",
+        isOpenhandsCloud: true,
+        isCustomHost: false,
+        hasApiKey: true,
+        source: "add_backend_modal",
+      });
+
+      expect(captureMock).toHaveBeenCalledWith("backend_added", {
+        backend_kind: "cloud",
+        connection_method: "cloud_login",
+        is_openhands_cloud: true,
+        is_custom_host: false,
+        has_api_key: true,
+        source: "add_backend_modal",
+        ...COMMON,
+      });
+    });
+  });
+
   describe("consent gate", () => {
     it("does not capture when posthog is not initialized", () => {
       posthogMock = undefined;

--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -14,6 +14,7 @@ import { SettingsInput } from "#/components/features/settings/settings-input";
 import { useActiveBackendContext } from "#/contexts/active-backend-context";
 import { useNavigation } from "#/context/navigation-context";
 import { useBackendsHealth } from "#/hooks/query/use-backends-health";
+import { useTracking } from "#/hooks/use-tracking";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
 import { getLockedCloudHost } from "#/api/agent-server-config";
 import {
@@ -40,6 +41,8 @@ interface BackendFormModalProps {
   /** Required when `mode === "edit"`. */
   backend?: Backend;
   onClose: () => void;
+  /** Analytics surface for the `backend_added` event (add mode only). */
+  source?: BackendAddedSource;
 }
 
 function inferKindFromHost(host: string): BackendKind {
@@ -124,6 +127,10 @@ function isValidHostUrl(host: string): boolean {
 }
 
 const DEFAULT_OPENHANDS_CLOUD_HOST = "https://app.all-hands.dev";
+
+export type BackendConnectionMethod = "manual" | "cloud_login";
+
+export type BackendAddedSource = "add_backend_modal" | "manage_backends_modal";
 
 function getConnectionTestFailedTitle(
   t: ReturnType<typeof useTranslation>["t"],
@@ -663,7 +670,10 @@ function useRedirectAfterAddBackend() {
 }
 
 interface BackendConnectionOptionsProps {
-  onConnected: (payload: BackendFormSubmitPayload) => void;
+  onConnected: (
+    payload: BackendFormSubmitPayload,
+    connectionMethod: BackendConnectionMethod,
+  ) => void;
   testIdRoot?: string;
   initialManualBackend?: Partial<
     Pick<BackendFormSubmitPayload, "name" | "host" | "apiKey">
@@ -736,7 +746,10 @@ export function BackendConnectionOptions({
 }
 
 interface ManualConnectionColumnProps {
-  onConnected: (payload: BackendFormSubmitPayload) => void;
+  onConnected: (
+    payload: BackendFormSubmitPayload,
+    connectionMethod: BackendConnectionMethod,
+  ) => void;
   testIdRoot: string;
   initialBackend?: Partial<
     Pick<BackendFormSubmitPayload, "name" | "host" | "apiKey">
@@ -781,12 +794,15 @@ function ManualConnectionColumn({
     initialApiKey: initialBackend?.apiKey ?? "",
     onTestConnection: testBackendConnection,
     onSuccess: () => {
-      onConnected({
-        name: name.trim(),
-        host: normalizeHost(host),
-        apiKey: apiKey.trim(),
-        kind,
-      });
+      onConnected(
+        {
+          name: name.trim(),
+          host: normalizeHost(host),
+          apiKey: apiKey.trim(),
+          kind,
+        },
+        "manual",
+      );
     },
     requireApiKey,
   });
@@ -879,7 +895,10 @@ function ManualConnectionColumn({
 }
 
 interface CloudLoginColumnProps {
-  onConnected: (payload: BackendFormSubmitPayload) => void;
+  onConnected: (
+    payload: BackendFormSubmitPayload,
+    connectionMethod: BackendConnectionMethod,
+  ) => void;
   testIdRoot: string;
   lockedHost?: string;
 }
@@ -903,12 +922,15 @@ function CloudLoginColumn({
     lockedHost ?? (customHost.trim() || DEFAULT_OPENHANDS_CLOUD_HOST);
 
   const handleLoginSuccess = (apiKey: string) => {
-    onConnected({
-      name: "OpenHands Cloud",
-      host: normalizeHost(effectiveHost),
-      apiKey,
-      kind: "cloud",
-    });
+    onConnected(
+      {
+        name: "OpenHands Cloud",
+        host: normalizeHost(effectiveHost),
+        apiKey,
+        kind: "cloud",
+      },
+      "cloud_login",
+    );
   };
 
   return (
@@ -979,17 +1001,37 @@ function CloudLoginColumn({
   );
 }
 
-function AddBackendConnectionOptions({ onClose }: { onClose: () => void }) {
+function AddBackendConnectionOptions({
+  onClose,
+  source,
+}: {
+  onClose: () => void;
+  source: BackendAddedSource;
+}) {
   const { addBackend } = useActiveBackendContext();
   const redirectAfterAdd = useRedirectAfterAddBackend();
+  const { trackBackendAdded } = useTracking();
 
   const handleConnected = React.useCallback(
-    (payload: BackendFormSubmitPayload) => {
+    (
+      payload: BackendFormSubmitPayload,
+      connectionMethod: BackendConnectionMethod,
+    ) => {
       addBackend(payload);
+      // Coarse, non-sensitive host classification — never emit the raw host.
+      const isOpenHandsCloud = payload.host === DEFAULT_OPENHANDS_CLOUD_HOST;
+      trackBackendAdded({
+        backendKind: payload.kind,
+        connectionMethod,
+        isOpenhandsCloud: isOpenHandsCloud,
+        isCustomHost: !isOpenHandsCloud,
+        hasApiKey: Boolean(payload.apiKey),
+        source,
+      });
       redirectAfterAdd();
       onClose();
     },
-    [addBackend, redirectAfterAdd, onClose],
+    [addBackend, redirectAfterAdd, onClose, trackBackendAdded, source],
   );
 
   return <BackendConnectionOptions onConnected={handleConnected} />;
@@ -1006,6 +1048,7 @@ export function BackendFormModal({
   mode,
   backend,
   onClose,
+  source = "add_backend_modal",
 }: BackendFormModalProps) {
   const { t } = useTranslation("openhands");
 
@@ -1033,7 +1076,7 @@ export function BackendFormModal({
           </div>
 
           <div className="px-6 pb-6 pt-2">
-            <AddBackendConnectionOptions onClose={onClose} />
+            <AddBackendConnectionOptions onClose={onClose} source={source} />
           </div>
         </div>
       </ModalBackdrop>

--- a/src/components/features/backends/manage-backends-modal.tsx
+++ b/src/components/features/backends/manage-backends-modal.tsx
@@ -193,7 +193,11 @@ export function ManageBackendsModal({
       </ModalBackdrop>
 
       {showAddForm ? (
-        <BackendFormModal mode="add" onClose={() => setShowAddForm(false)} />
+        <BackendFormModal
+          mode="add"
+          source="manage_backends_modal"
+          onClose={() => setShowAddForm(false)}
+        />
       ) : null}
 
       {editingBackend ? (

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -1,6 +1,7 @@
 import { usePostHog } from "posthog-js/react";
 import { useSettings } from "./query/use-settings";
 import { Provider } from "#/types/settings";
+import type { BackendKind } from "#/api/backend-registry/types";
 
 /**
  * Hook that provides tracking functions with automatic data collection
@@ -146,6 +147,31 @@ export const useTracking = () => {
     track("download_trajectory_button_clicked");
   };
 
+  const trackBackendAdded = ({
+    backendKind,
+    connectionMethod,
+    isOpenhandsCloud,
+    isCustomHost,
+    hasApiKey,
+    source,
+  }: {
+    backendKind: BackendKind;
+    connectionMethod: "manual" | "cloud_login";
+    isOpenhandsCloud: boolean;
+    isCustomHost: boolean;
+    hasApiKey: boolean;
+    source?: "add_backend_modal" | "manage_backends_modal";
+  }) => {
+    track("backend_added", {
+      backend_kind: backendKind,
+      connection_method: connectionMethod,
+      is_openhands_cloud: isOpenhandsCloud,
+      is_custom_host: isCustomHost,
+      has_api_key: hasApiKey,
+      source,
+    });
+  };
+
   return {
     trackLoginButtonClick,
     trackConversationCreated,
@@ -160,5 +186,6 @@ export const useTracking = () => {
     trackSettingsSaved,
     trackMcpConfigUpdated,
     trackDownloadTrajectoryButtonClicked,
+    trackBackendAdded,
   };
 };


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

Add a typed `trackBackendAdded` helper to `useTracking` and fire a `backend_added` event once after a user successfully adds an additional backend through the add-backend UI (Add Backend modal and Manage Backends "Add"). The two connection columns now pass a `connection_method` discriminator ("manual" | "cloud_login") to `onConnected` so the event can distinguish OpenHands Cloud login from manual configuration, and the modal threads a `source` surface ("add_backend_modal" | "manage_backends_modal").

Properties are coarse and non-sensitive: backend_kind, connection_method, is_openhands_cloud, is_custom_host, has_api_key (boolean), source. No host URL, API key, or token is ever emitted. The event is routed through the existing consent-gated track() wrapper, never posthog.capture() directly.

Editing (updateBackend), removals, and the launcher-seeded default backend (which bypasses addBackend) do not emit. First-backend setup flows (onboarding, public-auth API-key gate) are intentionally excluded: the consent flag is unavailable before a backend exists, so the event would be suppressed there in production.

Tests: unit coverage for the helper contract, plus integration tests that a manual add emits once with the expected properties, that adds from Manage Backends carry source=manage_backends_modal, and that editing emits nothing.

- [x] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

We currently have no telemetry on backend additions. Product wants to measure backend adoption — OpenHands Cloud vs local/custom, which connection flow was used, and basic non-sensitive segmentation — to understand how users connect.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Added a typed `trackBackendAdded` helper to `useTracking` (consent-gated; no direct `posthog.capture` from components) that emits `backend_added` with `backend_kind`, `connection_method`, `is_openhands_cloud`, `is_custom_host`, `has_api_key`, and an optional `source`.
- Emit once in the add-backend success path after the backend is persisted; threaded a `manual` / `cloud_login` discriminator from the two connection columns and a `source` surface (`add_backend_modal` default, `manage_backends_modal` from Manage Backends).
- No sensitive data is sent (no host URLs, API keys, or tokens — host reduced to two coarse booleans); edits, removals, the seeded default backend, and pre-backend setup flows do not emit.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

This change has no UI/visual change; correctness is the emitted analytics event, covered by automated tests that assert the real `posthog.capture` call.

```bash
npm install

# 1) Types
npm run typecheck            # ✅ passes

# 2) Lint + format (changed source files)
npx eslint src/hooks/use-tracking.ts \
  src/components/features/backends/backend-form-modal.tsx \
  src/components/features/backends/manage-backends-modal.tsx   # ✅ 0 errors
npx prettier --check "src/hooks/use-tracking.ts" \
  "src/components/features/backends/backend-form-modal.tsx" \
  "src/components/features/backends/manage-backends-modal.tsx" # ✅ all formatted

# 3) Targeted + regression test run
npx vitest run __tests__/components/backends __tests__/components/onboarding \
  __tests__/hooks/use-tracking.test.ts

```

Result of (3):

```text
 Test Files  14 passed (14)
      Tests  167 passed (167)

```

New tests added (all green):

```text
✓ useTracking > trackBackendAdded > captures backend_added with coarse, non-sensitive backend metadata
✓ AddBackendModal – analytics > captures backend_added once with manual connection metadata
✓ ManageBackendsModal > captures backend_added with source manage_backends_modal when adding from here
✓ ManageBackendsModal > does not capture backend_added when editing an existing backend

```

Manual end-to-end verification (in a running app with `VITE_POSTHOG_CLIENT_KEY` set and analytics consent enabled):

1. `npm run dev` and open the app with at least one backend already connected.
2. Open **Add Backend** (sidebar or backend selector), connect a local server via the manual form, or log in via **OpenHands Cloud**.
3. In PostHog (or the browser Network tab → `[us.i.posthog.com/e](https://us.i.posthog.com/e)`), confirm a single `backend_added` event with the expected `connection_method` / `backend_kind` / `is_openhands_cloud` / `is_custom_host` / `has_api_key` / `source: add_backend_modal`.
4. Repeat from **Manage Backends → Add** and confirm `source: manage_backends_modal`.
5. Edit or remove a backend and confirm **no** `backend_added` event is emitted.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.29.3-python` |
| **Automation** | `openhands-automation==1.0.0a13` |
| **Commit** | `357233a15733d7b55f1f7a3ec975ae66974fea32` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-357233a
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-357233a
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-357233a-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-2506-amd64
ghcr.io/openhands/agent-canvas:pr-1548-amd64
ghcr.io/openhands/agent-canvas:sha-357233a-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-2506-arm64
ghcr.io/openhands/agent-canvas:pr-1548-arm64
ghcr.io/openhands/agent-canvas:sha-357233a
ghcr.io/openhands/agent-canvas:hieptl-app-2506
ghcr.io/openhands/agent-canvas:pr-1548
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-357233a`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-357233a-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->