### PR TITLE
fix(backends): hide edit/remove row actions when locked to cloud

### DIFF
--- a/__tests__/components/backends/manage-backends-modal.test.tsx
+++ b/__tests__/components/backends/manage-backends-modal.test.tsx
@@ -83,7 +83,6 @@ function TestSeed({
   const ctx = useActiveBackendContext();
   React.useEffect(() => {
     onMount(ctx);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return children as React.ReactElement;
 }
@@ -128,6 +127,9 @@ beforeEach(() => {
 afterEach(() => {
   window.localStorage.clear();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  delete (window as unknown as Record<string, unknown>)
+    .__AGENT_CANVAS_LOCK_TO_CLOUD__;
   __resetActiveStoreForTests();
   __resetHealthStoreForTests();
 });
@@ -229,6 +231,13 @@ describe("ManageBackendsModal", () => {
   });
 
   it("opens an edit form pre-filled with the row's backend, and persists changes via updateBackend", async () => {
+    // These tests exercise edit-form behavior, not lock behavior; isolate
+    // them from a local .env that sets VITE_LOCK_TO_CLOUD and would hide the
+    // pencil button this test depends on.
+    vi.stubEnv("VITE_LOCK_TO_CLOUD", "");
+    delete (window as unknown as Record<string, unknown>)
+      .__AGENT_CANVAS_LOCK_TO_CLOUD__;
+
     const user = userEvent.setup();
 
     let backendId = "";
@@ -279,6 +288,10 @@ describe("ManageBackendsModal", () => {
   });
 
   it("preserves kind:cloud when renaming a cloud backend on a custom domain", async () => {
+    vi.stubEnv("VITE_LOCK_TO_CLOUD", "");
+    delete (window as unknown as Record<string, unknown>)
+      .__AGENT_CANVAS_LOCK_TO_CLOUD__;
+
     const user = userEvent.setup();
 
     let backendId = "";
@@ -328,6 +341,10 @@ describe("ManageBackendsModal", () => {
   });
 
   it("closes the edit form when the header close button is clicked", async () => {
+    vi.stubEnv("VITE_LOCK_TO_CLOUD", "");
+    delete (window as unknown as Record<string, unknown>)
+      .__AGENT_CANVAS_LOCK_TO_CLOUD__;
+
     const user = userEvent.setup();
 
     renderWithProviders(
@@ -611,5 +628,116 @@ describe("BackendRow", () => {
     expect(deviceFlowMocks.startDeviceFlow).toHaveBeenCalledWith(
       cloudBackend.host,
     );
+  });
+
+  it("renders edit and remove buttons when the deployment is not locked to a cloud host", async () => {
+    // The repo's .env may set VITE_LOCK_TO_CLOUD; clear it explicitly so this
+    // test exercises the unlocked code path regardless of local env state.
+    vi.stubEnv("VITE_LOCK_TO_CLOUD", "");
+    delete (window as unknown as Record<string, unknown>)
+      .__AGENT_CANVAS_LOCK_TO_CLOUD__;
+
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    const onRemove = vi.fn();
+
+    renderInQueryClient(
+      <ul>
+        <BackendRow
+          backend={cloudBackend}
+          health={{
+            isConnected: true,
+            consecutiveFailures: 0,
+            lastError: null,
+            disabled: false,
+          }}
+          onSelect={vi.fn()}
+          onEdit={onEdit}
+          onRemove={onRemove}
+        />
+      </ul>,
+    );
+
+    const row = screen.getByTestId(`manage-backends-row-${cloudBackend.name}`);
+    const editButton = within(row).getByTestId(
+      `manage-backends-edit-${cloudBackend.name}`,
+    );
+    const removeButton = within(row).getByTestId(
+      `manage-backends-remove-${cloudBackend.name}`,
+    );
+
+    expect(editButton).toHaveAccessibleName("BACKEND$EDIT");
+    expect(removeButton).toHaveAccessibleName("BACKEND$REMOVE");
+
+    await user.click(editButton);
+    await user.click(removeButton);
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides edit and remove buttons when locked to a cloud host via VITE_LOCK_TO_CLOUD", () => {
+    vi.stubEnv("VITE_LOCK_TO_CLOUD", "https://cloud.example.com");
+    const onEdit = vi.fn();
+    const onRemove = vi.fn();
+
+    renderInQueryClient(
+      <ul>
+        <BackendRow
+          backend={cloudBackend}
+          health={{
+            isConnected: true,
+            consecutiveFailures: 0,
+            lastError: null,
+            disabled: false,
+          }}
+          onSelect={vi.fn()}
+          onEdit={onEdit}
+          onRemove={onRemove}
+        />
+      </ul>,
+    );
+
+    const row = screen.getByTestId(`manage-backends-row-${cloudBackend.name}`);
+    expect(
+      within(row).queryByTestId(`manage-backends-edit-${cloudBackend.name}`),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row).queryByTestId(`manage-backends-remove-${cloudBackend.name}`),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides edit and remove buttons when locked to a cloud host via window.__AGENT_CANVAS_LOCK_TO_CLOUD__", () => {
+    (
+      window as unknown as Record<string, unknown>
+    ).__AGENT_CANVAS_LOCK_TO_CLOUD__ = "https://cloud.example.com";
+
+    renderInQueryClient(
+      <ul>
+        <BackendRow
+          backend={cloudBackend}
+          health={{
+            isConnected: true,
+            consecutiveFailures: 0,
+            lastError: null,
+            disabled: false,
+          }}
+          onSelect={vi.fn()}
+          onEdit={vi.fn()}
+          onRemove={vi.fn()}
+        />
+      </ul>,
+    );
+
+    const row = screen.getByTestId(`manage-backends-row-${cloudBackend.name}`);
+    expect(
+      within(row).queryByTestId(`manage-backends-edit-${cloudBackend.name}`),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row).queryByTestId(`manage-backends-remove-${cloudBackend.name}`),
+    ).not.toBeInTheDocument();
+    // Row identity (name + host) is still rendered so the user can see the
+    // locked backend is selected, just not mutate it.
+    expect(within(row).getByText(cloudBackend.name)).toBeInTheDocument();
+    expect(within(row).getByText(cloudBackend.host)).toBeInTheDocument();
   });
 });

--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -912,7 +912,7 @@ function CloudLoginColumn({
   };
 
   return (
-    <div className="flex flex-1 min-w-0 flex-col items-center gap-3">
+    <div className="flex flex-1 min-w-0 flex-col items-center gap-3 pb-7">
       <div className="flex flex-col items-center gap-1">
         <OpenHandsLogoWhite width={56} height={56} aria-hidden />
 

--- a/src/components/features/backends/backend-row.tsx
+++ b/src/components/features/backends/backend-row.tsx
@@ -13,6 +13,7 @@ import { BackendStatusDot } from "./backend-status-dot";
 import { BackendVersion } from "./backend-version";
 import { DeviceFlowAuth } from "./device-flow-auth";
 import { getBackendStatusLabel } from "./backend-status-label";
+import { getLockedCloudHost } from "#/api/agent-server-config";
 
 const ROW_ACTION_BUTTON_CLASS =
   "inline-flex cursor-pointer items-center justify-center rounded-md p-1 text-muted transition-colors hover:bg-interactive-hover hover:text-white";
@@ -59,6 +60,7 @@ export function BackendRow({
         : "text-[var(--oh-muted)]";
   const dotStatus = isInvalidApiKey ? false : (health?.isConnected ?? null);
   const canSelect = health?.isConnected === true && !isInvalidApiKey;
+  const lockedCloudHost = getLockedCloudHost();
 
   return (
     <li
@@ -131,24 +133,28 @@ export function BackendRow({
             statusDisplay="modal"
           />
         ) : null}
-        <button
-          type="button"
-          onClick={onEdit}
-          aria-label={t(I18nKey.BACKEND$EDIT)}
-          data-testid={`manage-backends-edit-${backend.name}`}
-          className={ROW_ACTION_BUTTON_CLASS}
-        >
-          <Pencil aria-hidden className="size-4" strokeWidth={2} />
-        </button>
-        <button
-          type="button"
-          onClick={onRemove}
-          aria-label={t(I18nKey.BACKEND$REMOVE)}
-          data-testid={`manage-backends-remove-${backend.name}`}
-          className={ROW_ACTION_BUTTON_CLASS}
-        >
-          <Trash2 aria-hidden className="size-4" strokeWidth={2} />
-        </button>
+        {!lockedCloudHost && (
+          <button
+            type="button"
+            onClick={onEdit}
+            aria-label={t(I18nKey.BACKEND$EDIT)}
+            data-testid={`manage-backends-edit-${backend.name}`}
+            className={ROW_ACTION_BUTTON_CLASS}
+          >
+            <Pencil aria-hidden className="size-4" strokeWidth={2} />
+          </button>
+        )}
+        {!lockedCloudHost && (
+          <button
+            type="button"
+            onClick={onRemove}
+            aria-label={t(I18nKey.BACKEND$REMOVE)}
+            data-testid={`manage-backends-remove-${backend.name}`}
+            className={ROW_ACTION_BUTTON_CLASS}
+          >
+            <Trash2 aria-hidden className="size-4" strokeWidth={2} />
+          </button>
+        )}
       </div>
     </li>
   );


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

End-to-end verification performed by the agent that opened this PR:

- `npm run typecheck` — passes, no TypeScript errors.
- `npm run build` — production build succeeds in ~2s; the
  `manage-backends-modal-*.js` chunk (which contains the changed
  `BackendRow`) is 16.62 kB / gzip 4.97 kB and built without warnings
  about the modified files.
- `npx vitest run __tests__/components/backends/manage-backends-modal.test.tsx`
  — 19/19 pass with `VITE_LOCK_TO_CLOUD` unset (CI conditions).
  Three of those tests are new and exercise the row-button gating; the
  three pre-existing edit-form tests that previously clicked the pencil
  were isolated with `vi.stubEnv("VITE_LOCK_TO_CLOUD", "")` so they
  continue to test edit-form behavior rather than regressing because
  the user's local `.env` sets `VITE_LOCK_TO_CLOUD`.
- `npx vitest run __tests__/components/backends` — 69/69 pass with
  `VITE_LOCK_TO_CLOUD` unset.
- `npx eslint __tests__/components/backends/manage-backends-modal.test.tsx`
  — clean. Prettier reformatted the JSX in `backend-row.tsx` during
  the pre-commit hook (no-op style change).

The agent did NOT perform a live browser smoke test of the modal. The
row-button gating is fully exercised by the new unit tests (which
mount `BackendRow` directly, assert button presence/absence under both
lock paths, and click the handlers when present), but a reviewer
should still click through Manage Backends in both dev modes:

- Locked: `VITE_LOCK_TO_CLOUD=https://app.all-hands.dev npm run dev` —
  open Manage Backends, the row should show the locked backend with
  no pencil and no trash.
- Unlocked: `npm run dev` — open Manage Backends, the row should show
  pencil + trash, click pencil opens the edit modal.

---

## Why

The Manage Backends modal renders a row per registered backend with
pencil (edit) and trash (remove) icon buttons on each row. When a
deployment is started with `scripts/static-server.mjs --lock-to-cloud
<url>` (or `VITE_LOCK_TO_CLOUD` baked in at build time),
`getLockedCloudHost()` returns a non-null host so the rest of the UI
already restricts the user to that single cloud backend —
`backend-form-modal.tsx` short-circuits to the `CloudLoginColumn`,
`onboarding-modal.tsx` and `check-backend-step.tsx` guard against wrong
hosts, `root.tsx` redirects, and `default-backend.ts` refuses to seed
a local backend.

The row actions were the one remaining hole: a user in locked mode
could still click the pencil to open the edit form, change the locked
host / name / api-key, and submit; or click the trash to remove the
locked backend outright. This change closes that hole by gating both
row actions on the same lock state, matching the rest of the
locked-mode plumbing.

## Summary

- `src/components/features/backends/backend-row.tsx`: import
  `getLockedCloudHost` and skip rendering both the edit and remove
  buttons when a locked cloud host is configured. Row identity (name
  + host) is unchanged so the user can still see which backend is
  locked.
- `__tests__/components/backends/manage-backends-modal.test.tsx`:
  - three new tests in `describe("BackendRow", ...)` covering the
    happy path, the `VITE_LOCK_TO_CLOUD` build-time path, and the
    `window.__AGENT_CANVAS_LOCK_TO_CLOUD__` serve-time path
  - `afterEach` extended with `vi.unstubAllEnvs()` + window-global
    cleanup (consistent with `backend-form-modal.test.tsx`)
  - three pre-existing edit-form tests isolated from a local `.env`
    that sets `VITE_LOCK_TO_CLOUD`, with a comment explaining why
- `src/components/features/backends/backend-form-modal.tsx`: minor
  visual tweak (`pb-7` on the `CloudLoginColumn` outer wrapper) that
  was already in the working tree.

## Issue Number

N/A

## How to Test

```bash
# Install + verify typecheck + production build + targeted tests + full backends suite
npm ci
npm run typecheck
npm run build
npx vitest run __tests__/components/backends/manage-backends-modal.test.tsx
npx vitest run __tests__/components/backends
```

Manual smoke (two modes):

```bash
# Locked mode (UI hides edit + trash)
VITE_LOCK_TO_CLOUD=https://app.all-hands.dev npm run dev
# open Manage Backends → row shows the locked backend with no pencil/trash

# Unlocked mode (default)
npm run dev
# open Manage Backends → row shows pencil + trash, click pencil opens edit modal
```

## Video/Screenshots

Not applicable — purely a UI affordance gating change with no visual
regression when unlocked, and the only visible difference when locked
is the absence of two icon buttons in an existing modal.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- All 19 `manage-backends-modal.test.tsx` tests and all 69 tests in
  `__tests__/components/backends` pass with `VITE_LOCK_TO_CLOUD` unset
  (CI conditions). The four pre-existing failures that show up in
  local runs when the user's `.env` sets `VITE_LOCK_TO_CLOUD` are not
  introduced by this PR — they were failing before because
  `makeDefaultLocalBackend()` returns `null` in locked mode, leaving
  the seeded-default-Local-backend tests with an empty list.
- Per AGENTS.md, the `HUMAN:` section of
  `.github/pull_request_template.md` is intentionally left
  untouched.