### PR TITLE
Show agent/model metadata by default

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-card.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-card.test.tsx
@@ -606,10 +606,10 @@ describe("ConversationCard", () => {
 
   describe("Agent chip", () => {
     // The agent chip is gated by the conversation panel's "Agent / model"
-    // toggle (``showLlmProfiles``), off by default — one control for both ACP and
-    // OpenHands cards. The renders below pass ``showLlmProfiles`` to exercise
-    // the chip; the gating itself is covered by the first two tests.
-    it("hides the chip by default (LLM-model toggle off) for ACP", () => {
+    // toggle (``showLlmProfiles``) — one control for both ACP and OpenHands
+    // cards. The renders below pass ``showLlmProfiles`` to exercise the chip;
+    // the omitted-prop fallback is covered by the first two tests.
+    it("hides the chip when showLlmProfiles is omitted for ACP", () => {
       renderWithProviders(
         <ConversationCard
           title="Conversation 1"
@@ -626,7 +626,7 @@ describe("ConversationCard", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("hides the chip by default (LLM-model toggle off) for OpenHands", () => {
+    it("hides the chip when showLlmProfiles is omitted for OpenHands", () => {
       renderWithProviders(
         <ConversationCard
           title="Conversation 1"

--- a/__tests__/stores/conversation-panel-preferences-store.test.ts
+++ b/__tests__/stores/conversation-panel-preferences-store.test.ts
@@ -8,11 +8,11 @@ describe("conversation-panel-preferences store", () => {
     window.localStorage.clear();
   });
 
-  it("defaults to showing older conversations, chronological list, and expected toggles", () => {
+  it("defaults to showing older conversations, LLM profiles, chronological list, and expected toggles", () => {
     const state = useConversationPanelPreferencesStore.getState();
     expect(state.showOlderConversations).toBe(true);
     expect(state.showRepoBranchMetadata).toBe(false);
-    expect(state.showLlmProfiles).toBe(false);
+    expect(state.showLlmProfiles).toBe(true);
     expect(state.organizeMode).toBe("chronological");
     expect(state.conversationSort).toBe("updated");
     expect(state.threadScope).toBe("all");
@@ -143,10 +143,30 @@ describe("conversation-panel-preferences store", () => {
       showOlderConversations: false,
       showRepoBranchMetadata: true,
       // Filled with defaults for missing fields.
-      showLlmProfiles: false,
+      showLlmProfiles: true,
       organizeMode: "chronological",
       conversationSort: "updated",
       threadScope: "all",
     });
+  });
+
+  it("preserves an explicitly hidden LLM-profiles preference from persisted storage", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          showOlderConversations: true,
+          showRepoBranchMetadata: false,
+          showLlmProfiles: false,
+        },
+        version: 0,
+      }),
+    );
+
+    await useConversationPanelPreferencesStore.persist.rehydrate();
+
+    expect(
+      useConversationPanelPreferencesStore.getState().showLlmProfiles,
+    ).toBe(false);
   });
 });

--- a/src/components/features/conversation-panel/conversation-card/conversation-card-footer.tsx
+++ b/src/components/features/conversation-panel/conversation-card/conversation-card-footer.tsx
@@ -29,7 +29,7 @@ interface ConversationCardFooterProps {
   llmModel?: string | null;
   /**
    * Whether to render the agent/model chip. Wired to the conversation
-   * panel's "LLM model" toggle (off by default); gates the chip uniformly
+   * panel's "LLM model" toggle; gates the chip uniformly
    * for both ACP and OpenHands cards.
    */
   showAgentChip?: boolean;
@@ -68,7 +68,7 @@ export function ConversationCardFooter({
   const isPaused = isExecutionPaused(executionStatus);
 
   // Single inline chip per conversation: [brand mark] {model text}. Gated by
-  // the conversation panel's "LLM model" toggle (off by default) and applied
+  // the conversation panel's "LLM model" toggle and applied
   // uniformly to both kinds — OpenHands shows the logo + ``agent.llm.model``;
   // ACP shows the provider brand mark + model resolved through PR 730's
   // adapter chain, falling back to the provider display name when no model is

--- a/src/stores/conversation-panel-preferences-store.ts
+++ b/src/stores/conversation-panel-preferences-store.ts
@@ -51,7 +51,7 @@ type ConversationPanelPreferencesStore = ConversationPanelPreferencesState &
 const initialState: ConversationPanelPreferencesState = {
   showOlderConversations: true,
   showRepoBranchMetadata: false,
-  showLlmProfiles: false,
+  showLlmProfiles: true,
   showHoverMetadata: true,
   organizeMode: "chronological",
   conversationSort: "updated",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN: 

i ran it locally and the agent/model chips are visible by default and the metadata filter hides them when turned off

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [x] A human has tested these changes.

AGENT:

Automated validation performed by Codex:
- Rechecked issue #1512 before work and before handoff: open, unassigned, no comments.
- Used a red/green store test for the default preference change; the updated test failed before the implementation because new state still defaulted to `showLlmProfiles: false`.
- Ran focused store/conversation-panel/card/filter-menu tests after the change.
- Ran the documented verification command and full Vitest suite.

---

## Why

Users have asked for the agent/model used by a conversation to be visible in the conversation list. The metadata chip already exists behind the Agent/model filter option, but the option is easy to miss because new installs hide it by default.

## Summary

- Default the conversation panel's Agent/model metadata preference to visible for new users.
- Preserve an explicitly persisted hidden preference for users who already turned the chip off.
- Update focused tests and stale comments that still described the chip as off by default.

## Issue Number

Closes #1512

## How to Test

Automated checks run locally:

- `npx vitest run __tests__/stores/conversation-panel-preferences-store.test.ts __tests__/components/features/conversation-panel/conversation-panel.test.tsx __tests__/components/features/conversation-panel/conversation-card.test.tsx __tests__/components/features/conversation-panel/conversation-panel-filter-menu.test.tsx` — passed post-commit: 95/95 tests.
- `npm run typecheck && npm run build` — passed.
- `npm test` — passed: 454 test files, 3459 tests.

Manual reviewer check:

1. Start Agent Canvas with at least one conversation that has agent/model metadata.
2. Confirm the Agent/model chip is visible in the conversation list without enabling the filter manually.
3. Open the conversation-list filter menu, turn Agent/model off, and confirm the chip hides.

## Video/Screenshots

No screenshot attached in this draft. The change is a persisted default preference with focused test coverage and a passing production build.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Existing localStorage values are still respected. Users who already hid Agent/model metadata should keep that choice after upgrading.