### PR TITLE
refactor: split cloud API and runtime proxy calls

### DIFF
--- a/__tests__/api/agent-server-git-service.test.ts
+++ b/__tests__/api/agent-server-git-service.test.ts
@@ -5,7 +5,7 @@ import {
   setActiveSelection,
   setRegisteredBackends,
 } from "#/api/backend-registry/active-store";
-import { callCloudProxy } from "#/api/cloud/proxy";
+import { callCloudApi } from "#/api/cloud/proxy";
 import type { Backend } from "#/api/backend-registry/types";
 import AgentServerGitService from "../../src/api/git-service/agent-server-git-service.api";
 
@@ -24,7 +24,7 @@ vi.mock("@openhands/typescript-client/workspace/remote-workspace", () => ({
 }));
 
 vi.mock("#/api/cloud/proxy", () => ({
-  callCloudProxy: vi.fn(),
+  callCloudApi: vi.fn(),
 }));
 
 describe("AgentServerGitService", () => {
@@ -184,7 +184,7 @@ describe("AgentServerGitService", () => {
       __resetActiveStoreForTests();
       setRegisteredBackends([cloudBackend]);
       setActiveSelection({ backendId: cloudBackend.id, orgId: "org-1" });
-      vi.mocked(callCloudProxy).mockReset();
+      vi.mocked(callCloudApi).mockReset();
     });
 
     afterEach(() => {
@@ -195,7 +195,7 @@ describe("AgentServerGitService", () => {
     describe("getGitChanges", () => {
       test("fetches changes via the cloud app-conversations git endpoint and maps statuses", async () => {
         // Arrange
-        vi.mocked(callCloudProxy).mockResolvedValue([
+        vi.mocked(callCloudApi).mockResolvedValue([
           { status: "ADDED", path: "new-file.ts" },
           { status: "UPDATED", path: "changed-file.ts" },
         ]);
@@ -211,7 +211,7 @@ describe("AgentServerGitService", () => {
         // Assert — addressed by conversation id on the cloud API itself
         // (no hostOverride / session-api-key runtime hop), with the
         // relative git path normalized to an absolute runtime path.
-        expect(callCloudProxy).toHaveBeenCalledWith({
+        expect(callCloudApi).toHaveBeenCalledWith({
           backend: cloudBackend,
           method: "GET",
           path: "/api/v1/app-conversations/conv-1/git/changes?path=%2Fworkspace%2Fproject",
@@ -224,7 +224,7 @@ describe("AgentServerGitService", () => {
 
       test("throws when the cloud endpoint returns a non-array response", async () => {
         // Arrange — a dead runtime can surface as a non-JSON-array body.
-        vi.mocked(callCloudProxy).mockResolvedValue(
+        vi.mocked(callCloudApi).mockResolvedValue(
           "<!DOCTYPE html><html>...</html>",
         );
 
@@ -243,7 +243,7 @@ describe("AgentServerGitService", () => {
     describe("getGitChangeDiff", () => {
       test("fetches the diff via the cloud app-conversations git endpoint", async () => {
         // Arrange
-        vi.mocked(callCloudProxy).mockResolvedValue({
+        vi.mocked(callCloudApi).mockResolvedValue({
           original: "old content",
           modified: "new content",
         });
@@ -257,7 +257,7 @@ describe("AgentServerGitService", () => {
         );
 
         // Assert
-        expect(callCloudProxy).toHaveBeenCalledWith({
+        expect(callCloudApi).toHaveBeenCalledWith({
           backend: cloudBackend,
           method: "GET",
           path: "/api/v1/app-conversations/conv-1/git/diff?path=%2Fworkspace%2Fproject%2Fsrc%2Ffile.ts",
@@ -271,7 +271,7 @@ describe("AgentServerGitService", () => {
 
     test("does not touch the runtime workspace SDK on cloud backends", async () => {
       // Arrange
-      vi.mocked(callCloudProxy).mockResolvedValue([]);
+      vi.mocked(callCloudApi).mockResolvedValue([]);
 
       // Act
       await AgentServerGitService.getGitChanges(

--- a/__tests__/api/automation-service.test.ts
+++ b/__tests__/api/automation-service.test.ts
@@ -15,18 +15,20 @@ const {
   mockPatch,
   mockPost,
   mockDelete,
-  mockCallCloudProxy,
+  mockCallCloudApi,
   mockGetActive,
   mockGetEffectiveLocal,
   capturedInterceptors,
 } = vi.hoisted(() => {
-  const interceptors: Array<(config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig> = [];
+  const interceptors: Array<
+    (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig
+  > = [];
   return {
     mockGet: vi.fn(),
     mockPatch: vi.fn(),
     mockPost: vi.fn(),
     mockDelete: vi.fn(),
-    mockCallCloudProxy: vi.fn(),
+    mockCallCloudApi: vi.fn(),
     mockGetActive: vi.fn(),
     mockGetEffectiveLocal: vi.fn(),
     capturedInterceptors: interceptors,
@@ -43,7 +45,11 @@ vi.mock("axios", () => ({
       delete: mockDelete,
       interceptors: {
         request: {
-          use: (fn: (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig) => {
+          use: (
+            fn: (
+              config: InternalAxiosRequestConfig,
+            ) => InternalAxiosRequestConfig,
+          ) => {
             capturedInterceptors.push(fn);
           },
         },
@@ -53,7 +59,7 @@ vi.mock("axios", () => ({
 }));
 
 vi.mock("#/api/cloud/proxy", () => ({
-  callCloudProxy: mockCallCloudProxy,
+  callCloudApi: mockCallCloudApi,
 }));
 
 vi.mock("#/api/backend-registry/active-store", () => ({
@@ -127,7 +133,7 @@ describe("AutomationService", () => {
     mockPatch.mockReset();
     mockPost.mockReset();
     mockDelete.mockReset();
-    mockCallCloudProxy.mockReset();
+    mockCallCloudApi.mockReset();
     // Default: active backend is local. Cloud-routing tests override this.
     mockGetActive.mockReset();
     mockGetActive.mockReturnValue({ backend: localBackend, orgId: null });
@@ -335,7 +341,7 @@ describe("AutomationService", () => {
   });
 
   // When the active backend is cloud the local axios instance must be
-  // bypassed entirely; calls must route through `callCloudProxy`, which
+  // bypassed entirely; calls must route through `callCloudApi`, which
   // sends them directly to the cloud host from the browser (the automation
   // service grants permissive CORS to API-key requests, automation#185).
   describe("cloud routing", () => {
@@ -343,81 +349,86 @@ describe("AutomationService", () => {
       mockGetActive.mockReturnValue({ backend: cloudBackend, orgId: null });
     });
 
-    it("listAutomations routes to callCloudProxy with pagination in the path", async () => {
+    it("listAutomations routes to callCloudApi with pagination in the path", async () => {
       const response: AutomationsResponse = {
         automations: [mockAutomation],
         total: 1,
       };
-      mockCallCloudProxy.mockResolvedValue(response);
+      mockCallCloudApi.mockResolvedValue(response);
 
       const result = await AutomationService.listAutomations({
         limit: 10,
         offset: 5,
       });
 
-      expect(mockCallCloudProxy).toHaveBeenCalledWith({
+      expect(mockCallCloudApi).toHaveBeenCalledWith({
         backend: cloudBackend,
         method: "GET",
-        path: "/api/automation/v1?limit=10&offset=5",      });
+        path: "/api/automation/v1?limit=10&offset=5",
+      });
       expect(mockGet).not.toHaveBeenCalled();
       expect(result).toEqual(response);
     });
 
-    it("getAutomation routes to callCloudProxy with the id in the path", async () => {
-      mockCallCloudProxy.mockResolvedValue(mockAutomation);
+    it("getAutomation routes to callCloudApi with the id in the path", async () => {
+      mockCallCloudApi.mockResolvedValue(mockAutomation);
 
       const result = await AutomationService.getAutomation("abc");
 
-      expect(mockCallCloudProxy).toHaveBeenCalledWith({
+      expect(mockCallCloudApi).toHaveBeenCalledWith({
         backend: cloudBackend,
         method: "GET",
-        path: "/api/automation/v1/abc",      });
+        path: "/api/automation/v1/abc",
+      });
       expect(result).toEqual(mockAutomation);
     });
 
-    it("dispatchAutomation forwards method POST via callCloudProxy", async () => {
-      mockCallCloudProxy.mockResolvedValue(mockRun);
+    it("dispatchAutomation forwards method POST via callCloudApi", async () => {
+      mockCallCloudApi.mockResolvedValue(mockRun);
 
       const result = await AutomationService.dispatchAutomation("abc");
 
-      expect(mockCallCloudProxy).toHaveBeenCalledWith({
+      expect(mockCallCloudApi).toHaveBeenCalledWith({
         backend: cloudBackend,
         method: "POST",
-        path: "/api/automation/v1/abc/dispatch",      });
+        path: "/api/automation/v1/abc/dispatch",
+      });
       expect(mockPost).not.toHaveBeenCalled();
       expect(result).toEqual(mockRun);
     });
 
-    it("updateAutomation forwards method PATCH and body via callCloudProxy", async () => {
+    it("updateAutomation forwards method PATCH and body via callCloudApi", async () => {
       const updated = { ...mockAutomation, enabled: false };
-      mockCallCloudProxy.mockResolvedValue(updated);
+      mockCallCloudApi.mockResolvedValue(updated);
 
       const result = await AutomationService.updateAutomation("abc", {
         enabled: false,
       });
 
-      expect(mockCallCloudProxy).toHaveBeenCalledWith({
+      expect(mockCallCloudApi).toHaveBeenCalledWith({
         backend: cloudBackend,
         method: "PATCH",
         path: "/api/automation/v1/abc",
-        body: { enabled: false },      });
+        body: { enabled: false },
+      });
       expect(mockPatch).not.toHaveBeenCalled();
       expect(result).toEqual(updated);
     });
 
-    it("deleteAutomation forwards method DELETE via callCloudProxy", async () => {
-      mockCallCloudProxy.mockResolvedValue(undefined);
+    it("deleteAutomation forwards method DELETE via callCloudApi", async () => {
+      mockCallCloudApi.mockResolvedValue(undefined);
 
       await AutomationService.deleteAutomation("abc");
 
-      expect(mockCallCloudProxy).toHaveBeenCalledWith({
+      expect(mockCallCloudApi).toHaveBeenCalledWith({
         backend: cloudBackend,
         method: "DELETE",
-        path: "/api/automation/v1/abc",      });
+        path: "/api/automation/v1/abc",
+      });
       expect(mockDelete).not.toHaveBeenCalled();
     });
 
-    it("dispatchAutomation forwards method POST via callCloudProxy", async () => {
+    it("dispatchAutomation forwards method POST via callCloudApi", async () => {
       const run = {
         id: "run-1",
         status: "PENDING",
@@ -427,26 +438,27 @@ describe("AutomationService", () => {
         started_at: "2026-01-01T00:00:00Z",
         completed_at: null,
       };
-      mockCallCloudProxy.mockResolvedValue(run);
+      mockCallCloudApi.mockResolvedValue(run);
 
       const result = await AutomationService.dispatchAutomation("abc");
 
-      expect(mockCallCloudProxy).toHaveBeenCalledWith({
+      expect(mockCallCloudApi).toHaveBeenCalledWith({
         backend: cloudBackend,
         method: "POST",
-        path: "/api/automation/v1/abc/dispatch",      });
+        path: "/api/automation/v1/abc/dispatch",
+      });
       expect(mockPost).not.toHaveBeenCalled();
       expect(result).toEqual(run);
     });
 
     it("checkHealth calls the cloud host with a fail-fast timeout and returns the upstream status", async () => {
-      mockCallCloudProxy.mockResolvedValue({ status: "ok" });
+      mockCallCloudApi.mockResolvedValue({ status: "ok" });
 
       const result = await AutomationService.checkHealth();
 
       // Property access (vs whole-object matching) keeps these assertions
       // resilient to future additive CloudProxyRequest fields.
-      const call = mockCallCloudProxy.mock.calls[0]![0];
+      const call = mockCallCloudApi.mock.calls[0]![0];
       expect(call.method).toBe("GET");
       expect(call.path).toBe("/api/automation/health");
       expect(call.timeoutSeconds).toBe(5);
@@ -455,7 +467,7 @@ describe("AutomationService", () => {
     });
 
     it("checkHealth resolves to an error status instead of throwing when the cloud call fails", async () => {
-      mockCallCloudProxy.mockRejectedValue(new Error("proxy unreachable"));
+      mockCallCloudApi.mockRejectedValue(new Error("proxy unreachable"));
 
       const result = await AutomationService.checkHealth();
 

--- a/__tests__/api/bash-service.test.ts
+++ b/__tests__/api/bash-service.test.ts
@@ -6,7 +6,7 @@ import {
   setRegisteredBackends,
 } from "#/api/backend-registry/active-store";
 import BashService from "#/api/bash-service/bash-service.api";
-import { callCloudProxy } from "#/api/cloud/proxy";
+import { callLegacyRuntimeCloudProxy } from "#/api/cloud/proxy";
 import type { Backend } from "#/api/backend-registry/types";
 
 const { searchEventsMock } = vi.hoisted(() => ({
@@ -28,7 +28,7 @@ vi.mock("#/api/agent-server-client-options", () => ({
 }));
 
 vi.mock("#/api/cloud/proxy", () => ({
-  callCloudProxy: vi.fn(),
+  callLegacyRuntimeCloudProxy: vi.fn(),
 }));
 
 const localBackend: Backend = {
@@ -78,7 +78,7 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   vi.mocked(BashClient).mockClear();
   searchEventsMock.mockReset();
-  vi.mocked(callCloudProxy).mockReset();
+  vi.mocked(callLegacyRuntimeCloudProxy).mockReset();
 });
 
 afterEach(() => {
@@ -116,7 +116,7 @@ describe("BashService.listOutputs — local backend", () => {
     expect(searchEventsMock.mock.calls[1][0]).toMatchObject({
       page_id: "next",
     });
-    expect(callCloudProxy).not.toHaveBeenCalled();
+    expect(callLegacyRuntimeCloudProxy).not.toHaveBeenCalled();
     expect(outputs).toEqual([OUTPUT_1, OUTPUT_2]);
   });
 
@@ -126,7 +126,7 @@ describe("BashService.listOutputs — local backend", () => {
     const outputs = await BashService.listOutputs(null, null, BASH_CMD_ID);
 
     expect(BashClient).toHaveBeenCalled();
-    expect(callCloudProxy).not.toHaveBeenCalled();
+    expect(callLegacyRuntimeCloudProxy).not.toHaveBeenCalled();
     expect(outputs).toEqual([OUTPUT_1]);
   });
 });
@@ -137,8 +137,8 @@ describe("BashService.listOutputs — cloud backend", () => {
     setActiveSelection({ backendId: cloudBackend.id, orgId: null });
   });
 
-  it("routes through callCloudProxy with hostOverride and session-api-key", async () => {
-    vi.mocked(callCloudProxy).mockResolvedValueOnce({
+  it("routes through callLegacyRuntimeCloudProxy with runtime host and session API key", async () => {
+    vi.mocked(callLegacyRuntimeCloudProxy).mockResolvedValueOnce({
       items: [OUTPUT_1, OUTPUT_2],
     });
 
@@ -149,11 +149,10 @@ describe("BashService.listOutputs — cloud backend", () => {
     );
 
     expect(BashClient).not.toHaveBeenCalled();
-    const proxyCall = vi.mocked(callCloudProxy).mock.calls[0][0];
+    const proxyCall = vi.mocked(callLegacyRuntimeCloudProxy).mock.calls[0][0];
     expect(proxyCall.method).toBe("GET");
     expect(proxyCall.path).toMatch(/^\/api\/bash\/bash_events\/search\?/);
-    expect(proxyCall.hostOverride).toBe("https://runtime.example.com");
-    expect(proxyCall.authMode).toBe("session-api-key");
+    expect(proxyCall.host).toBe("https://runtime.example.com");
     expect(proxyCall.sessionApiKey).toBe(SESSION_KEY);
 
     const searchUrl = new URL(
@@ -170,6 +169,6 @@ describe("BashService.listOutputs — cloud backend", () => {
     await expect(
       BashService.listOutputs(null, SESSION_KEY, BASH_CMD_ID),
     ).rejects.toThrow(/requires a conversation URL/);
-    expect(callCloudProxy).not.toHaveBeenCalled();
+    expect(callLegacyRuntimeCloudProxy).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/cloud-conversation-service.test.ts
+++ b/__tests__/api/cloud-conversation-service.test.ts
@@ -11,12 +11,12 @@ import {
   searchCloudConversations,
 } from "#/api/cloud/conversation-service.api";
 
-const { mockCallCloudProxy } = vi.hoisted(() => ({
-  mockCallCloudProxy: vi.fn(),
+const { mockCallCloudApi } = vi.hoisted(() => ({
+  mockCallCloudApi: vi.fn(),
 }));
 
 vi.mock("#/api/cloud/proxy", () => ({
-  callCloudProxy: (...args: unknown[]) => mockCallCloudProxy(...args),
+  callCloudApi: (...args: unknown[]) => mockCallCloudApi(...args),
 }));
 
 const cloudBackend: Backend = {
@@ -33,13 +33,13 @@ describe("cloud conversation-service overlay", () => {
     __resetActiveStoreForTests();
     setRegisteredBackends([cloudBackend]);
     setActiveSelection({ backendId: cloudBackend.id, orgId: null });
-    mockCallCloudProxy.mockReset();
+    mockCallCloudApi.mockReset();
   });
 
   afterEach(() => {
     window.localStorage.clear();
     __resetActiveStoreForTests();
-    mockCallCloudProxy.mockReset();
+    mockCallCloudApi.mockReset();
   });
 
   it("overlays locally-stored repo selection onto batchGetCloudConversations results when the server returns nulls", async () => {
@@ -49,7 +49,7 @@ describe("cloud conversation-service overlay", () => {
       git_provider: "github",
     });
 
-    mockCallCloudProxy.mockResolvedValueOnce([
+    mockCallCloudApi.mockResolvedValueOnce([
       {
         id: "conv-1",
         title: "Hello",
@@ -74,7 +74,7 @@ describe("cloud conversation-service overlay", () => {
       git_provider: "gitlab",
     });
 
-    mockCallCloudProxy.mockResolvedValueOnce([
+    mockCallCloudApi.mockResolvedValueOnce([
       {
         id: "conv-1",
         title: "Hello",
@@ -92,7 +92,7 @@ describe("cloud conversation-service overlay", () => {
   });
 
   it("leaves null entries untouched when the cloud server returns null for a missing conversation", async () => {
-    mockCallCloudProxy.mockResolvedValueOnce([null]);
+    mockCallCloudApi.mockResolvedValueOnce([null]);
 
     const result = await batchGetCloudConversations(["missing"]);
 
@@ -103,7 +103,7 @@ describe("cloud conversation-service overlay", () => {
     const result = await batchGetCloudConversations([]);
 
     expect(result).toEqual([]);
-    expect(mockCallCloudProxy).not.toHaveBeenCalled();
+    expect(mockCallCloudApi).not.toHaveBeenCalled();
   });
 
   it("only fills server-side nulls — server-populated fields are preserved", async () => {
@@ -113,7 +113,7 @@ describe("cloud conversation-service overlay", () => {
       git_provider: "gitlab",
     });
 
-    mockCallCloudProxy.mockResolvedValueOnce([
+    mockCallCloudApi.mockResolvedValueOnce([
       {
         id: "conv-1",
         title: "Hello",
@@ -139,7 +139,7 @@ describe("cloud conversation-service overlay", () => {
       git_provider: null,
     });
 
-    mockCallCloudProxy.mockResolvedValueOnce([
+    mockCallCloudApi.mockResolvedValueOnce([
       {
         id: "conv-1",
         title: "Hello",
@@ -168,7 +168,7 @@ describe("cloud conversation-service overlay", () => {
       git_provider: "github",
     });
 
-    mockCallCloudProxy.mockResolvedValueOnce([
+    mockCallCloudApi.mockResolvedValueOnce([
       {
         id: "conv-1",
         title: "First",
@@ -219,7 +219,7 @@ describe("cloud conversation-service overlay", () => {
       git_provider: "github",
     });
 
-    mockCallCloudProxy.mockResolvedValueOnce({
+    mockCallCloudApi.mockResolvedValueOnce({
       items: [
         {
           id: "conv-1",

--- a/__tests__/api/cloud/conversation-runtime-info.test.ts
+++ b/__tests__/api/cloud/conversation-runtime-info.test.ts
@@ -61,16 +61,26 @@ describe("AgentServerConversationService.getRuntimeConversation", () => {
       __resetActiveStoreForTests();
       setRegisteredBackends([cloudBackend]);
       setActiveSelection({ backendId: cloudBackend.id });
+      vi.mocked(axios.request).mockReset();
       vi.mocked(axios.post).mockReset();
     });
 
-    it("routes through /api/cloud-proxy targeting the conversation runtime host", async () => {
-      // Arrange
-      vi.mocked(axios.post).mockResolvedValue({ data: runtimeResponse });
+    it("reads runtime info from the first-class app-conversations API", async () => {
+      vi.mocked(axios.request).mockResolvedValue({
+        data: [
+          {
+            ...runtimeResponse,
+            metrics: {
+              accumulated_cost: 1.23,
+              max_budget_per_task: null,
+              accumulated_token_usage: null,
+            },
+          },
+        ],
+      });
       const conversationUrl =
         "http://abc123.runtime.all-hands.dev/api/conversations/conv-abc";
 
-      // Act
       const result =
         await AgentServerConversationService.getRuntimeConversation(
           "conv-abc",
@@ -78,17 +88,15 @@ describe("AgentServerConversationService.getRuntimeConversation", () => {
           "session-xyz",
         );
 
-      // Assert
-      expect(axios.post).toHaveBeenCalledOnce();
-      const [url, body] = vi.mocked(axios.post).mock.calls[0]!;
-      expect(url).toMatch(/\/api\/cloud-proxy$/);
-      expect(body).toMatchObject({
-        host: "http://abc123.runtime.all-hands.dev",
+      expect(axios.post).not.toHaveBeenCalled();
+      expect(axios.request).toHaveBeenCalledOnce();
+      const [config] = vi.mocked(axios.request).mock.calls[0]!;
+      expect(config).toMatchObject({
+        url: `${cloudBackend.host}/api/v1/app-conversations?ids=conv-abc`,
         method: "GET",
-        path: "/api/conversations/conv-abc",
-        headers: { "X-Session-API-Key": "session-xyz" },
       });
-      expect(result.stats.usage_to_metrics.agent?.accumulated_cost).toBe(1.23);
+      expect(result.metrics?.accumulated_cost).toBe(1.23);
+      expect(result.stats).toEqual({ usage_to_metrics: {} });
     });
   });
 

--- a/__tests__/api/cloud/proxy.test.ts
+++ b/__tests__/api/cloud/proxy.test.ts
@@ -5,7 +5,7 @@ import {
   setActiveSelection,
   setRegisteredBackends,
 } from "#/api/backend-registry/active-store";
-import { callCloudProxy } from "#/api/cloud/proxy";
+import { callCloudApi, callLegacyRuntimeCloudProxy } from "#/api/cloud/proxy";
 import type { Backend } from "#/api/backend-registry/types";
 
 vi.mock("axios");
@@ -42,27 +42,20 @@ afterEach(() => {
   vi.mocked(axios.post).mockReset();
 });
 
-describe("callCloudProxy X-Org-Id injection", () => {
+describe("callCloudApi X-Org-Id injection", () => {
   it("sends X-Org-Id when targeting the active cloud backend with a selected orgId", async () => {
-    // Arrange — active selection points at the cloud backend with a
-    // resolved orgId. This is the steady-state case after the user picks
-    // an org row in the BackendSelector.
     setRegisteredBackends([cloudPersonal]);
     setActiveSelection({
       backendId: cloudPersonal.id,
       orgId: "org-personal-uuid",
     });
 
-    // Act
-    await callCloudProxy({
+    await callCloudApi({
       backend: cloudPersonal,
       method: "GET",
       path: "/api/v1/app-conversations/search",
     });
 
-    // Assert — the request carries the X-Org-Id of the active selection so the
-    // cloud backend can scope this request to the user's locally-chosen org
-    // without depending on user.current_org_id.
     const [config] = vi.mocked(axios.request).mock.calls[0]!;
     expect(config).toMatchObject({
       url: `${cloudPersonal.host}/api/v1/app-conversations/search`,
@@ -74,24 +67,18 @@ describe("callCloudProxy X-Org-Id injection", () => {
   });
 
   it("omits X-Org-Id when targeting a different cloud backend than the active one", async () => {
-    // Arrange — the BackendSelector fan-out (e.g. useAllCloudOrganizations)
-    // calls callCloudProxy(b) for every registered cloud backend. Sending
-    // the active backend's orgId across an unrelated API key would cause
-    // the cloud backend to 403 on api_key_org_id / X-Org-Id mismatch.
     setRegisteredBackends([cloudPersonal, cloudAcme]);
     setActiveSelection({
       backendId: cloudPersonal.id,
       orgId: "org-personal-uuid",
     });
 
-    // Act — request targets the non-active backend.
-    await callCloudProxy({
+    await callCloudApi({
       backend: cloudAcme,
       method: "GET",
       path: "/api/keys/current",
     });
 
-    // Assert
     const [config] = vi.mocked(axios.request).mock.calls[0]!;
     expect(
       (config as { headers: Record<string, string> }).headers,
@@ -99,26 +86,19 @@ describe("callCloudProxy X-Org-Id injection", () => {
   });
 });
 
-describe("callCloudProxy automation direct routing", () => {
-  it("sends automation requests straight to the cloud host with the API key instead of the /api/cloud-proxy envelope", async () => {
-    // Arrange — the automation service grants permissive CORS to API-key
-    // requests (automation#185), so app-host automation calls no longer
-    // need the same-origin proxy hop through the bundled agent-server.
+describe("callCloudApi direct routing", () => {
+  it("sends automation requests straight to the cloud host with the API key", async () => {
     setRegisteredBackends([cloudPersonal]);
     setActiveSelection({ backendId: cloudPersonal.id, orgId: null });
     const page = { automations: [], total: 0 };
     vi.mocked(axios.request).mockResolvedValue({ data: page });
 
-    // Act
-    const result = await callCloudProxy({
+    const result = await callCloudApi({
       backend: cloudPersonal,
       method: "GET",
       path: "/api/automation/v1?limit=50&offset=0",
     });
 
-    // Assert — the browser calls the automation API on the cloud host
-    // directly, authenticated by the backend's API key, and no envelope
-    // POST reaches /api/cloud-proxy.
     expect(axios.post).not.toHaveBeenCalled();
     const [config] = vi.mocked(axios.request).mock.calls[0]!;
     expect(config).toMatchObject({
@@ -132,14 +112,10 @@ describe("callCloudProxy automation direct routing", () => {
   });
 
   it("forwards the blob responseType and fail-fast timeout to the direct request", async () => {
-    // Arrange — tarball downloads and health probes rely on these
-    // per-request options surviving the switch from the proxy envelope to
-    // the direct call.
     setRegisteredBackends([cloudPersonal]);
     setActiveSelection({ backendId: cloudPersonal.id, orgId: null });
 
-    // Act
-    await callCloudProxy({
+    await callCloudApi({
       backend: cloudPersonal,
       method: "GET",
       path: "/api/automation/v1/auto-1/tarball",
@@ -147,7 +123,6 @@ describe("callCloudProxy automation direct routing", () => {
       timeoutSeconds: 5,
     });
 
-    // Assert
     const [config] = vi.mocked(axios.request).mock.calls[0]!;
     expect(config).toMatchObject({
       responseType: "blob",
@@ -156,28 +131,22 @@ describe("callCloudProxy automation direct routing", () => {
   });
 });
 
-describe("callCloudProxy hostOverride routing", () => {
+describe("callLegacyRuntimeCloudProxy routing", () => {
   const runtimeHost = "https://abc123.prod-runtime.all-hands.dev";
 
-  it("routes through the local /api/cloud-proxy instead of the upstream host when hostOverride is set", async () => {
-    // Arrange — runtime-sandbox endpoints need the proxy hop because the
-    // per-conversation runtime hosts reject browser requests from the
-    // local GUI origin.
+  it("routes through local /api/cloud-proxy instead of the upstream runtime host", async () => {
     setRegisteredBackends([cloudPersonal]);
     setActiveSelection({ backendId: cloudPersonal.id, orgId: null });
     vi.mocked(axios.post).mockResolvedValue({ data: { items: [] } });
 
-    // Act
-    const result = await callCloudProxy({
+    const result = await callLegacyRuntimeCloudProxy({
       backend: cloudPersonal,
       method: "GET",
+      host: runtimeHost,
       path: "/api/bash/bash_events/search",
-      hostOverride: runtimeHost,
+      sessionApiKey: "sandbox-session",
     });
 
-    // Assert — the browser only makes a same-origin POST to the bundled
-    // agent-server's proxy endpoint carrying the upstream call as an
-    // envelope, and the upstream payload is unwrapped for the caller.
     expect(axios.request).not.toHaveBeenCalled();
     const [url, envelope] = vi.mocked(axios.post).mock.calls[0]!;
     expect(url).toMatch(/\/api\/cloud-proxy$/);
@@ -185,35 +154,33 @@ describe("callCloudProxy hostOverride routing", () => {
       host: runtimeHost,
       method: "GET",
       path: "/api/bash/bash_events/search",
+      headers: { "X-Session-API-Key": "sandbox-session" },
     });
     expect(result).toEqual({ items: [] });
   });
 
-  it("carries bearer auth and X-Org-Id inside the proxy envelope", async () => {
-    // Arrange — org scoping must survive the server-side hop: the envelope
-    // headers are what the agent-server attaches to the upstream call in
-    // place of the headers a direct browser request would have sent.
+  it("carries explicit headers inside the proxy envelope", async () => {
     setRegisteredBackends([cloudPersonal]);
     setActiveSelection({
       backendId: cloudPersonal.id,
       orgId: "org-personal-uuid",
     });
 
-    // Act
-    await callCloudProxy({
+    await callLegacyRuntimeCloudProxy({
       backend: cloudPersonal,
       method: "GET",
+      host: runtimeHost,
       path: "/api/bash/bash_events/search",
-      hostOverride: runtimeHost,
+      sessionApiKey: "sandbox-session",
+      headers: { "X-Custom": "custom" },
     });
 
-    // Assert
     const [, envelope] = vi.mocked(axios.post).mock.calls[0]!;
     expect(
       (envelope as { headers: Record<string, string> }).headers,
     ).toMatchObject({
-      Authorization: `Bearer ${cloudPersonal.apiKey}`,
-      "X-Org-Id": "org-personal-uuid",
+      "X-Session-API-Key": "sandbox-session",
+      "X-Custom": "custom",
     });
   });
 });

--- a/__tests__/api/event-service.test.ts
+++ b/__tests__/api/event-service.test.ts
@@ -5,11 +5,11 @@ import {
   setRegisteredBackends,
 } from "#/api/backend-registry/active-store";
 import EventService from "#/api/event-service/event-service.api";
-import { callCloudProxy } from "#/api/cloud/proxy";
+import { callCloudApi } from "#/api/cloud/proxy";
 import type { Backend } from "#/api/backend-registry/types";
 
 vi.mock("#/api/cloud/proxy", () => ({
-  callCloudProxy: vi.fn(),
+  callCloudApi: vi.fn(),
 }));
 
 const cloudBackend: Backend = {
@@ -25,8 +25,8 @@ beforeEach(() => {
   __resetActiveStoreForTests();
   setRegisteredBackends([cloudBackend]);
   setActiveSelection({ backendId: cloudBackend.id, orgId: "org-1" });
-  vi.mocked(callCloudProxy).mockReset();
-  vi.mocked(callCloudProxy).mockResolvedValue({
+  vi.mocked(callCloudApi).mockReset();
+  vi.mocked(callCloudApi).mockResolvedValue({
     items: [],
     next_page_id: null,
   });
@@ -35,7 +35,7 @@ beforeEach(() => {
 afterEach(() => {
   window.localStorage.clear();
   __resetActiveStoreForTests();
-  vi.mocked(callCloudProxy).mockReset();
+  vi.mocked(callCloudApi).mockReset();
 });
 
 describe("EventService.searchEvents — cloud branch", () => {
@@ -50,7 +50,7 @@ describe("EventService.searchEvents — cloud branch", () => {
 
     await EventService.searchEvents("conv-1", null, null, options);
 
-    const proxyCall = vi.mocked(callCloudProxy).mock.calls[0][0];
+    const proxyCall = vi.mocked(callCloudApi).mock.calls[0][0];
     const url = new URL(`https://x${proxyCall.path}`);
     expect(url.searchParams.get("limit")).toBe("100");
     expect(url.searchParams.get("sort_order")).toBe("TIMESTAMP_DESC");
@@ -66,7 +66,7 @@ describe("EventService.searchEvents — cloud branch", () => {
   it("sends only limit when no filter params are provided", async () => {
     await EventService.searchEvents("conv-1", null, null, { limit: 50 });
 
-    const proxyCall = vi.mocked(callCloudProxy).mock.calls[0][0];
+    const proxyCall = vi.mocked(callCloudApi).mock.calls[0][0];
     expect(proxyCall.path).toBe(
       "/api/v1/conversation/conv-1/events/search?limit=50",
     );
@@ -75,7 +75,7 @@ describe("EventService.searchEvents — cloud branch", () => {
   it("returns empty page when full-param request fails (graceful degradation)", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    vi.mocked(callCloudProxy).mockRejectedValueOnce(
+    vi.mocked(callCloudApi).mockRejectedValueOnce(
       new Error("Internal Server Error"),
     );
 
@@ -86,7 +86,7 @@ describe("EventService.searchEvents — cloud branch", () => {
     });
 
     // Only one call — no retry, just returns empty page to stop pagination.
-    expect(vi.mocked(callCloudProxy)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(callCloudApi)).toHaveBeenCalledTimes(1);
     expect(result.items).toHaveLength(0);
     expect(result.next_page_id).toBeNull();
     expect(warnSpy).toHaveBeenCalledWith(
@@ -97,19 +97,17 @@ describe("EventService.searchEvents — cloud branch", () => {
   });
 
   it("rethrows when a limit-only request (no filter params) fails", async () => {
-    vi.mocked(callCloudProxy).mockRejectedValueOnce(
-      new Error("Network error"),
-    );
+    vi.mocked(callCloudApi).mockRejectedValueOnce(new Error("Network error"));
 
     await expect(
       EventService.searchEvents("conv-1", null, null, { limit: 50 }),
     ).rejects.toThrow("Network error");
 
-    expect(vi.mocked(callCloudProxy)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(callCloudApi)).toHaveBeenCalledTimes(1);
   });
 
   it("stops pagination when server returns fewer items than limit", async () => {
-    vi.mocked(callCloudProxy).mockResolvedValueOnce({
+    vi.mocked(callCloudApi).mockResolvedValueOnce({
       items: [{ id: "evt-1" }, { id: "evt-2" }],
       next_page_id: null,
     });

--- a/__tests__/api/runtime-service/agent-server-runtime-service.test.ts
+++ b/__tests__/api/runtime-service/agent-server-runtime-service.test.ts
@@ -7,7 +7,7 @@ import {
   setRegisteredBackends,
 } from "#/api/backend-registry/active-store";
 import AgentServerRuntimeService from "#/api/runtime-service/agent-server-runtime-service";
-import { callCloudProxy } from "#/api/cloud/proxy";
+import { callLegacyRuntimeCloudProxy } from "#/api/cloud/proxy";
 import type { Backend } from "#/api/backend-registry/types";
 
 // ─── SDK client mocks ───────────────────────────────────────────────────────
@@ -38,7 +38,7 @@ vi.mock("#/api/agent-server-client-options", () => ({
 }));
 
 vi.mock("#/api/cloud/proxy", () => ({
-  callCloudProxy: vi.fn(),
+  callLegacyRuntimeCloudProxy: vi.fn(),
 }));
 
 // ─── Backend fixtures ────────────────────────────────────────────────────────
@@ -71,7 +71,7 @@ beforeEach(() => {
   vi.mocked(FileClient).mockClear();
   executeCommandMock.mockReset();
   downloadFileMock.mockReset();
-  vi.mocked(callCloudProxy).mockReset();
+  vi.mocked(callLegacyRuntimeCloudProxy).mockReset();
 });
 
 afterEach(() => {
@@ -107,7 +107,7 @@ describe("AgentServerRuntimeService.executeCommand", () => {
       expect(result).toEqual({ exit_code: 0, stdout: "main\n", stderr: "" });
     });
 
-    it("does not call callCloudProxy for local backends", async () => {
+    it("does not call callLegacyRuntimeCloudProxy for local backends", async () => {
       executeCommandMock.mockResolvedValue({
         exit_code: 0,
         stdout: "",
@@ -116,15 +116,15 @@ describe("AgentServerRuntimeService.executeCommand", () => {
 
       await AgentServerRuntimeService.executeCommand(null, null, "ls", "/", 5);
 
-      expect(callCloudProxy).not.toHaveBeenCalled();
+      expect(callLegacyRuntimeCloudProxy).not.toHaveBeenCalled();
     });
   });
 
   describe("cloud backend", () => {
     beforeEach(activateCloud);
 
-    it("routes through callCloudProxy with correct path, body, and auth", async () => {
-      vi.mocked(callCloudProxy).mockResolvedValue({
+    it("routes through callLegacyRuntimeCloudProxy with correct path, body, and auth", async () => {
+      vi.mocked(callLegacyRuntimeCloudProxy).mockResolvedValue({
         exit_code: 0,
         stdout: "src/index.ts\n",
         stderr: "",
@@ -138,16 +138,15 @@ describe("AgentServerRuntimeService.executeCommand", () => {
         30,
       );
 
-      const proxyCall = vi.mocked(callCloudProxy).mock.calls[0][0];
+      const proxyCall = vi.mocked(callLegacyRuntimeCloudProxy).mock.calls[0][0];
       expect(proxyCall.method).toBe("POST");
       expect(proxyCall.path).toBe("/api/bash/execute_bash_command");
-      expect(proxyCall.hostOverride).toBe("https://runtime.example.com");
+      expect(proxyCall.host).toBe("https://runtime.example.com");
       expect(proxyCall.body).toEqual({
         command: "find . -type f",
         cwd: "/workspace/project",
         timeout: 30,
       });
-      expect(proxyCall.authMode).toBe("session-api-key");
       expect(proxyCall.sessionApiKey).toBe(SESSION_KEY);
       expect(proxyCall.timeoutSeconds).toBe(40);
       expect(result).toEqual({
@@ -158,7 +157,9 @@ describe("AgentServerRuntimeService.executeCommand", () => {
     });
 
     it("omits cwd from proxy body when not provided", async () => {
-      vi.mocked(callCloudProxy).mockResolvedValue({ exit_code: 0 });
+      vi.mocked(callLegacyRuntimeCloudProxy).mockResolvedValue({
+        exit_code: 0,
+      });
 
       await AgentServerRuntimeService.executeCommand(
         CLOUD_CONVERSATION_URL,
@@ -168,13 +169,16 @@ describe("AgentServerRuntimeService.executeCommand", () => {
         10,
       );
 
-      const proxyBody = vi.mocked(callCloudProxy).mock.calls[0][0].body as Record<string, unknown>;
+      const proxyBody = vi.mocked(callLegacyRuntimeCloudProxy).mock.calls[0][0]
+        .body as Record<string, unknown>;
       expect(proxyBody).not.toHaveProperty("cwd");
       expect(proxyBody.command).toBe("echo hi");
     });
 
     it("normalises missing stdout/stderr fields to empty strings", async () => {
-      vi.mocked(callCloudProxy).mockResolvedValue({ exit_code: 1 });
+      vi.mocked(callLegacyRuntimeCloudProxy).mockResolvedValue({
+        exit_code: 1,
+      });
 
       const result = await AgentServerRuntimeService.executeCommand(
         CLOUD_CONVERSATION_URL,
@@ -188,7 +192,9 @@ describe("AgentServerRuntimeService.executeCommand", () => {
     });
 
     it("does not create a RemoteWorkspace for cloud calls", async () => {
-      vi.mocked(callCloudProxy).mockResolvedValue({ exit_code: 0 });
+      vi.mocked(callLegacyRuntimeCloudProxy).mockResolvedValue({
+        exit_code: 0,
+      });
 
       await AgentServerRuntimeService.executeCommand(
         CLOUD_CONVERSATION_URL,
@@ -212,7 +218,7 @@ describe("AgentServerRuntimeService.executeCommand", () => {
         "echo ok",
       );
 
-      expect(callCloudProxy).not.toHaveBeenCalled();
+      expect(callLegacyRuntimeCloudProxy).not.toHaveBeenCalled();
       expect(RemoteWorkspace).toHaveBeenCalledTimes(1);
     });
   });
@@ -239,7 +245,7 @@ describe("AgentServerRuntimeService.downloadFile", () => {
       expect(result).toBe(fileBytes.buffer);
     });
 
-    it("does not call callCloudProxy for local backends", async () => {
+    it("does not call callLegacyRuntimeCloudProxy for local backends", async () => {
       downloadFileMock.mockResolvedValue(new ArrayBuffer(0));
 
       await AgentServerRuntimeService.downloadFile(
@@ -248,16 +254,16 @@ describe("AgentServerRuntimeService.downloadFile", () => {
         "/workspace/file.txt",
       );
 
-      expect(callCloudProxy).not.toHaveBeenCalled();
+      expect(callLegacyRuntimeCloudProxy).not.toHaveBeenCalled();
     });
   });
 
   describe("cloud backend", () => {
     beforeEach(activateCloud);
 
-    it("routes through callCloudProxy with GET and URL-encoded path", async () => {
+    it("routes through callLegacyRuntimeCloudProxy with GET and URL-encoded path", async () => {
       const blob = new Blob([new TextEncoder().encode("file content")]);
-      vi.mocked(callCloudProxy).mockResolvedValue(blob);
+      vi.mocked(callLegacyRuntimeCloudProxy).mockResolvedValue(blob);
 
       const result = await AgentServerRuntimeService.downloadFile(
         CLOUD_CONVERSATION_URL,
@@ -265,13 +271,12 @@ describe("AgentServerRuntimeService.downloadFile", () => {
         "/workspace/project/src/main.ts",
       );
 
-      const proxyCall = vi.mocked(callCloudProxy).mock.calls[0][0];
+      const proxyCall = vi.mocked(callLegacyRuntimeCloudProxy).mock.calls[0][0];
       expect(proxyCall.method).toBe("GET");
       expect(proxyCall.path).toBe(
         "/api/file/download?path=%2Fworkspace%2Fproject%2Fsrc%2Fmain.ts",
       );
-      expect(proxyCall.hostOverride).toBe("https://runtime.example.com");
-      expect(proxyCall.authMode).toBe("session-api-key");
+      expect(proxyCall.host).toBe("https://runtime.example.com");
       expect(proxyCall.sessionApiKey).toBe(SESSION_KEY);
       expect(proxyCall.responseType).toBe("blob");
 
@@ -280,7 +285,7 @@ describe("AgentServerRuntimeService.downloadFile", () => {
     });
 
     it("does not create a FileClient for cloud calls", async () => {
-      vi.mocked(callCloudProxy).mockResolvedValue(new Blob());
+      vi.mocked(callLegacyRuntimeCloudProxy).mockResolvedValue(new Blob());
 
       await AgentServerRuntimeService.downloadFile(
         CLOUD_CONVERSATION_URL,
@@ -300,7 +305,7 @@ describe("AgentServerRuntimeService.downloadFile", () => {
         "/workspace/file.txt",
       );
 
-      expect(callCloudProxy).not.toHaveBeenCalled();
+      expect(callLegacyRuntimeCloudProxy).not.toHaveBeenCalled();
       expect(FileClient).toHaveBeenCalledTimes(1);
     });
   });

--- a/__tests__/hooks/query/use-workspace-session.test.tsx
+++ b/__tests__/hooks/query/use-workspace-session.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import { callCloudProxy } from "#/api/cloud/proxy";
+import { callLegacyRuntimeCloudProxy } from "#/api/cloud/proxy";
 import {
   joinWorkspaceUrl,
   useWorkspaceSession,
@@ -23,9 +23,10 @@ vi.mock("@openhands/typescript-client/workspace/remote-workspace", () => ({
   }),
 }));
 
-const callCloudProxyMock = vi.fn();
+const callLegacyRuntimeCloudProxyMock = vi.fn();
 vi.mock("#/api/cloud/proxy", () => ({
-  callCloudProxy: (...args: unknown[]) => callCloudProxyMock(...args),
+  callLegacyRuntimeCloudProxy: (...args: unknown[]) =>
+    callLegacyRuntimeCloudProxyMock(...args),
 }));
 
 const getAgentServerClientOptionsMock = vi.fn();
@@ -77,7 +78,7 @@ function flushScheduler(ms = 10): Promise<void> {
 
 beforeEach(() => {
   startWorkspaceSessionMock.mockReset();
-  callCloudProxyMock.mockReset();
+  callLegacyRuntimeCloudProxyMock.mockReset();
   getAgentServerClientOptionsMock.mockReset();
   vi.mocked(RemoteWorkspace).mockClear();
   getActiveBackendMock.mockReset();
@@ -94,7 +95,11 @@ describe("useWorkspaceSession", () => {
   describe("local backend", () => {
     it("calls startWorkspaceSession and exposes the returned baseUrl", async () => {
       getActiveBackendMock.mockReturnValue({
-        backend: { id: "local-1", kind: "local", host: "http://localhost:8000" },
+        backend: {
+          id: "local-1",
+          kind: "local",
+          host: "http://localhost:8000",
+        },
       });
       useActiveConversationMock.mockReturnValue({
         data: {
@@ -125,8 +130,7 @@ describe("useWorkspaceSession", () => {
 
       expect(getAgentServerClientOptionsMock).toHaveBeenCalledTimes(1);
       expect(getAgentServerClientOptionsMock).toHaveBeenCalledWith({
-        conversationUrl:
-          "https://agent.example.com/api/conversations/conv-1",
+        conversationUrl: "https://agent.example.com/api/conversations/conv-1",
         sessionApiKey: "key-abc",
       });
       expect(RemoteWorkspace).toHaveBeenCalledTimes(1);
@@ -137,7 +141,7 @@ describe("useWorkspaceSession", () => {
       });
       expect(startWorkspaceSessionMock).toHaveBeenCalledTimes(1);
       expect(startWorkspaceSessionMock).toHaveBeenCalledWith("conv-1");
-      expect(callCloudProxyMock).not.toHaveBeenCalled();
+      expect(callLegacyRuntimeCloudProxyMock).not.toHaveBeenCalled();
     });
   });
 
@@ -164,7 +168,7 @@ describe("useWorkspaceSession", () => {
       });
 
       await flushScheduler();
-      expect(callCloudProxyMock).not.toHaveBeenCalled();
+      expect(callLegacyRuntimeCloudProxyMock).not.toHaveBeenCalled();
       expect(startWorkspaceSessionMock).not.toHaveBeenCalled();
       expect(result.current.data).toBeNull();
     });
@@ -177,8 +181,7 @@ describe("useWorkspaceSession", () => {
     useActiveConversationMock.mockReturnValue({
       data: {
         id: "conv-1",
-        conversation_url:
-          "https://agent.example.com/api/conversations/conv-1",
+        conversation_url: "https://agent.example.com/api/conversations/conv-1",
         session_api_key: "key-abc",
       },
     });
@@ -191,7 +194,7 @@ describe("useWorkspaceSession", () => {
     // Give react-query a tick to schedule (it shouldn't).
     await flushScheduler();
     expect(startWorkspaceSessionMock).not.toHaveBeenCalled();
-    expect(callCloudProxyMock).not.toHaveBeenCalled();
+    expect(callLegacyRuntimeCloudProxyMock).not.toHaveBeenCalled();
     expect(result.current.data).toBeNull();
   });
 
@@ -205,7 +208,7 @@ describe("useWorkspaceSession", () => {
 
     await flushScheduler();
     expect(startWorkspaceSessionMock).not.toHaveBeenCalled();
-    expect(callCloudProxyMock).not.toHaveBeenCalled();
+    expect(callLegacyRuntimeCloudProxyMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/api/automation-service/automation-service.api.ts
+++ b/src/api/automation-service/automation-service.api.ts
@@ -10,7 +10,7 @@ import {
   getEffectiveLocalBackend,
 } from "../backend-registry/active-store";
 import { NoBackendAvailableError } from "../agent-server-client-options";
-import { callCloudProxy } from "../cloud/proxy";
+import { callCloudApi } from "../cloud/proxy";
 
 const AUTOMATION_BASE_PATH = "/api/automation";
 
@@ -61,7 +61,7 @@ class AutomationService {
     const active = getActiveBackend().backend;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<AutomationsResponse>({
+      return callCloudApi<AutomationsResponse>({
         backend: active,
         method: "GET",
         path: `${AUTOMATION_BASE_PATH}/v1?${buildPaginationQuery(limit, offset)}`,
@@ -87,7 +87,7 @@ class AutomationService {
     const path = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}`;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<Automation>({
+      return callCloudApi<Automation>({
         backend: active,
         method: "GET",
         path,
@@ -106,7 +106,7 @@ class AutomationService {
     const path = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}`;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<Automation>({
+      return callCloudApi<Automation>({
         backend: active,
         method: "PATCH",
         path,
@@ -123,7 +123,7 @@ class AutomationService {
     const path = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}`;
 
     if (active.kind === "cloud") {
-      await callCloudProxy<unknown>({
+      await callCloudApi<unknown>({
         backend: active,
         method: "DELETE",
         path,
@@ -139,7 +139,7 @@ class AutomationService {
     const path = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}/dispatch`;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<AutomationRun>({
+      return callCloudApi<AutomationRun>({
         backend: active,
         method: "POST",
         path,
@@ -159,7 +159,7 @@ class AutomationService {
     const basePath = `${AUTOMATION_BASE_PATH}/v1/${encodeURIComponent(id)}/runs`;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<AutomationRunsResponse>({
+      return callCloudApi<AutomationRunsResponse>({
         backend: active,
         method: "GET",
         path: `${basePath}?${buildPaginationQuery(limit, offset)}`,
@@ -194,7 +194,7 @@ class AutomationService {
 
     let blob: Blob;
     if (active.kind === "cloud") {
-      blob = await callCloudProxy<Blob>({
+      blob = await callCloudApi<Blob>({
         backend: active,
         method: "GET",
         path,
@@ -221,7 +221,7 @@ class AutomationService {
 
     try {
       if (active.kind === "cloud") {
-        const response = await callCloudProxy<AutomationHealthResponse>({
+        const response = await callCloudApi<AutomationHealthResponse>({
           backend: active,
           method: "GET",
           path,

--- a/src/api/bash-service/bash-service.api.ts
+++ b/src/api/bash-service/bash-service.api.ts
@@ -6,7 +6,7 @@ import type {
 } from "@openhands/typescript-client";
 import { buildHttpBaseUrl } from "#/utils/websocket-url";
 import { getActiveBackend } from "../backend-registry/active-store";
-import { callCloudProxy } from "../cloud/proxy";
+import { callLegacyRuntimeCloudProxy } from "../cloud/proxy";
 import { getAgentServerClientOptions } from "../agent-server-client-options";
 
 interface SearchOptions {
@@ -31,10 +31,10 @@ function isBashOutput(event: BashEvent): event is BashOutput {
  * agent-server directly with the SDK's `BashClient` (a per-conversation
  * URL is honoured when known, otherwise we fall back to the backend
  * host — a single local agent-server hosts all conversations). In
- * **cloud** mode we tunnel through `callCloudProxy` with the runtime URL
- * as `hostOverride`: direct browser calls to `*.prod-runtime.all-hands.dev`
- * are blocked by CORS, and runtime endpoints authenticate with the
- * conversation's `X-Session-API-Key`.
+ * **cloud** mode we tunnel through `callLegacyRuntimeCloudProxy` with the
+ * runtime URL: direct browser calls to `*.prod-runtime.all-hands.dev` are
+ * blocked by CORS, and runtime endpoints authenticate with the conversation's
+ * `X-Session-API-Key`.
  *
  * Note on the search filter name: the agent-server API uses
  * `command_id__eq` (not `bash_command_id__eq`) — that's the parameter the
@@ -95,12 +95,11 @@ class BashService {
       Object.entries(options).forEach(([k, v]) => {
         if (v !== undefined && v !== null) params.set(k, String(v));
       });
-      return callCloudProxy<BashEventPage>({
+      return callLegacyRuntimeCloudProxy<BashEventPage>({
         backend: active,
         method: "GET",
-        hostOverride: buildHttpBaseUrl(conversationUrl),
+        host: buildHttpBaseUrl(conversationUrl),
         path: `/api/bash/bash_events/search?${params.toString()}`,
-        authMode: "session-api-key",
         sessionApiKey,
       });
     }

--- a/src/api/cloud/conversation-service.api.ts
+++ b/src/api/cloud/conversation-service.api.ts
@@ -6,8 +6,9 @@ import type {
   AppConversationPage,
   AppConversationStartRequest,
   AppConversationStartTask,
+  SendMessageRequest,
 } from "../conversation-service/agent-server-conversation-service.types";
-import { callCloudProxy } from "./proxy";
+import { callCloudApi } from "./proxy";
 
 /**
  * The cloud backend does not always echo `selected_repository` /
@@ -65,7 +66,7 @@ export async function searchCloudConversations(
   if (pageId) params.set("page_id", pageId);
   params.set("sort_order", "UPDATED_AT_DESC");
 
-  const data = await callCloudProxy<{
+  const data = await callCloudApi<{
     items: AppConversation[];
     next_page_id: string | null;
   }>({
@@ -93,7 +94,7 @@ export async function batchGetCloudConversations(
   const backend = getActiveCloudBackend();
   const params = new URLSearchParams();
   for (const id of ids) params.append("ids", id);
-  const data = await callCloudProxy<(AppConversation | null)[]>({
+  const data = await callCloudApi<(AppConversation | null)[]>({
     backend,
     method: "GET",
     path: `/api/v1/app-conversations?${params.toString()}`,
@@ -121,7 +122,7 @@ export async function createCloudAppConversation(
   request: AppConversationStartRequest,
 ): Promise<AppConversationStartTask> {
   const backend = getActiveCloudBackend();
-  const data = await callCloudProxy<AppConversationStartTask>({
+  const data = await callCloudApi<AppConversationStartTask>({
     backend,
     method: "POST",
     path: "/api/v1/app-conversations",
@@ -141,7 +142,7 @@ export async function downloadCloudConversation(
   conversationId: string,
 ): Promise<Blob> {
   const backend = getActiveCloudBackend();
-  return callCloudProxy<Blob>({
+  return callCloudApi<Blob>({
     backend,
     method: "GET",
     path: `/api/v1/app-conversations/${conversationId}/download`,
@@ -160,7 +161,7 @@ export async function deleteCloudConversation(
   conversationId: string,
 ): Promise<void> {
   const backend = getActiveCloudBackend();
-  await callCloudProxy<unknown>({
+  await callCloudApi<unknown>({
     backend,
     method: "DELETE",
     path: `/api/v1/app-conversations/${conversationId}`,
@@ -178,7 +179,7 @@ export async function updateCloudConversationPublicFlag(
   isPublic: boolean,
 ): Promise<AppConversation> {
   const backend = getActiveCloudBackend();
-  const data = await callCloudProxy<AppConversation>({
+  const data = await callCloudApi<AppConversation>({
     backend,
     method: "PATCH",
     path: `/api/v1/app-conversations/${conversationId}`,
@@ -195,7 +196,7 @@ export async function updateCloudConversationPublicFlag(
  */
 export async function pauseCloudSandbox(sandboxId: string): Promise<void> {
   const backend = getActiveCloudBackend();
-  await callCloudProxy<unknown>({
+  await callCloudApi<unknown>({
     backend,
     method: "POST",
     path: `/api/v1/sandboxes/${sandboxId}/pause`,
@@ -213,10 +214,28 @@ export async function pauseCloudSandbox(sandboxId: string): Promise<void> {
  */
 export async function resumeCloudSandbox(sandboxId: string): Promise<void> {
   const backend = getActiveCloudBackend();
-  await callCloudProxy<unknown>({
+  await callCloudApi<unknown>({
     backend,
     method: "POST",
     path: `/api/v1/sandboxes/${sandboxId}/resume`,
+  });
+}
+
+/**
+ * Send a follow-up message through the cloud app-conversation API. The cloud
+ * backend resolves the live runtime and attaches the sandbox session key
+ * server-side, so the frontend does not need the removed generic cloud proxy.
+ */
+export async function sendCloudConversationMessage(
+  conversationId: string,
+  message: SendMessageRequest,
+): Promise<void> {
+  const backend = getActiveCloudBackend();
+  await callCloudApi<unknown>({
+    backend,
+    method: "POST",
+    path: `/api/v1/app-conversations/${conversationId}/send-message`,
+    body: { ...message, run: true },
   });
 }
 
@@ -233,7 +252,7 @@ export async function readCloudConversationFile(
   const backend = getActiveCloudBackend();
   const params = new URLSearchParams();
   params.append("file_path", filePath);
-  const data = await callCloudProxy<string>({
+  const data = await callCloudApi<string>({
     backend,
     method: "GET",
     path: `/api/v1/app-conversations/${conversationId}/file?${params.toString()}`,
@@ -252,7 +271,7 @@ export async function getCloudAppConversationStartTask(
   const backend = getActiveCloudBackend();
   const params = new URLSearchParams();
   params.set("ids", taskId);
-  const data = await callCloudProxy<(AppConversationStartTask | null)[]>({
+  const data = await callCloudApi<(AppConversationStartTask | null)[]>({
     backend,
     method: "GET",
     path: `/api/v1/app-conversations/start-tasks?${params.toString()}`,

--- a/src/api/cloud/git-service.api.ts
+++ b/src/api/cloud/git-service.api.ts
@@ -7,7 +7,7 @@ import type {
 import type { Provider } from "#/types/settings";
 import { getActiveBackend } from "../backend-registry/active-store";
 import type { Backend } from "../backend-registry/types";
-import { callCloudProxy } from "./proxy";
+import { callCloudApi } from "./proxy";
 
 function getActiveCloudBackend(): Backend {
   const active = getActiveBackend().backend;
@@ -32,7 +32,7 @@ export async function searchCloudRepositories(args: {
   if (args.pageId) params.set("page_id", args.pageId);
   if (args.installationId) params.set("installation_id", args.installationId);
 
-  const data = await callCloudProxy<{
+  const data = await callCloudApi<{
     items: GitRepository[];
     next_page_id: string | null;
   }>({
@@ -58,7 +58,7 @@ export async function getCloudInstallations(args: {
   params.set("limit", String(args.limit ?? 100));
   if (args.pageId) params.set("page_id", args.pageId);
 
-  const data = await callCloudProxy<{
+  const data = await callCloudApi<{
     items: string[];
     next_page_id: string | null;
   }>({
@@ -88,7 +88,7 @@ export async function getCloudRepositoryBranches(args: {
   params.set("query", args.query ?? "");
   if (args.pageId) params.set("page_id", args.pageId);
 
-  const data = await callCloudProxy<{
+  const data = await callCloudApi<{
     items: BranchPage["items"];
     next_page_id: string | null;
   }>({

--- a/src/api/cloud/organization-service.api.ts
+++ b/src/api/cloud/organization-service.api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { getActiveBackend } from "../backend-registry/active-store";
 import type { Backend } from "../backend-registry/types";
-import { callCloudProxy } from "./proxy";
+import { callCloudApi } from "./proxy";
 import type {
   CloudApiKeyMetadata,
   CloudOrganization,
@@ -44,7 +44,7 @@ export async function getCloudOrganizations(
   backend?: Backend,
 ): Promise<OrganizationsResult> {
   const target = resolveBackend(backend);
-  const data = await callCloudProxy<CloudOrganizationsResponse>({
+  const data = await callCloudApi<CloudOrganizationsResponse>({
     backend: target,
     method: "GET",
     path: "/api/organizations",
@@ -68,7 +68,7 @@ export async function getCurrentCloudApiKey(
 ): Promise<{ orgId: string | null; isLegacyKey: boolean }> {
   const target = resolveBackend(backend);
   try {
-    const data = await callCloudProxy<CloudApiKeyMetadata>({
+    const data = await callCloudApi<CloudApiKeyMetadata>({
       backend: target,
       method: "GET",
       path: "/api/keys/current",
@@ -94,7 +94,7 @@ export async function getCloudOrganizationMe(
   backend?: Backend,
 ): Promise<{ orgId: string; userId: string }> {
   const target = resolveBackend(backend);
-  const data = await callCloudProxy<{ org_id: string; user_id: string }>({
+  const data = await callCloudApi<{ org_id: string; user_id: string }>({
     backend: target,
     method: "GET",
     path: `/api/organizations/${encodeURIComponent(orgId)}/me`,

--- a/src/api/cloud/proxy.ts
+++ b/src/api/cloud/proxy.ts
@@ -8,124 +8,93 @@ import { NoBackendAvailableError } from "../agent-server-client-options";
 import { buildAuthHeaders } from "../backend-registry/auth";
 import type { Backend } from "../backend-registry/types";
 
-export interface CloudProxyRequest {
-  /**
-   * Cloud backend whose bearer token authenticates the upstream call.
-   * `backend.host` is also the default upstream host unless `hostOverride`
-   * is set.
-   */
+type CloudMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+
+export interface CloudApiRequest {
   backend: Backend;
-  /** HTTP method against the upstream host. */
-  method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
-  /** Path on the upstream host, e.g. "/api/v1/conversation/123/events/search". */
+  method: CloudMethod;
   path: string;
-  /** Optional JSON body for non-GET methods. */
   body?: unknown;
-  /** Extra headers merged with the auth header for the upstream call. */
   headers?: Record<string, string>;
-  /** Override the upstream timeout, in seconds. */
   timeoutSeconds?: number;
-  /**
-   * Override the upstream host. When set, the proxy targets this host
-   * instead of `backend.host`. Used for runtime-sandbox calls where the
-   * upstream lives at the conversation's runtime URL (e.g.
-   * `http://<id>.prod-runtime.all-hands.dev`) rather than the cloud API.
-   * The host must still pass the proxy's allowlist server-side.
-   */
-  hostOverride?: string;
-  /**
-   * Auth strategy for the upstream call. Defaults to "bearer" (uses the
-   * cloud backend's bearer token via `buildAuthHeaders`). For
-   * runtime-sandbox calls, set to "session-api-key" and pass
-   * `sessionApiKey` — those endpoints don't accept bearer tokens, only
-   * `X-Session-API-Key`. "none" sends no auth header.
-   */
-  authMode?: "bearer" | "session-api-key" | "none";
-  /** Required when `authMode === "session-api-key"`. */
-  sessionApiKey?: string | null;
-  /**
-   * Axios responseType for the inner POST to the bundled agent-server.
-   * Set to "blob" when the upstream cloud endpoint returns a binary
-   * payload (e.g. ZIP downloads); leave undefined for default JSON.
-   */
   responseType?: "blob";
 }
 
-function buildUpstreamAuthHeaders(
-  req: CloudProxyRequest,
-): Record<string, string> {
-  const mode = req.authMode ?? "bearer";
-  if (mode === "bearer") return buildAuthHeaders(req.backend);
-  if (mode === "session-api-key") {
-    return req.sessionApiKey ? { "X-Session-API-Key": req.sessionApiKey } : {};
-  }
-  return {};
+export interface LegacyRuntimeCloudProxyRequest {
+  backend: Backend;
+  method: CloudMethod;
+  host: string;
+  path: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+  timeoutSeconds?: number;
+  sessionApiKey?: string | null;
+  responseType?: "blob";
 }
 
-/**
- * Send a cloud request. App-host calls (`backend.host`) go directly to the
- * cloud API with the cloud backend's auth headers. Runtime-sandbox calls
- * pass `hostOverride`, and those go through `/api/cloud-proxy` because the
- * per-conversation runtime hosts are not the configured cloud app origin.
- *
- * App-host auth headers are sent directly to the cloud host. Proxied auth
- * headers are carried in the proxy envelope and attached server-side.
- */
-export async function callCloudProxy<TResponse = unknown>(
-  req: CloudProxyRequest,
-): Promise<TResponse> {
-  // Send `X-Org-Id` so the upstream scopes per-request to the org the user
-  // selected locally, instead of the user's globally-shared
-  // `current_org_id` on the cloud backend. Restricted to calls against the active
-  // backend: the selector also fans out per-backend bookkeeping calls
-  // (e.g. `getCloudOrganizations(b)`) that would otherwise carry the
-  // active backend's orgId across an unrelated API key, which the cloud backend
-  // rejects when api_key_org_id and X-Org-Id disagree.
+function buildCloudHeaders(req: CloudApiRequest): Record<string, string> {
   const active = getActiveBackend();
-  const orgIdHeader =
+  const orgIdHeader: Record<string, string> =
     active.backend.id === req.backend.id && active.orgId
       ? { "X-Org-Id": active.orgId }
       : {};
-  const upstreamHeaders = {
-    ...buildUpstreamAuthHeaders(req),
+
+  return {
+    ...buildAuthHeaders(req.backend),
     ...orgIdHeader,
     ...(req.headers ?? {}),
   };
-  const upstreamHost = req.hostOverride ?? req.backend.host;
+}
 
-  if (!req.hostOverride) {
-    const response = await axios.request<TResponse>({
-      url: `${upstreamHost.replace(/\/+$/, "")}${req.path}`,
-      method: req.method,
-      headers: upstreamHeaders,
-      ...(req.body !== undefined ? { data: req.body } : {}),
-      timeout: (req.timeoutSeconds ?? 30) * 1000,
-      ...(req.responseType ? { responseType: req.responseType } : {}),
-    });
+/**
+ * Send a first-class request to the configured cloud/app backend.
+ *
+ * This does not use `/api/cloud-proxy`: the browser calls `backend.host`
+ * directly with the cloud backend's auth headers.
+ */
+export async function callCloudApi<TResponse = unknown>(
+  req: CloudApiRequest,
+): Promise<TResponse> {
+  const response = await axios.request<TResponse>({
+    url: `${req.backend.host.replace(/\/+$/, "")}${req.path}`,
+    method: req.method,
+    headers: buildCloudHeaders(req),
+    ...(req.body !== undefined ? { data: req.body } : {}),
+    timeout: (req.timeoutSeconds ?? 30) * 1000,
+    ...(req.responseType ? { responseType: req.responseType } : {}),
+  });
 
-    return response.data;
-  }
+  return response.data;
+}
 
+/**
+ * @deprecated Legacy bridge for runtime-sandbox endpoints that still lack a
+ * first-class cloud/app API. Prefer `callCloudApi` and app-server gateway
+ * routes for any new or migrated code.
+ */
+export async function callLegacyRuntimeCloudProxy<TResponse = unknown>(
+  req: LegacyRuntimeCloudProxyRequest,
+): Promise<TResponse> {
   const proxyBaseUrl = getAgentServerBaseUrl();
   if (!proxyBaseUrl) throw new NoBackendAvailableError();
-  const localAuthHeaders = getAgentServerHeaders();
 
-  // Talk to the configured app/ingress origin that exposes /api/cloud-proxy.
-  // Do not resolve this through the backend registry: when the active backend
-  // is cloud, borrowing some other registered local backend would silently
-  // route cloud traffic through the wrong user-configured server.
+  const headers = {
+    ...(req.sessionApiKey ? { "X-Session-API-Key": req.sessionApiKey } : {}),
+    ...(req.headers ?? {}),
+  };
+
   const response = await axios.post<TResponse>(
     `${proxyBaseUrl.replace(/\/+$/, "")}/api/cloud-proxy`,
     {
-      host: upstreamHost,
+      host: req.host,
       method: req.method,
       path: req.path,
-      headers: upstreamHeaders,
+      headers,
       body: req.body ?? null,
       ...(req.timeoutSeconds ? { timeout_seconds: req.timeoutSeconds } : {}),
     },
     {
-      headers: localAuthHeaders,
+      headers: getAgentServerHeaders(),
       timeout: 30_000,
       ...(req.responseType ? { responseType: req.responseType } : {}),
     },

--- a/src/api/cloud/sandbox-service.api.ts
+++ b/src/api/cloud/sandbox-service.api.ts
@@ -1,6 +1,6 @@
 import { getActiveBackend } from "../backend-registry/active-store";
 import type { Backend } from "../backend-registry/types";
-import { callCloudProxy } from "./proxy";
+import { callCloudApi } from "./proxy";
 import type { V1SandboxInfo } from "./sandbox-service.types";
 
 function getActiveCloudBackend(): Backend {
@@ -30,7 +30,7 @@ export async function batchGetCloudSandboxes(
   const backend = getActiveCloudBackend();
   const params = new URLSearchParams();
   for (const id of ids) params.append("id", id);
-  const data = await callCloudProxy<(V1SandboxInfo | null)[]>({
+  const data = await callCloudApi<(V1SandboxInfo | null)[]>({
     backend,
     method: "GET",
     path: `/api/v1/sandboxes?${params.toString()}`,

--- a/src/api/cloud/secrets-service.api.ts
+++ b/src/api/cloud/secrets-service.api.ts
@@ -1,7 +1,7 @@
 import { getActiveBackend } from "../backend-registry/active-store";
 import type { Backend } from "../backend-registry/types";
 import type { CustomSecretWithoutValue } from "../secrets-service.types";
-import { callCloudProxy } from "./proxy";
+import { callCloudApi } from "./proxy";
 
 interface CloudSecretsPage {
   items: CustomSecretWithoutValue[];
@@ -33,7 +33,7 @@ export async function fetchCloudSecrets(): Promise<CustomSecretWithoutValue[]> {
     const query = new URLSearchParams({ limit: String(PAGE_LIMIT) });
     if (pageId) query.set("page_id", pageId);
 
-    const page = await callCloudProxy<CloudSecretsPage>({
+    const page = await callCloudApi<CloudSecretsPage>({
       backend,
       method: "GET",
       path: `/api/v1/secrets/search?${query.toString()}`,
@@ -52,7 +52,7 @@ export async function createCloudSecret(
   description?: string,
 ): Promise<void> {
   const backend = getActiveCloudBackend();
-  await callCloudProxy<unknown>({
+  await callCloudApi<unknown>({
     backend,
     method: "POST",
     path: "/api/v1/secrets",
@@ -71,7 +71,7 @@ export async function updateCloudSecret(
   description?: string,
 ): Promise<void> {
   const backend = getActiveCloudBackend();
-  await callCloudProxy<unknown>({
+  await callCloudApi<unknown>({
     backend,
     method: "PUT",
     path: `/api/v1/secrets/${encodeURIComponent(secretToEdit)}`,
@@ -81,7 +81,7 @@ export async function updateCloudSecret(
 
 export async function deleteCloudSecret(name: string): Promise<void> {
   const backend = getActiveCloudBackend();
-  await callCloudProxy<unknown>({
+  await callCloudApi<unknown>({
     backend,
     method: "DELETE",
     path: `/api/v1/secrets/${encodeURIComponent(name)}`,

--- a/src/api/cloud/settings-service.api.ts
+++ b/src/api/cloud/settings-service.api.ts
@@ -7,7 +7,7 @@ import {
 import { type AppPreferences } from "../settings-service/settings-service.api";
 import { getActiveBackend } from "../backend-registry/active-store";
 import type { Backend } from "../backend-registry/types";
-import { callCloudProxy } from "./proxy";
+import { callCloudApi } from "./proxy";
 
 /**
  * The cloud Settings response is mostly flat — top-level fields like
@@ -130,7 +130,7 @@ function deriveConversationSettings(
  */
 export async function fetchCloudSettings(): Promise<Partial<Settings>> {
   const backend = getActiveCloudBackend();
-  const flat = await callCloudProxy<CloudSettingsResponse>({
+  const flat = await callCloudApi<CloudSettingsResponse>({
     backend,
     method: "GET",
     path: "/api/v1/settings",
@@ -200,7 +200,7 @@ export async function saveCloudSettings(diff: {
       }
     }
   }
-  await callCloudProxy<unknown>({
+  await callCloudApi<unknown>({
     backend,
     method: "POST",
     path: "/api/v1/settings",
@@ -210,7 +210,7 @@ export async function saveCloudSettings(diff: {
 
 export async function fetchCloudSettingsSchema(): Promise<unknown> {
   const backend = getActiveCloudBackend();
-  return callCloudProxy<unknown>({
+  return callCloudApi<unknown>({
     backend,
     method: "GET",
     path: "/api/v1/settings/agent-schema",
@@ -219,7 +219,7 @@ export async function fetchCloudSettingsSchema(): Promise<unknown> {
 
 export async function fetchCloudConversationSettingsSchema(): Promise<unknown> {
   const backend = getActiveCloudBackend();
-  return callCloudProxy<unknown>({
+  return callCloudApi<unknown>({
     backend,
     method: "GET",
     path: "/api/v1/settings/conversation-schema",

--- a/src/api/cloud/skills-service.api.ts
+++ b/src/api/cloud/skills-service.api.ts
@@ -1,7 +1,7 @@
 import type { SkillInfo } from "#/types/settings";
 import { getActiveBackend } from "../backend-registry/active-store";
 import type { Backend } from "../backend-registry/types";
-import { callCloudProxy } from "./proxy";
+import { callCloudApi } from "./proxy";
 
 interface CloudSkillsPage {
   items: SkillInfo[];
@@ -35,7 +35,7 @@ export async function fetchCloudSkills(): Promise<SkillInfo[]> {
     const query = new URLSearchParams({ limit: String(PAGE_LIMIT) });
     if (pageId) query.set("page_id", pageId);
 
-    const page = await callCloudProxy<CloudSkillsPage>({
+    const page = await callCloudApi<CloudSkillsPage>({
       backend,
       method: "GET",
       path: `/api/v1/skills/search?${query.toString()}`,

--- a/src/api/cloud/suggestions-service.api.ts
+++ b/src/api/cloud/suggestions-service.api.ts
@@ -1,7 +1,7 @@
 import { SuggestedTask } from "#/utils/types";
 import { getActiveBackend } from "../backend-registry/active-store";
 import type { Backend } from "../backend-registry/types";
-import { callCloudProxy } from "./proxy";
+import { callCloudApi } from "./proxy";
 
 function getActiveCloudBackend(): Backend {
   const active = getActiveBackend().backend;
@@ -20,7 +20,7 @@ export async function getCloudSuggestedTasks(args: {
   params.set("limit", String(args.limit ?? 30));
   if (args.pageId) params.set("page_id", args.pageId);
 
-  const data = await callCloudProxy<{
+  const data = await callCloudApi<{
     items: SuggestedTask[];
     next_page_id: string | null;
   }>({

--- a/src/api/config-service/config-service.api.ts
+++ b/src/api/config-service/config-service.api.ts
@@ -1,7 +1,7 @@
 import { LLMMetadataClient } from "@openhands/typescript-client/clients";
 import { getAgentServerClientOptions } from "../agent-server-client-options";
 import { getActiveBackend } from "../backend-registry/active-store";
-import { callCloudProxy } from "../cloud/proxy";
+import { callCloudApi } from "../cloud/proxy";
 import type {
   LLMModel,
   LLMModelPage,
@@ -78,7 +78,7 @@ class ConfigService {
         verified__eq: params.verified__eq,
         provider__eq: params.provider__eq,
       });
-      return callCloudProxy<LLMModelPage>({
+      return callCloudApi<LLMModelPage>({
         backend: active.backend,
         method: "GET",
         path: `/api/v1/config/models/search${qs}`,
@@ -149,7 +149,7 @@ class ConfigService {
         query: params.query,
         verified__eq: params.verified__eq,
       });
-      return callCloudProxy<ProviderPage>({
+      return callCloudApi<ProviderPage>({
         backend: active.backend,
         method: "GET",
         path: `/api/v1/config/providers/search${qs}`,

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -11,7 +11,6 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import { Provider } from "#/types/settings";
 import type { ConversationRuntimeContext } from "#/api/conversation-file-upload.api";
-import { buildHttpBaseUrl } from "#/utils/websocket-url";
 import {
   buildConversationWorkingDir,
   getAgentServerWorkingDir,
@@ -21,7 +20,7 @@ import {
   getActiveBackend,
   getEffectiveLocalBackend,
 } from "../backend-registry/active-store";
-import { callCloudProxy } from "../cloud/proxy";
+import { callCloudApi } from "../cloud/proxy";
 import {
   batchGetCloudConversations,
   createCloudAppConversation,
@@ -30,6 +29,7 @@ import {
   getCloudAppConversationStartTask,
   readCloudConversationFile,
   searchCloudConversations,
+  sendCloudConversationMessage,
   updateCloudConversationPublicFlag,
 } from "../cloud/conversation-service.api";
 import {
@@ -301,34 +301,11 @@ class AgentServerConversationService {
     runtime?: ConversationRuntimeContext | null,
   ): Promise<SendMessageResponse> {
     const active = getActiveBackend().backend;
-    let conversationUrl = runtime?.conversationUrl ?? null;
-    let sessionApiKey = runtime?.sessionApiKey ?? null;
+    const conversationUrl = runtime?.conversationUrl ?? null;
+    const sessionApiKey = runtime?.sessionApiKey ?? null;
 
     if (active.kind === "cloud") {
-      if (!conversationUrl || !sessionApiKey) {
-        const [conversation] = await batchGetCloudConversations([
-          conversationId,
-        ]);
-        conversationUrl = conversation?.conversation_url?.trim() ?? null;
-        sessionApiKey = conversation?.session_api_key?.trim() ?? null;
-      }
-
-      if (!conversationUrl || !sessionApiKey) {
-        throw new Error(
-          "Conversation sandbox is still starting. Wait for it to finish, then try again.",
-        );
-      }
-
-      await callCloudProxy({
-        backend: active,
-        method: "POST",
-        hostOverride: buildHttpBaseUrl(conversationUrl),
-        path: `/api/conversations/${conversationId}/events`,
-        body: { ...message, run: true },
-        authMode: "session-api-key",
-        sessionApiKey,
-      });
-
+      await sendCloudConversationMessage(conversationId, message);
       return message;
     }
 
@@ -593,26 +570,28 @@ class AgentServerConversationService {
       stats?: RuntimeConversationInfo["stats"];
     };
 
-    // Cloud mode: route through the cloud-proxy to the runtime sandbox at
-    // the conversation's runtime URL — same pattern as getVSCodeUrl. Local
-    // mode forwards conversationUrl so the host explicitly resolves to the
-    // conversation's runtime instead of falling back to the active backend.
-    const response =
-      active.kind === "cloud" && conversationUrl
-        ? await callCloudProxy<RawRuntime>({
-            backend: active,
-            method: "GET",
-            hostOverride: buildHttpBaseUrl(conversationUrl),
-            path: `/api/conversations/${conversationId}`,
-            authMode: "session-api-key",
-            sessionApiKey,
-          })
-        : await new ConversationClient(
-            getAgentServerClientOptions({
-              conversationUrl,
-              sessionApiKey,
-            }),
-          ).getConversation<RawRuntime>(conversationId);
+    if (active.kind === "cloud") {
+      const [conversation] = await batchGetCloudConversations([conversationId]);
+      const data = requireAppConversation(conversation, conversationId);
+      return {
+        id: data.id,
+        title: data.title?.trim()
+          ? data.title
+          : getDefaultConversationTitle(data.id),
+        metrics: normalizeMetrics(data.metrics),
+        created_at: data.created_at,
+        updated_at: data.updated_at,
+        status: toRuntimeStatus(data.execution_status),
+        stats: { usage_to_metrics: {} },
+      };
+    }
+
+    const response = await new ConversationClient(
+      getAgentServerClientOptions({
+        conversationUrl,
+        sessionApiKey,
+      }),
+    ).getConversation<RawRuntime>(conversationId);
     const data = requireDirectConversationInfo(response);
     const stats = isRecord(response) ? response.stats : null;
 
@@ -740,7 +719,7 @@ class AgentServerConversationService {
   ): Promise<void> {
     const { backend } = getActiveBackend();
     if (backend.kind === "cloud") {
-      await callCloudProxy({
+      await callCloudApi({
         backend,
         method: "POST",
         path: `/api/v1/app-conversations/${conversationId}/switch_acp_model`,

--- a/src/api/event-service/event-service.api.ts
+++ b/src/api/event-service/event-service.api.ts
@@ -3,7 +3,7 @@ import { RemoteEventsList } from "@openhands/typescript-client/events/remote-eve
 import { OpenHandsEvent } from "#/types/agent-server/core";
 import { buildHttpBaseUrl } from "#/utils/websocket-url";
 import { getActiveBackend } from "../backend-registry/active-store";
-import { callCloudProxy } from "../cloud/proxy";
+import { callCloudApi, callLegacyRuntimeCloudProxy } from "../cloud/proxy";
 import {
   getAgentServerClientOptions,
   getAgentServerHttpClientOptions,
@@ -16,25 +16,10 @@ import type {
 } from "./event-service.types";
 
 /**
- * Cloud-mode REST calls are split between two upstream hosts (matching
- * OpenHands' cloud frontend):
- *
- *   - **App API** (`backend.host`, default in `callCloudProxy`):
- *     event *history* (`/api/v1/conversation/{id}/events/search`).
- *     Persisted by the cloud backend — survives the runtime sandbox.
- *
- *   - **Runtime sandbox** (extracted from `conversation.conversation_url`
- *     and passed as `hostOverride`): live runtime endpoints like
- *     `/api/conversations/{id}/events/count` and
- *     `/api/conversations/{id}/events/respond_to_confirmation`. Auth on
- *     these endpoints is `X-Session-API-Key`, not `Authorization: Bearer`.
- *
- * App API calls go directly to the cloud backend with bearer auth. Runtime
- * sandbox calls go through `/api/cloud-proxy`, which avoids depending on CORS
- * for per-conversation runtime hosts.
- *
- * Local mode keeps the existing typescript-client path: it targets the
- * conversation's host directly via typed client classes.
+ * Cloud-mode event history and counts use first-class cloud App API routes.
+ * Responding to confirmation requests still targets the live runtime endpoint,
+ * so it remains behind the explicit legacy runtime proxy until the cloud/app
+ * backend exposes a dedicated gateway route for it.
  */
 class EventService {
   static async respondToConfirmation(
@@ -46,13 +31,12 @@ class EventService {
     const active = getActiveBackend().backend;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<ConfirmationResponseResponse>({
+      return callLegacyRuntimeCloudProxy<ConfirmationResponseResponse>({
         backend: active,
         method: "POST",
-        hostOverride: buildHttpBaseUrl(conversationUrl),
+        host: buildHttpBaseUrl(conversationUrl),
         path: `/api/conversations/${conversationId}/events/respond_to_confirmation`,
         body: request,
-        authMode: "session-api-key",
         sessionApiKey,
       });
     }
@@ -76,13 +60,10 @@ class EventService {
     const active = getActiveBackend().backend;
 
     if (active.kind === "cloud") {
-      return callCloudProxy<number>({
+      return callCloudApi<number>({
         backend: active,
         method: "GET",
-        hostOverride: buildHttpBaseUrl(conversationUrl),
-        path: `/api/conversations/${conversationId}/events/count`,
-        authMode: "session-api-key",
-        sessionApiKey,
+        path: `/api/v1/conversation/${conversationId}/events/count`,
       });
     }
 
@@ -134,7 +115,7 @@ class EventService {
       if (options.timestampLt) params.set("timestamp__lt", options.timestampLt);
 
       const doCloudSearch = (searchParams: URLSearchParams) =>
-        callCloudProxy<EventSearchPage<OpenHandsEvent>>({
+        callCloudApi<EventSearchPage<OpenHandsEvent>>({
           backend: active,
           method: "GET",
           path: `/api/v1/conversation/${conversationId}/events/search?${searchParams.toString()}`,

--- a/src/api/git-service/agent-server-git-service.api.ts
+++ b/src/api/git-service/agent-server-git-service.api.ts
@@ -2,7 +2,7 @@ import { RemoteWorkspace } from "@openhands/typescript-client/workspace/remote-w
 import { mapAnyGitStatusToClientStatus } from "#/utils/git-status-mapper";
 import type { GitChange, GitChangeDiff } from "../open-hands.types";
 import { getActiveBackend } from "../backend-registry/active-store";
-import { callCloudProxy } from "../cloud/proxy";
+import { callCloudApi } from "../cloud/proxy";
 import { getAgentServerClientOptions } from "../agent-server-client-options";
 
 interface AgentServerGitChange {
@@ -48,7 +48,7 @@ class AgentServerGitService {
     if (active.kind === "cloud" && conversationId) {
       const params = new URLSearchParams();
       params.set("path", toAbsoluteRuntimePath(path));
-      const data = await callCloudProxy<AgentServerGitChange[]>({
+      const data = await callCloudApi<AgentServerGitChange[]>({
         backend: active,
         method: "GET",
         path: `/api/v1/app-conversations/${conversationId}/git/changes?${params.toString()}`,
@@ -99,7 +99,7 @@ class AgentServerGitService {
     if (active.kind === "cloud" && conversationId) {
       const params = new URLSearchParams();
       params.set("path", toAbsoluteRuntimePath(path));
-      const diff = await callCloudProxy<GitChangeDiff & { diff?: string }>({
+      const diff = await callCloudApi<GitChangeDiff & { diff?: string }>({
         backend: active,
         method: "GET",
         path: `/api/v1/app-conversations/${conversationId}/git/diff?${params.toString()}`,

--- a/src/api/runtime-service/agent-server-runtime-service.ts
+++ b/src/api/runtime-service/agent-server-runtime-service.ts
@@ -2,7 +2,7 @@ import { FileClient } from "@openhands/typescript-client/clients";
 import { RemoteWorkspace } from "@openhands/typescript-client/workspace/remote-workspace";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
 import { getActiveBackend } from "#/api/backend-registry/active-store";
-import { callCloudProxy } from "#/api/cloud/proxy";
+import { callLegacyRuntimeCloudProxy } from "#/api/cloud/proxy";
 import { buildHttpBaseUrl } from "#/utils/websocket-url";
 
 export interface CommandResult {
@@ -17,8 +17,8 @@ export interface CommandResult {
  * In **local** mode the runtime is reachable directly from the browser
  * (e.g. `127.0.0.1:18000`) so the SDK's typed clients work fine.
  * In **cloud** mode the runtime lives at `*.prod-runtime.all-hands.dev`,
- * which doesn't allow CORS from `localhost`, so all calls go through
- * `callCloudProxy` with the runtime URL as `hostOverride` and the
+ * which doesn't allow CORS from `localhost`, so remaining runtime-only calls
+ * go through `callLegacyRuntimeCloudProxy` with the runtime URL and the
  * conversation's `session_api_key` as auth — server-side hop, no CORS.
  */
 class AgentServerRuntimeService {
@@ -32,21 +32,20 @@ class AgentServerRuntimeService {
     const active = getActiveBackend().backend;
 
     if (active.kind === "cloud" && conversationUrl) {
-      const output = await callCloudProxy<{
+      const output = await callLegacyRuntimeCloudProxy<{
         exit_code?: number;
         stdout?: string;
         stderr?: string;
       }>({
         backend: active,
         method: "POST",
-        hostOverride: buildHttpBaseUrl(conversationUrl),
+        host: buildHttpBaseUrl(conversationUrl),
         path: "/api/bash/execute_bash_command",
         body: {
           command,
           ...(cwd ? { cwd } : {}),
           timeout: Math.floor(timeout),
         },
-        authMode: "session-api-key",
         sessionApiKey,
         timeoutSeconds: timeout + 10,
       });
@@ -75,12 +74,11 @@ class AgentServerRuntimeService {
     const active = getActiveBackend().backend;
 
     if (active.kind === "cloud" && conversationUrl) {
-      const blob = await callCloudProxy<Blob>({
+      const blob = await callLegacyRuntimeCloudProxy<Blob>({
         backend: active,
         method: "GET",
-        hostOverride: buildHttpBaseUrl(conversationUrl),
+        host: buildHttpBaseUrl(conversationUrl),
         path: `/api/file/download?path=${encodeURIComponent(path)}`,
-        authMode: "session-api-key",
         sessionApiKey,
         responseType: "blob",
       });

--- a/src/components/features/backends/backend-selector.tsx
+++ b/src/components/features/backends/backend-selector.tsx
@@ -212,7 +212,7 @@ export function BackendSelector({
   // the selection onto the personal-workspace org (or, lacking a /me
   // result, the first org). The selection is recorded locally only;
   // the cloud request scope follows from the API key's bound org and the
-  // X-Org-Id header sent by `callCloudProxy`, so the cloud UI's
+  // X-Org-Id header sent by `callCloudApi`, so the cloud UI's
   // org choice is never mutated as a side effect.
   React.useEffect(() => {
     if (noBackendSelected || active.backend.kind !== "cloud" || active.orgId)

--- a/src/hooks/query/use-workspace-file-content.ts
+++ b/src/hooks/query/use-workspace-file-content.ts
@@ -176,7 +176,7 @@ export function useWorkspaceFileContent(relativePath: string | null) {
 
       if (isCloud) {
         // Cloud: no static fileserver cookie path is reachable from the
-        // browser. Fetch bytes server-side through callCloudProxy and
+        // browser. Fetch bytes server-side through callLegacyRuntimeCloudProxy and
         // hand the consumer a self-contained `data:` URI for iframe /
         // <img> rendering.
         const buffer = await AgentServerRuntimeService.downloadFile(

--- a/src/hooks/query/use-workspace-session.ts
+++ b/src/hooks/query/use-workspace-session.ts
@@ -26,11 +26,11 @@ export interface WorkspaceSession {
  * request header.
  *
  * Local-only. The cookie flow is useless on cloud: the POST would be a
- * server-side hop through `callCloudProxy` (so the `Set-Cookie` never
+ * server-side hop through `callLegacyRuntimeCloudProxy` (so the `Set-Cookie` never
  * reaches the browser jar), and the runtime sandbox is cross-origin with
  * the GUI (so `fetch(staticUrl, { credentials: "include" })` couldn't
  * attach the cookie anyway). On cloud, `useWorkspaceFileContent` fetches
- * bytes through `callCloudProxy` directly and renders binary kinds as
+ * bytes through `callLegacyRuntimeCloudProxy` directly and renders binary kinds as
  * `data:` URIs, so this hook stays disabled and returns `data: null`.
  *
  * We treat the call as cache-once-per-conversation: the cookie lives in

--- a/src/utils/conversation-metrics.ts
+++ b/src/utils/conversation-metrics.ts
@@ -13,12 +13,17 @@ export function getCombinedMetrics(
 ): MetricsSnapshot {
   const { stats } = conversationInfo;
 
-  if (!stats?.usage_to_metrics) {
-    return {
-      accumulated_cost: 0,
-      max_budget_per_task: null,
-      accumulated_token_usage: null,
-    };
+  if (
+    !stats?.usage_to_metrics ||
+    Object.keys(stats.usage_to_metrics).length === 0
+  ) {
+    return (
+      conversationInfo.metrics ?? {
+        accumulated_cost: 0,
+        max_budget_per_task: null,
+        accumulated_token_usage: null,
+      }
+    );
   }
 
   let totalCost = 0;


### PR DESCRIPTION
## Summary

Split the misleading `callCloudProxy` helper into two explicit paths:

- `callCloudApi()` for first-class cloud/app backend API requests that go directly to `backend.host`
- `callLegacyRuntimeCloudProxy()` for the remaining runtime-only calls that still need the legacy `/api/cloud-proxy` bridge

Also migrated several old runtime-proxy usages to first-class cloud/app APIs:

- cloud follow-up messages now use `POST /api/v1/app-conversations/{id}/send-message`
- cloud event counts now use `GET /api/v1/conversation/{id}/events/count`
- cloud runtime metric lookups now use app-conversation data instead of the runtime host
- cloud event search continues to use the app API, now through the clearer `callCloudApi()` helper

Remaining runtime-only operations (bash output lookup, confirmation response, command execution, binary file download) are isolated behind the explicitly deprecated legacy helper so they are easier to audit/migrate when dedicated app-server routes exist.

## Validation

- `npm run lint` ✅
- targeted Vitest suite for touched API/query modules ✅
- `npm test` ✅ (3459 passed, 5 skipped, 9 todo)
- `npm run typecheck` ✅
- `npm run build` ✅

This PR was created by an AI agent (OpenHands) on behalf of the user.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e85f98d7-0ddd-48ff-8e07-a5587568a9bb)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.29.3-python` |
| **Automation** | `openhands-automation==1.0.0a13` |
| **Commit** | `ba1e90d3a5480e7601d68322226df0cb264c22c1` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-ba1e90d
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-ba1e90d
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-ba1e90d-amd64
ghcr.io/openhands/agent-canvas:openhands-clean-cloud-proxy-usages-amd64
ghcr.io/openhands/agent-canvas:pr-1561-amd64
ghcr.io/openhands/agent-canvas:sha-ba1e90d-arm64
ghcr.io/openhands/agent-canvas:openhands-clean-cloud-proxy-usages-arm64
ghcr.io/openhands/agent-canvas:pr-1561-arm64
ghcr.io/openhands/agent-canvas:sha-ba1e90d
ghcr.io/openhands/agent-canvas:openhands-clean-cloud-proxy-usages
ghcr.io/openhands/agent-canvas:pr-1561
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-ba1e90d`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-ba1e90d-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->