### PR TITLE
Fix paginated workspace folder listings

### DIFF
--- a/__tests__/components/features/home/workspace-selection-form.test.tsx
+++ b/__tests__/components/features/home/workspace-selection-form.test.tsx
@@ -213,6 +213,48 @@ describe("WorkspaceSelectionForm (server-backed workspaces)", () => {
     expect(await within(menu).findByText("repo1")).toBeInTheDocument();
   });
 
+  it("renders parent-derived workspaces from all paginated folders", async () => {
+    const workspaceParent = {
+      id: "/Users/me/dev",
+      name: "dev",
+      path: "/Users/me/dev",
+    };
+    mockSearchSubdirectories.mockImplementation(
+      async (path: string, options?: { pageId?: string | null }) => {
+        if (path === workspaceParent.path && !options?.pageId) {
+          return {
+            items: [{ name: "alpha", path: "/Users/me/dev/alpha" }],
+            next_page_id: "page-2",
+          };
+        }
+        if (path === workspaceParent.path && options?.pageId === "page-2") {
+          return {
+            items: [{ name: "paper", path: "/Users/me/dev/paper" }],
+            next_page_id: null,
+          };
+        }
+        return { items: [], next_page_id: null };
+      },
+    );
+    renderForm({ workspaceParents: [workspaceParent] });
+    const user = userEvent.setup();
+
+    const menu = await openWorkspaceDropdown(user);
+
+    expect(await within(menu).findByText("alpha")).toBeInTheDocument();
+    expect(await within(menu).findByText("paper")).toBeInTheDocument();
+    expect(mockSearchSubdirectories).toHaveBeenCalledWith(
+      workspaceParent.path,
+      undefined,
+    );
+    expect(mockSearchSubdirectories).toHaveBeenCalledWith(
+      workspaceParent.path,
+      {
+        pageId: "page-2",
+      },
+    );
+  });
+
   it("restores the selected workspace after unmounting and remounting", async () => {
     const workspace = {
       id: "/Users/me/dev/repo1",
@@ -334,6 +376,52 @@ describe("WorkspaceSelectionForm (server-backed workspaces)", () => {
     expect(addSpy).toHaveBeenCalledWith([
       { id: "/Users/me/dev", name: "dev", path: "/Users/me/dev" },
     ]);
+  });
+
+  it("shows all paginated folders in the Add Workspace browser", async () => {
+    mockSearchSubdirectories.mockImplementation(
+      async (path: string, options?: { pageId?: string | null }) => {
+        if (path === "/Users/me" && !options?.pageId) {
+          return {
+            items: [{ name: "alpha", path: "/Users/me/alpha" }],
+            next_page_id: "page-2",
+          };
+        }
+        if (path === "/Users/me" && options?.pageId === "page-2") {
+          return {
+            items: [
+              { name: "paper", path: "/Users/me/paper" },
+              { name: "zeta", path: "/Users/me/zeta" },
+            ],
+            next_page_id: null,
+          };
+        }
+        return { items: [], next_page_id: null };
+      },
+    );
+    renderForm();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByTestId("workspace-dropdown"));
+    await user.click(await screen.findByTestId("add-workspaces-button"));
+    await screen.findByTestId("folder-browser-modal");
+
+    expect(
+      await screen.findByTestId("folder-browser-entry-alpha"),
+    ).toBeVisible();
+    expect(
+      await screen.findByTestId("folder-browser-entry-paper"),
+    ).toBeVisible();
+    expect(
+      await screen.findByTestId("folder-browser-entry-zeta"),
+    ).toBeVisible();
+    expect(mockSearchSubdirectories).toHaveBeenCalledWith(
+      "/Users/me",
+      undefined,
+    );
+    expect(mockSearchSubdirectories).toHaveBeenCalledWith("/Users/me", {
+      pageId: "page-2",
+    });
   });
 
   it("handles Windows paths when browsing and adding a workspace", async () => {

--- a/src/hooks/query/use-resolved-workspaces.ts
+++ b/src/hooks/query/use-resolved-workspaces.ts
@@ -1,12 +1,9 @@
 import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
-import {
-  FileClient,
-  isAgentServerVersionError,
-} from "@openhands/typescript-client/clients";
+import { isAgentServerVersionError } from "@openhands/typescript-client/clients";
 
-import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
 import { useLocalWorkspaces } from "#/hooks/query/use-local-workspaces";
+import { searchAllSubdirectories } from "#/hooks/query/use-search-subdirs";
 import { LocalWorkspace, LocalWorkspaceParent } from "#/types/workspace";
 
 interface UseResolvedWorkspacesResult {
@@ -74,10 +71,7 @@ export function useResolvedWorkspaces(): UseResolvedWorkspacesResult {
       ? []
       : workspaceParents.map((parent) => ({
           queryKey: ["file", "search_subdirs", parent.path],
-          queryFn: () =>
-            new FileClient(getAgentServerClientOptions()).searchSubdirectories(
-              parent.path,
-            ),
+          queryFn: () => searchAllSubdirectories(parent.path),
           retry: false,
           meta: { disableToast: true },
         })),

--- a/src/hooks/query/use-search-subdirs.ts
+++ b/src/hooks/query/use-search-subdirs.ts
@@ -3,6 +3,11 @@ import { FileClient } from "@openhands/typescript-client/clients";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
 import { useActiveBackend } from "#/contexts/active-backend-context";
 
+type FileSubdirectoryPage = Awaited<
+  ReturnType<FileClient["searchSubdirectories"]>
+>;
+type FileClientLike = Pick<FileClient, "searchSubdirectories">;
+
 export interface FileBrowserEntry {
   label: string;
   path: string;
@@ -18,11 +23,38 @@ function getFileClient() {
   return new FileClient(getAgentServerClientOptions());
 }
 
+export async function searchAllSubdirectories(
+  path: string,
+  fileClient: FileClientLike = getFileClient(),
+): Promise<FileSubdirectoryPage> {
+  const items: FileSubdirectoryPage["items"] = [];
+  const seenPageIds = new Set<string>();
+  let pageId: string | null | undefined;
+
+  while (true) {
+    const page = await fileClient.searchSubdirectories(
+      path,
+      pageId ? { pageId } : undefined,
+    );
+    items.push(...page.items);
+    pageId = page.next_page_id;
+
+    if (!pageId) {
+      return { items, next_page_id: null };
+    }
+
+    if (seenPageIds.has(pageId)) {
+      throw new Error("File search returned a repeated page id");
+    }
+    seenPageIds.add(pageId);
+  }
+}
+
 export const useSearchSubdirs = (path: string | null) => {
   const active = useActiveBackend();
   return useQuery({
     queryKey: ["file", "search_subdirs", path, active.backend.id, active.orgId],
-    queryFn: () => getFileClient().searchSubdirectories(path as string),
+    queryFn: () => searchAllSubdirectories(path as string),
     enabled: !!path,
     retry: false,
     meta: { disableToast: true },


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

Implemented by OpenHands. Validation run:

- `npm run test -- __tests__/components/features/home/workspace-selection-form.test.tsx` — 15 tests passed, including paginated folder-list regressions.
- `npx prettier --check __tests__/components/features/home/workspace-selection-form.test.tsx` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- `npm run lint` — passed.

Reproduction coverage: the new tests simulate `/api/file/search_subdirs` returning a first page with `next_page_id: "page-2"` and verify both the Add Workspace folder browser and saved workspace-parent dropdown include folders from the later page, such as `paper`.

---

## Why

The Agent Canvas Add Workspace folder browser only used the first `/api/file/search_subdirs` response page. Directories beyond the backend page limit were omitted, so users with many subfolders could not select later folders.

Fixes OpenHands/OpenHands#15078.

## Summary

- Added a shared `searchAllSubdirectories` helper that follows `next_page_id` until all subdirectory pages are loaded.
- Reused that helper in both the Add Workspace folder browser query and saved workspace-parent resolution.
- Added regression coverage for paginated folder listings in both flows.

## Issue Number

Fixes OpenHands/OpenHands#15078

## How to Test

1. Create a directory with enough subfolders for `/api/file/search_subdirs` to paginate.
2. Run Agent Canvas and click Add Workspace.
3. Browse to that directory and verify folders from later pages are visible and selectable.
4. Optionally add the directory via Add all subdirectories and verify later-page child workspaces appear in the workspace dropdown.

Automated validation run by the agent:

```bash
npm run test -- __tests__/components/features/home/workspace-selection-form.test.tsx
npx prettier --check __tests__/components/features/home/workspace-selection-form.test.tsx
npm run typecheck
npm run build
npm run lint
```

## Video/Screenshots

No screenshot captured. The regression is covered by component tests that mock the paginated backend response and assert later-page folders are rendered.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

@VascoSch92 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/250226c0-2e6b-4460-a8d8-21356514aaa1)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.29.3-python` |
| **Automation** | `openhands-automation==1.0.0a13` |
| **Commit** | `980bff011f32f840b2cd0e389d9c13c4548bc911` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-980bff0
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-980bff0
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-980bff0-amd64
ghcr.io/openhands/agent-canvas:openhands-fix-workspace-pagination-amd64
ghcr.io/openhands/agent-canvas:pr-1566-amd64
ghcr.io/openhands/agent-canvas:sha-980bff0-arm64
ghcr.io/openhands/agent-canvas:openhands-fix-workspace-pagination-arm64
ghcr.io/openhands/agent-canvas:pr-1566-arm64
ghcr.io/openhands/agent-canvas:sha-980bff0
ghcr.io/openhands/agent-canvas:openhands-fix-workspace-pagination
ghcr.io/openhands/agent-canvas:pr-1566
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-980bff0`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-980bff0-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->