### PR TITLE
test: add mock-LLM e2e coverage for recent PRs (2026-07-01)

### DIFF
--- a/tests/e2e/mock-llm/backends/mock-llm-locked-cloud-backends.spec.ts
+++ b/tests/e2e/mock-llm/backends/mock-llm-locked-cloud-backends.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test, type Page } from "@playwright/test";
+import { waitForTestId } from "../utils/mock-llm-helpers";
+
+const LOCKED_CLOUD_BACKEND_ID = "locked-cloud";
+const LOCKED_CLOUD_BACKEND_NAME = "Locked Cloud";
+const LOCKED_CLOUD_ORG_ID = "locked-org";
+const LOCKED_CLOUD_ORG_NAME = "Locked Organization";
+const LOCKED_CLOUD_USER_ID = "locked-user";
+const LOCKED_CLOUD_API_KEY = "mock-cloud-api-key";
+
+test.describe.configure({ mode: "serial" });
+
+async function seedLockedCloudMode(page: Page) {
+  await page.addInitScript(
+    ({ backendId, backendName, orgId, apiKey }) => {
+      const lockedHost = window.location.origin;
+      const backend = {
+        id: backendId,
+        name: backendName,
+        host: lockedHost,
+        apiKey,
+        kind: "cloud",
+      };
+      const selection = JSON.stringify({ backendId, orgId });
+
+      (
+        window as unknown as Record<string, unknown>
+      ).__AGENT_CANVAS_LOCK_TO_CLOUD__ = lockedHost;
+      window.localStorage.setItem("openhands-onboarded", "1");
+      window.localStorage.setItem("analytics-consent", "false");
+      window.localStorage.setItem("openhands-telemetry-consent", "denied");
+      window.localStorage.setItem("openhands-telemetry-first-use", "true");
+      window.localStorage.setItem(
+        "openhands-backends",
+        JSON.stringify([backend]),
+      );
+      window.localStorage.setItem("openhands-active-backend", selection);
+      window.sessionStorage.setItem("openhands-active-backend", selection);
+    },
+    {
+      backendId: LOCKED_CLOUD_BACKEND_ID,
+      backendName: LOCKED_CLOUD_BACKEND_NAME,
+      orgId: LOCKED_CLOUD_ORG_ID,
+      apiKey: LOCKED_CLOUD_API_KEY,
+    },
+  );
+}
+
+async function routeLockedCloudApi(page: Page) {
+  await page.route("**/api/keys/current", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "locked-key",
+        name: "Locked key",
+        org_id: LOCKED_CLOUD_ORG_ID,
+        user_id: LOCKED_CLOUD_USER_ID,
+        auth_type: "pat",
+      }),
+    });
+  });
+
+  await page.route("**/api/organizations", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        items: [
+          {
+            id: LOCKED_CLOUD_ORG_ID,
+            name: LOCKED_CLOUD_ORG_NAME,
+          },
+        ],
+        current_org_id: LOCKED_CLOUD_ORG_ID,
+      }),
+    });
+  });
+
+  await page.route(
+    `**/api/organizations/${LOCKED_CLOUD_ORG_ID}/me`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          org_id: LOCKED_CLOUD_ORG_ID,
+          user_id: LOCKED_CLOUD_USER_ID,
+        }),
+      });
+    },
+  );
+}
+
+test.describe("locked Cloud backend management", () => {
+  test("shows the locked Cloud row without edit or remove actions", async ({
+    page,
+  }) => {
+    await seedLockedCloudMode(page);
+    await routeLockedCloudApi(page);
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForTestId(page, "backend-selector");
+
+    await page.getByTestId("backend-selector").click();
+    await page.getByTestId("manage-backends-menu-item").click();
+
+    const modal = page.getByTestId("manage-backends-modal");
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    const row = page.getByTestId(
+      `manage-backends-row-${LOCKED_CLOUD_BACKEND_NAME}`,
+    );
+    await expect(row).toBeVisible();
+    await expect(row.getByText(LOCKED_CLOUD_BACKEND_NAME)).toBeVisible();
+    await expect(row.getByText(LOCKED_CLOUD_ORG_NAME)).toBeVisible();
+    await expect(
+      row.getByTestId(`manage-backends-edit-${LOCKED_CLOUD_BACKEND_NAME}`),
+    ).toHaveCount(0);
+    await expect(
+      row.getByTestId(`manage-backends-remove-${LOCKED_CLOUD_BACKEND_NAME}`),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add mock-LLM E2E coverage for the locked Cloud Manage Backends regression from #1555.
- Verify the locked Cloud backend row remains visible while edit/remove row actions are hidden.

## Covered PRs
- #1555 — fix(backends): hide edit/remove row actions when locked to cloud

## Verification
- npm ci
- npm run typecheck (initially failed because generated i18n declarations were missing; after `npm run make-i18n`, rerun passed)
- npx prettier --check tests/e2e/mock-llm/backends/mock-llm-locked-cloud-backends.spec.ts

This PR was created by an AI agent (OpenHands) on behalf of the user.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.29.3-python` |
| **Automation** | `openhands-automation==1.0.0a13` |
| **Commit** | `88e8a8570ca9e21012b9fcc4ef70a604eddca8d4` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-88e8a85
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-88e8a85
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-88e8a85-amd64
ghcr.io/openhands/agent-canvas:auto-e2e-coverage-2026-07-01-amd64
ghcr.io/openhands/agent-canvas:pr-1564-amd64
ghcr.io/openhands/agent-canvas:sha-88e8a85-arm64
ghcr.io/openhands/agent-canvas:auto-e2e-coverage-2026-07-01-arm64
ghcr.io/openhands/agent-canvas:pr-1564-arm64
ghcr.io/openhands/agent-canvas:sha-88e8a85
ghcr.io/openhands/agent-canvas:auto-e2e-coverage-2026-07-01
ghcr.io/openhands/agent-canvas:pr-1564
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-88e8a85`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-88e8a85-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->