### PR TITLE
feat: instrument PostHog events for automation lifecycle

### DIFF
--- a/__tests__/components/automations/add-automation-modal.test.tsx
+++ b/__tests__/components/automations/add-automation-modal.test.tsx
@@ -9,6 +9,14 @@ import {
 import { AddAutomationModal } from "#/components/features/automations/add-automation-modal";
 import { I18nKey } from "#/i18n/declaration";
 
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => undefined,
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => ({ data: { user_consents_to_analytics: true } }),
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => key,

--- a/__tests__/components/automations/create-instructions.test.tsx
+++ b/__tests__/components/automations/create-instructions.test.tsx
@@ -10,6 +10,15 @@ import { CreateInstructions } from "#/components/features/automations/create-ins
 import { I18nKey } from "#/i18n/declaration";
 import { useConversationStore } from "#/stores/conversation-store";
 
+const captureMock = vi.fn();
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => ({ data: { user_consents_to_analytics: true } }),
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => {
@@ -78,7 +87,20 @@ function renderCreateInstructions() {
 
 describe("CreateInstructions", () => {
   beforeEach(() => {
+    captureMock.mockClear();
     useConversationStore.setState({ messageToSend: null });
+  });
+
+  it("captures automation_created with the active backend kind when Create Automation is clicked", async () => {
+    const user = userEvent.setup();
+    renderCreateInstructions();
+
+    await user.click(screen.getByTestId("automations-create-automation"));
+
+    expect(captureMock).toHaveBeenCalledWith(
+      "automation_created",
+      expect.objectContaining({ backend_kind: "local" }),
+    );
   });
 
   it("navigates to conversations with a prefilled prompt when Create Automation is clicked", async () => {

--- a/__tests__/hooks/query/use-automations-backend-switch.test.tsx
+++ b/__tests__/hooks/query/use-automations-backend-switch.test.tsx
@@ -13,6 +13,9 @@ import { ActiveBackendProvider } from "#/contexts/active-backend-context";
 import {
   useAutomations,
   useDispatchAutomation,
+  useDeleteAutomation,
+  useToggleAutomation,
+  useUpdateAutomation,
 } from "#/hooks/query/use-automations";
 import {
   useAutomationDetail,
@@ -33,7 +36,19 @@ vi.mock("#/api/automation-service/automation-service.api", () => ({
     getAutomation: vi.fn(),
     getAutomationRuns: vi.fn(),
     dispatchAutomation: vi.fn(),
+    deleteAutomation: vi.fn(),
+    updateAutomation: vi.fn(),
+    toggleAutomation: vi.fn(),
   },
+}));
+
+const captureMock = vi.fn();
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => ({ data: { user_consents_to_analytics: true } }),
 }));
 
 const localBackend: Backend = {
@@ -102,6 +117,13 @@ beforeEach(() => {
   vi.mocked(AutomationService.dispatchAutomation).mockResolvedValue(
     automationRun,
   );
+  vi.mocked(AutomationService.deleteAutomation).mockReset();
+  vi.mocked(AutomationService.updateAutomation).mockReset();
+  vi.mocked(AutomationService.toggleAutomation).mockReset();
+  vi.mocked(AutomationService.deleteAutomation).mockResolvedValue(undefined);
+  vi.mocked(AutomationService.updateAutomation).mockResolvedValue(automation);
+  vi.mocked(AutomationService.toggleAutomation).mockResolvedValue(automation);
+  captureMock.mockClear();
 
   vi.mocked(AutomationService.getAutomations).mockResolvedValue(listResponse);
   vi.mocked(AutomationService.getAutomation).mockResolvedValue(automation);
@@ -229,4 +251,92 @@ describe("useAutomationRuns — polling", () => {
     },
     15000,
   );
+});
+
+describe("automation mutation hooks — analytics tracking", () => {
+  it("captures automation_executed after a successful dispatch", async () => {
+    const { result } = renderHook(() => useDispatchAutomation(), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("auto-1");
+    });
+
+    await waitFor(() => {
+      expect(captureMock).toHaveBeenCalledWith(
+        "automation_executed",
+        expect.objectContaining({ backend_kind: "local" }),
+      );
+    });
+  });
+
+  it("captures automation_deleted after a successful delete", async () => {
+    const { result } = renderHook(() => useDeleteAutomation(), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("auto-1");
+    });
+
+    await waitFor(() => {
+      expect(captureMock).toHaveBeenCalledWith(
+        "automation_deleted",
+        expect.objectContaining({ backend_kind: "local" }),
+      );
+    });
+  });
+
+  it("captures automation_edited after a successful update", async () => {
+    const { result } = renderHook(() => useUpdateAutomation(), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: "auto-1",
+        body: { name: "Renamed" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(captureMock).toHaveBeenCalledWith(
+        "automation_edited",
+        expect.objectContaining({ backend_kind: "local" }),
+      );
+    });
+  });
+
+  it("captures automation_deactivated when an automation is disabled", async () => {
+    const { result } = renderHook(() => useToggleAutomation(), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: "auto-1", enabled: false });
+    });
+
+    await waitFor(() => {
+      expect(captureMock).toHaveBeenCalledWith(
+        "automation_deactivated",
+        expect.objectContaining({ backend_kind: "local" }),
+      );
+    });
+  });
+
+  it("does not capture automation_deactivated when an automation is enabled", async () => {
+    const { result } = renderHook(() => useToggleAutomation(), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: "auto-1", enabled: true });
+    });
+
+    expect(captureMock).not.toHaveBeenCalledWith(
+      "automation_deactivated",
+      expect.anything(),
+    );
+  });
 });

--- a/src/components/features/automations/create-instructions.tsx
+++ b/src/components/features/automations/create-instructions.tsx
@@ -6,6 +6,8 @@ import MessageSquareShareIcon from "#/icons/message-square-share.svg?react";
 import { cn } from "#/utils/utils";
 import { BrandButton } from "#/components/features/settings/brand-button";
 import { useLaunchSkillInChat } from "#/hooks/use-launch-skill-in-chat";
+import { useActiveBackend } from "#/contexts/active-backend-context";
+import { useTracking } from "#/hooks/use-tracking";
 
 const DOCS_URL =
   "https://docs.openhands.dev/openhands/usage/automations/overview";
@@ -52,8 +54,11 @@ export function CreateInstructionsContent({
 }: CreateInstructionsContentProps = {}) {
   const { t } = useTranslation("openhands");
   const launchInChat = useLaunchSkillInChat();
+  const active = useActiveBackend();
+  const { trackAutomationCreated } = useTracking();
 
   const handleCreateAutomation = () => {
+    trackAutomationCreated({ backendKind: active.backend.kind });
     launchInChat(t(I18nKey.AUTOMATIONS$CREATE_AUTOMATION_PROMPT), onLaunch);
   };
 

--- a/src/hooks/query/use-automations.ts
+++ b/src/hooks/query/use-automations.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import AutomationService from "#/api/automation-service/automation-service.api";
 import { useActiveBackend } from "#/contexts/active-backend-context";
+import { useTracking } from "#/hooks/use-tracking";
 import type { Automation } from "#/types/automation";
 import {
   AUTOMATION_DETAIL_QUERY_KEY,
@@ -33,40 +34,53 @@ export function useAutomations(options: UseAutomationsOptions = {}) {
 
 export function useToggleAutomation() {
   const queryClient = useQueryClient();
+  const active = useActiveBackend();
+  const { trackAutomationDeactivated } = useTracking();
   return useMutation({
     mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
       AutomationService.toggleAutomation(id, enabled),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: AUTOMATIONS_QUERY_KEY });
       queryClient.invalidateQueries({ queryKey: AUTOMATION_DETAIL_QUERY_KEY });
+      if (!variables.enabled) {
+        trackAutomationDeactivated({ backendKind: active.backend.kind });
+      }
     },
   });
 }
 
 export function useUpdateAutomation() {
   const queryClient = useQueryClient();
+  const active = useActiveBackend();
+  const { trackAutomationEdited } = useTracking();
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body: Partial<Automation> }) =>
       AutomationService.updateAutomation(id, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: AUTOMATIONS_QUERY_KEY });
       queryClient.invalidateQueries({ queryKey: AUTOMATION_DETAIL_QUERY_KEY });
+      trackAutomationEdited({ backendKind: active.backend.kind });
     },
   });
 }
 
 export function useDeleteAutomation() {
   const queryClient = useQueryClient();
+  const active = useActiveBackend();
+  const { trackAutomationDeleted } = useTracking();
   return useMutation({
     mutationFn: (id: string) => AutomationService.deleteAutomation(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: AUTOMATIONS_QUERY_KEY });
+      trackAutomationDeleted({ backendKind: active.backend.kind });
     },
   });
 }
 
 export function useDispatchAutomation() {
   const queryClient = useQueryClient();
+  const active = useActiveBackend();
+  const { trackAutomationExecuted } = useTracking();
   return useMutation({
     mutationFn: (id: string) => AutomationService.dispatchAutomation(id),
     onSuccess: (_run, id) => {
@@ -75,6 +89,7 @@ export function useDispatchAutomation() {
       queryClient.invalidateQueries({
         queryKey: [...AUTOMATION_RUNS_QUERY_KEY, id],
       });
+      trackAutomationExecuted({ backendKind: active.backend.kind });
     },
   });
 }

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -1,6 +1,7 @@
 import { usePostHog } from "posthog-js/react";
 import { useSettings } from "./query/use-settings";
 import { Provider } from "#/types/settings";
+import type { BackendKind } from "#/api/backend-registry/types";
 
 /**
  * Hook that provides tracking functions with automatic data collection
@@ -146,6 +147,46 @@ export const useTracking = () => {
     track("download_trajectory_button_clicked");
   };
 
+  const trackAutomationCreated = ({
+    backendKind,
+  }: {
+    backendKind: BackendKind;
+  }) => {
+    track("automation_created", { backend_kind: backendKind });
+  };
+
+  const trackAutomationExecuted = ({
+    backendKind,
+  }: {
+    backendKind: BackendKind;
+  }) => {
+    track("automation_executed", { backend_kind: backendKind });
+  };
+
+  const trackAutomationDeleted = ({
+    backendKind,
+  }: {
+    backendKind: BackendKind;
+  }) => {
+    track("automation_deleted", { backend_kind: backendKind });
+  };
+
+  const trackAutomationDeactivated = ({
+    backendKind,
+  }: {
+    backendKind: BackendKind;
+  }) => {
+    track("automation_deactivated", { backend_kind: backendKind });
+  };
+
+  const trackAutomationEdited = ({
+    backendKind,
+  }: {
+    backendKind: BackendKind;
+  }) => {
+    track("automation_edited", { backend_kind: backendKind });
+  };
+
   return {
     trackLoginButtonClick,
     trackConversationCreated,
@@ -160,5 +201,10 @@ export const useTracking = () => {
     trackSettingsSaved,
     trackMcpConfigUpdated,
     trackDownloadTrajectoryButtonClicked,
+    trackAutomationCreated,
+    trackAutomationExecuted,
+    trackAutomationDeleted,
+    trackAutomationDeactivated,
+    trackAutomationEdited,
   };
 };


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

Add application-level PostHog analytics for the Automation lifecycle to support redefining the activation funnel. All events go through the existing consent-gated useTracking hook; payloads carry only backend_kind (local vs cloud/OHE) — no ids, names, prompts, or schedules.

Events:

- automation_created fired at the create-launch CTA (create-instructions)
- automation_executed useDispatchAutomation onSuccess (manual Run Now)
- automation_deleted useDeleteAutomation onSuccess
- automation_deactivated useToggleAutomation onSuccess (enabled === false)
- automation_edited useUpdateAutomation onSuccess (additional signal)

The existing toggle-ON tracking (prebuilt_automation_enabled) is left untouched, so there is no double-count and no behavior change. Each event fires exactly once: created on the click handler, the rest in mutation onSuccess (retries resolve before success; rerenders/remounts never refire).

Adds five typed helpers to use-tracking.ts (reusing the BackendKind type) and tests covering each event plus the deactivate enable/disable guard.

- [x] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

We need granular Automation lifecycle data to redefine the product activation funnel. **Automation Created** is expected to become a high-value activation event and may eventually replace the "5+ conversations" metric. Until now, the only automation analytics was `prebuilt_automation_enabled`; create / execute / delete / deactivate were untracked.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Added five typed helpers to `useTracking` (`automation_created`, `automation_executed`, `automation_deleted`, `automation_deactivated`, `automation_edited`), each emitting only `backend_kind` (`local` | `cloud`).
- Wired `automation_created` to the create-launch CTA and the other four to the respective automation mutation `onSuccess` handlers (deactivated guarded on `enabled === false`); existing toggle-ON tracking is untouched.
- Added unit/integration tests covering each event and the deactivate enable/disable guard, exercising the real `useTracking` with the PostHog service mocked.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm install`
2. Run the targeted tests: `npx vitest run __tests__/components/automations/create-instructions.test.tsx __tests__/hooks/query/use-automations-backend-switch.test.tsx`
3. Run `npm run lint` to confirm typecheck + eslint + prettier pass.
4. (Optional, manual) Run the app with a PostHog client key configured and analytics consent granted, then: launch the "Create automation" CTA, click "Run Now", delete an automation, toggle one off, and save an edit. Confirm exactly one `posthog.capture` per action with the correct event name and a `backend_kind` property (PostHog debug or the `[us.i.posthog.com/e](https://us.i.posthog.com/e)` request). With consent withheld or no key configured, confirm no events are captured.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- No new i18n strings, no UI changes, and no changes to the consent system (consent is enforced centrally inside `track()`).
- Payloads intentionally contain only `backend_kind` — no ids, names, prompts, or schedules — to keep analytics free of sensitive data.
- `automation_created` fires at creation **intent** (the create-launch CTA), because there is no client-side create API; this matches the existing `prebuilt_automation_enabled` convention. Follow-up: if a server-confirmed "created" signal is later required, it can be added without changing these helpers.

---

### Changed files

| File                                                            | Change                                                           |
| --------------------------------------------------------------- | ---------------------------------------------------------------- |
| `src/hooks/use-tracking.ts`                                     | +46 — five typed helpers, `BackendKind` import, returns          |
| `src/components/features/automations/create-instructions.tsx`   | +5 — fire `automation_created` at CTA                            |
| `src/hooks/query/use-automations.ts`                            | +17/-1 — fire executed/deleted/deactivated/edited in `onSuccess` |
| `__tests__/components/automations/create-instructions.test.tsx` | +22 — created-event test                                         |
| `__tests__/hooks/query/use-automations-backend-switch.test.tsx` | +110 — five mutation-event tests                                 |


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.29.3-python` |
| **Automation** | `openhands-automation==1.0.0a13` |
| **Commit** | `1fc5e3223df602d844117284e61d7b9cc374acf7` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-1fc5e32
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-1fc5e32
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-1fc5e32-amd64
ghcr.io/openhands/agent-canvas:hieptl-app-1510-amd64
ghcr.io/openhands/agent-canvas:pr-1549-amd64
ghcr.io/openhands/agent-canvas:sha-1fc5e32-arm64
ghcr.io/openhands/agent-canvas:hieptl-app-1510-arm64
ghcr.io/openhands/agent-canvas:pr-1549-arm64
ghcr.io/openhands/agent-canvas:sha-1fc5e32
ghcr.io/openhands/agent-canvas:hieptl-app-1510
ghcr.io/openhands/agent-canvas:pr-1549
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-1fc5e32`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-1fc5e32-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->